### PR TITLE
fix(verification): use AST for Python and language patterns for TS/JS/C#/PS

### DIFF
--- a/scripts/memory_enhancement/verification.py
+++ b/scripts/memory_enhancement/verification.py
@@ -6,6 +6,7 @@ are added by registering a new verifier function, satisfying OCP.
 
 from __future__ import annotations
 
+import ast
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -27,7 +28,22 @@ VerifierFn = Callable[[Citation, Path], VerificationResult]
 
 _ISSUE_PR_PATTERN = re.compile(r"^#?\d+$")
 _FILE_LINE_PATTERN = re.compile(r"^(?P<path>[^:]+)(?::(?P<line>\d+))?$")
-_FUNCTION_PATTERN = re.compile(r"^(?P<path>[^:]+)::(?P<func>\w+)$")
+_FUNCTION_PATTERN = re.compile(r"^(?P<path>[^:]+)::(?P<func>[\w][\w-]*)$")
+
+# Extensions handled via ast.parse (avoids false positives on comments/strings).
+_PYTHON_EXTS: frozenset[str] = frozenset({".py", ".pyi"})
+
+# Pattern templates for non-Python languages. {name} is replaced with
+# re.escape(func_name) at call time.
+_LANG_PATTERN_TEMPLATES: dict[str, str] = {
+    ".ts": r"\bfunction\s+{name}\b",
+    ".tsx": r"\bfunction\s+{name}\b",
+    ".js": r"\bfunction\s+{name}\b",
+    ".jsx": r"\bfunction\s+{name}\b",
+    ".cs": r"\b{name}\s*\(",
+    ".ps1": r"\bfunction\s+{name}\b",
+    ".psm1": r"\bfunction\s+{name}\b",
+}
 
 
 def verify_citation(citation: Citation, repo_root: Path) -> VerificationResult:
@@ -46,9 +62,7 @@ def verify_citation(citation: Citation, repo_root: Path) -> VerificationResult:
     return verifier(citation, repo_root)
 
 
-def verify_all_citations(
-    memory: MemoryWithCitations, repo_root: Path
-) -> list[VerificationResult]:
+def verify_all_citations(memory: MemoryWithCitations, repo_root: Path) -> list[VerificationResult]:
     """Verify every citation in a memory.
 
     Args:
@@ -123,9 +137,7 @@ def _verify_file(citation: Citation, repo_root: Path) -> VerificationResult:
     return VerificationResult.create(citation, True, "File exists")
 
 
-def _verify_file_line(
-    citation: Citation, file_path: Path, line_num: int
-) -> VerificationResult:
+def _verify_file_line(citation: Citation, file_path: Path, line_num: int) -> VerificationResult:
     """Check that a file has at least the specified number of lines."""
     if line_num < 1:
         return VerificationResult.create(
@@ -169,16 +181,89 @@ def _search_function_in_file(
 ) -> VerificationResult:
     """Search for a function definition in a file.
 
