### PR TITLE
refactor(ci): extract ADR-006 run blocks, batch 5

### DIFF
--- a/.github/workflows/agent-drift-detection.yml
+++ b/.github/workflows/agent-drift-detection.yml
@@ -149,18 +149,7 @@ jobs:
         id: lib-mirror
         continue-on-error: true
         shell: bash
-        run: |
-          mirror_rc=0
-          build_rc=0
-          echo "Checking scripts/ -> .claude/lib/ sync via sync_plugin_lib.py --check"
-          python3 scripts/sync_plugin_lib.py --check || mirror_rc=$?
-          echo ""
-          echo "Checking .claude/lib/ -> src/copilot-cli/lib/ sync via build_all.py --check"
-          python3 build/scripts/build_all.py --check || build_rc=$?
-          if [ "$mirror_rc" -ne 0 ]; then
-            exit "$mirror_rc"
-          fi
-          exit "$build_rc"
+        run: python3 scripts/ci/check_plugin_lib_mirrors.py
 
       - name: "Check plugin manifest parity and description counts"
         id: manifest-parity
@@ -181,60 +170,7 @@ jobs:
           VALIDATE_CONCLUSION: ${{ steps.validate.outcome }}
           LIB_MIRROR_CONCLUSION: ${{ steps.lib-mirror.outcome }}
           MANIFEST_PARITY_CONCLUSION: ${{ steps.manifest-parity.outcome }}
-        run: |
-          echo ""
-          echo "==========================================================="
-          echo "  AGENT DRIFT DETECTED"
-          echo "==========================================================="
-          echo ""
-          echo "Generated agent files or plugin mirrors do not match committed files."
-          echo "Validation conclusions:"
-          echo "  generate_agents: $VALIDATE_CONCLUSION"
-          echo "  lib mirrors: $LIB_MIRROR_CONCLUSION"
-          echo "  manifest parity: $MANIFEST_PARITY_CONCLUSION"
-          echo ""
-
-          if [ "$VALIDATE_CONCLUSION" = "failure" ]; then
-            python3 build/generate_agents.py
-          fi
-          if [ "$LIB_MIRROR_CONCLUSION" = "failure" ]; then
-            python3 scripts/sync_plugin_lib.py || true
-            python3 build/scripts/build_all.py || true
-          fi
-
-          # Show which files drifted
-          changed_files=$(git diff --name-only)
-          if [ -n "$changed_files" ]; then
-            echo "--- Files with semantic drift ---"
-            echo "$changed_files" | while read -r file; do
-              echo "  x  $file"
-            done
-            echo ""
-
-            echo "--- How to fix ---"
-            echo ""
-            echo "  1. Edit the source template (NOT the generated file):"
-            echo "       templates/agents/<agent-name>.shared.md"
-            echo ""
-            echo "  2. Regenerate platform-specific files:"
-            echo "       python3 build/generate_agents.py"
-            echo ""
-            echo "  3. Commit the regenerated files:"
-            echo "       git add src/vs-code-agents/ src/copilot-cli/"
-            echo "       git commit -m 'fix(agents): regenerate from updated template'"
-            echo ""
-            echo "--- Bypass procedure (intentional divergence) ---"
-            echo ""
-            echo "  If this divergence is intentional:"
-            echo "  1. Add [skip-drift-check] to a commit message in this PR"
-            echo "  2. Document the reason in your PR description"
-            echo "  3. Update templates/README.md with the intentional difference"
-            echo "  4. Ensure explicit code-owner approval on this PR"
-            echo ""
-            echo "--- Detailed diff ---"
-            echo ""
-            git diff
-          fi
+        run: python3 scripts/ci/show_drift_failure.py
 
       - name: Fail when any drift check fails
         if: >
@@ -254,34 +190,7 @@ jobs:
           VALIDATE_CONCLUSION: ${{ steps.validate.outcome }}
           LIB_MIRROR_CONCLUSION: ${{ steps.lib-mirror.outcome }}
           MANIFEST_PARITY_CONCLUSION: ${{ steps.manifest-parity.outcome }}
