### PR TITLE
docs(instructions): move Copilot gotchas into the shared governance file

### DIFF
--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -9,7 +9,65 @@ byte gates disagree: `tests/test_workspace_limits.py` allows 3072 per file,
 `scripts/validate_workspace_budget.py` allows 3000. **Write to 3000.** The
 stricter gate binds, and a file between the two passes one and fails the other
 (Refs #3951). These entries live here instead so detail is not paid for on
-every turn. `AGENTS.md` points at this file from its Retrieval section.
+every turn. `AGENTS.md` points at this file from its Retrieval section, and
+`.github/copilot-instructions.md` points at it from its Gotchas section.
+
+`.github/copilot-instructions.md` is injected into every Copilot session too,
+at roughly twice that per-file budget, and **no gate measures it**: the
+workspace budget covers only `CLAUDE.md`, `AGENTS.md`, and `.claude/CLAUDE.md`,
+and `instruction_budget.py` covers only `.github/instructions/*.instructions.md`.
+New always-on guidance therefore belongs here, not there (Refs #3991).
+
+## Three portability checkers exist and their names do not tell you the scope
+
+Running two of them is not running the third, and only the third reads
+Markdown.
+
+| Script | Scans | Catches |
+|---|---|---|
+| `build/scripts/check_vendor_portability.py` | skill scripts | code that reads an upstream-only path |
+| `build/scripts/check_skill_portability.py` | skill scripts | drift against the script baseline |
+| `scripts/validation/check_skill_md_portability.py` | skill `.md` | an upstream path cited in **prose** |
+
+Symptom: the first two pass, you commit, and the push is rejected by
+`pre_pr.py` with `[FAIL] Skill Markdown Portability` naming a reference file
+you just added. A new `.md` under `.claude/skills/` that cites a repo path such
+as `.agents/analysis/...` starts at baseline 0 and any reference is drift.
+
+Fix: resolve the path through the plugin or skill root, or declare it with an
+HTML comment marker on its own line at the end of the file:
+
+```text
+<!-- vendor-portability: declared. <what the path is, why the file cites it,
+and what a vendored install loses without it>. Issue #2050. -->
+```
+
+Both the canonical file and its `src/copilot-cli/` mirror carry the marker,
+because the checker scans both trees.
+
+## Pass explicit file paths to taste-lints, never a directory
+
+`taste_lints.py --rules file-size <dir>` scans **zero** files and reports "no
+violations". That is a false pass, not a clean result. It only reads paths you
+name.
+
+```
+uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py \
+  --rules file-size path/to/one.md path/to/two.md
+```
+
+Authored file size is a **hard error at 501 lines** and a warning from 301 to
+500, so a file that silently skipped the check can block a later commit.
+
+## A commit touching `.agents/` must carry the session log
+
+`session-policy` rejects any commit that stages a file under `.agents/` unless
+the JSON session log is staged in that **same** commit. Splitting the work into
+"content commit, then log commit" fails on the first one.
+
+Symptom: a commit touching `.agents/analysis/` or `.agents/architecture/` is
+rejected while the identical change under any other path commits fine. See also
+"Session log ordering" below, which governs when the log may first be staged.
 
 ## Session log ordering
 
@@ -84,3 +142,49 @@ These matter only when running `scripts/eval/`. Full detail lives in
 - A single eval run cannot resolve a delta under about 1.0 on a 0-5 scale.
   Measured run-to-run spread on identical inputs was 0.94 on Opus 5 and 1.11 on
   Sol 5.6. Run four times per model and count sign consistency, not means.
+
+## The PR description gate blocks on paths and on dashes
+
+`scripts/validation/pr_description.py --ci` runs as `PR Validation / Validate
+PR` in branch protection and blocks merge on two things.
+
+**A file path mentioned but not in the diff.** The validator extracts paths
+only from inline code, bold, list items, and Markdown links, so a path in plain
+prose is fine but an inline-backtick mention is not. Silence a genuine
+reference the way the validator recognizes: a citation cue (`see` before the
+path), a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual
+H2 such as `## References`, `## Related Files`, `## See Also`, `## Notes`,
+`## Background`, `## Evidence`, `## Out of Scope`, or `## Prior Art`. The full
+set is `_CONTEXTUAL_SECTION_NAMES` and `_REFERENCE_SECTION_PREFIXES` in the
+validator.
+
+**Any em-dash (U+2014) or en-dash (U+2013).** Byte-verify rather than trusting
+a visual scan:
+
+```
+python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md
+```
+
+Editing the body re-triggers the gate on `pull_request: edited`, so no new
+commit is needed. Bot reviewers produce false positives on both checks; verify
+at byte level before editing.
+
+The validator takes `--pr-number` and fetches the **live** body, so push and
+update the PR before running it locally.
+
+## Never put a literal pipe inside a Markdown table cell
+
+Escape it as `\|` or reword. A bare `|` breaks rendering and trips bot
+table-format flags.
+
+## Reference skill scripts by plugin root, not a bare `.claude/` path
+
+Use `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/..."`. A
+bare `.claude/skills/...` path fails under Copilot CLI and trips
+`check_skill_md_exec_portability.py`.
+
+## `gh pr view --json reviewThreads` is not a valid field
+
+The field does not exist on that command and the error does not suggest the
+alternative. Use `gh api graphql` with a `reviewThreads` query on the pull
+request instead.

--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -45,16 +45,29 @@ and what a vendored install loses without it>. Issue #2050. -->
 Both the canonical file and its `src/copilot-cli/` mirror carry the marker,
 because the checker scans both trees.
 
-## Pass explicit file paths to taste-lints, never a directory
+## A bare directory argument to taste-lints is a silent false pass
 
-`taste_lints.py --rules file-size <dir>` scans **zero** files and reports "no
-violations". That is a false pass, not a clean result. It only reads paths you
-name.
+`taste_lints.py --rules file-size <dir>` with the directory as a **positional**
+argument scans **zero** files, prints "0 files scanned, no violations found",
+and exits 0. That is a false pass, not a clean result: positional arguments go
+into the `files` list, and a directory is not a file.
+
+Directory scanning is supported, but only through the flag:
 
 ```
+# works: 4 files scanned
 uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py \
-  --rules file-size path/to/one.md path/to/two.md
+  --rules file-size --directory .claude/skills/context-optimizer/references
+
+# silent no-op: 0 files scanned, exit 0
+uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py \
+  --rules file-size .claude/skills/context-optimizer/references
 ```
+
+Also available: `--git-staged` and `--diff-scope BASE_BRANCH`. Explicit file
+paths remain the safest habit, because the count in the output line is the
+only thing that distinguishes a real pass from the no-op, and "no violations
+found" reads identically either way.
 
 Authored file size is a **hard error at 501 lines** and a warning from 301 to
 500, so a file that silently skipped the check can block a later commit.

--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -130,6 +130,45 @@ removed in a later one nets out and passes. Existing lines on `main` are
 grandfathered because only added lines are scanned, which is why inert
 suppressions can sit in the tree looking like sanctioned precedent. Refs #3940.
 
+## The push blocks at 21 commits, and the check runs at push time
+
+The pre-push `push-ref-policy` hook hard-fails at more than 20 commits ahead of
+`origin/main`. It runs at push time, so a long branch discovers the ceiling
+after the work is committed, not while it accumulates. Check it mid-session:
+
+```
+git rev-list --count HEAD ^origin/main
+```
+
+Relief is the `commit-limit-bypass` label on the PR, and nothing else. Squashing
+is often the wrong repair, because the five-file atomic-commit rule then makes
+the collapsed commit a violation of a different rule. Prefer the label when the
+branch is one coherent thread, and split into a second PR when it is not.
+
+## Never revert a source file with `git checkout` to negative-control a fix
+
+Negative-controlling a fix means reverting the source, confirming the new tests
+fail, then restoring. `git checkout <file>` restores the file to HEAD, which
+silently discards **every other uncommitted change in it**, not just the one
+you meant to undo. On a file carrying two unrelated in-progress fixes, one
+control run destroyed both.
+
+Copy the file aside and copy it back:
+
+```
+cp scripts/eval/thing.py /tmp/thing.bak
+# ... sabotage, run the test, observe the failure ...
+cp /tmp/thing.bak scripts/eval/thing.py
+```
+
+`git stash push <file>` is safe by comparison (the change is recoverable) but
+still moves *all* of the file's changes, so a control run that expects only
+one behavior to regress will see several.
+
+Symptom: a control that should fail passes instead, because the sabotage never
+applied to the code you thought you were editing. Check `git status` before
+concluding the test is weak.
+
 ## The mypy and ruff gates are ratchets, not clean-tree checks
 
 `git_hook_policy.py mypy` tolerates the pre-existing error count in a file and

--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -151,12 +151,36 @@ PR` in branch protection and blocks merge on two things.
 **A file path mentioned but not in the diff.** The validator extracts paths
 only from inline code, bold, list items, and Markdown links, so a path in plain
 prose is fine but an inline-backtick mention is not. Silence a genuine
-reference the way the validator recognizes: a citation cue (`see` before the
-path), a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual
-H2 such as `## References`, `## Related Files`, `## See Also`, `## Notes`,
+reference the way the validator recognizes: a citation cue, a fenced code
+block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 such as
+`## References`, `## Related Files`, `## See Also`, `## Notes`,
 `## Background`, `## Evidence`, `## Out of Scope`, or `## Prior Art`. The full
 set is `_CONTEXTUAL_SECTION_NAMES` and `_REFERENCE_SECTION_PREFIXES` in the
 validator.
+
+A citation cue is narrower than it looks, and both constraints are
+load-bearing. The cue (`see`, `per`, `defined in`, `for example`, and the rest
+of `_INLINE_CITATION_PATTERN`) must sit on the same line and immediately
+before the path, separated only by whitespace, colons, or an open paren. And
+the backtick span must end at the extension: `` `taste_lints.py` `` is
+suppressible, `` `taste_lints.py --rules file-size` `` is not, because the
+trailing flags push the closing backtick past the extension. Reword so the
+path stands alone in its own span.
+
+Do not guess at the shape and push to find out. The extractor imports and runs
+offline against a candidate body, which turns a round trip through CI into a
+one-second check:
+
+```python
+import importlib.util, sys, pathlib
+spec = importlib.util.spec_from_file_location("prd", "scripts/validation/pr_description.py")
+m = importlib.util.module_from_spec(spec)
+sys.modules["prd"] = m  # dataclass resolution needs the module registered
+spec.loader.exec_module(m)
+print(sorted(m.extract_mentioned_files(pathlib.Path(sys.argv[1]).read_text())))
+```
+
+Anything it prints that is not in the diff is a CRITICAL waiting to happen.
 
 **Any em-dash (U+2014) or en-dash (U+2013).** Byte-verify rather than trusting
 a visual scan:

--- a/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -94,6 +94,22 @@
       "content": "Rewrote the entry to name the trap and the supported remedy, and to point at the file count in the output line as the only thing distinguishing a real pass from the no-op.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added two gotchas learned while running negative controls on the eval parser. First: git checkout on a source file to revert a sabotage discards every other uncommitted change in that file, which destroyed two in-progress fixes in one run. Copy the file aside instead.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Second: the pre-push hook hard-fails above 20 commits ahead of origin/main and only runs at push time, so a long branch finds the ceiling after the work is committed. Recorded the mid-session check and why squashing is often the wrong repair, since the five-file atomic rule then makes the collapsed commit a different violation.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -46,6 +46,30 @@
       "content": "Commit: 0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The PR description gate failed on this very PR for three paths that were references rather than change claims, which is the trap the entry I had just written was supposed to prevent.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The entry was missing the two load-bearing constraints: the citation cue must sit immediately before the path, and the backtick span must end at the extension, so a span carrying trailing flags is not suppressible.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added the offline reproduction recipe instead of only the rule. extract_mentioned_files imports and runs against a candidate body, which turns a round trip through CI into a one-second check.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -1,0 +1,52 @@
+{
+  "id": "episode-2026-07-30-session-3991-dedupe-copilot-gotchas",
+  "session": "2026-07-30-session-3991-dedupe-copilot-gotchas",
+  "timestamp": "2026-07-30T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Move the Copilot inline gotchas into .agents/governance/GOTCHAS.md so the three always-on entry points cite one source",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Establish that .github/copilot-instructions.md is always-on and unmeasured",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirm the duplication before moving anything",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Move the three unique entries into GOTCHAS.md",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replace the inline section with a pointer",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -70,6 +70,30 @@
       "content": "Added the offline reproduction recipe instead of only the rule. extract_mentioned_files imports and runs against a candidate body, which turns a round trip through CI into a one-second check.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bot review flagged the taste-lints gotcha as implying directories are unsupported. Verified against the argparse block: --directory / -d exists, along with --git-staged and --diff-scope. The bot is right and my entry was imprecise.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced both behaviours before rewriting. A positional directory prints '0 files scanned, no violations found' and exits 0; --directory on the same path scans 4 files and reports the warning. The trap is the positional form specifically, not directories.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rewrote the entry to name the trap and the supported remedy, and to point at the file count in the output line as the only thing distinguishing a real pass from the no-op.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -38,6 +38,14 @@
       "content": "Replace the inline section with a pointer",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -45,7 +53,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -153,6 +153,14 @@
     {
       "step": "Rewrote the entry to name the trap and the supported remedy, and to point at the file count in the output line as the only thing distinguishing a real pass from the no-op.",
       "timestamp": "2026-07-30T14:45:37.012204Z"
+    },
+    {
+      "step": "Added two gotchas learned while running negative controls on the eval parser. First: git checkout on a source file to revert a sabotage discards every other uncommitted change in that file, which destroyed two in-progress fixes in one run. Copy the file aside instead.",
+      "timestamp": "2026-07-30T16:14:28.109511Z"
+    },
+    {
+      "step": "Second: the pre-push hook hard-fails above 20 commits ahead of origin/main and only runs at push time, so a long branch finds the ceiling after the work is committed. Recorded the mid-session check and why squashing is often the wrong repair, since the five-file atomic rule then makes the collapsed commit a different violation.",
+      "timestamp": "2026-07-30T16:14:29.109511Z"
     }
   ],
   "endingCommit": "0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",

--- a/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -141,6 +141,18 @@
     {
       "step": "Added the offline reproduction recipe instead of only the rule. extract_mentioned_files imports and runs against a candidate body, which turns a round trip through CI into a one-second check.",
       "timestamp": "2026-07-30T14:12:35.222102Z"
+    },
+    {
+      "step": "Bot review flagged the taste-lints gotcha as implying directories are unsupported. Verified against the argparse block: --directory / -d exists, along with --git-staged and --diff-scope. The bot is right and my entry was imprecise.",
+      "timestamp": "2026-07-30T14:45:37.012204Z"
+    },
+    {
+      "step": "Reproduced both behaviours before rewriting. A positional directory prints '0 files scanned, no violations found' and exits 0; --directory on the same path scans 4 files and reports the warning. The trap is the positional form specifically, not directories.",
+      "timestamp": "2026-07-30T14:45:37.012204Z"
+    },
+    {
+      "step": "Rewrote the entry to name the trap and the supported remedy, and to point at the file count in the output line as the only thing distinguishing a real pass from the no-op.",
+      "timestamp": "2026-07-30T14:45:37.012204Z"
     }
   ],
   "endingCommit": "0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",

--- a/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3991,
+    "date": "2026-07-30",
+    "branch": "rjmurillo/dedupe-copilot-gotchas",
+    "startingCommit": "32af5363f",
+    "objective": "Move the Copilot inline gotchas into .agents/governance/GOTCHAS.md so the three always-on entry points cite one source"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP tools are not exposed by this harness; AGENTS.md and .agents/governance/ read directly per the documented fallback"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not available in this harness; fallback path used"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read and left unmodified"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "taste-lints and validation scripts located and run; .claude/skills/taste-lints/scripts/taste_lints.py invoked with explicit file paths"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md Boundaries and Skill-First sections read; skill-first rule honored for validation"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md consulted for the generated-artifact and always-on budget rules"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Prior session context for issue 3991 carried forward; no separate issue handoff file exists"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "rjmurillo/dedupe-copilot-gotchas"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On rjmurillo/dedupe-copilot-gotchas, branched from origin/main at 32af5363f"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Two modified files and this new session log; worktree otherwise clean"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "32af5363f"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Workspace budget gate passed at 5651/6600 bytes; taste-lints file-size passed on both changed files; dash count byte-verified at zero on both"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP is not reachable in this harness. The durable knowledge from this session is a cross-harness convention, which .claude/rules/knowledge-persistence.md routes to the governance tree rather than to Serena memory: it was written to .agents/governance/GOTCHAS.md, which every harness reaches."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdown-autofix and markdown-check both passed in the pre-commit run"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This commit carries GOTCHAS.md, copilot-instructions.md, and this log. endingCommit is recorded in a follow-up commit rather than by amending, which would orphan the SHA (issue #3618)."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre_pr.py run recorded in the work log below"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue 3991 referenced by the commit and the PR"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Establish that .github/copilot-instructions.md is always-on and unmeasured",
+      "outcome": "The file appears verbatim in the agent context, so it is always-on. validate_workspace_budget.py covers only CLAUDE.md, AGENTS.md, and .claude/CLAUDE.md at 3000 bytes each; instruction_budget.py covers only .github/instructions/*.instructions.md. copilot-instructions.md is in neither, at 6351 bytes. Filed as issue 3991."
+    },
+    {
+      "task": "Confirm the duplication before moving anything",
+      "outcome": "The inline uv-run entry already restated .agents/governance/GOTCHAS.md with no gate to catch drift. Confirmed the three copilot-instructions.md files in the repository (.github/, src/vs-code-agents/, src/copilot-cli/docs/) are 6351, 1565, and 1913 bytes and are not mirrors of each other, so this edit carries no mirror-sync burden."
+    },
+    {
+      "task": "Move the three unique entries into GOTCHAS.md",
+      "outcome": "PR description gate, literal pipes in Markdown table cells, and plugin-root script references moved verbatim. Added three traps found while shipping PR 3983: the three portability checkers with confusable names, taste-lints reporting a false pass when given a directory, and the session-log ordering requirement. GOTCHAS.md grew 86 to 190 lines."
+    },
+    {
+      "task": "Replace the inline section with a pointer",
+      "outcome": ".github/copilot-instructions.md fell from 6351 to 4579 bytes, a 28 percent cut, with no knowledge lost. All three always-on entry points now reach one source: AGENTS.md points at GOTCHAS.md directly, CLAUDE.md inherits through its @AGENTS.md import, and copilot-instructions.md now points at the same file."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push the branch and open a PR referencing issue 3991.",
+    "Add .github/copilot-instructions.md to a budget gate so the 4579-byte figure cannot silently regrow."
+  ]
+}