-    Detects both sync and async Python function definitions.
+    Dispatch strategy by file extension:
+
+    - ``.py`` / ``.pyi``: use ``ast.parse`` so that occurrences inside comments
+      or string literals are ignored.  Falls back to a ``def``/``async def``
+      regex search if the file contains a syntax error; the reason field notes
+      "syntax-error fallback" in that case.
+    - ``.ts`` / ``.tsx`` / ``.js`` / ``.jsx``: match the ``function`` keyword.
+    - ``.cs``: match ``<name>(``.
+    - ``.ps1`` / ``.psm1``: match the ``function`` keyword (supports
+      hyphenated Verb-Noun names via the ``_FUNCTION_PATTERN`` fix).
+    - Any other extension: returns ``is_valid=False`` with a message directing
+      authors to use a file or file:line citation instead.
+
+    Args:
+        citation: The original citation being verified.
+        file_path: Resolved path to the file on disk.
+        func_name: Name of the function to search for.
+
+    Returns:
+        VerificationResult indicating whether the function was found.
     """
-    pattern = re.compile(rf"\b(?:async\s+)?def\s+{re.escape(func_name)}\b")
     try:
         content = file_path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         return VerificationResult.create(citation, False, f"Cannot read file: {exc}")
 
+    ext = file_path.suffix.lower()
+
+    if ext in _PYTHON_EXTS:
+        return _search_python_function(citation, func_name, content)
+
+    template = _LANG_PATTERN_TEMPLATES.get(ext)
+    if template is None:
+        return VerificationResult.create(
+            citation,
+            False,
+            f"Function-level citation unsupported for '{ext}' files; "
+            "use file or file:line citation instead",
+        )
+
+    pattern = re.compile(template.format(name=re.escape(func_name)))
     if pattern.search(content):
         return VerificationResult.create(citation, True, f"Function '{func_name}' found")
+    return VerificationResult.create(citation, False, f"Function '{func_name}' not found in file")
+
+
+def _search_python_function(citation: Citation, func_name: str, content: str) -> VerificationResult:
+    """Check for a function definition in Python source using ``ast.parse``.
+
+    Using the AST means occurrences inside comments or string literals
+    do not produce false positives.  If the source has a syntax error
+    (e.g. the file is incomplete or uses future syntax), falls back to a
+    regex search and notes "syntax-error fallback" in the reason.
+
+    Args:
+        citation: The original citation being verified.
+        func_name: Name of the function to find.
+        content: Full text of the Python file.
+
+    Returns:
+        VerificationResult indicating whether the function was found.
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        pattern = re.compile(rf"\b(?:async\s+)?def\s+{re.escape(func_name)}\b")
+        if pattern.search(content):
+            return VerificationResult.create(
+                citation,
+                True,
+                f"Function '{func_name}' found (syntax-error fallback; result may be imprecise)",
+            )
+        return VerificationResult.create(
+            citation,
+            False,
+            f"Function '{func_name}' not found in file (syntax-error fallback)",
+        )
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == func_name:
+                return VerificationResult.create(citation, True, f"Function '{func_name}' found")
+
     return VerificationResult.create(citation, False, f"Function '{func_name}' not found in file")
 
 

--- a/scripts/memory_enhancement/verification.py
+++ b/scripts/memory_enhancement/verification.py
@@ -36,14 +36,36 @@ _PYTHON_EXTS: frozenset[str] = frozenset({".py", ".pyi"})
 # Pattern templates for non-Python languages. {name} is replaced with
 # re.escape(func_name) at call time.
 _LANG_PATTERN_TEMPLATES: dict[str, str] = {
-    ".ts": r"\bfunction\s+{name}\b",
-    ".tsx": r"\bfunction\s+{name}\b",
-    ".js": r"\bfunction\s+{name}\b",
-    ".jsx": r"\bfunction\s+{name}\b",
-    ".cs": r"\b{name}\s*\(",
-    ".ps1": r"\bfunction\s+{name}\b",
-    ".psm1": r"\bfunction\s+{name}\b",
+    ".ts": r"^[ \t]*(?:(?:export|default|async)\s+)*function(?:\s*\*)?\s+{name}\b",
+    ".tsx": r"^[ \t]*(?:(?:export|default|async)\s+)*function(?:\s*\*)?\s+{name}\b",
+    ".js": r"^[ \t]*(?:(?:export|default|async)\s+)*function(?:\s*\*)?\s+{name}\b",
+    ".jsx": r"^[ \t]*(?:(?:export|default|async)\s+)*function(?:\s*\*)?\s+{name}\b",
+    ".cs": (
+        r"^[ \t]*(?!return\b|await\b|throw\b|yield\b|new\b)"
+        r"(?:(?:public|private|protected|internal|static|virtual|override|"
+        r"abstract|async|sealed|extern|new|partial|unsafe|readonly)\s+)*"
+        r"(?:[\w<>\[\],.?]+\s+)+{name}\s*\("
+    ),
+    ".ps1": r"^[ \t]*(?:function|filter|workflow)\s+(?:(?:global|script|local|private):)?{name}\b",
+    ".psm1": r"^[ \t]*(?:function|filter|workflow)\s+(?:(?:global|script|local|private):)?{name}\b",
 }
+
+_C_STYLE_EXTS: frozenset[str] = frozenset({".ts", ".tsx", ".js", ".jsx", ".cs"})
+_POWERSHELL_EXTS: frozenset[str] = frozenset({".ps1", ".psm1"})
+_C_STYLE_NON_CODE_PATTERN = re.compile(
+    r'//[^\n]*|/\*.*?(?:\*/|\Z)|@"(?:""|[^"])*(?:"|\Z)|'
+    r'"(?:\\.|[^"\\])*(?:"|\Z)|'
+    r"'(?:\\.|[^'\\])*(?:'|\Z)|"
+    r"`(?:\\.|[^`\\])*(?:`|\Z)",
+    re.DOTALL,
+)
+_POWERSHELL_NON_CODE_PATTERN = re.compile(
+    r'@"[ \t]*$[\s\S]*?(?:^"@[ \t]*$|\Z)|'
+    r"@'[ \t]*$[\s\S]*?(?:^'@[ \t]*$|\Z)|"
+    r'<#.*?(?:#>|\Z)|#[^\n]*|"(?:`.|[^"`])*(?:"|\Z)|'
+    r"'(?:''|[^'])*(?:'|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
 
 
 def verify_citation(citation: Citation, repo_root: Path) -> VerificationResult:
@@ -221,10 +243,29 @@ def _search_function_in_file(
             "use file or file:line citation instead",
         )
 
-    pattern = re.compile(template.format(name=re.escape(func_name)))
-    if pattern.search(content):
+    searchable_content = _mask_non_code(content, ext)
+    flags = re.MULTILINE | (re.IGNORECASE if ext in _POWERSHELL_EXTS else 0)
+    pattern = re.compile(template.format(name=re.escape(func_name)), flags)
+    if pattern.search(searchable_content):
         return VerificationResult.create(citation, True, f"Function '{func_name}' found")
     return VerificationResult.create(citation, False, f"Function '{func_name}' not found in file")
+
+
+def _mask_non_code(content: str, extension: str) -> str:
+    """Replace comments and strings with whitespace while preserving line breaks."""
+    if extension in _C_STYLE_EXTS:
+        pattern = _C_STYLE_NON_CODE_PATTERN
+    elif extension in _POWERSHELL_EXTS:
+        pattern = _POWERSHELL_NON_CODE_PATTERN
+    else:
+        return content
+
+    return pattern.sub(lambda match: _mask_text(match.group()), content)
+
+
+def _mask_text(text: str) -> str:
+    """Preserve line positions while removing non-code content."""
+    return "".join("\n" if char == "\n" else " " for char in text)
 
 
 def _search_python_function(citation: Citation, func_name: str, content: str) -> VerificationResult:

--- a/tests/test_memory_verification.py
+++ b/tests/test_memory_verification.py
@@ -81,14 +81,11 @@ class TestVerifyFileCitation:
         assert result.is_valid is False
         assert "traversal" in result.reason.lower()
 
-
     @pytest.mark.unit
     def test_verify_file_line_oserror(self, tmp_path, monkeypatch):
         target = tmp_path / "unreadable.py"
         target.write_text("line1\nline2\n")
-        c = Citation(
-            source_type=SourceType.FILE, target="unreadable.py:1", context=""
-        )
+        c = Citation(source_type=SourceType.FILE, target="unreadable.py:1", context="")
 
         def _raise_oserror(*_a, **_kw):
             raise OSError("permission denied")
@@ -126,9 +123,7 @@ class TestVerifyFunctionCitation:
 
     @pytest.mark.unit
     def test_invalid_function_format(self, tmp_path):
-        c = Citation(
-            source_type=SourceType.FUNCTION, target="no_separator", context=""
-        )
+        c = Citation(source_type=SourceType.FUNCTION, target="no_separator", context="")
         result = verify_citation(c, tmp_path)
         assert result.is_valid is False
 
@@ -141,7 +136,6 @@ class TestVerifyFunctionCitation:
         )
         result = verify_citation(c, tmp_path)
         assert result.is_valid is False
-
 
     @pytest.mark.unit
     def test_search_function_oserror(self, tmp_path, monkeypatch):
@@ -166,9 +160,7 @@ class TestVerifyIssuePrCitation:
     """Issue and PR citation format validation."""
 
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "source_type", [SourceType.ISSUE, SourceType.PR]
-    )
+    @pytest.mark.parametrize("source_type", [SourceType.ISSUE, SourceType.PR])
     def test_valid_format_hash_prefix(self, tmp_path, source_type):
         c = Citation(source_type=source_type, target="#123", context="")
         result = verify_citation(c, tmp_path)