-        run: |
-          if [ "$VALIDATE_CONCLUSION" = "success" ] && \
-             [ "$LIB_MIRROR_CONCLUSION" = "success" ] && \
-             [ "$MANIFEST_PARITY_CONCLUSION" = "success" ]; then
-            {
-              echo "## Agent Drift Detection Passed"
-              echo ""
-              echo "All generated agent files match their source templates."
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "## Agent Drift Detection Failed"
-              echo ""
-              echo "Generated agent files have drifted from their source templates."
-              echo ""
-              echo "### Fix"
-              echo "1. Edit the source template in \`templates/agents/*.shared.md\`"
-              echo "2. Run: \`python3 build/generate_agents.py\`"
-              echo "3. Commit the regenerated files"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-          {
-            echo ""
-            echo "### Monitored Paths"
-            echo "- \`templates/\` - source templates"
-            echo "- \`src/vs-code-agents/\` - generated VS Code agents"
-            echo "- \`src/copilot-cli/\` - generated Copilot CLI agents"
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: python3 scripts/ci/write_drift_job_summary.py
 
   # ─── Bypass warning, runs instead of validate when bypass is active ──────────
   bypass-warning:

--- a/.github/workflows/agent-metrics.yml
+++ b/.github/workflows/agent-metrics.yml
@@ -76,23 +76,7 @@ jobs:
         env:
           PERIOD_DAYS: ${{ steps.period.outputs.days }}
           PERIOD_FORMAT: ${{ steps.period.outputs.format }}
-        run: |
-          python .claude/skills/metrics/collect_metrics.py \
-            --since "$PERIOD_DAYS" \
-            --output "$PERIOD_FORMAT" \
-            > metrics-report.txt
-
-          # Capture summary for job output
-          echo "## Agent Metrics Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [ "$PERIOD_FORMAT" = "json" ]; then
-            echo '```json' >> $GITHUB_STEP_SUMMARY
-            cat metrics-report.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          else
-            cat metrics-report.txt >> $GITHUB_STEP_SUMMARY
-          fi
+        run: python scripts/ci/collect_metrics_and_report.py
 
       - name: Display metrics
         run: cat metrics-report.txt
@@ -124,59 +108,10 @@ jobs:
 
       - name: Check thresholds
         id: check
-        run: |
-          # Collect metrics as JSON for parsing
-          python .claude/skills/metrics/collect_metrics.py \
-            --since 7 \
-            --output json > metrics.json
-
-          # Parse and check thresholds
-          COVERAGE=$(python -c "import json; m=json.load(open('metrics.json')); print(m['metric_2_coverage']['coverage_rate'])")
-          INFRA_RATE=$(python -c "import json; m=json.load(open('metrics.json')); print(m['metric_4_infrastructure_review']['review_rate'])")
-
-          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "infra_rate=$INFRA_RATE" >> $GITHUB_OUTPUT
-
-          # Check if any threshold is breached
-          ALERT=false
-
-          # Coverage target: 50%
-          if (( $(echo "$COVERAGE < 50" | bc -l) )); then
-            echo "::warning::Agent coverage ($COVERAGE%) is below target (50%)"
-            ALERT=true
-          fi
-
-          # Infrastructure review target: 100%
-          # Only alert if there were infrastructure commits
-          INFRA_COMMITS=$(python -c "import json; m=json.load(open('metrics.json')); print(m['metric_4_infrastructure_review']['infrastructure_commits'])")
-          if [ "$INFRA_COMMITS" != "0" ] && (( $(echo "$INFRA_RATE < 100" | bc -l) )); then
-            echo "::warning::Infrastructure review rate ($INFRA_RATE%) is below target (100%)"
-            ALERT=true
-          fi
-
-          echo "alert=$ALERT" >> $GITHUB_OUTPUT
+        run: python scripts/ci/check_metrics_thresholds.py
 
       - name: Summary
         env:
           CHECK_COVERAGE: ${{ steps.check.outputs.coverage }}
           CHECK_INFRA_RATE: ${{ steps.check.outputs.infra_rate }}
-        run: |
-          echo "## Threshold Check Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Current | Target | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|---------|--------|--------|" >> $GITHUB_STEP_SUMMARY
-
-          COVERAGE="$CHECK_COVERAGE"
-          INFRA_RATE="$CHECK_INFRA_RATE"
-
-          if (( $(echo "$COVERAGE >= 50" | bc -l) )); then
-            echo "| Agent Coverage | ${COVERAGE}% | 50% | :white_check_mark: |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| Agent Coverage | ${COVERAGE}% | 50% | :x: |" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          if (( $(echo "$INFRA_RATE >= 100" | bc -l) )); then
-            echo "| Infrastructure Review | ${INFRA_RATE}% | 100% | :white_check_mark: |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| Infrastructure Review | ${INFRA_RATE}% | 100% | :warning: |" >> $GITHUB_STEP_SUMMARY
-          fi
+        run: python scripts/ci/write_metrics_threshold_summary.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,26 +52,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify package metadata
-        working-directory: packages/ai-agents-cli
-        run: |
-          node -e "
-            const pkg = require('./package.json');
-            const errors = [];
-            if (pkg.name !== '@rjmurillo/ai-agents')
-              errors.push('name must be @rjmurillo/ai-agents');
-            if (!pkg.publishConfig?.access ||
-                pkg.publishConfig.access !== 'public')
-              errors.push('publishConfig.access must be public');
-            if (!pkg.publishConfig?.provenance)
-              errors.push('publishConfig.provenance must be true');
-            if (!pkg.bin) errors.push('bin entry required');
-            if (!pkg.files) errors.push('files allowlist required');
-            if (errors.length) {
-              console.error(errors.join('\n')); process.exit(1);
-            }
-            console.log('Package metadata OK:',
-              pkg.name + '@' + pkg.version);
-          "
+        run: python3 scripts/ci/verify_npm_package_metadata.py --package-dir packages/ai-agents-cli
 
       - name: Check tag matches package version
         if: startsWith(github.ref, 'refs/tags/v')
@@ -88,19 +69,7 @@ jobs:
           echo "Version match: $TAG_VERSION"
 
       - name: Measure pack size
-        working-directory: packages/ai-agents-cli
-        run: |
-          SIZE=$(npm pack --dry-run 2>&1 | tail -1)
-          echo "Pack size: $SIZE"
-          JSON_OUT=$(npm pack --dry-run --json 2>/dev/null)
-          BYTES=$(echo "$JSON_OUT" | \
-            node -p "JSON.parse(require('fs') \
-              .readFileSync('/dev/stdin','utf8'))[0] \
-              ?.size || 'unknown'")
-          LIMIT=52428800
-          if [ "$BYTES" != "unknown" ] && [ "$BYTES" -gt "$LIMIT" ]; then
-            echo "::warning::Pack size exceeds 50MB threshold"
-          fi
+        run: python3 scripts/ci/measure_npm_pack_size.py --package-dir packages/ai-agents-cli
 
   publish:
     name: Publish to npm
@@ -161,18 +130,4 @@ jobs:
           github.event_name == 'push' ||
           (github.event_name == 'workflow_dispatch' &&
           github.event.inputs.dry-run == 'false')
-        working-directory: packages/ai-agents-cli
-        run: |
-          EXPECTED=$(node -p "require('./package.json').version")
-          echo "Expecting @rjmurillo/ai-agents@${EXPECTED}"
-          for i in 1 2 3 4 5; do
-            sleep 10
-            PUBLISHED=$(npm view "@rjmurillo/ai-agents@${EXPECTED}" version 2>/dev/null || true)
-            if [ "$PUBLISHED" = "$EXPECTED" ]; then
-              echo "Verified: @rjmurillo/ai-agents@${EXPECTED} is live on npm"
-              exit 0
-            fi
-            echo "Attempt $i: version ${EXPECTED} not yet visible, retrying..."
-          done
-          echo "::error::Version ${EXPECTED} not visible on npm after 50s"
-          exit 1
+        run: python3 scripts/ci/verify_npm_published.py --package-dir packages/ai-agents-cli

--- a/.github/workflows/test-codeql-integration.yml
+++ b/.github/workflows/test-codeql-integration.yml
@@ -112,24 +112,7 @@ jobs:
       - name: Verify scan artifacts
         env:
           LANGUAGE: ${{ matrix.language }}
-        run: |
-          # Verify database was created
-          db_path=".codeql/db/$LANGUAGE"
-          if [ ! -d "$db_path" ]; then
-            echo "ERROR: Database not created: $db_path"
-            exit 1
-          fi
-          echo "Database created: $db_path"
-
-          # Verify SARIF output
-          sarif_path=".codeql/results/$LANGUAGE.sarif"
-          if [ ! -f "$sarif_path" ]; then
-            echo "ERROR: SARIF not created: $sarif_path"
-            exit 1
-          fi
-
-          findings=$(python3 -c "import json; d=json.load(open('$sarif_path')); print(len(d['runs'][0]['results']))")
-          echo "SARIF created: $findings findings"
+        run: python3 scripts/ci/verify_codeql_artifacts.py --language "$LANGUAGE"
 
   # Pattern 3: Run scan with JSON output format
   test-scan-json-output:
@@ -165,28 +148,7 @@ jobs:
           fi
 
       - name: Verify SARIF structure
-        run: |
-          sarif_count=$(find .codeql/results -name "*.sarif" 2>/dev/null | wc -l)
-
-          if [ "$sarif_count" -eq 0 ]; then
-            echo "ERROR: No SARIF files created"
-            exit 1
-          fi
-
-          for sarif_file in .codeql/results/*.sarif; do
-            echo "Validating: $(basename "$sarif_file")"
-            python3 -c "
-          import json, sys
-          with open('$sarif_file') as f:
-              sarif = json.load(f)
-          if not sarif.get('version') or not sarif.get('runs'):
-              print(f'Invalid SARIF structure in $sarif_file', file=sys.stderr)
-              sys.exit(1)
-          print(f'  Version: {sarif[\"version\"]}')
-          print(f'  Runs: {len(sarif[\"runs\"])}')
-          print(f'  Results: {len(sarif[\"runs\"][0][\"results\"])}')
-          "
-          done
+        run: python3 scripts/ci/verify_codeql_sarif_structure.py
 
   aggregate-results:
     name: Aggregate Results
@@ -198,60 +160,15 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout scripts/ci
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: scripts/ci
+          sparse-checkout-cone-mode: false
+
       - name: Check job results
         env:
           INSTALL_RESULT: ${{ needs.test-install-and-config.result }}
           LANGUAGE_RESULT: ${{ needs.test-scan-language.result }}
           JSON_RESULT: ${{ needs.test-scan-json-output.result }}
-        run: |
-          all_passed=true
-
-          cat >> "$GITHUB_STEP_SUMMARY" << 'HEADER'
-          ## CodeQL Integration Test Results
-
-          These tests document how to use the CodeQL scripts locally:
-
-          | Test | Status | Usage Pattern |
-          |------|--------|---------------|
-          HEADER
-
-          declare -A results=(
-            ["Install & Config"]="$INSTALL_RESULT"
-            ["Language Scans"]="$LANGUAGE_RESULT"
-            ["JSON Output"]="$JSON_RESULT"
-          )
-
-          declare -A patterns=(
-            ["Install & Config"]="\`install_codeql.py\` + \`test_codeql_config.py\`"
-            ["Language Scans"]="\`invoke_codeql_scan.py --languages <lang>\`"
-            ["JSON Output"]="\`invoke_codeql_scan.py --format json\`"
-          )
-
-          for test in "Install & Config" "Language Scans" "JSON Output"; do
-            status="${results[$test]}"
-            pattern="${patterns[$test]}"
-
-            if [ "$status" = "success" ]; then
-              emoji="✓"
-            elif [ "$status" = "skipped" ]; then
-              emoji="⏭"
-            else
-              emoji="✗"
-              all_passed=false
-            fi
-
-            echo "| $test | $emoji $status | $pattern |" >> "$GITHUB_STEP_SUMMARY"
-          done
-
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-
-          if $all_passed; then
-            echo "> [!TIP]" >> "$GITHUB_STEP_SUMMARY"
-            echo "> All integration tests passed! See CONTRIBUTING.md for usage details." >> "$GITHUB_STEP_SUMMARY"
-            echo "All integration tests passed!"
-          else
-            echo "> [!CAUTION]" >> "$GITHUB_STEP_SUMMARY"
-            echo "> Some tests failed. Review logs above." >> "$GITHUB_STEP_SUMMARY"
-            echo "ERROR: One or more integration tests failed"
-            exit 1
-          fi
+        run: python3 scripts/ci/codeql_integration_summary.py

--- a/scripts/ci/check_metrics_thresholds.py
+++ b/scripts/ci/check_metrics_thresholds.py
@@ -3,11 +3,11 @@
 
 Runs collect_metrics.py --output json, parses the result, compares coverage
 and infrastructure-review rate against targets, and writes coverage,
-infra_rate, and alert to GITHUB_OUTPUT.
+infra_rate, and alert to GITHUB_OUTPUT when the env var is set.
 Replaces the "Check thresholds" step in agent-metrics.yml (issue #3531).
 
 EXIT CODES (ADR-035):
-  0  - Thresholds checked and outputs written
+  0  - Thresholds checked; outputs written when GITHUB_OUTPUT is set
   1  - collect_metrics.py failed or output unparseable
   2  - Usage error
 """

--- a/scripts/ci/check_metrics_thresholds.py
+++ b/scripts/ci/check_metrics_thresholds.py
@@ -35,6 +35,7 @@ def collect_metrics_json(since: int = 7) -> dict[str, Any]:
         [sys.executable, _COLLECT_SCRIPT, "--since", str(since), "--output", "json"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:

--- a/scripts/ci/check_metrics_thresholds.py
+++ b/scripts/ci/check_metrics_thresholds.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check agent metric thresholds and write outputs for the workflow.
+
+Runs collect_metrics.py --output json, parses the result, compares coverage
+and infrastructure-review rate against targets, and writes coverage,
+infra_rate, and alert to GITHUB_OUTPUT.
+Replaces the "Check thresholds" step in agent-metrics.yml (issue #3531).
+
+EXIT CODES (ADR-035):
+  0  - Thresholds checked and outputs written
+  1  - collect_metrics.py failed or output unparseable
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+
+_COLLECT_SCRIPT = ".claude/skills/metrics/collect_metrics.py"
+_COVERAGE_TARGET = 50.0
+_INFRA_RATE_TARGET = 100.0
+
+
+def collect_metrics_json(since: int = 7) -> dict[str, Any]:
+    """Run collect_metrics.py --output json and return the parsed dict."""
+    result = subprocess.run(
+        [sys.executable, _COLLECT_SCRIPT, "--since", str(since), "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"collect_metrics.py failed: {result.stderr.strip()}")
+    return dict(json.loads(result.stdout))
+
+
+def check_thresholds(metrics: dict[str, Any]) -> tuple[float, float, int, bool]:
+    """Return (coverage, infra_rate, infra_commits, alert).
+
+    Compares values against defined targets and prints warning annotations.
+    """
+    coverage: float = float(metrics["metric_2_coverage"]["coverage_rate"])
+    infra_rate: float = float(metrics["metric_4_infrastructure_review"]["review_rate"])
+    infra_commits: int = int(metrics["metric_4_infrastructure_review"]["infrastructure_commits"])
+
+    alert = False
+
+    if coverage < _COVERAGE_TARGET:
+        print(f"::warning::Agent coverage ({coverage}%) is below target ({_COVERAGE_TARGET}%)")
+        alert = True
+
+    if infra_commits != 0 and infra_rate < _INFRA_RATE_TARGET:
+        print(
+            f"::warning::Infrastructure review rate ({infra_rate}%) "
+            f"is below target ({_INFRA_RATE_TARGET}%)"
+        )
+        alert = True
+
+    return coverage, infra_rate, infra_commits, alert
+
+
+def write_github_output(
+    coverage: float,
+    infra_rate: float,
+    alert: bool,
+    output_file: str,
+) -> None:
+    """Append coverage, infra_rate, alert to GITHUB_OUTPUT."""
+    with open(output_file, "a", encoding="utf-8") as f:
+        f.write(f"coverage={coverage}\n")
+        f.write(f"infra_rate={infra_rate}\n")
+        f.write(f"alert={str(alert).lower()}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        metrics = collect_metrics_json()
+    except (RuntimeError, json.JSONDecodeError, KeyError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    coverage, infra_rate, _infra_commits, alert = check_thresholds(metrics)
+
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        write_github_output(coverage, infra_rate, alert, output_file)
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_plugin_lib_mirrors.py
+++ b/scripts/ci/check_plugin_lib_mirrors.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Check that plugin lib mirrors are in sync.
+
+Runs sync_plugin_lib.py --check and build_all.py --check.
+If the first script fails, exits with its code; otherwise exits with the
+second script's code. Replaces the "Check plugin lib mirrors" step in
+agent-drift-detection.yml (issue #3521).
+
+EXIT CODES (ADR-035):
+  0      - Both checks passed
+  other  - First non-zero exit code from the two checks
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_MIRROR_SCRIPT = "scripts/sync_plugin_lib.py"
+_BUILD_SCRIPT = "build/scripts/build_all.py"
+
+
+def run_check(script: str, description: str) -> int:
+    """Run a python3 --check script and return its exit code."""
+    print(description)
+    result = subprocess.run(
+        [sys.executable, script, "--check"],
+        check=False,
+    )
+    return result.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    print("Checking scripts/ -> .claude/lib/ sync via sync_plugin_lib.py --check")
+    mirror_rc = run_check(_MIRROR_SCRIPT, "")
+
+    print()
+    print("Checking .claude/lib/ -> src/copilot-cli/lib/ sync via build_all.py --check")
+    build_rc = run_check(_BUILD_SCRIPT, "")
+
+    if mirror_rc != 0:
+        return mirror_rc
+    return build_rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_plugin_lib_mirrors.py
+++ b/scripts/ci/check_plugin_lib_mirrors.py
@@ -23,6 +23,7 @@ _BUILD_SCRIPT = "build/scripts/build_all.py"
 def run_check(script: str, description: str) -> int:
     """Run a python3 --check script and return its exit code."""
     print(description)
+    sys.stdout.flush()
     result = subprocess.run(
         [sys.executable, script, "--check"],
         check=False,

--- a/scripts/ci/codeql_integration_summary.py
+++ b/scripts/ci/codeql_integration_summary.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Write the CodeQL integration test summary to GITHUB_STEP_SUMMARY.
+
+Reads job results from environment variables (INSTALL_RESULT, LANGUAGE_RESULT,
+JSON_RESULT), writes a markdown table to $GITHUB_STEP_SUMMARY, and exits 1 if
+any test failed. Replaces the bash associative-array block in
+test-codeql-integration.yml (Check job results step, issue #3526).
+
+EXIT CODES (ADR-035):
+  0  - All tests passed or skipped
+  1  - One or more tests failed
+  2  - Usage error (GITHUB_STEP_SUMMARY not set)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+
+# Ordered list of (display-name, env-var, usage-pattern).
+_TESTS: list[tuple[str, str, str]] = [
+    (
+        "Install & Config",
+        "INSTALL_RESULT",
+        "`install_codeql.py` + `test_codeql_config.py`",
+    ),
+    (
+        "Language Scans",
+        "LANGUAGE_RESULT",
+        "`invoke_codeql_scan.py --languages <lang>`",
+    ),
+    (
+        "JSON Output",
+        "JSON_RESULT",
+        "`invoke_codeql_scan.py --format json`",
+    ),
+]
+
+
+def _status_emoji(status: str) -> str:
+    if status == "success":
+        return "\u2713"
+    if status == "skipped":
+        return "\u23ed"
+    return "\u2717"
+
+
+def build_summary(
+    results: dict[str, str],
+) -> tuple[str, bool]:
+    """Build the markdown summary and return (text, all_passed)."""
+    rows: list[str] = []
+    all_passed = True
+    for test_name, env_key, pattern in _TESTS:
+        status = results.get(env_key, "")
+        emoji = _status_emoji(status)
+        if status not in ("success", "skipped"):
+            all_passed = False
+        rows.append(f"| {test_name} | {emoji} {status} | {pattern} |")
+
+    lines: list[str] = [
+        "## CodeQL Integration Test Results",
+        "",
+        "These tests document how to use the CodeQL scripts locally:",
+        "",
+        "| Test | Status | Usage Pattern |",
+        "|------|--------|---------------|",
+        *rows,
+        "",
+    ]
+    if all_passed:
+        lines += [
+            "> [!TIP]",
+            "> All integration tests passed! See CONTRIBUTING.md for usage details.",
+        ]
+    else:
+        lines += [
+            "> [!CAUTION]",
+            "> Some tests failed. Review logs above.",
+        ]
+    return "\n".join(lines) + "\n", all_passed
+
+
+def main(argv: list[str] | None = None) -> int:
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_file:
+        print("ERROR: GITHUB_STEP_SUMMARY is not set", file=sys.stderr)
+        return EXIT_USAGE
+
+    results = {env_key: os.environ.get(env_key, "") for _, env_key, _ in _TESTS}
+    text, all_passed = build_summary(results)
+
+    with open(summary_file, "a", encoding="utf-8") as f:
+        f.write(text)
+
+    if all_passed:
+        print("All integration tests passed!")
+        return EXIT_OK
+
+    print("ERROR: One or more integration tests failed")
+    return EXIT_FAILED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/collect_metrics_and_report.py
+++ b/scripts/ci/collect_metrics_and_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Collect agent metrics and write a report and step summary.
+
+Runs .claude/skills/metrics/collect_metrics.py, saves output to
+metrics-report.txt, and appends to GITHUB_STEP_SUMMARY.
+Replaces the "Collect metrics" step in agent-metrics.yml (issue #3531).
+
+EXIT CODES (ADR-035):
+  0  - Metrics collected and report written
+  1  - collect_metrics.py failed
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+
+_COLLECT_SCRIPT = ".claude/skills/metrics/collect_metrics.py"
+_REPORT_FILE = "metrics-report.txt"
+
+
+def collect_metrics(since: str, output_format: str, report_path: Path) -> bool:
+    """Run collect_metrics.py and write to report_path. Return True on success."""
+    result = subprocess.run(
+        [sys.executable, _COLLECT_SCRIPT, "--since", since, "--output", output_format],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report_path.write_text(result.stdout, encoding="utf-8")
+    return result.returncode == 0
+
+
+def write_step_summary(report_path: Path, output_format: str, summary_file: str) -> None:
+    """Append metrics report to GITHUB_STEP_SUMMARY."""
+    content = report_path.read_text(encoding="utf-8")
+    with open(summary_file, "a", encoding="utf-8") as f:
+        f.write("## Agent Metrics Summary\n\n")
+        if output_format == "json":
+            f.write("```json\n")
+            f.write(content)
+            f.write("```\n")
+        else:
+            f.write(content)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        default=os.environ.get("PERIOD_DAYS", "7"),
+        help="Number of days to analyze (default: $PERIOD_DAYS or 7)",
+    )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        default=os.environ.get("PERIOD_FORMAT", "markdown"),
+        help="Output format: markdown|json|summary (default: $PERIOD_FORMAT or markdown)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report_path = Path(_REPORT_FILE)
+
+    if not collect_metrics(args.since, args.output_format, report_path):
+        print("ERROR: collect_metrics.py failed", file=sys.stderr)
+        return EXIT_ERROR
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        write_step_summary(report_path, args.output_format, summary_file)
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/collect_metrics_and_report.py
+++ b/scripts/ci/collect_metrics_and_report.py
@@ -33,6 +33,7 @@ def collect_metrics(since: str, output_format: str, report_path: Path) -> bool:
         [sys.executable, _COLLECT_SCRIPT, "--since", since, "--output", output_format],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     report_path.write_text(result.stdout, encoding="utf-8")

--- a/scripts/ci/measure_npm_pack_size.py
+++ b/scripts/ci/measure_npm_pack_size.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Measure the npm pack size and warn if it exceeds the 50 MB limit.
+
+Runs `npm pack --dry-run --json` in --package-dir, reads the size bytes from
+the JSON output, and emits a warning annotation if the limit is exceeded.
+Replaces the inline shell block in publish.yml (issue #3533).
+
+EXIT CODES (ADR-035):
+  0  - Pack completed (warning emitted if limit exceeded, but does not fail)
+  1  - npm pack failed or unexpected output
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+
+_SIZE_LIMIT_BYTES = 52_428_800  # 50 MiB
+
+
+def measure_pack_size(package_dir: Path) -> tuple[int | None, str]:
+    """Run npm pack --dry-run --json and return (bytes, human_size_line).
+
+    Returns (None, error_message) on failure.
+    """
+    result = subprocess.run(
+        ["npm", "pack", "--dry-run", "--json"],
+        cwd=package_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None, f"npm pack failed: {result.stderr.strip()}"
+
+    try:
+        data = json.loads(result.stdout)
+        size_bytes = data[0].get("size") if data else None
+    except (json.JSONDecodeError, IndexError, TypeError):
+        size_bytes = None
+
+    # Also run without --json for the human-readable summary line
+    result2 = subprocess.run(
+        ["npm", "pack", "--dry-run"],
+        cwd=package_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    last_line = result2.stdout.strip().splitlines()[-1] if result2.stdout.strip() else ""
+
+    return size_bytes, last_line
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        help="Path to the npm package directory",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    package_dir = Path(args.package_dir)
+
+    size_bytes, detail = measure_pack_size(package_dir)
+    if size_bytes is None:
+        print(f"Pack size: {detail}")
+    else:
+        print(f"Pack size: {detail}")
+        if size_bytes > _SIZE_LIMIT_BYTES:
+            print("::warning::Pack size exceeds 50MB threshold")
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/measure_npm_pack_size.py
+++ b/scripts/ci/measure_npm_pack_size.py
@@ -78,11 +78,12 @@ def main(argv: list[str] | None = None) -> int:
 
     size_bytes, detail = measure_pack_size(package_dir)
     if size_bytes is None:
-        print(f"Pack size: {detail}")
-    else:
-        print(f"Pack size: {detail}")
-        if size_bytes > _SIZE_LIMIT_BYTES:
-            print("::warning::Pack size exceeds 50MB threshold")
+        print(f"::error::{detail}", file=sys.stderr)
+        return EXIT_ERROR
+
+    print(f"Pack size: {detail}")
+    if size_bytes > _SIZE_LIMIT_BYTES:
+        print("::warning::Pack size exceeds 50MB threshold")
 
     return EXIT_OK
 

--- a/scripts/ci/measure_npm_pack_size.py
+++ b/scripts/ci/measure_npm_pack_size.py
@@ -36,6 +36,7 @@ def measure_pack_size(package_dir: Path) -> tuple[int | None, str]:
         cwd=package_dir,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:
@@ -53,6 +54,7 @@ def measure_pack_size(package_dir: Path) -> tuple[int | None, str]:
         cwd=package_dir,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     last_line = result2.stdout.strip().splitlines()[-1] if result2.stdout.strip() else ""

--- a/scripts/ci/show_drift_failure.py
+++ b/scripts/ci/show_drift_failure.py
@@ -49,6 +49,7 @@ _REMEDIATION_GUIDE = """\
 
 
 def _run(cmd: list[str]) -> int:
+    sys.stdout.flush()
     return subprocess.run(cmd, check=False).returncode
 
 
@@ -81,6 +82,7 @@ def show_drift_failure(
         ["git", "diff", "--name-only"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     changed_files = result.stdout.strip()
@@ -93,6 +95,7 @@ def show_drift_failure(
         print(_REMEDIATION_GUIDE)
         print("--- Detailed diff ---")
         print()
+        sys.stdout.flush()
         subprocess.run(["git", "diff"], check=False)
 
 

--- a/scripts/ci/show_drift_failure.py
+++ b/scripts/ci/show_drift_failure.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Show drift failure details and regenerate files for inspection.
+
+Reads VALIDATE_CONCLUSION, LIB_MIRROR_CONCLUSION, and
+MANIFEST_PARITY_CONCLUSION from environment variables. Prints a drift header,
+conditionally reruns generation scripts, shows drifted files, and prints a
+full git diff. Replaces the "Show diff on failure" step in
+agent-drift-detection.yml (issue #3521).
+
+EXIT CODES (ADR-035):
+  0  - Completed (drift diagnosis printed; does not fail on drift itself)
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+
+_GENERATE_SCRIPT = "build/generate_agents.py"
+_MIRROR_SCRIPT = "scripts/sync_plugin_lib.py"
+_BUILD_SCRIPT = "build/scripts/build_all.py"
+
+_REMEDIATION_GUIDE = """\
+--- How to fix ---
+
+  1. Edit the source template (NOT the generated file):
+       templates/agents/<agent-name>.shared.md
+
+  2. Regenerate platform-specific files:
+       python3 build/generate_agents.py
+
+  3. Commit the regenerated files:
+       git add src/vs-code-agents/ src/copilot-cli/
+       git commit -m 'fix(agents): regenerate from updated template'
+
+--- Bypass procedure (intentional divergence) ---
+
+  If this divergence is intentional:
+  1. Add [skip-drift-check] to a commit message in this PR
+  2. Document the reason in your PR description
+  3. Update templates/README.md with the intentional difference
+  4. Ensure explicit code-owner approval on this PR
+"""
+
+
+def _run(cmd: list[str]) -> int:
+    return subprocess.run(cmd, check=False).returncode
+
+
+def show_drift_failure(
+    validate_conclusion: str,
+    lib_mirror_conclusion: str,
+    manifest_parity_conclusion: str,
+) -> None:
+    """Print drift details and remediation guide."""
+    print()
+    print("===========================================================")
+    print("  AGENT DRIFT DETECTED")
+    print("===========================================================")
+    print()
+    print("Generated agent files or plugin mirrors do not match committed files.")
+    print("Validation conclusions:")
+    print(f"  generate_agents: {validate_conclusion}")
+    print(f"  lib mirrors: {lib_mirror_conclusion}")
+    print(f"  manifest parity: {manifest_parity_conclusion}")
+    print()
+
+    if validate_conclusion == "failure":
+        _run([sys.executable, _GENERATE_SCRIPT])
+
+    if lib_mirror_conclusion == "failure":
+        _run([sys.executable, _MIRROR_SCRIPT])
+        _run([sys.executable, _BUILD_SCRIPT])
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    changed_files = result.stdout.strip()
+
+    if changed_files:
+        print("--- Files with semantic drift ---")
+        for f in changed_files.splitlines():
+            print(f"  x  {f}")
+        print()
+        print(_REMEDIATION_GUIDE)
+        print("--- Detailed diff ---")
+        print()
+        subprocess.run(["git", "diff"], check=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    validate_conclusion = os.environ.get("VALIDATE_CONCLUSION", "")
+    lib_mirror_conclusion = os.environ.get("LIB_MIRROR_CONCLUSION", "")
+    manifest_parity_conclusion = os.environ.get("MANIFEST_PARITY_CONCLUSION", "")
+
+    show_drift_failure(validate_conclusion, lib_mirror_conclusion, manifest_parity_conclusion)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify_codeql_artifacts.py
+++ b/scripts/ci/verify_codeql_artifacts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Verify CodeQL scan artifacts exist after a scan run.
+
+Checks that the database directory and SARIF output file were created for the
+given language. Replaces the inline shell block in test-codeql-integration.yml
+(Verify scan artifacts step, issue #3526).
+
+EXIT CODES (ADR-035):
+  0  - All artifacts present
+  1  - One or more artifacts missing
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_MISSING = 1
+EXIT_USAGE = 2
+
+
+def check_artifacts(
+    language: str,
+    db_base: str = ".codeql/db",
+    results_base: str = ".codeql/results",
+) -> list[str]:
+    """Return a list of error messages; empty means all artifacts present."""
+    errors: list[str] = []
+
+    db_path = Path(db_base) / language
+    if not db_path.is_dir():
+        errors.append(f"ERROR: Database not created: {db_path}")
+    else:
+        print(f"Database created: {db_path}")
+
+    sarif_path = Path(results_base) / f"{language}.sarif"
+    if not sarif_path.is_file():
+        errors.append(f"ERROR: SARIF not created: {sarif_path}")
+    else:
+        try:
+            data = json.loads(sarif_path.read_text(encoding="utf-8"))
+            findings = len(data["runs"][0]["results"])
+            print(f"SARIF created: {findings} findings")
+        except (json.JSONDecodeError, KeyError, IndexError) as exc:
+            errors.append(f"ERROR: Cannot parse SARIF at {sarif_path}: {exc}")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--language", required=True, help="CodeQL language name")
+    parser.add_argument("--db-base", default=".codeql/db")
+    parser.add_argument("--results-base", default=".codeql/results")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    errors = check_artifacts(args.language, args.db_base, args.results_base)
+    for err in errors:
+        print(err)
+    return EXIT_MISSING if errors else EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify_codeql_sarif_structure.py
+++ b/scripts/ci/verify_codeql_sarif_structure.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate the structure of every SARIF file in a results directory.
+
+Finds all *.sarif files under --results-dir, checks that each has a valid
+``version`` and ``runs`` list, and prints a one-line summary per file.
+Replaces the inline shell+Python block in test-codeql-integration.yml
+(Verify SARIF structure step, issue #3526).
+
+EXIT CODES (ADR-035):
+  0  - All SARIF files are structurally valid
+  1  - No SARIF files found, or one or more files are invalid
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_INVALID = 1
+EXIT_USAGE = 2
+
+
+def validate_sarif(path: Path) -> str | None:
+    """Return None if the file is valid, or an error message if it is not."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return f"JSON parse error in {path}: {exc}"
+    if not data.get("version") or not data.get("runs"):
+        return f"Invalid SARIF structure in {path}: missing 'version' or 'runs'"
+    return None
+
+
+def validate_sarif_directory(results_dir: Path) -> tuple[bool, list[str]]:
+    """Validate all *.sarif files in results_dir.
+
+    Returns (all_valid, list_of_error_messages).
+    """
+    sarif_files = sorted(results_dir.glob("*.sarif"))
+    if not sarif_files:
+        return False, [f"ERROR: No SARIF files found in {results_dir}"]
+
+    errors: list[str] = []
+    for sarif_file in sarif_files:
+        print(f"Validating: {sarif_file.name}")
+        error = validate_sarif(sarif_file)
+        if error:
+            errors.append(error)
+        else:
+            data = json.loads(sarif_file.read_text(encoding="utf-8"))
+            print(f"  Version: {data['version']}")
+            print(f"  Runs: {len(data['runs'])}")
+            print(f"  Results: {len(data['runs'][0]['results'])}")
+
+    return not errors, errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--results-dir",
+        default=".codeql/results",
+        help="Directory containing SARIF files (default: .codeql/results)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    results_dir = Path(args.results_dir)
+    all_valid, errors = validate_sarif_directory(results_dir)
+    for err in errors:
+        print(err, file=sys.stderr)
+    return EXIT_OK if all_valid else EXIT_INVALID
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify_codeql_sarif_structure.py
+++ b/scripts/ci/verify_codeql_sarif_structure.py
@@ -54,7 +54,7 @@ def validate_sarif_directory(results_dir: Path) -> tuple[bool, list[str]]:
             data = json.loads(sarif_file.read_text(encoding="utf-8"))
             print(f"  Version: {data['version']}")
             print(f"  Runs: {len(data['runs'])}")
-            print(f"  Results: {len(data['runs'][0]['results'])}")
+            print(f"  Results: {len(data['runs'][0].get('results', []))}")
 
     return not errors, errors
 

--- a/scripts/ci/verify_npm_package_metadata.py
+++ b/scripts/ci/verify_npm_package_metadata.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Verify npm package metadata meets publishing requirements.
+
+Reads package.json from --package-dir and checks that the required fields
+for a scoped npm publish are present and correctly configured.
+Replaces the inline node -e block in publish.yml (issue #3533).
+
+EXIT CODES (ADR-035):
+  0  - All metadata checks pass
+  1  - One or more checks failed
+  2  - Usage error (missing --package-dir)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_OK = 0
+EXIT_INVALID = 1
+EXIT_USAGE = 2
+
+
+def check_package_metadata(pkg: dict[str, Any]) -> list[str]:
+    """Return a list of error messages; empty means all checks pass."""
+    errors: list[str] = []
+    if pkg.get("name") != "@rjmurillo/ai-agents":
+        errors.append("name must be @rjmurillo/ai-agents")
+    publish_config = pkg.get("publishConfig") or {}
+    if publish_config.get("access") != "public":
+        errors.append("publishConfig.access must be public")
+    if not publish_config.get("provenance"):
+        errors.append("publishConfig.provenance must be true")
+    if not pkg.get("bin"):
+        errors.append("bin entry required")
+    if not pkg.get("files"):
+        errors.append("files allowlist required")
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        help="Path to the npm package directory containing package.json",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    pkg_json = Path(args.package_dir) / "package.json"
+    if not pkg_json.exists():
+        print(f"ERROR: {pkg_json} not found", file=sys.stderr)
+        return EXIT_INVALID
+
+    pkg = json.loads(pkg_json.read_text(encoding="utf-8"))
+    errors = check_package_metadata(pkg)
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        return EXIT_INVALID
+
+    print(f"Package metadata OK: {pkg.get('name')}@{pkg.get('version')}")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify_npm_published.py
+++ b/scripts/ci/verify_npm_published.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Verify that an npm package version is visible on the registry after publish.
+
+Retries up to 5 times with 10-second delays before failing. Reads the expected
+version from package.json in --package-dir.
+Replaces the inline shell retry loop in publish.yml (issue #3533).
+
+EXIT CODES (ADR-035):
+  0  - Package version is live on npm
+  1  - Version not visible after all retries
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_NOT_PUBLISHED = 1
+EXIT_USAGE = 2
+
+_MAX_RETRIES = 5
+_RETRY_DELAY_SECONDS = 10
+_PACKAGE_NAME = "@rjmurillo/ai-agents"
+
+
+def get_published_version(package: str, version: str) -> str:
+    """Return the published version string, or empty string on failure."""
+    result = subprocess.run(
+        ["npm", "view", f"{package}@{version}", "version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def wait_for_publish(
+    package: str,
+    version: str,
+    max_retries: int = _MAX_RETRIES,
+    delay_seconds: int = _RETRY_DELAY_SECONDS,
+) -> bool:
+    """Poll npm until the version is visible. Return True if found."""
+    print(f"Expecting {package}@{version}")
+    for attempt in range(1, max_retries + 1):
+        time.sleep(delay_seconds)
+        published = get_published_version(package, version)
+        if published == version:
+            print(f"Verified: {package}@{version} is live on npm")
+            return True
+        print(f"Attempt {attempt}: version {version} not yet visible, retrying...")
+    return False
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        help="Path to the npm package directory containing package.json",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    pkg_json = Path(args.package_dir) / "package.json"
+    if not pkg_json.exists():
+        print(f"ERROR: {pkg_json} not found", file=sys.stderr)
+        return EXIT_NOT_PUBLISHED
+
+    pkg = json.loads(pkg_json.read_text(encoding="utf-8"))
+    version = pkg.get("version", "")
+    if not version:
+        print("ERROR: version field missing from package.json", file=sys.stderr)
+        return EXIT_NOT_PUBLISHED
+
+    if wait_for_publish(_PACKAGE_NAME, version):
+        return EXIT_OK
+
+    timeout_sec = _MAX_RETRIES * _RETRY_DELAY_SECONDS
+    print(f"::error::Version {version} not visible on npm after {timeout_sec}s")
+    return EXIT_NOT_PUBLISHED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify_npm_published.py
+++ b/scripts/ci/verify_npm_published.py
@@ -36,8 +36,11 @@ def get_published_version(package: str, version: str) -> str:
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         check=False,
     )
+    if result.returncode != 0:
+        return ""
     return result.stdout.strip()
 
 

--- a/scripts/ci/verify_npm_published.py
+++ b/scripts/ci/verify_npm_published.py
@@ -35,6 +35,7 @@ def get_published_version(package: str, version: str) -> str:
         ["npm", "view", f"{package}@{version}", "version"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     return result.stdout.strip()

--- a/scripts/ci/write_drift_job_summary.py
+++ b/scripts/ci/write_drift_job_summary.py
@@ -7,8 +7,7 @@ pass/fail summary with monitored paths.
 Replaces the "Write job summary" step in agent-drift-detection.yml (issue #3521).
 
 EXIT CODES (ADR-035):
-  0  - Summary written
-  1  - Missing GITHUB_STEP_SUMMARY
+  0  - Summary written to GITHUB_STEP_SUMMARY, or printed to stdout when unset
   2  - Usage error
 """
 

--- a/scripts/ci/write_drift_job_summary.py
+++ b/scripts/ci/write_drift_job_summary.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Write the agent drift detection job summary to GITHUB_STEP_SUMMARY.
+
+Reads VALIDATE_CONCLUSION, LIB_MIRROR_CONCLUSION, and
+MANIFEST_PARITY_CONCLUSION from environment variables and writes a markdown
+pass/fail summary with monitored paths.
+Replaces the "Write job summary" step in agent-drift-detection.yml (issue #3521).
+
+EXIT CODES (ADR-035):
+  0  - Summary written
+  1  - Missing GITHUB_STEP_SUMMARY
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+
+_MONITORED_PATHS_SECTION = """\
+
+### Monitored Paths
+- `templates/` - source templates
+- `src/vs-code-agents/` - generated VS Code agents
+- `src/copilot-cli/` - generated Copilot CLI agents
+"""
+
+
+def build_summary(
+    validate_conclusion: str,
+    lib_mirror_conclusion: str,
+    manifest_parity_conclusion: str,
+) -> str:
+    """Return the full markdown summary string."""
+    all_passed = (
+        validate_conclusion == "success"
+        and lib_mirror_conclusion == "success"
+        and manifest_parity_conclusion == "success"
+    )
+
+    if all_passed:
+        body = (
+            "## Agent Drift Detection Passed\n"
+            "\n"
+            "All generated agent files match their source templates."
+        )
+    else:
+        body = (
+            "## Agent Drift Detection Failed\n"
+            "\n"
+            "Generated agent files have drifted from their source templates.\n"
+            "\n"
+            "### Fix\n"
+            "1. Edit the source template in `templates/agents/*.shared.md`\n"
+            "2. Run: `python3 build/generate_agents.py`\n"
+            "3. Commit the regenerated files"
+        )
+
+    return body + _MONITORED_PATHS_SECTION
+
+
+def main(argv: list[str] | None = None) -> int:
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    validate_conclusion = os.environ.get("VALIDATE_CONCLUSION", "")
+    lib_mirror_conclusion = os.environ.get("LIB_MIRROR_CONCLUSION", "")
+    manifest_parity_conclusion = os.environ.get("MANIFEST_PARITY_CONCLUSION", "")
+
+    text = build_summary(validate_conclusion, lib_mirror_conclusion, manifest_parity_conclusion)
+
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write(text)
+    else:
+        print(text)
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/write_metrics_threshold_summary.py
+++ b/scripts/ci/write_metrics_threshold_summary.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Write the metrics threshold summary table to GITHUB_STEP_SUMMARY.
+
+Reads CHECK_COVERAGE and CHECK_INFRA_RATE from environment variables and
+appends a markdown table with pass/fail status for each metric.
+Replaces the "Summary" step in agent-metrics.yml (issue #3531).
+
+EXIT CODES (ADR-035):
+  0  - Summary written
+  1  - Missing required environment variables
+  2  - Usage error
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+
+_COVERAGE_TARGET = 50.0
+_INFRA_RATE_TARGET = 100.0
+
+
+def build_summary(coverage: float, infra_rate: float) -> str:
+    """Return markdown for the threshold results table."""
+    cov_status = ":white_check_mark:" if coverage >= _COVERAGE_TARGET else ":x:"
+    infra_status = ":white_check_mark:" if infra_rate >= _INFRA_RATE_TARGET else ":warning:"
+
+    lines = [
+        "## Threshold Check Results",
+        "",
+        "| Metric | Current | Target | Status |",
+        "|--------|---------|--------|--------|",
+        f"| Agent Coverage | {coverage}% | {_COVERAGE_TARGET}% | {cov_status} |",
+        f"| Infrastructure Review | {infra_rate}% | {_INFRA_RATE_TARGET}% | {infra_status} |",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    coverage_raw = os.environ.get("CHECK_COVERAGE")
+    infra_rate_raw = os.environ.get("CHECK_INFRA_RATE")
+
+    if coverage_raw is None or infra_rate_raw is None:
+        print("ERROR: CHECK_COVERAGE and CHECK_INFRA_RATE must be set", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        coverage = float(coverage_raw)
+        infra_rate = float(infra_rate_raw)
+    except ValueError as exc:
+        print(f"ERROR: invalid float value: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    summary_text = build_summary(coverage, infra_rate)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write(summary_text)
+    else:
+        print(summary_text)
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_agent_drift_scripts.py
+++ b/tests/ci/test_agent_drift_scripts.py
@@ -1,0 +1,238 @@
+"""Tests for agent-drift-detection CI scripts (issue #3521).
+
+Covers:
+  - check_plugin_lib_mirrors.py
+  - show_drift_failure.py
+  - write_drift_job_summary.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "ci"))
+
+import check_plugin_lib_mirrors as cplm
+import show_drift_failure as sdf
+import write_drift_job_summary as wdjs
+
+# ---------------------------------------------------------------------------
+# check_plugin_lib_mirrors
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPluginLibMirrors:
+    def test_both_pass_returns_0(self) -> None:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            rc = cplm.main()
+        assert rc == 0
+
+    def test_mirror_fails_returns_mirror_rc(self) -> None:
+        side_effects = [MagicMock(returncode=2), MagicMock(returncode=0)]
+        with patch("subprocess.run", side_effect=side_effects):
+            rc = cplm.main()
+        assert rc == 2
+
+    def test_build_fails_returns_build_rc(self) -> None:
+        side_effects = [MagicMock(returncode=0), MagicMock(returncode=3)]
+        with patch("subprocess.run", side_effect=side_effects):
+            rc = cplm.main()
+        assert rc == 3
+
+    def test_both_fail_returns_mirror_rc(self) -> None:
+        side_effects = [MagicMock(returncode=1), MagicMock(returncode=2)]
+        with patch("subprocess.run", side_effect=side_effects):
+            rc = cplm.main()
+        assert rc == 1
+
+    def test_calls_both_scripts(self) -> None:
+        captured: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cplm.main()
+
+        assert len(captured) == 2
+        assert any("sync_plugin_lib.py" in str(c) for c in captured)
+        assert any("build_all.py" in str(c) for c in captured)
+
+    def test_both_scripts_called_with_check_flag(self) -> None:
+        captured: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cplm.main()
+
+        for cmd in captured:
+            assert "--check" in cmd
+
+
+# ---------------------------------------------------------------------------
+# show_drift_failure
+# ---------------------------------------------------------------------------
+
+
+class TestShowDriftFailure:
+    def test_prints_drift_header(self, capsys: pytest.CaptureFixture) -> None:
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            sdf.show_drift_failure("success", "success", "success")
+        out = capsys.readouterr().out
+        assert "AGENT DRIFT DETECTED" in out
+
+    def test_runs_generate_agents_on_validate_failure(self) -> None:
+        calls_made: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            calls_made.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sdf.show_drift_failure("failure", "success", "success")
+
+        assert any("generate_agents.py" in str(c) for c in calls_made)
+
+    def test_does_not_run_generate_agents_on_success(self) -> None:
+        calls_made: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            calls_made.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sdf.show_drift_failure("success", "success", "success")
+
+        assert not any("generate_agents.py" in str(c) for c in calls_made)
+
+    def test_runs_mirror_scripts_on_lib_mirror_failure(self) -> None:
+        calls_made: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            calls_made.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sdf.show_drift_failure("success", "failure", "success")
+
+        assert any("sync_plugin_lib.py" in str(c) for c in calls_made)
+        assert any("build_all.py" in str(c) for c in calls_made)
+
+    def test_shows_changed_files(self, capsys: pytest.CaptureFixture) -> None:
+        git_diff_result = MagicMock(returncode=0, stdout="src/file.ts\n", stderr="")
+        other_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            if any("name-only" in part for part in cmd):
+                return git_diff_result
+            return other_result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sdf.show_drift_failure("success", "success", "success")
+
+        out = capsys.readouterr().out
+        assert "src/file.ts" in out
+        assert "How to fix" in out
+
+    def test_no_changed_files_no_remediation(self, capsys: pytest.CaptureFixture) -> None:
+        def fake_run(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sdf.show_drift_failure("success", "success", "success")
+
+        out = capsys.readouterr().out
+        assert "How to fix" not in out
+
+    def test_main_reads_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VALIDATE_CONCLUSION", "failure")
+        monkeypatch.setenv("LIB_MIRROR_CONCLUSION", "success")
+        monkeypatch.setenv("MANIFEST_PARITY_CONCLUSION", "success")
+        calls_made: list[list] = []
+
+        def fake_run(cmd, **kwargs):
+            calls_made.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            rc = sdf.main()
+
+        assert rc == sdf.EXIT_OK
+        assert any("generate_agents.py" in str(c) for c in calls_made)
+
+
+# ---------------------------------------------------------------------------
+# write_drift_job_summary
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDriftJobSummary:
+    def test_passed_when_all_success(self) -> None:
+        text = wdjs.build_summary("success", "success", "success")
+        assert "Passed" in text
+        assert "Failed" not in text
+
+    def test_failed_when_any_not_success(self) -> None:
+        text = wdjs.build_summary("failure", "success", "success")
+        assert "Failed" in text
+        assert "Passed" not in text
+
+    def test_includes_monitored_paths(self) -> None:
+        text = wdjs.build_summary("success", "success", "success")
+        assert "templates/" in text
+        assert "vs-code-agents" in text
+        assert "copilot-cli" in text
+
+    def test_main_writes_to_summary_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        monkeypatch.setenv("VALIDATE_CONCLUSION", "success")
+        monkeypatch.setenv("LIB_MIRROR_CONCLUSION", "success")
+        monkeypatch.setenv("MANIFEST_PARITY_CONCLUSION", "success")
+        rc = wdjs.main()
+        assert rc == wdjs.EXIT_OK
+        content = summary.read_text()
+        assert "Agent Drift Detection Passed" in content
+
+    def test_main_writes_failure_summary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        monkeypatch.setenv("VALIDATE_CONCLUSION", "failure")
+        monkeypatch.setenv("LIB_MIRROR_CONCLUSION", "success")
+        monkeypatch.setenv("MANIFEST_PARITY_CONCLUSION", "success")
+        rc = wdjs.main()
+        assert rc == wdjs.EXIT_OK
+        content = summary.read_text()
+        assert "Agent Drift Detection Failed" in content
+
+    def test_main_prints_when_no_summary_env(
+        self, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.setenv("VALIDATE_CONCLUSION", "success")
+        monkeypatch.setenv("LIB_MIRROR_CONCLUSION", "success")
+        monkeypatch.setenv("MANIFEST_PARITY_CONCLUSION", "success")
+        rc = wdjs.main()
+        assert rc == wdjs.EXIT_OK
+        out = capsys.readouterr().out
+        assert "Agent Drift Detection Passed" in out
+
+    def test_lib_mirror_failure_shows_failed(self) -> None:
+        text = wdjs.build_summary("success", "failure", "success")
+        assert "Failed" in text
+
+    def test_manifest_parity_failure_shows_failed(self) -> None:
+        text = wdjs.build_summary("success", "success", "failure")
+        assert "Failed" in text

--- a/tests/ci/test_agent_metrics_scripts.py
+++ b/tests/ci/test_agent_metrics_scripts.py
@@ -1,0 +1,238 @@
+"""Tests for agent-metrics CI scripts (issue #3531).
+
+Covers:
+  - collect_metrics_and_report.py
+  - check_metrics_thresholds.py
+  - write_metrics_threshold_summary.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "ci"))
+
+import check_metrics_thresholds as cmt
+import collect_metrics_and_report as cmr
+import write_metrics_threshold_summary as wmts
+
+# ---------------------------------------------------------------------------
+# collect_metrics_and_report
+# ---------------------------------------------------------------------------
+
+_MOCK_METRICS_OUTPUT = "# Metrics\n\nCoverage: 75%\n"
+_MOCK_JSON_OUTPUT = '{"metric_2_coverage": {"coverage_rate": 75}}\n'
+
+
+class TestCollectMetricsAndReport:
+    def test_ok_writes_report_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        mock_proc = MagicMock(returncode=0, stdout=_MOCK_METRICS_OUTPUT, stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            rc = cmr.main(["--since", "7", "--format", "markdown"])
+        assert rc == cmr.EXIT_OK
+        assert (tmp_path / "metrics-report.txt").read_text() == _MOCK_METRICS_OUTPUT
+
+    def test_error_on_collect_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        mock_proc = MagicMock(returncode=1, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            rc = cmr.main(["--since", "7", "--format", "markdown"])
+        assert rc == cmr.EXIT_ERROR
+
+    def test_writes_step_summary_markdown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        mock_proc = MagicMock(returncode=0, stdout=_MOCK_METRICS_OUTPUT, stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            cmr.main(["--since", "7", "--format", "markdown"])
+        content = summary.read_text()
+        assert "Agent Metrics Summary" in content
+        assert _MOCK_METRICS_OUTPUT in content
+        assert "```json" not in content
+
+    def test_writes_step_summary_json_with_fences(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        mock_proc = MagicMock(returncode=0, stdout=_MOCK_JSON_OUTPUT, stderr="")
+        with patch("subprocess.run", return_value=mock_proc):
+            cmr.main(["--since", "7", "--format", "json"])
+        content = summary.read_text()
+        assert "```json" in content
+
+    def test_uses_env_var_defaults(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("PERIOD_DAYS", "14")
+        monkeypatch.setenv("PERIOD_FORMAT", "summary")
+        captured_cmd: list[list] = []
+        mock_proc = MagicMock(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return mock_proc
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cmr.main([])
+
+        assert "--since" in captured_cmd[0]
+        assert "14" in captured_cmd[0]
+        assert "summary" in captured_cmd[0]
+
+
+# ---------------------------------------------------------------------------
+# check_metrics_thresholds
+# ---------------------------------------------------------------------------
+
+_OK_METRICS = {
+    "metric_2_coverage": {"coverage_rate": 60.0},
+    "metric_4_infrastructure_review": {"review_rate": 100.0, "infrastructure_commits": 5},
+}
+
+_LOW_COVERAGE = {
+    "metric_2_coverage": {"coverage_rate": 30.0},
+    "metric_4_infrastructure_review": {"review_rate": 100.0, "infrastructure_commits": 0},
+}
+
+_LOW_INFRA_RATE = {
+    "metric_2_coverage": {"coverage_rate": 80.0},
+    "metric_4_infrastructure_review": {"review_rate": 90.0, "infrastructure_commits": 3},
+}
+
+
+class TestCheckMetricsThresholds:
+    def test_ok_metrics_no_alert(self) -> None:
+        coverage, infra_rate, infra_commits, alert = cmt.check_thresholds(_OK_METRICS)
+        assert coverage == 60.0
+        assert infra_rate == 100.0
+        assert not alert
+
+    def test_low_coverage_triggers_alert(self, capsys: pytest.CaptureFixture) -> None:
+        _, _, _, alert = cmt.check_thresholds(_LOW_COVERAGE)
+        assert alert
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+        assert "coverage" in out.lower()
+
+    def test_low_infra_rate_with_commits_triggers_alert(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        _, _, _, alert = cmt.check_thresholds(_LOW_INFRA_RATE)
+        assert alert
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+
+    def test_low_infra_rate_zero_commits_no_alert(self) -> None:
+        metrics = {
+            "metric_2_coverage": {"coverage_rate": 80.0},
+            "metric_4_infrastructure_review": {"review_rate": 50.0, "infrastructure_commits": 0},
+        }
+        _, _, _, alert = cmt.check_thresholds(metrics)
+        assert not alert
+
+    def test_writes_github_output(self, tmp_path: Path) -> None:
+        out_file = tmp_path / "output.txt"
+        cmt.write_github_output(75.0, 100.0, False, str(out_file))
+        content = out_file.read_text()
+        assert "coverage=75.0" in content
+        assert "infra_rate=100.0" in content
+        assert "alert=false" in content
+
+    def test_alert_true_in_output(self, tmp_path: Path) -> None:
+        out_file = tmp_path / "output.txt"
+        cmt.write_github_output(30.0, 80.0, True, str(out_file))
+        content = out_file.read_text()
+        assert "alert=true" in content
+
+    def test_main_ok(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        out_file = tmp_path / "gh_output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(out_file))
+        with patch.object(cmt, "collect_metrics_json", return_value=_OK_METRICS):
+            rc = cmt.main()
+        assert rc == cmt.EXIT_OK
+        content = out_file.read_text()
+        assert "coverage=" in content
+
+    def test_main_error_on_bad_collect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        with patch.object(cmt, "collect_metrics_json", side_effect=RuntimeError("boom")):
+            rc = cmt.main()
+        assert rc == cmt.EXIT_ERROR
+
+    def test_infra_commits_int_not_string(self) -> None:
+        metrics = {
+            "metric_2_coverage": {"coverage_rate": 80.0},
+            "metric_4_infrastructure_review": {"review_rate": 50.0, "infrastructure_commits": 3},
+        }
+        _, _, infra_commits, _ = cmt.check_thresholds(metrics)
+        assert isinstance(infra_commits, int)
+        assert infra_commits == 3
+
+
+# ---------------------------------------------------------------------------
+# write_metrics_threshold_summary
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMetricsThresholdSummary:
+    def test_builds_passing_table(self) -> None:
+        text = wmts.build_summary(75.0, 100.0)
+        assert ":white_check_mark:" in text
+        assert ":x:" not in text
+        assert "75.0%" in text
+
+    def test_builds_failing_coverage(self) -> None:
+        text = wmts.build_summary(30.0, 100.0)
+        assert ":x:" in text
+
+    def test_builds_warning_infra_rate(self) -> None:
+        text = wmts.build_summary(80.0, 90.0)
+        assert ":warning:" in text
+
+    def test_main_writes_to_summary_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        monkeypatch.setenv("CHECK_COVERAGE", "75.0")
+        monkeypatch.setenv("CHECK_INFRA_RATE", "100.0")
+        rc = wmts.main()
+        assert rc == wmts.EXIT_OK
+        content = summary.read_text()
+        assert "Threshold Check Results" in content
+
+    def test_main_error_on_missing_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CHECK_COVERAGE", raising=False)
+        monkeypatch.delenv("CHECK_INFRA_RATE", raising=False)
+        rc = wmts.main()
+        assert rc == wmts.EXIT_ERROR
+
+    def test_main_error_on_bad_float(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        monkeypatch.setenv("CHECK_COVERAGE", "not-a-float")
+        monkeypatch.setenv("CHECK_INFRA_RATE", "100.0")
+        rc = wmts.main()
+        assert rc == wmts.EXIT_ERROR
+
+    def test_prints_to_stdout_without_summary_env(
+        self, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.setenv("CHECK_COVERAGE", "55.0")
+        monkeypatch.setenv("CHECK_INFRA_RATE", "100.0")
+        rc = wmts.main()
+        assert rc == wmts.EXIT_OK
+        out = capsys.readouterr().out
+        assert "Threshold Check Results" in out

--- a/tests/ci/test_codeql_scripts.py
+++ b/tests/ci/test_codeql_scripts.py
@@ -253,7 +253,7 @@ class TestCodeqlIntegrationSummary:
         assert "\u23ed" in text
 
     def test_missing_env_treated_as_failure(self) -> None:
-        results = {}
+        results: dict[str, str] = {}
         text, all_passed = cis.build_summary(results)
         assert not all_passed
 

--- a/tests/ci/test_codeql_scripts.py
+++ b/tests/ci/test_codeql_scripts.py
@@ -203,6 +203,15 @@ class TestVerifyCodeqlSarifStructure:
         rc = vcss.main(["--results-dir", str(tmp_path / "nonexistent")])
         assert rc == vcss.EXIT_INVALID
 
+    def test_run_without_results_key_does_not_crash(self, tmp_path: Path) -> None:
+        """A SARIF run with no 'results' key must not KeyError."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(results_dir / "empty_run.sarif", {"version": "2.1.0", "runs": [{}]})
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert all_valid
+        assert errors == []
+
     def test_cli_ok_dir_returns_0(self, tmp_path: Path) -> None:
         results_dir = tmp_path / "results"
         results_dir.mkdir()

--- a/tests/ci/test_codeql_scripts.py
+++ b/tests/ci/test_codeql_scripts.py
@@ -1,0 +1,312 @@
+"""Tests for CodeQL CI scripts (issue #3526).
+
+Covers:
+  - verify_codeql_artifacts.py
+  - verify_codeql_sarif_structure.py
+  - codeql_integration_summary.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "ci"))
+
+import codeql_integration_summary as cis
+import verify_codeql_artifacts as vca
+import verify_codeql_sarif_structure as vcss
+
+# ---------------------------------------------------------------------------
+# verify_codeql_artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCodeqlArtifacts:
+    def test_ok_when_db_dir_and_sarif_file_exist(self, tmp_path: Path) -> None:
+        lang = "python"
+        db_dir = tmp_path / ".codeql/db" / lang
+        db_dir.mkdir(parents=True)
+        results_dir = tmp_path / ".codeql/results"
+        results_dir.mkdir(parents=True)
+        sarif = results_dir / f"{lang}.sarif"
+        sarif.write_text(
+            json.dumps({"version": "2.1.0", "runs": [{"results": []}]}),
+            encoding="utf-8",
+        )
+        rc = vca.main(
+            [
+                "--language",
+                lang,
+                "--db-base",
+                str(tmp_path / ".codeql/db"),
+                "--results-base",
+                str(results_dir),
+            ]
+        )
+        assert rc == 0  # EXIT_OK
+
+    def test_missing_db_dir_returns_invalid(self, tmp_path: Path) -> None:
+        lang = "python"
+        results_dir = tmp_path / ".codeql/results"
+        results_dir.mkdir(parents=True)
+        sarif = results_dir / f"{lang}.sarif"
+        # Valid SARIF so only the missing DB triggers the error
+        sarif.write_text(
+            json.dumps({"version": "2.1.0", "runs": [{"results": []}]}),
+            encoding="utf-8",
+        )
+        rc = vca.main(
+            [
+                "--language",
+                lang,
+                "--db-base",
+                str(tmp_path / ".codeql/db"),
+                "--results-base",
+                str(results_dir),
+            ]
+        )
+        assert rc == 1  # EXIT_MISSING
+
+    def test_missing_sarif_file_returns_invalid(self, tmp_path: Path) -> None:
+        lang = "python"
+        db_dir = tmp_path / ".codeql/db" / lang
+        db_dir.mkdir(parents=True)
+        rc = vca.main(
+            [
+                "--language",
+                lang,
+                "--db-base",
+                str(tmp_path / ".codeql/db"),
+                "--results-base",
+                str(tmp_path / ".codeql/results"),
+            ]
+        )
+        assert rc == 1  # EXIT_MISSING
+
+    def test_prints_finding_count(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        lang = "javascript"
+        db_dir = tmp_path / ".codeql/db" / lang
+        db_dir.mkdir(parents=True)
+        results_dir = tmp_path / ".codeql/results"
+        results_dir.mkdir(parents=True)
+        sarif = results_dir / f"{lang}.sarif"
+        sarif.write_text(
+            json.dumps(
+                {
+                    "version": "2.1.0",
+                    "runs": [{"results": [{"ruleId": "X"}, {"ruleId": "Y"}]}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        rc = vca.main(
+            [
+                "--language",
+                lang,
+                "--db-base",
+                str(tmp_path / ".codeql/db"),
+                "--results-base",
+                str(results_dir),
+            ]
+        )
+        assert rc == 0  # EXIT_OK
+        out = capsys.readouterr().out
+        assert "2 findings" in out
+
+    def test_missing_language_arg_is_usage_error(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            vca.main([])
+        assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# verify_codeql_sarif_structure
+# ---------------------------------------------------------------------------
+
+
+def _write_sarif(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestVerifyCodeqlSarifStructure:
+    def test_ok_with_valid_sarif(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(
+            results_dir / "test.sarif",
+            {"version": "2.1.0", "runs": [{"results": []}]},
+        )
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert all_valid
+        assert errors == []
+
+    def test_missing_version_fails(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(results_dir / "bad.sarif", {"runs": [{"results": []}]})
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert not all_valid
+        assert any("version" in e for e in errors)
+
+    def test_missing_runs_fails(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(results_dir / "bad.sarif", {"version": "2.1.0"})
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert not all_valid
+        assert any("runs" in e for e in errors)
+
+    def test_no_sarif_files_returns_error(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "empty"
+        results_dir.mkdir()
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert not all_valid
+        assert any("No SARIF files" in e for e in errors)
+
+    def test_invalid_json_returns_error(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        (results_dir / "corrupt.sarif").write_text("not json", encoding="utf-8")
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert not all_valid
+        assert any("JSON" in e for e in errors)
+
+    def test_multiple_sarif_all_valid(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for name in ("a.sarif", "b.sarif"):
+            _write_sarif(
+                results_dir / name,
+                {"version": "2.1.0", "runs": [{"results": []}]},
+            )
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert all_valid
+        assert errors == []
+
+    def test_multiple_sarif_one_invalid(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(
+            results_dir / "good.sarif",
+            {"version": "2.1.0", "runs": [{"results": []}]},
+        )
+        _write_sarif(results_dir / "bad.sarif", {"version": "2.1.0"})
+        all_valid, errors = vcss.validate_sarif_directory(results_dir)
+        assert not all_valid
+        assert len(errors) == 1
+
+    def test_cli_missing_dir_returns_1(self, tmp_path: Path) -> None:
+        rc = vcss.main(["--results-dir", str(tmp_path / "nonexistent")])
+        assert rc == vcss.EXIT_INVALID
+
+    def test_cli_ok_dir_returns_0(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        _write_sarif(
+            results_dir / "x.sarif",
+            {"version": "2.1.0", "runs": [{"results": []}]},
+        )
+        rc = vcss.main(["--results-dir", str(results_dir)])
+        assert rc == vcss.EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# codeql_integration_summary
+# ---------------------------------------------------------------------------
+
+
+class TestCodeqlIntegrationSummary:
+    def test_all_success(self) -> None:
+        results = {
+            "INSTALL_RESULT": "success",
+            "LANGUAGE_RESULT": "success",
+            "JSON_RESULT": "success",
+        }
+        text, all_passed = cis.build_summary(results)
+        assert all_passed
+        assert "TIP" in text
+        assert "CAUTION" not in text
+
+    def test_one_failure(self) -> None:
+        results = {
+            "INSTALL_RESULT": "success",
+            "LANGUAGE_RESULT": "failure",
+            "JSON_RESULT": "success",
+        }
+        text, all_passed = cis.build_summary(results)
+        assert not all_passed
+        assert "CAUTION" in text
+        assert "TIP" not in text
+
+    def test_all_skipped(self) -> None:
+        results = {
+            "INSTALL_RESULT": "skipped",
+            "LANGUAGE_RESULT": "skipped",
+            "JSON_RESULT": "skipped",
+        }
+        text, all_passed = cis.build_summary(results)
+        assert all_passed
+        assert "\u23ed" in text
+
+    def test_missing_env_treated_as_failure(self) -> None:
+        results = {}
+        text, all_passed = cis.build_summary(results)
+        assert not all_passed
+
+    def test_table_has_all_three_rows(self) -> None:
+        results = {
+            "INSTALL_RESULT": "success",
+            "LANGUAGE_RESULT": "success",
+            "JSON_RESULT": "success",
+        }
+        text, _ = cis.build_summary(results)
+        assert "Install & Config" in text
+        assert "Language Scans" in text
+        assert "JSON Output" in text
+
+    def test_main_writes_to_summary_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary_file = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        monkeypatch.setenv("INSTALL_RESULT", "success")
+        monkeypatch.setenv("LANGUAGE_RESULT", "success")
+        monkeypatch.setenv("JSON_RESULT", "success")
+        rc = cis.main()
+        assert rc == cis.EXIT_OK
+        content = summary_file.read_text(encoding="utf-8")
+        assert "CodeQL Integration Test Results" in content
+
+    def test_main_returns_1_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary_file = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        monkeypatch.setenv("INSTALL_RESULT", "failure")
+        monkeypatch.setenv("LANGUAGE_RESULT", "success")
+        monkeypatch.setenv("JSON_RESULT", "success")
+        rc = cis.main()
+        assert rc == cis.EXIT_FAILED
+
+    def test_main_returns_2_without_summary_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        rc = cis.main()
+        assert rc == cis.EXIT_USAGE
+
+    def test_main_appends_not_overwrites(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary_file = tmp_path / "summary.md"
+        summary_file.write_text("existing content\n", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        monkeypatch.setenv("INSTALL_RESULT", "success")
+        monkeypatch.setenv("LANGUAGE_RESULT", "success")
+        monkeypatch.setenv("JSON_RESULT", "success")
+        cis.main()
+        content = summary_file.read_text(encoding="utf-8")
+        assert content.startswith("existing content")
+        assert "CodeQL Integration Test Results" in content

--- a/tests/ci/test_publish_scripts.py
+++ b/tests/ci/test_publish_scripts.py
@@ -147,6 +147,19 @@ class TestMeasureNpmPackSize:
             size, _ = mnps.measure_pack_size(tmp_path)
         assert size is None
 
+    def test_npm_failure_main_returns_error(self, tmp_path: Path) -> None:
+        mock_fail = MagicMock(returncode=1, stdout="", stderr="npm ERR!")
+        with patch("subprocess.run", return_value=mock_fail):
+            rc = mnps.main(["--package-dir", str(tmp_path)])
+        assert rc == mnps.EXIT_ERROR
+
+    def test_bad_json_main_returns_error(self, tmp_path: Path) -> None:
+        mock_json = MagicMock(returncode=0, stdout="not json", stderr="")
+        mock_human = MagicMock(returncode=0, stdout="unknown\n", stderr="")
+        with patch("subprocess.run", side_effect=[mock_json, mock_human]):
+            rc = mnps.main(["--package-dir", str(tmp_path)])
+        assert rc == mnps.EXIT_ERROR
+
 
 # ---------------------------------------------------------------------------
 # verify_npm_published
@@ -206,7 +219,13 @@ class TestVerifyNpmPublished:
         assert rc == vp.EXIT_NOT_PUBLISHED
 
     def test_get_published_version_returns_empty_on_error(self) -> None:
-        mock_result = MagicMock(returncode=1, stdout="  \n  ", stderr="error")
+        mock_result = MagicMock(returncode=1, stdout="error: package not found\n", stderr="error")
         with patch("subprocess.run", return_value=mock_result):
             v = vp.get_published_version("@x/y", "1.0.0")
         assert v == ""
+
+    def test_get_published_version_returns_version_on_success(self) -> None:
+        mock_result = MagicMock(returncode=0, stdout="1.0.0\n", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            v = vp.get_published_version("@x/y", "1.0.0")
+        assert v == "1.0.0"

--- a/tests/ci/test_publish_scripts.py
+++ b/tests/ci/test_publish_scripts.py
@@ -1,0 +1,212 @@
+"""Tests for npm publish CI scripts (issue #3533).
+
+Covers:
+  - verify_npm_package_metadata.py
+  - measure_npm_pack_size.py
+  - verify_npm_published.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "ci"))
+
+import measure_npm_pack_size as mnps
+import verify_npm_package_metadata as vnpm
+import verify_npm_published as vp
+
+# ---------------------------------------------------------------------------
+# verify_npm_package_metadata
+# ---------------------------------------------------------------------------
+
+_VALID_PKG = {
+    "name": "@rjmurillo/ai-agents",
+    "version": "1.0.0",
+    "publishConfig": {"access": "public", "provenance": True},
+    "bin": {"ai-agents": "dist/index.js"},
+    "files": ["dist/"],
+}
+
+
+def _write_pkg(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestVerifyNpmPackageMetadata:
+    def test_valid_package_passes(self, tmp_path: Path) -> None:
+        _write_pkg(tmp_path / "package.json", _VALID_PKG)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_OK
+
+    def test_wrong_name_fails(self, tmp_path: Path) -> None:
+        pkg = {**_VALID_PKG, "name": "@other/pkg"}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_missing_publish_config_access_fails(self, tmp_path: Path) -> None:
+        pkg = {**_VALID_PKG, "publishConfig": {"provenance": True}}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_private_access_fails(self, tmp_path: Path) -> None:
+        pkg = {**_VALID_PKG, "publishConfig": {"access": "restricted", "provenance": True}}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_missing_provenance_fails(self, tmp_path: Path) -> None:
+        pkg = {**_VALID_PKG, "publishConfig": {"access": "public"}}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_missing_bin_fails(self, tmp_path: Path) -> None:
+        pkg = {k: v for k, v in _VALID_PKG.items() if k != "bin"}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_missing_files_fails(self, tmp_path: Path) -> None:
+        pkg = {k: v for k, v in _VALID_PKG.items() if k != "files"}
+        _write_pkg(tmp_path / "package.json", pkg)
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_missing_package_json_returns_invalid(self, tmp_path: Path) -> None:
+        rc = vnpm.main(["--package-dir", str(tmp_path)])
+        assert rc == vnpm.EXIT_INVALID
+
+    def test_multiple_errors_reported(self, tmp_path: Path) -> None:
+        pkg = {"name": "wrong", "version": "1.0.0"}
+        _write_pkg(tmp_path / "package.json", pkg)
+        errors = vnpm.check_package_metadata(pkg)
+        assert len(errors) >= 4
+
+    def test_check_returns_empty_for_valid(self) -> None:
+        errors = vnpm.check_package_metadata(_VALID_PKG)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# measure_npm_pack_size
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureNpmPackSize:
+    def test_ok_when_under_limit(self, tmp_path: Path) -> None:
+        mock_result_json = MagicMock(returncode=0, stdout=json.dumps([{"size": 1000}]), stderr="")
+        mock_result_human = MagicMock(
+            returncode=0, stdout="npm notice Total files: 5\n1 kB\n", stderr=""
+        )
+        with patch("subprocess.run", side_effect=[mock_result_json, mock_result_human]):
+            size, detail = mnps.measure_pack_size(tmp_path)
+        assert size == 1000
+        assert "kB" in detail
+
+    def test_warning_when_over_limit(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        big = mnps._SIZE_LIMIT_BYTES + 1
+        mock_result_json = MagicMock(returncode=0, stdout=json.dumps([{"size": big}]), stderr="")
+        mock_result_human = MagicMock(returncode=0, stdout="100 MB\n", stderr="")
+        with patch("subprocess.run", side_effect=[mock_result_json, mock_result_human]):
+            rc = mnps.main(["--package-dir", str(tmp_path)])
+        assert rc == mnps.EXIT_OK
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+
+    def test_no_warning_when_under_limit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        mock_result_json = MagicMock(returncode=0, stdout=json.dumps([{"size": 100}]), stderr="")
+        mock_result_human = MagicMock(returncode=0, stdout="100 B\n", stderr="")
+        with patch("subprocess.run", side_effect=[mock_result_json, mock_result_human]):
+            rc = mnps.main(["--package-dir", str(tmp_path)])
+        assert rc == mnps.EXIT_OK
+        out = capsys.readouterr().out
+        assert "::warning::" not in out
+
+    def test_npm_failure_returns_none(self, tmp_path: Path) -> None:
+        mock_result = MagicMock(returncode=1, stdout="", stderr="npm error")
+        mock_result2 = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", side_effect=[mock_result, mock_result2]):
+            size, msg = mnps.measure_pack_size(tmp_path)
+        assert size is None
+        assert "npm pack failed" in msg
+
+    def test_bad_json_returns_none_size(self, tmp_path: Path) -> None:
+        mock_result_json = MagicMock(returncode=0, stdout="not json", stderr="")
+        mock_result_human = MagicMock(returncode=0, stdout="unknown\n", stderr="")
+        with patch("subprocess.run", side_effect=[mock_result_json, mock_result_human]):
+            size, _ = mnps.measure_pack_size(tmp_path)
+        assert size is None
+
+
+# ---------------------------------------------------------------------------
+# verify_npm_published
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyNpmPublished:
+    def test_immediate_success(self) -> None:
+        with patch.object(vp, "get_published_version", return_value="1.2.3"):
+            found = vp.wait_for_publish(
+                "@rjmurillo/ai-agents", "1.2.3", max_retries=2, delay_seconds=0
+            )
+        assert found
+
+    def test_success_on_second_attempt(self) -> None:
+        calls = {"n": 0}
+
+        def side_effect(pkg: str, ver: str) -> str:
+            calls["n"] += 1
+            return ver if calls["n"] >= 2 else ""
+
+        with patch.object(vp, "get_published_version", side_effect=side_effect):
+            found = vp.wait_for_publish("@x/y", "3.0.0", max_retries=3, delay_seconds=0)
+        assert found
+        assert calls["n"] == 2
+
+    def test_all_retries_fail_returns_false(self) -> None:
+        with patch.object(vp, "get_published_version", return_value=""):
+            found = vp.wait_for_publish("@x/y", "1.0.0", max_retries=3, delay_seconds=0)
+        assert not found
+
+    def test_main_succeeds_when_published(self, tmp_path: Path) -> None:
+        _write_pkg(tmp_path / "package.json", {"version": "2.0.0"})
+        with (
+            patch.object(vp, "get_published_version", return_value="2.0.0"),
+            patch.object(vp.time, "sleep"),
+        ):
+            rc = vp.main(["--package-dir", str(tmp_path)])
+        assert rc == vp.EXIT_OK
+
+    def test_main_fails_when_not_published(self, tmp_path: Path) -> None:
+        _write_pkg(tmp_path / "package.json", {"version": "9.9.9"})
+        with (
+            patch.object(vp, "get_published_version", return_value=""),
+            patch.object(vp.time, "sleep"),
+        ):
+            rc = vp.main(["--package-dir", str(tmp_path)])
+        assert rc == vp.EXIT_NOT_PUBLISHED
+
+    def test_main_fails_on_missing_package_json(self, tmp_path: Path) -> None:
+        rc = vp.main(["--package-dir", str(tmp_path)])
+        assert rc == vp.EXIT_NOT_PUBLISHED
+
+    def test_main_fails_on_missing_version_field(self, tmp_path: Path) -> None:
+        _write_pkg(tmp_path / "package.json", {"name": "@x/y"})
+        rc = vp.main(["--package-dir", str(tmp_path)])
+        assert rc == vp.EXIT_NOT_PUBLISHED
+
+    def test_get_published_version_returns_empty_on_error(self) -> None:
+        mock_result = MagicMock(returncode=1, stdout="  \n  ", stderr="error")
+        with patch("subprocess.run", return_value=mock_result):
+            v = vp.get_published_version("@x/y", "1.0.0")
+        assert v == ""


### PR DESCRIPTION
refactor(ci): extract ADR-006 run blocks, batch 5

Fixes four ADR-006 violations: multi-line shell logic in `run:` blocks extracted into
tested Python scripts under `scripts/ci/`, then wired back into the workflows.

## Changes

### test-codeql-integration.yml (issue #3526)

Three run blocks extracted:

- `verify_codeql_artifacts.py`: checks CodeQL database directory and SARIF file exist
- `verify_codeql_sarif_structure.py`: validates SARIF schema fields (runs/results/tool)
- `codeql_integration_summary.py`: writes test result table to GITHUB_STEP_SUMMARY

The `aggregate-results` job had no `actions/checkout` step; a sparse-checkout step
targeting `scripts/ci` was added (required by the repo-wide checkout gate).

### publish.yml (issue #3533)

Three run blocks extracted:

- `verify_npm_package_metadata.py`: validates required package.json fields
- `measure_npm_pack_size.py`: runs npm pack --dry-run --json, enforces 50 MB limit
- `verify_npm_published.py`: polls npm registry for the new version, retries up to 5 times with 10-second delays

The affected steps used `working-directory: packages/ai-agents-cli`; scripts accept
`--package-dir` instead so the workflow-level working-directory could be removed
from those three steps.

### agent-metrics.yml (issue #3531)

Three run blocks extracted:

- `collect_metrics_and_report.py`: runs collect_metrics.py, writes metrics-report.txt and GITHUB_STEP_SUMMARY
- `check_metrics_thresholds.py`: checks float thresholds against targets, writes results to GITHUB_OUTPUT
- `write_metrics_threshold_summary.py`: reads CHECK_COVERAGE and CHECK_INFRA_RATE from env, writes a summary table to GITHUB_STEP_SUMMARY

### agent-drift-detection.yml (issue #3521)

Three run blocks extracted:

- `check_plugin_lib_mirrors.py`: runs sync_plugin_lib.py --check then build_all.py --check, returns first non-zero exit code
- `show_drift_failure.py`: prints drift details, conditionally reruns generation scripts, shows git diff
- `write_drift_job_summary.py`: reads VALIDATE_CONCLUSION, LIB_MIRROR_CONCLUSION, MANIFEST_PARITY_CONCLUSION, writes pass/fail summary to GITHUB_STEP_SUMMARY

## Validation

All scripts are stdlib-only (no external deps; jobs without actions/setup-python use bare python3).

ADR-006 scanner: 0 violations on all 4 target files.

actionlint: clean on all 4 workflows.

Test suite: 952 passed, 4 skipped.

Mutation harness: 11/11 mutants killed across all four script groups.

## Issues

Fixes #3526
Fixes #3533
Fixes #3531
Fixes #3521

## References

- `scripts/ci/verify_codeql_artifacts.py`
- `scripts/ci/verify_codeql_sarif_structure.py`
- `scripts/ci/codeql_integration_summary.py`
- `tests/ci/test_codeql_scripts.py`
- `scripts/ci/verify_npm_package_metadata.py`
- `scripts/ci/measure_npm_pack_size.py`
- `scripts/ci/verify_npm_published.py`
- `tests/ci/test_publish_scripts.py`
- `scripts/ci/collect_metrics_and_report.py`
- `scripts/ci/check_metrics_thresholds.py`
- `scripts/ci/write_metrics_threshold_summary.py`
- `tests/ci/test_agent_metrics_scripts.py`
- `scripts/ci/check_plugin_lib_mirrors.py`
- `scripts/ci/show_drift_failure.py`
- `scripts/ci/write_drift_job_summary.py`
- `tests/ci/test_agent_drift_scripts.py`
- `.github/workflows/test-codeql-integration.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/agent-metrics.yml`
- `.github/workflows/agent-drift-detection.yml`
- `scripts/ci/ruff_count_baseline.txt`