--- a/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -129,6 +129,18 @@
     {
       "task": "Replace the inline section with a pointer",
       "outcome": ".github/copilot-instructions.md fell from 6351 to 4579 bytes, a 28 percent cut, with no knowledge lost. All three always-on entry points now reach one source: AGENTS.md points at GOTCHAS.md directly, CLAUDE.md inherits through its @AGENTS.md import, and copilot-instructions.md now points at the same file."
+    },
+    {
+      "step": "The PR description gate failed on this very PR for three paths that were references rather than change claims, which is the trap the entry I had just written was supposed to prevent.",
+      "timestamp": "2026-07-30T14:12:35.222102Z"
+    },
+    {
+      "step": "The entry was missing the two load-bearing constraints: the citation cue must sit immediately before the path, and the backtick span must end at the extension, so a span carrying trailing flags is not suppressible.",
+      "timestamp": "2026-07-30T14:12:35.222102Z"
+    },
+    {
+      "step": "Added the offline reproduction recipe instead of only the rule. extract_mentioned_files imports and runs against a candidate body, which turns a round trip through CI into a one-second check.",
+      "timestamp": "2026-07-30T14:12:35.222102Z"
     }
   ],
   "endingCommit": "0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",

--- a/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
+++ b/.agents/sessions/2026-07-30-session-3991-dedupe-copilot-gotchas.json
@@ -131,7 +131,7 @@
       "outcome": ".github/copilot-instructions.md fell from 6351 to 4579 bytes, a 28 percent cut, with no knowledge lost. All three always-on entry points now reach one source: AGENTS.md points at GOTCHAS.md directly, CLAUDE.md inherits through its @AGENTS.md import, and copilot-instructions.md now points at the same file."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "0d610bc2f7d43f531d8a9fa9c03854fbca7a6b4e",
   "nextSteps": [
     "Push the branch and open a PR referencing issue 3991.",
     "Add .github/copilot-instructions.md to a budget gate so the 4579-byte figure cannot silently regrow."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,25 +101,15 @@ Serena MCP tools available → MUST call FIRST:
 
 ## Gotchas (non-obvious, save cycles)
 
-These recur across PRs and are not covered by AGENTS.md.
+Traps that recur across PRs and cannot be inferred from the code: the PR
+description gate, the three portability checkers, taste-lints, session-log
+ordering, the suppression and ratchet gates, and the eval harness.
 
-### PR description gate
+**Read `.agents/governance/GOTCHAS.md` before your first push on a branch.**
 
-The "PR Validation" workflow's description gate (`scripts/validation/pr_description.py --ci`, shown in branch protection as `PR Validation / Validate PR`) blocks merge on:
-
-- A file-looking path (one with a known extension) that appears in inline code, bold, a list item, or a Markdown link and is not in the diff: CRITICAL "file mentioned but not in diff". The validator extracts paths only from those Markdown shapes, not from arbitrary prose, so a path mentioned in a plain sentence does not trip it, but an inline-backtick mention (`` `app.js` ``) does. Silence a real mention the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`, and other proof or reference headings such as `## Evidence`, `## Out of Scope`, `## Prior Art`; see `_CONTEXTUAL_SECTION_NAMES` and `_REFERENCE_SECTION_PREFIXES` in the validator for the full set).
-- Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify both: `python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md`.
-
-Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.
-
-### Markdown tables
-
-Never place a literal `|` inside a table cell. Escape it (`\|`) or reword. A bare pipe breaks rendering and trips bot table-format flags.
-
-### Invoking skill and hook scripts
-
-- Prefer `uv run python` over bare `python3` for scripts that import project or third-party deps (for example `yaml`). Those resolve only in the project venv, so bare `python3` can fail `ModuleNotFoundError`; `uv run python` selects the venv deterministically. Dependency-free scripts run fine under either.
-- Reference scripts by env-var-qualified plugin root, not a bare `.claude/skills/...` path: `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/..."`. Bare `.claude/skills` paths fail under Copilot CLI and trip `check_skill_md_exec_portability.py`.
+They live there rather than here so the detail is not paid for on every turn,
+and so the Claude and Copilot entry points cite one source instead of drifting
+apart. Add new ones there.
 
 ## Key Documents
 


### PR DESCRIPTION
## Summary

`.github/copilot-instructions.md` is always-on and unmeasured. It is in neither budget gate, and it carried its own inline gotchas section whose `uv run` entry already restated `.agents/governance/GOTCHAS.md`. Two copies, no gate to catch drift.

This moves the unique entries into the governance file and replaces the section with a pointer. All three always-on entry points now cite one source.

## Why this file is unmeasured

Two gates measure always-on instruction text, and this file is in neither:

| Gate | Covers | Budget |
| --- | --- | --- |
| see `scripts/validation/validate_workspace_budget.py` | see `CLAUDE.md`, `AGENTS.md`, `.claude/CLAUDE.md` | 3000 bytes each |
| see `scripts/validation/instruction_budget.py` | files under `.github/instructions/` | per-file |

The file is verifiably always-on: it appears verbatim in the agent context on every turn. At 6351 bytes it was larger than all three workspace files combined (5651 bytes).

The gate shape actively steers new guidance into the unmeasured file. Per `AGENTS.md`, that file sits at 2999 of its 3000 bytes, so anyone adding an always-on line has one byte of headroom there and unlimited headroom here. Filed as #3991.

## What moved

Seven sections are added to the governance file. Three were unique to the Copilot file and moved verbatim:

- The PR description gate.
- Literal pipes in Markdown table cells.
- Referencing skill scripts by plugin root rather than a bare path.

Four are new, from traps hit while shipping #3983 and this PR itself:

- Three portability checkers exist with confusable names, and running two of them is not running the third.
- A bare directory argument to the file-size linter is a silent false pass. It prints "0 files scanned, no violations found" and exits 0, because a positional argument has to be a file. Directory scanning works, but only behind `--directory`.
- A commit touching `.agents/` must carry the JSON session log in the same commit.
- `gh pr view --json reviewThreads` is not a valid field. Review threads need a GraphQL query.

## Corrections from review

Two bot findings, both confirmed against the source before changing anything.

The taste-lints entry originally read as if directories were unsupported. They are supported. Reproduced both forms: the positional directory scans zero files and exits 0, while the same path behind the flag scans four and reports the warning. The entry now names the trap, the supported flags, and the file count in the output line, which is the only thing separating a real pass from the no-op.

The section count above was three short. The `gh pr view` entry was added by this PR and went uncounted, which is the same undercount shape the description gate exists to catch.

## Result

`.github/copilot-instructions.md`: 6351 to 4579 bytes, a 28 percent cut with no knowledge lost. `.agents/governance/GOTCHAS.md`: 86 to 227 lines.

Entry points after this change:

- Per `AGENTS.md`, the governance file is referenced directly.
- See `CLAUDE.md`, which imports that same file and so needs no edit of its own.
- `.github/copilot-instructions.md` now points at the same file.

## Testing

Workspace budget gate passes at 5651 of 6600 bytes. The file-size rule passes on both changed files with explicit paths. Dash count byte-verified at zero. Session log validates PASS. Full push gate green, including `pre-pr-validation` and the Python suite.

## Review kind / scrutiny / urgency

Documentation move, normal scrutiny, no rush. The claim under review is that nothing unique was lost in the move and that a pointer costs less than a copy.

Refs #3991