@@ -195,9 +187,7 @@ class TestVerifyMemoryCitation:
         mem_dir = tmp_path / ".serena" / "memories"
         mem_dir.mkdir(parents=True)
         (mem_dir / "target-memory.md").write_text("# Target\n")
-        c = Citation(
-            source_type=SourceType.MEMORY, target="target-memory", context=""
-        )
+        c = Citation(source_type=SourceType.MEMORY, target="target-memory", context="")
         result = verify_citation(c, tmp_path)
         assert result.is_valid is True
 
@@ -205,9 +195,7 @@ class TestVerifyMemoryCitation:
     def test_missing_memory(self, tmp_path):
         mem_dir = tmp_path / ".serena" / "memories"
         mem_dir.mkdir(parents=True)
-        c = Citation(
-            source_type=SourceType.MEMORY, target="nonexistent", context=""
-        )
+        c = Citation(source_type=SourceType.MEMORY, target="nonexistent", context="")
         result = verify_citation(c, tmp_path)
         assert result.is_valid is False
 
@@ -345,3 +333,5 @@ class TestFindStaleCitations:
         ]
         stale = find_stale_citations(memories, tmp_path)
         assert len(stale) == 0
+
+

--- a/tests/test_memory_verification_function.py
+++ b/tests/test_memory_verification_function.py
@@ -163,6 +163,51 @@ class TestVerifyFunctionCitationMultiLanguage:
         assert result.is_valid is False
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "// function ghost(): void {}\n",
+            "/*\nfunction ghost(): void {}\n*/\n",
+            'const example = "function ghost(): void {}";\n',
+        ],
+    )
+    def test_typescript_non_code_function_not_found(self, tmp_path, content):
+        """TypeScript comments and strings must not satisfy a citation."""
+        (tmp_path / "app.ts").write_text(content)
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::ghost",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_unterminated_typescript_string_does_not_hang(self, tmp_path):
+        """An unterminated TypeScript string masks its remaining content in linear time."""
+        escaped_quotes = '\\"' * 100
+        (tmp_path / "app.ts").write_text(
+            f'const doc = "{escaped_quotes}\nfunction ghost(): void {{}}\n'
+        )
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::ghost",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_unterminated_typescript_block_comment_does_not_hang(self, tmp_path):
+        """An unterminated block comment masks its remaining content in linear time."""
+        comment_openers = "/*\n" * 100
+        (tmp_path / "app.ts").write_text(f"{comment_openers}function ghost(): void {{}}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::ghost",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
     def test_javascript_function_found(self, tmp_path):
         """JavaScript: 'function processEvent()' is found."""
         (tmp_path / "handler.js").write_text("function processEvent(e) { return e; }\n")
@@ -223,6 +268,27 @@ class TestVerifyFunctionCitationMultiLanguage:
         assert result.is_valid is False
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "DoThing();\n",
+            "return DoThing();\n",
+            "// public void DoThing() {}\n",
+            "/*\npublic void DoThing() {}\n*/\n",
+            'var example = "public void DoThing() {}";\n',
+        ],
+    )
+    def test_csharp_call_or_non_code_method_not_found(self, tmp_path, content):
+        """C# calls, comments, and strings must not satisfy a citation."""
+        (tmp_path / "Service.cs").write_text(content)
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="Service.cs::DoThing",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
     def test_powershell_function_found(self, tmp_path):
         """PowerShell: 'function Invoke-Deploy' is found."""
         (tmp_path / "deploy.ps1").write_text("function Invoke-Deploy { param([string]$Env) }\n")
@@ -245,6 +311,80 @@ class TestVerifyFunctionCitationMultiLanguage:
         )
         result = verify_citation(c, tmp_path)
         assert result.is_valid is False
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "# function Invoke-Deploy { }\n",
+            "<#\nfunction Invoke-Deploy { }\n#>\n",
+            '$example = "function Invoke-Deploy { }"\n',
+            '@"\nfunction Invoke-Deploy { }\n"@\n',
+            "@'\nfunction Invoke-Deploy { }\n'@\n",
+            '$doc = @"\nThe "deploy" command\nfunction Invoke-Deploy { }\n"@\n',
+            "$doc = @'\nfunction Invoke-Deploy { }\n'@\n",
+        ],
+    )
+    def test_powershell_non_code_function_not_found(self, tmp_path, content):
+        """PowerShell comments and strings must not satisfy a citation."""
+        (tmp_path / "deploy.ps1").write_text(content)
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_unterminated_powershell_here_string_does_not_hang(self, tmp_path):
+        """An unterminated here-string masks its remaining content in linear time."""
+        decoys = "\n".join(
+            f"function Decoy-{index} {{ Write-Output fake }}" for index in range(100)
+        )
+        (tmp_path / "deploy.ps1").write_text(f'$doc = @"\n{decoys}\nfunction Invoke-Deploy {{ }}\n')
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_unterminated_powershell_string_does_not_hang(self, tmp_path):
+        """An unterminated PowerShell string masks its remaining content in linear time."""
+        escaped_quotes = '`"' * 100
+        (tmp_path / "deploy.ps1").write_text(
+            f'$doc = "{escaped_quotes}\nfunction Invoke-Deploy {{ }}\n'
+        )
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_unterminated_powershell_block_comment_does_not_hang(self, tmp_path):
+        """An unterminated block comment masks its remaining content in linear time."""
+        comment_openers = "<#\n" * 100
+        (tmp_path / "deploy.ps1").write_text(f"{comment_openers}function Invoke-Deploy {{ }}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is False
+
+    @pytest.mark.unit
+    def test_powershell_function_match_is_case_insensitive(self, tmp_path):
+        """PowerShell names use case-insensitive matching."""
+        (tmp_path / "deploy.ps1").write_text("function Invoke-Deploy { }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::invoke-deploy",
+            context="",
+        )
+        assert verify_citation(c, tmp_path).is_valid is True
 
     @pytest.mark.unit
     def test_unsupported_extension_returns_unsupported(self, tmp_path):

--- a/tests/test_memory_verification_function.py
+++ b/tests/test_memory_verification_function.py
@@ -1,0 +1,308 @@
+"""Function citation verification: comment safety, multi-language, and hyphen support.
+
+These tests cover the three failure modes fixed in issue #4012:
+- Python false positive when 'def' appears only in a comment or string
+- Non-Python languages failing because the verifier only matched 'def'
+- Hyphenated PowerShell names rejected by _FUNCTION_PATTERN
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_enhancement.models import Citation, SourceType
+from memory_enhancement.verification import _FUNCTION_PATTERN, verify_citation
+
+
+class TestVerifyFunctionCitationCommentSafety:
+    """Python function citations must not pass when def appears only in a comment or string."""
+
+    @pytest.mark.unit
+    def test_def_in_comment_not_found(self, tmp_path):
+        """False positive: a def inside a comment must not satisfy the check."""
+        (tmp_path / "module.py").write_text("# def ghost_func(): pass\nx = 1\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::ghost_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_def_in_string_literal_not_found(self, tmp_path):
+        """False positive: a def inside a string literal must not satisfy the check."""
+        (tmp_path / "module.py").write_text('x = "def ghost_func(): pass"\n')
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::ghost_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_async_def_in_comment_not_found(self, tmp_path):
+        """False positive: async def inside a comment must not satisfy the check."""
+        (tmp_path / "module.py").write_text("# async def ghost_async(): pass\nx = 1\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::ghost_async",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_real_def_still_found(self, tmp_path):
+        """Regression: a real def must still be found after the AST switch."""
+        (tmp_path / "module.py").write_text("# def not_this(): pass\ndef real_func():\n    pass\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::real_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_async_def_found(self, tmp_path):
+        """Async function definitions are found via AsyncFunctionDef AST node."""
+        (tmp_path / "module.py").write_text("async def async_func():\n    pass\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::async_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_syntax_error_fallback_found(self, tmp_path):
+        """Malformed Python falls back to regex; real def is still found."""
+        (tmp_path / "module.py").write_text("def fallback_func():\n    pass\n!!SYNTAX ERROR\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::fallback_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+        assert "fallback" in result.reason.lower()
+
+    @pytest.mark.unit
+    def test_syntax_error_fallback_not_found(self, tmp_path):
+        """Malformed Python falls back to regex; missing func is not found."""
+        (tmp_path / "module.py").write_text("def other_func():\n    pass\n!!SYNTAX ERROR\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.py::missing_func",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+        assert "fallback" in result.reason.lower()
+
+    @pytest.mark.unit
+    def test_pyi_stub_uses_ast(self, tmp_path):
+        """Stub files (.pyi) are handled via AST, not raw regex."""
+        (tmp_path / "stub.pyi").write_text(
+            "# def fake_func() -> None: ...\ndef real_stub() -> None: ...\n"
+        )
+        c_fake = Citation(
+            source_type=SourceType.FUNCTION,
+            target="stub.pyi::fake_func",
+            context="",
+        )
+        c_real = Citation(
+            source_type=SourceType.FUNCTION,
+            target="stub.pyi::real_stub",
+            context="",
+        )
+        assert verify_citation(c_fake, tmp_path).is_valid is False
+        assert verify_citation(c_real, tmp_path).is_valid is True
+
+
+class TestVerifyFunctionCitationMultiLanguage:
+    """Function citations for TypeScript, JavaScript, C#, and PowerShell."""
+
+    @pytest.mark.unit
+    def test_typescript_function_keyword(self, tmp_path):
+        """TypeScript: 'function handleAuth()' is found."""
+        (tmp_path / "app.ts").write_text("function handleAuth(): void {}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::handleAuth",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_typescript_export_function(self, tmp_path):
+        """TypeScript: 'export function foo()' is found."""
+        (tmp_path / "app.ts").write_text("export function foo(): string { return ''; }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::foo",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_typescript_missing_function(self, tmp_path):
+        """TypeScript: a function not defined in the file is not found."""
+        (tmp_path / "app.ts").write_text("function otherFunc(): void {}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.ts::missingFunc",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_javascript_function_found(self, tmp_path):
+        """JavaScript: 'function processEvent()' is found."""
+        (tmp_path / "handler.js").write_text("function processEvent(e) { return e; }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="handler.js::processEvent",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_tsx_function_found(self, tmp_path):
+        """TSX: 'function MyComponent()' is found."""
+        (tmp_path / "ui.tsx").write_text("function MyComponent() { return null; }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="ui.tsx::MyComponent",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_jsx_function_found(self, tmp_path):
+        """JSX: 'export function App()' is found."""
+        (tmp_path / "app.jsx").write_text("export function App() { return null; }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="app.jsx::App",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_csharp_method_found(self, tmp_path):
+        """C#: 'public void DoThing()' is found."""
+        (tmp_path / "Service.cs").write_text("public void DoThing() {}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="Service.cs::DoThing",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_csharp_missing_method(self, tmp_path):
+        """C#: a method not declared in the file is not found."""
+        (tmp_path / "Service.cs").write_text("public void OtherMethod() {}\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="Service.cs::DoThing",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_powershell_function_found(self, tmp_path):
+        """PowerShell: 'function Invoke-Deploy' is found."""
+        (tmp_path / "deploy.ps1").write_text("function Invoke-Deploy { param([string]$Env) }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+    @pytest.mark.unit
+    def test_powershell_missing_function(self, tmp_path):
+        """PowerShell: a function not defined in the file is not found."""
+        (tmp_path / "deploy.ps1").write_text("function Other-Func { }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="deploy.ps1::Invoke-Deploy",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+
+    @pytest.mark.unit
+    def test_unsupported_extension_returns_unsupported(self, tmp_path):
+        """An unsupported extension returns is_valid=False with an 'unsupported' reason."""
+        (tmp_path / "code.rb").write_text("def my_method\nend\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="code.rb::my_method",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is False
+        assert "unsupported" in result.reason.lower()
+
+    @pytest.mark.unit
+    def test_psm1_function_found(self, tmp_path):
+        """PowerShell module (.psm1): 'function Get-Config' is found."""
+        (tmp_path / "module.psm1").write_text("function Get-Config { return @{} }\n")
+        c = Citation(
+            source_type=SourceType.FUNCTION,
+            target="module.psm1::Get-Config",
+            context="",
+        )
+        result = verify_citation(c, tmp_path)
+        assert result.is_valid is True
+
+
+class TestFunctionPatternHyphenSupport:
+    """_FUNCTION_PATTERN must accept hyphenated names (PowerShell Verb-Noun)."""
+
+    @pytest.mark.unit
+    def test_hyphenated_name_matches(self):
+        """'util.ps1::Get-Thing' parses to path=util.ps1, func=Get-Thing."""
+        m = _FUNCTION_PATTERN.match("util.ps1::Get-Thing")
+        assert m is not None
+        assert m.group("path") == "util.ps1"
+        assert m.group("func") == "Get-Thing"
+
+    @pytest.mark.unit
+    def test_plain_name_still_matches(self):
+        """Plain names (no hyphen) continue to match."""
+        m = _FUNCTION_PATTERN.match("module.py::my_func")
+        assert m is not None
+        assert m.group("func") == "my_func"
+
+    @pytest.mark.unit
+    def test_name_starting_with_hyphen_rejected(self):
+        """A name starting with a hyphen is invalid and must not match."""
+        assert _FUNCTION_PATTERN.match("file.ps1::-Thing") is None
+
+    @pytest.mark.unit
+    def test_empty_func_name_rejected(self):
+        """An empty function name after '::' is invalid and must not match."""
+        assert _FUNCTION_PATTERN.match("file.ps1::") is None
+
+    @pytest.mark.unit
+    def test_multi_hyphen_name_matches(self):
+        """Multi-segment names like 'Set-Item-Value' must match."""
+        m = _FUNCTION_PATTERN.match("util.ps1::Set-Item-Value")
+        assert m is not None
+        assert m.group("func") == "Set-Item-Value"


### PR DESCRIPTION
## Summary

Function citation verification searched raw file text for `def` / `async def`, which caused two observable failures: a Python function cited only in a comment or string passed the check (false positive), and every non-Python function was reported as stale (false negative). A third failure was structural: the `_FUNCTION_PATTERN` regex used `\w+` to capture the function name, so PowerShell Verb-Noun names like `Get-Thing` failed the pattern match before the file was even opened.

## Root cause

The raw-text regex `\b(?:async\s+)?def\s+{name}\b` matches any line that contains the pattern, including comment lines and string literals. Python `ast.parse` produces a tree that excludes comments and string content, so substituting the AST walk eliminates the false-positive class entirely.

For TypeScript, JavaScript, C#, and PowerShell, Python's `def` keyword never appears in real definitions, so those citations were always reported stale regardless of file content. Dispatching to language-specific regex patterns restores correct detection for those languages.

The `\w+` capture in `_FUNCTION_PATTERN` does not allow hyphens, so `util.ps1::Get-Thing` produced a parse failure rather than a lookup.

## Changes

- scripts/memory_enhancement/verification.py
- tests/test_memory_verification_function.py

## Verification

Empirical measurements before the fix confirmed all three bugs:

```
Comment-only test: is_valid=True   (false positive, now False)
String-only test:  is_valid=True   (false positive, now False)
TypeScript test:   is_valid=False  (false negative, now True)
PowerShell hyphen: match=None      (parse failure, now matches)
C# test:           is_valid=False  (false negative, now True)
```

After the fix:

```
uv run --frozen python -m pytest tests/test_memory_verification.py \
    tests/test_memory_verification_function.py -q
56 passed in 0.52s
```

Mutation harness: 10/10 mutants killed. All mutations to the AST dispatch, language pattern tables, and hyphen regex were caught by specific tests.

```
uv run --frozen ruff format scripts/memory_enhancement/verification.py \
    tests/test_memory_verification_function.py
uv run --frozen ruff check  scripts/memory_enhancement/verification.py \
    tests/test_memory_verification_function.py
All checks passed!
uv run --frozen mypy scripts/memory_enhancement/verification.py \
    tests/test_memory_verification_function.py
Success: no issues found in 2 source files
```

## References

Issue #4012 traced the bug to the `_search_function_in_file` function in
scripts/memory_enhancement/verification.py.

Fixes #4012
