### PR TITLE
fix(golden-principles): make model field optional per ADR-080 in GP-003

### DIFF
--- a/.agents/governance/golden-principles.md
+++ b/.agents/governance/golden-principles.md
@@ -35,9 +35,9 @@ Each commit addresses a single logical change with 5 or fewer files.
 
 ### GP-003: Skill Frontmatter Required
 
-Every SKILL.md MUST have valid YAML frontmatter with `name`, `version`, `model`, `description`, and `license`.
+Every SKILL.md MUST have valid YAML frontmatter with `name`, `version`, `description`, and `license`. The `model` field is optional per ADR-080: omitting it inherits the harness default, which is the correct default. When `model` is present it MUST be a bare rolling alias (`sonnet`, `opus`, or `haiku`) accompanied by a `model-rationale:` field. Versioned model ids (e.g. `claude-opus-4-6`) are forbidden for skills.
 
-- **Rationale**: Consistent metadata enables tooling, discovery, and validation.
+- **Rationale**: Consistent metadata enables tooling, discovery, and validation. ADR-080 removes versioned model pins from skills to eliminate format drift, version drift, and CI-break risk from model retirement.
 - **Enforcement**: `scan_principles.py` rule `skill-frontmatter`
 - **Exception**: None. All skills must comply.
 

--- a/.agents/memory/episodes/episode-2026-07-30-session-4006-fix-golden-principles-governance.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-4006-fix-golden-principles-governance.json
@@ -1,0 +1,106 @@
+{
+  "id": "episode-2026-07-30-session-4006-fix-golden-principles-governance",
+  "session": "2026-07-30-session-4006-fix-golden-principles-governance",
+  "timestamp": "2026-07-30T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix GP-003 skill-frontmatter scanner to treat model field as optional per ADR-080; close #4000 after re-measuring actual line count",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measure #4006 premise",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measure #4000 premise",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix scan_principles.py for ADR-080",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Update golden-principles.md GP-003",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Update and add tests",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Mutation harness (mut_gold.py)",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Close issue #4000",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-30T18:41:06+00:00",
+      "type": "commit",
+      "content": "Commit: 52a2e3daf",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-30-session-4006-fix-golden-principles-governance.json
+++ b/.agents/sessions/2026-07-30-session-4006-fix-golden-principles-governance.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4006,
+    "date": "2026-07-30",
+    "branch": "fix/golden-principles-governance",
+    "startingCommit": "b5ddf441e",
+    "objective": "Fix GP-003 skill-frontmatter scanner to treat model field as optional per ADR-080; close #4000 after re-measuring actual line count"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP tools are not exposed by this harness; files read directly per the documented fallback"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not available in this harness; fallback path used"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md is read-only; referenced ADR-014; session proceeds from issue text and direct file reads"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/golden-principles-governance, branched from origin/main at b5ddf441e"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/golden-principles-governance confirmed via git status"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ruff format/check passed; mypy passed; 15 tests passed; 5/5 mutants killed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP not available in this harness. ADR-080 context is captured in .agents/governance/golden-principles.md (GP-003 update) and the updated scan_principles.py docstrings."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 run on golden-principles.md; .agents excluded by .markdownlint-cli2.yaml (0 linted, 0 issues)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed scan_principles.py, test_scan_principles.py, golden-principles.md, and both plugin.json manifests"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ruff check all checks passed; mypy no issues in 2 source files; pytest 15 passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #4006 fixed; issue #4000 closed with measured evidence"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Re-measure #4006 premise",
+      "outcome": "Confirmed: REQUIRED_SKILL_FIELDS at scan_principles.py:38 includes model. ADR-080 decision point 1 says omit model is the correct default. Exact contradiction at scan_principles.py line 38 vs ADR-080."
+    },
+    {
+      "task": "Re-measure #4000 premise",
+      "outcome": "rule-audit-procedure.md is 355 lines (not 464 as stated). taste-lints shows WARNING only (355 > 301 threshold), 0 errors, 145 lines of buffer before hard ceiling (501). Issue premise no longer holds; closed with evidence."
+    },
+    {
+      "task": "Fix scan_principles.py for ADR-080",
+      "outcome": "Removed model from REQUIRED_SKILL_FIELDS. Added _ALLOWED_MODEL_ALIASES and _MODEL_FIELD_RE. Added ADR-080 validation when model is present. Fixed remediation template to omit versioned-id example."
+    },
+    {
+      "task": "Update golden-principles.md GP-003",
+      "outcome": "Rewrote GP-003 text to describe model as optional per ADR-080 with valid states."
+    },
+    {
+      "task": "Update and add tests",
+      "outcome": "Updated one existing test; added 7 new tests; 15 total passing. Isolating negative control confirms the ADR-080 check is individually load-bearing."
+    },
+    {
+      "task": "Mutation harness (mut_gold.py)",
+      "outcome": "5 mutants, all killed. One comment-only mutant replaced with behavioral mutation (nullify model_match) after first run found it survived."
+    },
+    {
+      "task": "Close issue #4000",
+      "outcome": "Closed with gh issue close 4000 --comment citing measured 355-line count and 145-line buffer."
+    }
+  ],
+  "endingCommit": "52a2e3daf",
+  "nextSteps": [
+    "Push branch and open PR referencing Fixes #4006."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5428",
+  "version": "0.6.5429",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/golden-principles/scripts/scan_principles.py
+++ b/.claude/skills/golden-principles/scripts/scan_principles.py
@@ -35,7 +35,13 @@ ALL_RULES = (
     "actions-pinned",
 )
 
-REQUIRED_SKILL_FIELDS = ("name", "version", "model", "description", "license")
+REQUIRED_SKILL_FIELDS = ("name", "version", "description", "license")
+
+# ADR-080: skills inherit the harness model by default; model: is optional.
+# When present it must be a bare rolling alias (no versioned id) with a
+# model-rationale: field. Versioned ids like claude-opus-4-6 are forbidden.
+_ALLOWED_MODEL_ALIASES: frozenset[str] = frozenset({"sonnet", "opus", "haiku"})
+_MODEL_FIELD_RE = re.compile(r"^model:\s*(.+?)\s*$", re.MULTILINE)
 
 AGENT_REQUIRED_SECTIONS = ("description", "model")
 
@@ -53,6 +59,7 @@ SHA_PIN_PATTERN = re.compile(r"uses:\s+[\w-]+/[\w.-]+@([a-f0-9]{40})")
 TAG_PIN_PATTERN = re.compile(r"uses:\s+([\w-]+/[\w.-]+)@(v[\d.]+|[\w.-]+)")
 FIRST_PARTY_ACTIONS = {"actions/checkout", "actions/setup-python", "actions/setup-node"}
 
+
 @dataclass
 class Violation:
     """A detected principle violation with remediation."""
@@ -64,6 +71,7 @@ class Violation:
     line: int
     message: str
     remediation: str
+
 
 @dataclass
 class ScanResult:
@@ -81,12 +89,14 @@ class ScanResult:
     def warning_count(self) -> int:
         return sum(1 for v in self.violations if v.severity == "warning")
 
+
 def is_safe_path(filepath: str) -> bool:
     """Check if a path is safe from path traversal attacks (CWE-22)."""
     if os.path.isabs(filepath):
         return True
     parts = Path(filepath).parts
     return ".." not in parts
+
 
 def _path_parts(filepath: str) -> tuple[str, ...]:
     """Return path components with Windows separators normalized."""
@@ -97,11 +107,13 @@ def _marker_parts(marker: str) -> tuple[str, ...]:
     """Return path marker components without adding duplicate path literals."""
     return tuple(marker.strip("/").split("/"))
 
+
 def _has_path_parts(filepath: str, marker: tuple[str, ...]) -> bool:
     """Return True when marker appears as contiguous path components."""
     parts = _path_parts(filepath)
     width = len(marker)
-    return any(parts[index:index + width] == marker for index in range(len(parts) - width + 1))
+    return any(parts[index : index + width] == marker for index in range(len(parts) - width + 1))
+
 
 def read_file_lines(filepath: str) -> list[str]:
     """Read file lines, returning empty list on error."""
@@ -111,6 +123,7 @@ def read_file_lines(filepath: str) -> list[str]:
     except OSError:
         return []
 
+
 def has_suppression(lines: list[str], rule: str) -> bool:
     """Check if file has a suppression comment for the given rule."""
     for line in lines[:10]:
@@ -119,13 +132,13 @@ def has_suppression(lines: list[str], rule: str) -> bool:
             return True
     return False
 
+
 def get_repo_files(directory: str) -> list[str]:
     """Recursively collect files, skipping hidden dirs except .claude, .agents, .github."""
     files = []
     for root, dirs, filenames in os.walk(directory):
         dirs[:] = [
-            d for d in dirs
-            if not d.startswith(".") or d in (".claude", ".agents", ".github")
+            d for d in dirs if not d.startswith(".") or d in (".claude", ".agents", ".github")
         ]
         for filename in filenames:
             filepath = os.path.join(root, filename)
@@ -133,9 +146,11 @@ def get_repo_files(directory: str) -> list[str]:
                 files.append(filepath)
     return sorted(files)
 
+
 # Bound git subprocess calls so a hung or wedged git process cannot stall the
 # diff-scope pre-flight indefinitely.
 _GIT_TIMEOUT_SECONDS = 30
+
 
 def _git_root() -> str:
     """Return the absolute path of the git working tree root.
@@ -160,9 +175,7 @@ def _git_root() -> str:
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError("git rev-parse --show-toplevel timed out") from exc
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"git rev-parse --show-toplevel failed (exit {exc.returncode})"
-        ) from exc
+        raise RuntimeError(f"git rev-parse --show-toplevel failed (exit {exc.returncode})") from exc
     return result.stdout.strip()
 
 
@@ -198,11 +211,10 @@ def get_diff_files(base: str) -> list[str]:
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"git diff timed out for base {base!r}") from exc
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"git diff failed for base {base!r} (exit {exc.returncode})"
-        ) from exc
+        raise RuntimeError(f"git diff failed for base {base!r} (exit {exc.returncode})") from exc
     files = [f for f in result.stdout.splitlines() if f]
     return sorted(os.path.join(root, f) for f in files if is_safe_path(f))
+
 
 def check_script_language(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-001: No new .sh or .bash files."""
@@ -211,25 +223,34 @@ def check_script_language(filepath: str, lines: list[str]) -> list[Violation]:
         return []
     if has_suppression(lines, "script-language"):
         return []
-    return [Violation(
-        rule="script-language",
-        principle="GP-001",
-        severity="error",
-        file=filepath,
-        line=0,
-        message=f"Shell script detected: {Path(filepath).name}",
-        remediation=(
-            "AGENT_REMEDIATION: Convert this shell script to Python per ADR-042.\n"
-            "  1. Create a new Python file with the same base name\n"
-            "  2. Use subprocess.run() for shell commands that have no Python equivalent\n"
-            "  3. Use pathlib.Path for file operations\n"
-            "  4. Add argparse for CLI arguments\n"
-            "  5. Delete the original shell script"
-        ),
-    )]
+    return [
+        Violation(
+            rule="script-language",
+            principle="GP-001",
+            severity="error",
+            file=filepath,
+            line=0,
+            message=f"Shell script detected: {Path(filepath).name}",
+            remediation=(
+                "AGENT_REMEDIATION: Convert this shell script to Python per ADR-042.\n"
+                "  1. Create a new Python file with the same base name\n"
+                "  2. Use subprocess.run() for shell commands that have no Python equivalent\n"
+                "  3. Use pathlib.Path for file operations\n"
+                "  4. Add argparse for CLI arguments\n"
+                "  5. Delete the original shell script"
+            ),
+        )
+    ]
+
 
 def check_skill_frontmatter(filepath: str, lines: list[str]) -> list[Violation]:
-    """GP-003: SKILL.md must have required frontmatter fields."""
+    """GP-003: SKILL.md must have required frontmatter fields (ADR-080 aware).
+
+    model: is optional. Omitting it inherits the harness default, which is the
+    correct default per ADR-080. When present, it must be a bare rolling alias
+    (sonnet / opus / haiku) accompanied by a model-rationale: field. Versioned
+    ids (e.g. claude-opus-4-6) are forbidden for skills.
+    """
     if not filepath.endswith("SKILL.md") or not _has_path_parts(
         filepath, _marker_parts(_SKILLS_PATH_MARKER)
     ):
@@ -239,55 +260,110 @@ def check_skill_frontmatter(filepath: str, lines: list[str]) -> list[Violation]:
 
     content = "".join(lines)
     if not content.startswith("---"):
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="SKILL.md missing YAML frontmatter",
-            remediation=(
-                "AGENT_REMEDIATION: Add YAML frontmatter block at line 1.\n"
-                "  ---\n"
-                "  name: skill-name\n"
-                "  version: 1.0.0\n"
-                "  model: claude-sonnet-4-6\n"
-                "  description: What it does and when to use it\n"
-                "  license: MIT\n"
-                "  ---"
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="SKILL.md missing YAML frontmatter",
+                remediation=(
+                    "AGENT_REMEDIATION: Add YAML frontmatter block at line 1.\n"
+                    "  ---\n"
+                    "  name: skill-name\n"
+                    "  version: 1.0.0\n"
+                    "  description: What it does and when to use it\n"
+                    "  license: MIT\n"
+                    "  ---"
+                ),
+            )
+        ]
 
     parts = content.split("---", 2)
     if len(parts) < 3:
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="SKILL.md has unclosed frontmatter block",
-            remediation=(
-                "AGENT_REMEDIATION: Close the frontmatter block with --- on its own line."
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="SKILL.md has unclosed frontmatter block",
+                remediation=(
+                    "AGENT_REMEDIATION: Close the frontmatter block with --- on its own line."
+                ),
+            )
+        ]
 
     frontmatter = parts[1]
     missing = [f for f in REQUIRED_SKILL_FIELDS if f"{f}:" not in frontmatter]
     if missing:
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message=f"SKILL.md missing required fields: {', '.join(missing)}",
-            remediation=(
-                "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
-                + "\n".join(f"  {f}: <value>" for f in missing)
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message=f"SKILL.md missing required fields: {', '.join(missing)}",
+                remediation=(
+                    "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
+                    + "\n".join(f"  {f}: <value>" for f in missing)
+                ),
+            )
+        ]
+
+    # ADR-080: validate model field when present.
+    model_match = _MODEL_FIELD_RE.search(frontmatter)
+    if model_match:
+        model_value = model_match.group(1).strip()
+        if model_value not in _ALLOWED_MODEL_ALIASES:
+            return [
+                Violation(
+                    rule="skill-frontmatter",
+                    principle="GP-003",
+                    severity="error",
+                    file=filepath,
+                    line=1,
+                    message=(
+                        f"SKILL.md model field violates ADR-080: '{model_value}' is a versioned"
+                        " id; use a rolling alias (sonnet / opus / haiku) or omit the field"
+                    ),
+                    remediation=(
+                        "AGENT_REMEDIATION: Per ADR-080, skills must not carry a versioned"
+                        " model id.\n"
+                        "  Remove the model: field to inherit the harness default, or use a"
+                        " rolling alias with a cost rationale:\n"
+                        "    model: haiku\n"
+                        "    model-rationale: Cost-sensitive; haiku suffices for this task."
+                    ),
+                )
+            ]
+        if "model-rationale:" not in frontmatter:
+            return [
+                Violation(
+                    rule="skill-frontmatter",
+                    principle="GP-003",
+                    severity="error",
+                    file=filepath,
+                    line=1,
+                    message=(
+                        f"SKILL.md model field violates ADR-080: alias '{model_value}'"
+                        " requires a model-rationale: field"
+                    ),
+                    remediation=(
+                        "AGENT_REMEDIATION: Per ADR-080, a rolling alias requires a cost"
+                        " rationale.\n"
+                        "  Add model-rationale: explaining why this skill uses a cheaper"
+                        " model:\n"
+                        "    model-rationale: Cost-sensitive; haiku suffices for this task."
+                    ),
+                )
+            ]
+
     return []
+
 
 def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-004: Agent definitions must have required frontmatter."""
@@ -302,22 +378,24 @@ def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
 
     content = "".join(lines)
     if not content.startswith("---"):
-        return [Violation(
-            rule="agent-definition",
-            principle="GP-004",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="Agent definition missing YAML frontmatter",
-            remediation=(
-                "AGENT_REMEDIATION: Add YAML frontmatter with required fields.\n"
-                "  ---\n"
-                "  name: agent-name\n"
-                "  description: What the agent does\n"
-                "  model: sonnet\n"
-                "  ---"
-            ),
-        )]
+        return [
+            Violation(
+                rule="agent-definition",
+                principle="GP-004",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="Agent definition missing YAML frontmatter",
+                remediation=(
+                    "AGENT_REMEDIATION: Add YAML frontmatter with required fields.\n"
+                    "  ---\n"
+                    "  name: agent-name\n"
+                    "  description: What the agent does\n"
+                    "  model: sonnet\n"
+                    "  ---"
+                ),
+            )
+        ]
 
     parts = content.split("---", 2)
     if len(parts) < 3:
@@ -326,19 +404,22 @@ def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
     frontmatter = parts[1]
     missing = [f for f in AGENT_REQUIRED_SECTIONS if f"{f}:" not in frontmatter]
     if missing:
-        return [Violation(
-            rule="agent-definition",
-            principle="GP-004",
-            severity="warning",
-            file=filepath,
-            line=1,
-            message=f"Agent definition missing fields: {', '.join(missing)}",
-            remediation=(
-                "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
-                + "\n".join(f"  {f}: <value>" for f in missing)
-            ),
-        )]
+        return [
+            Violation(
+                rule="agent-definition",
+                principle="GP-004",
+                severity="warning",
+                file=filepath,
+                line=1,
+                message=f"Agent definition missing fields: {', '.join(missing)}",
+                remediation=(
+                    "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
+                    + "\n".join(f"  {f}: <value>" for f in missing)
+                ),
+            )
+        ]
     return []
+
 
 def _find_long_run_blocks(lines: list[str]) -> list[tuple[int, int]]:
     """Find multiline run blocks exceeding 5 lines. Returns (start_line, count) pairs."""
@@ -364,6 +445,7 @@ def _find_long_run_blocks(lines: list[str]) -> list[tuple[int, int]]:
         blocks.append((start, count))
     return blocks
 
+
 def check_yaml_logic(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-005: No inline logic in workflow YAML."""
     if not _has_path_parts(filepath, _marker_parts(_WORKFLOWS_PATH_MARKER)):
@@ -376,6 +458,7 @@ def check_yaml_logic(filepath: str, lines: list[str]) -> list[Violation]:
         _yaml_logic_violation(filepath, start, count)
         for start, count in _find_long_run_blocks(lines)
     ]
+
 
 def _yaml_logic_violation(filepath: str, line: int, count: int) -> Violation:
     return Violation(
@@ -392,6 +475,7 @@ def _yaml_logic_violation(filepath: str, line: int, count: int) -> Violation:
             "  3. Add argparse for any inputs from workflow context"
         ),
     )
+
 
 def check_actions_pinned(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-006: GitHub Actions must be pinned to SHA."""
@@ -418,23 +502,26 @@ def check_actions_pinned(filepath: str, lines: list[str]) -> list[Violation]:
         if action_name in FIRST_PARTY_ACTIONS:
             continue
 
-        violations.append(Violation(
-            rule="actions-pinned",
-            principle="GP-006",
-            severity="error",
-            file=filepath,
-            line=i,
-            message=f"Action '{action_name}' pinned to tag '{tag}' instead of SHA",
-            remediation=(
-                f"AGENT_REMEDIATION: Pin '{action_name}' to a full SHA.\n"
-                f"  1. Find the commit SHA for tag '{tag}' on the action repo\n"
-                f"  2. Replace: uses: {action_name}@{tag}\n"
-                f"     With:    uses: {action_name}@<full-sha> # {tag}\n"
-                f"  3. Add a comment with the tag for readability"
-            ),
-        ))
+        violations.append(
+            Violation(
+                rule="actions-pinned",
+                principle="GP-006",
+                severity="error",
+                file=filepath,
+                line=i,
+                message=f"Action '{action_name}' pinned to tag '{tag}' instead of SHA",
+                remediation=(
+                    f"AGENT_REMEDIATION: Pin '{action_name}' to a full SHA.\n"
+                    f"  1. Find the commit SHA for tag '{tag}' on the action repo\n"
+                    f"  2. Replace: uses: {action_name}@{tag}\n"
+                    f"     With:    uses: {action_name}@<full-sha> # {tag}\n"
+                    f"  3. Add a comment with the tag for readability"
+                ),
+            )
+        )
 
     return violations
+
 
 RULE_CHECKERS = {
     "script-language": check_script_language,
@@ -443,6 +530,7 @@ RULE_CHECKERS = {
     "yaml-logic": check_yaml_logic,
     "actions-pinned": check_actions_pinned,
 }
+
 
 def _is_applicable(filepath: str) -> bool:
     """Return True when a file falls in any golden-principle rule's file-type domain.
@@ -463,9 +551,7 @@ def _is_applicable(filepath: str) -> bool:
 
     if suffix in (".sh", ".bash"):
         return True
-    if name == "SKILL.md" and _has_path_parts(
-        filepath, _marker_parts(_SKILLS_PATH_MARKER)
-    ):
+    if name == "SKILL.md" and _has_path_parts(filepath, _marker_parts(_SKILLS_PATH_MARKER)):
         return True
     if (
         suffix == ".md"
@@ -478,6 +564,7 @@ def _is_applicable(filepath: str) -> bool:
     ):
         return True
     return False
+
 
 def run_scan(files: list[str], rules: tuple[str, ...]) -> ScanResult:
     """Run golden principle scan on the given files."""
@@ -500,6 +587,7 @@ def run_scan(files: list[str], rules: tuple[str, ...]) -> ScanResult:
                 result.violations.extend(checker(filepath, lines))
 
     return result
+
 
 def format_text(result: ScanResult) -> str:
     """Format results as human/agent-readable text."""
@@ -529,6 +617,7 @@ def format_text(result: ScanResult) -> str:
     output.append(summary)
     return "\n".join(output)
 
+
 def format_json(result: ScanResult) -> str:
     """Format results as JSON."""
     data = {
@@ -551,6 +640,7 @@ def format_json(result: ScanResult) -> str:
     }
     return json.dumps(data, indent=2)
 
+
 def parse_rules(rules_str: str) -> tuple[str, ...]:
     """Parse comma-separated rule names."""
     if not rules_str:
@@ -563,6 +653,7 @@ def parse_rules(rules_str: str) -> tuple[str, ...]:
         sys.exit(EXIT_ERROR)
     return rules
 
+
 def _find_repo_root() -> str | None:
     """Walk up from cwd to find .git directory."""
     current = Path.cwd()
@@ -571,15 +662,19 @@ def _find_repo_root() -> str | None:
             return str(parent)
     return None
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Golden principles scanner with agent-readable remediation",
     )
     parser.add_argument(
-        "files", nargs="*", help="Files to scan",
+        "files",
+        nargs="*",
+        help="Files to scan",
     )
     parser.add_argument(
-        "--directory", "-d",
+        "--directory",
+        "-d",
         help="Scan all files in directory (default: repo root)",
     )
     parser.add_argument(
@@ -588,7 +683,9 @@ def main() -> int:
         help="Scan only files changed in 'git diff --name-only BASE_BRANCH...HEAD'",
     )
     parser.add_argument(
-        "--format", choices=("text", "json"), default="text",
+        "--format",
+        choices=("text", "json"),
+        default="text",
         help="Output format (default: text)",
     )
     parser.add_argument(
@@ -596,7 +693,8 @@ def main() -> int:
         help=f"Comma-separated rules to run (default: all). Options: {','.join(ALL_RULES)}",
     )
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Write output to file instead of stdout",
     )
 
@@ -640,6 +738,7 @@ def main() -> int:
     if result.error_count > 0:
         return EXIT_VIOLATIONS
     return EXIT_SUCCESS
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/.claude/skills/golden-principles/tests/test_scan_principles.py
+++ b/.claude/skills/golden-principles/tests/test_scan_principles.py
@@ -77,9 +77,7 @@ def test_is_applicable_rejects_non_toolkit_files(tmp_path: Path) -> None:
 def test_path_markers_are_component_anchored(tmp_path: Path) -> None:
     fake_skill = _write(
         tmp_path,
-        "/".join(
-            ("my" + "." + "claude", "skills", "project", "demo", "SKILL.md")
-        ),
+        "/".join(("my" + "." + "claude", "skills", "project", "demo", "SKILL.md")),
         "---\n---\n",
     )
     real_skill = _write(tmp_path, _SKILL_DEMO, "---\n---\n")
@@ -89,11 +87,11 @@ def test_path_markers_are_component_anchored(tmp_path: Path) -> None:
 
 
 def test_applicable_clean_reports_no_violations(tmp_path: Path) -> None:
+    # model: field omitted -- correct default per ADR-080
     skill = _write(
         tmp_path,
         _SKILL_DEMO,
-        "---\nname: demo\nversion: 1.0.0\nmodel: claude-sonnet-4-6\n"
-        "description: demo\nlicense: MIT\n---\nBody.\n",
+        "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n---\nBody.\n",
     )
 
     result = _mod.run_scan([skill], _mod.ALL_RULES)
@@ -145,3 +143,110 @@ def test_format_json_includes_applicable_files(tmp_path: Path) -> None:
     assert data["files_scanned"] == 1
     assert data["applicable_files"] == 0
     assert data["violations"] == []
+
+
+# ADR-080: model field optional, rolling alias + rationale required when present.
+
+
+def test_skill_model_omitted_is_valid(tmp_path: Path) -> None:
+    """No model: field is the correct default per ADR-080 (inherit harness)."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n---\n",
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_valid_alias_with_rationale_is_valid(tmp_path: Path) -> None:
+    """Rolling alias + model-rationale: passes GP-003 per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: haiku\nmodel-rationale: Cost-sensitive scan.\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_versioned_id_fails_adr080(tmp_path: Path) -> None:
+    """Versioned model id (claude-opus-4-6) is forbidden for skills per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: claude-sonnet-4-6\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    v = result.violations[0]
+    assert v.rule == "skill-frontmatter"
+    assert "ADR-080" in v.message
+    assert "versioned" in v.message
+
+
+def test_skill_model_alias_without_rationale_fails_adr080(tmp_path: Path) -> None:
+    """Rolling alias without model-rationale: is forbidden per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        ("---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\nmodel: haiku\n---\n"),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    v = result.violations[0]
+    assert v.rule == "skill-frontmatter"
+    assert "ADR-080" in v.message
+    assert "model-rationale" in v.message
+
+
+def test_skill_model_sonnet_alias_valid_with_rationale(tmp_path: Path) -> None:
+    """sonnet alias with model-rationale: is a valid ADR-080 pin."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: sonnet\nmodel-rationale: Requires higher capability.\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_unknown_value_fails_adr080(tmp_path: Path) -> None:
+    """Non-alias model value (e.g. gpt-4) fails ADR-080 versioned-id check."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        ("---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\nmodel: gpt-4\n---\n"),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    assert "ADR-080" in result.violations[0].message
+
+
+def test_adr080_check_is_isolating_load_bearing(tmp_path: Path) -> None:
+    """Negative control: removing _ALLOWED_MODEL_ALIASES from the check would
+    mean a versioned id no longer raises a violation. This test fails if that
+    validation path is removed.
+    """
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: claude-opus-4-6\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    # Must produce exactly one violation citing ADR-080; if zero violations
+    # are returned the ADR-080 check was stripped and the mutation survived.
+    assert result.violations, "ADR-080 versioned-id check must be present and triggered"
+    assert any("ADR-080" in v.message for v in result.violations)

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5428",
+  "version": "0.6.5429",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/golden-principles/scripts/scan_principles.py
+++ b/src/copilot-cli/skills/golden-principles/scripts/scan_principles.py
@@ -35,7 +35,13 @@ ALL_RULES = (
     "actions-pinned",
 )
 
-REQUIRED_SKILL_FIELDS = ("name", "version", "model", "description", "license")
+REQUIRED_SKILL_FIELDS = ("name", "version", "description", "license")
+
+# ADR-080: skills inherit the harness model by default; model: is optional.
+# When present it must be a bare rolling alias (no versioned id) with a
+# model-rationale: field. Versioned ids like claude-opus-4-6 are forbidden.
+_ALLOWED_MODEL_ALIASES: frozenset[str] = frozenset({"sonnet", "opus", "haiku"})
+_MODEL_FIELD_RE = re.compile(r"^model:\s*(.+?)\s*$", re.MULTILINE)
 
 AGENT_REQUIRED_SECTIONS = ("description", "model")
 
@@ -53,6 +59,7 @@ SHA_PIN_PATTERN = re.compile(r"uses:\s+[\w-]+/[\w.-]+@([a-f0-9]{40})")
 TAG_PIN_PATTERN = re.compile(r"uses:\s+([\w-]+/[\w.-]+)@(v[\d.]+|[\w.-]+)")
 FIRST_PARTY_ACTIONS = {"actions/checkout", "actions/setup-python", "actions/setup-node"}
 
+
 @dataclass
 class Violation:
     """A detected principle violation with remediation."""
@@ -64,6 +71,7 @@ class Violation:
     line: int
     message: str
     remediation: str
+
 
 @dataclass
 class ScanResult:
@@ -81,12 +89,14 @@ class ScanResult:
     def warning_count(self) -> int:
         return sum(1 for v in self.violations if v.severity == "warning")
 
+
 def is_safe_path(filepath: str) -> bool:
     """Check if a path is safe from path traversal attacks (CWE-22)."""
     if os.path.isabs(filepath):
         return True
     parts = Path(filepath).parts
     return ".." not in parts
+
 
 def _path_parts(filepath: str) -> tuple[str, ...]:
     """Return path components with Windows separators normalized."""
@@ -97,11 +107,13 @@ def _marker_parts(marker: str) -> tuple[str, ...]:
     """Return path marker components without adding duplicate path literals."""
     return tuple(marker.strip("/").split("/"))
 
+
 def _has_path_parts(filepath: str, marker: tuple[str, ...]) -> bool:
     """Return True when marker appears as contiguous path components."""
     parts = _path_parts(filepath)
     width = len(marker)
-    return any(parts[index:index + width] == marker for index in range(len(parts) - width + 1))
+    return any(parts[index : index + width] == marker for index in range(len(parts) - width + 1))
+
 
 def read_file_lines(filepath: str) -> list[str]:
     """Read file lines, returning empty list on error."""
@@ -111,6 +123,7 @@ def read_file_lines(filepath: str) -> list[str]:
     except OSError:
         return []
 
+
 def has_suppression(lines: list[str], rule: str) -> bool:
     """Check if file has a suppression comment for the given rule."""
     for line in lines[:10]:
@@ -119,13 +132,13 @@ def has_suppression(lines: list[str], rule: str) -> bool:
             return True
     return False
 
+
 def get_repo_files(directory: str) -> list[str]:
     """Recursively collect files, skipping hidden dirs except .claude, .agents, .github."""
     files = []
     for root, dirs, filenames in os.walk(directory):
         dirs[:] = [
-            d for d in dirs
-            if not d.startswith(".") or d in (".claude", ".agents", ".github")
+            d for d in dirs if not d.startswith(".") or d in (".claude", ".agents", ".github")
         ]
         for filename in filenames:
             filepath = os.path.join(root, filename)
@@ -133,9 +146,11 @@ def get_repo_files(directory: str) -> list[str]:
                 files.append(filepath)
     return sorted(files)
 
+
 # Bound git subprocess calls so a hung or wedged git process cannot stall the
 # diff-scope pre-flight indefinitely.
 _GIT_TIMEOUT_SECONDS = 30
+
 
 def _git_root() -> str:
     """Return the absolute path of the git working tree root.
@@ -160,9 +175,7 @@ def _git_root() -> str:
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError("git rev-parse --show-toplevel timed out") from exc
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"git rev-parse --show-toplevel failed (exit {exc.returncode})"
-        ) from exc
+        raise RuntimeError(f"git rev-parse --show-toplevel failed (exit {exc.returncode})") from exc
     return result.stdout.strip()
 
 
@@ -198,11 +211,10 @@ def get_diff_files(base: str) -> list[str]:
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"git diff timed out for base {base!r}") from exc
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"git diff failed for base {base!r} (exit {exc.returncode})"
-        ) from exc
+        raise RuntimeError(f"git diff failed for base {base!r} (exit {exc.returncode})") from exc
     files = [f for f in result.stdout.splitlines() if f]
     return sorted(os.path.join(root, f) for f in files if is_safe_path(f))
+
 
 def check_script_language(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-001: No new .sh or .bash files."""
@@ -211,25 +223,34 @@ def check_script_language(filepath: str, lines: list[str]) -> list[Violation]:
         return []
     if has_suppression(lines, "script-language"):
         return []
-    return [Violation(
-        rule="script-language",
-        principle="GP-001",
-        severity="error",
-        file=filepath,
-        line=0,
-        message=f"Shell script detected: {Path(filepath).name}",
-        remediation=(
-            "AGENT_REMEDIATION: Convert this shell script to Python per ADR-042.\n"
-            "  1. Create a new Python file with the same base name\n"
-            "  2. Use subprocess.run() for shell commands that have no Python equivalent\n"
-            "  3. Use pathlib.Path for file operations\n"
-            "  4. Add argparse for CLI arguments\n"
-            "  5. Delete the original shell script"
-        ),
-    )]
+    return [
+        Violation(
+            rule="script-language",
+            principle="GP-001",
+            severity="error",
+            file=filepath,
+            line=0,
+            message=f"Shell script detected: {Path(filepath).name}",
+            remediation=(
+                "AGENT_REMEDIATION: Convert this shell script to Python per ADR-042.\n"
+                "  1. Create a new Python file with the same base name\n"
+                "  2. Use subprocess.run() for shell commands that have no Python equivalent\n"
+                "  3. Use pathlib.Path for file operations\n"
+                "  4. Add argparse for CLI arguments\n"
+                "  5. Delete the original shell script"
+            ),
+        )
+    ]
+
 
 def check_skill_frontmatter(filepath: str, lines: list[str]) -> list[Violation]:
-    """GP-003: SKILL.md must have required frontmatter fields."""
+    """GP-003: SKILL.md must have required frontmatter fields (ADR-080 aware).
+
+    model: is optional. Omitting it inherits the harness default, which is the
+    correct default per ADR-080. When present, it must be a bare rolling alias
+    (sonnet / opus / haiku) accompanied by a model-rationale: field. Versioned
+    ids (e.g. claude-opus-4-6) are forbidden for skills.
+    """
     if not filepath.endswith("SKILL.md") or not _has_path_parts(
         filepath, _marker_parts(_SKILLS_PATH_MARKER)
     ):
@@ -239,55 +260,110 @@ def check_skill_frontmatter(filepath: str, lines: list[str]) -> list[Violation]:
 
     content = "".join(lines)
     if not content.startswith("---"):
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="SKILL.md missing YAML frontmatter",
-            remediation=(
-                "AGENT_REMEDIATION: Add YAML frontmatter block at line 1.\n"
-                "  ---\n"
-                "  name: skill-name\n"
-                "  version: 1.0.0\n"
-                "  model: claude-sonnet-4-6\n"
-                "  description: What it does and when to use it\n"
-                "  license: MIT\n"
-                "  ---"
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="SKILL.md missing YAML frontmatter",
+                remediation=(
+                    "AGENT_REMEDIATION: Add YAML frontmatter block at line 1.\n"
+                    "  ---\n"
+                    "  name: skill-name\n"
+                    "  version: 1.0.0\n"
+                    "  description: What it does and when to use it\n"
+                    "  license: MIT\n"
+                    "  ---"
+                ),
+            )
+        ]
 
     parts = content.split("---", 2)
     if len(parts) < 3:
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="SKILL.md has unclosed frontmatter block",
-            remediation=(
-                "AGENT_REMEDIATION: Close the frontmatter block with --- on its own line."
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="SKILL.md has unclosed frontmatter block",
+                remediation=(
+                    "AGENT_REMEDIATION: Close the frontmatter block with --- on its own line."
+                ),
+            )
+        ]
 
     frontmatter = parts[1]
     missing = [f for f in REQUIRED_SKILL_FIELDS if f"{f}:" not in frontmatter]
     if missing:
-        return [Violation(
-            rule="skill-frontmatter",
-            principle="GP-003",
-            severity="error",
-            file=filepath,
-            line=1,
-            message=f"SKILL.md missing required fields: {', '.join(missing)}",
-            remediation=(
-                "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
-                + "\n".join(f"  {f}: <value>" for f in missing)
-            ),
-        )]
+        return [
+            Violation(
+                rule="skill-frontmatter",
+                principle="GP-003",
+                severity="error",
+                file=filepath,
+                line=1,
+                message=f"SKILL.md missing required fields: {', '.join(missing)}",
+                remediation=(
+                    "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
+                    + "\n".join(f"  {f}: <value>" for f in missing)
+                ),
+            )
+        ]
+
+    # ADR-080: validate model field when present.
+    model_match = _MODEL_FIELD_RE.search(frontmatter)
+    if model_match:
+        model_value = model_match.group(1).strip()
+        if model_value not in _ALLOWED_MODEL_ALIASES:
+            return [
+                Violation(
+                    rule="skill-frontmatter",
+                    principle="GP-003",
+                    severity="error",
+                    file=filepath,
+                    line=1,
+                    message=(
+                        f"SKILL.md model field violates ADR-080: '{model_value}' is a versioned"
+                        " id; use a rolling alias (sonnet / opus / haiku) or omit the field"
+                    ),
+                    remediation=(
+                        "AGENT_REMEDIATION: Per ADR-080, skills must not carry a versioned"
+                        " model id.\n"
+                        "  Remove the model: field to inherit the harness default, or use a"
+                        " rolling alias with a cost rationale:\n"
+                        "    model: haiku\n"
+                        "    model-rationale: Cost-sensitive; haiku suffices for this task."
+                    ),
+                )
+            ]
+        if "model-rationale:" not in frontmatter:
+            return [
+                Violation(
+                    rule="skill-frontmatter",
+                    principle="GP-003",
+                    severity="error",
+                    file=filepath,
+                    line=1,
+                    message=(
+                        f"SKILL.md model field violates ADR-080: alias '{model_value}'"
+                        " requires a model-rationale: field"
+                    ),
+                    remediation=(
+                        "AGENT_REMEDIATION: Per ADR-080, a rolling alias requires a cost"
+                        " rationale.\n"
+                        "  Add model-rationale: explaining why this skill uses a cheaper"
+                        " model:\n"
+                        "    model-rationale: Cost-sensitive; haiku suffices for this task."
+                    ),
+                )
+            ]
+
     return []
+
 
 def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-004: Agent definitions must have required frontmatter."""
@@ -302,22 +378,24 @@ def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
 
     content = "".join(lines)
     if not content.startswith("---"):
-        return [Violation(
-            rule="agent-definition",
-            principle="GP-004",
-            severity="error",
-            file=filepath,
-            line=1,
-            message="Agent definition missing YAML frontmatter",
-            remediation=(
-                "AGENT_REMEDIATION: Add YAML frontmatter with required fields.\n"
-                "  ---\n"
-                "  name: agent-name\n"
-                "  description: What the agent does\n"
-                "  model: sonnet\n"
-                "  ---"
-            ),
-        )]
+        return [
+            Violation(
+                rule="agent-definition",
+                principle="GP-004",
+                severity="error",
+                file=filepath,
+                line=1,
+                message="Agent definition missing YAML frontmatter",
+                remediation=(
+                    "AGENT_REMEDIATION: Add YAML frontmatter with required fields.\n"
+                    "  ---\n"
+                    "  name: agent-name\n"
+                    "  description: What the agent does\n"
+                    "  model: sonnet\n"
+                    "  ---"
+                ),
+            )
+        ]
 
     parts = content.split("---", 2)
     if len(parts) < 3:
@@ -326,19 +404,22 @@ def check_agent_definition(filepath: str, lines: list[str]) -> list[Violation]:
     frontmatter = parts[1]
     missing = [f for f in AGENT_REQUIRED_SECTIONS if f"{f}:" not in frontmatter]
     if missing:
-        return [Violation(
-            rule="agent-definition",
-            principle="GP-004",
-            severity="warning",
-            file=filepath,
-            line=1,
-            message=f"Agent definition missing fields: {', '.join(missing)}",
-            remediation=(
-                "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
-                + "\n".join(f"  {f}: <value>" for f in missing)
-            ),
-        )]
+        return [
+            Violation(
+                rule="agent-definition",
+                principle="GP-004",
+                severity="warning",
+                file=filepath,
+                line=1,
+                message=f"Agent definition missing fields: {', '.join(missing)}",
+                remediation=(
+                    "AGENT_REMEDIATION: Add the missing frontmatter fields:\n"
+                    + "\n".join(f"  {f}: <value>" for f in missing)
+                ),
+            )
+        ]
     return []
+
 
 def _find_long_run_blocks(lines: list[str]) -> list[tuple[int, int]]:
     """Find multiline run blocks exceeding 5 lines. Returns (start_line, count) pairs."""
@@ -364,6 +445,7 @@ def _find_long_run_blocks(lines: list[str]) -> list[tuple[int, int]]:
         blocks.append((start, count))
     return blocks
 
+
 def check_yaml_logic(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-005: No inline logic in workflow YAML."""
     if not _has_path_parts(filepath, _marker_parts(_WORKFLOWS_PATH_MARKER)):
@@ -376,6 +458,7 @@ def check_yaml_logic(filepath: str, lines: list[str]) -> list[Violation]:
         _yaml_logic_violation(filepath, start, count)
         for start, count in _find_long_run_blocks(lines)
     ]
+
 
 def _yaml_logic_violation(filepath: str, line: int, count: int) -> Violation:
     return Violation(
@@ -392,6 +475,7 @@ def _yaml_logic_violation(filepath: str, line: int, count: int) -> Violation:
             "  3. Add argparse for any inputs from workflow context"
         ),
     )
+
 
 def check_actions_pinned(filepath: str, lines: list[str]) -> list[Violation]:
     """GP-006: GitHub Actions must be pinned to SHA."""
@@ -418,23 +502,26 @@ def check_actions_pinned(filepath: str, lines: list[str]) -> list[Violation]:
         if action_name in FIRST_PARTY_ACTIONS:
             continue
 
-        violations.append(Violation(
-            rule="actions-pinned",
-            principle="GP-006",
-            severity="error",
-            file=filepath,
-            line=i,
-            message=f"Action '{action_name}' pinned to tag '{tag}' instead of SHA",
-            remediation=(
-                f"AGENT_REMEDIATION: Pin '{action_name}' to a full SHA.\n"
-                f"  1. Find the commit SHA for tag '{tag}' on the action repo\n"
-                f"  2. Replace: uses: {action_name}@{tag}\n"
-                f"     With:    uses: {action_name}@<full-sha> # {tag}\n"
-                f"  3. Add a comment with the tag for readability"
-            ),
-        ))
+        violations.append(
+            Violation(
+                rule="actions-pinned",
+                principle="GP-006",
+                severity="error",
+                file=filepath,
+                line=i,
+                message=f"Action '{action_name}' pinned to tag '{tag}' instead of SHA",
+                remediation=(
+                    f"AGENT_REMEDIATION: Pin '{action_name}' to a full SHA.\n"
+                    f"  1. Find the commit SHA for tag '{tag}' on the action repo\n"
+                    f"  2. Replace: uses: {action_name}@{tag}\n"
+                    f"     With:    uses: {action_name}@<full-sha> # {tag}\n"
+                    f"  3. Add a comment with the tag for readability"
+                ),
+            )
+        )
 
     return violations
+
 
 RULE_CHECKERS = {
     "script-language": check_script_language,
@@ -443,6 +530,7 @@ RULE_CHECKERS = {
     "yaml-logic": check_yaml_logic,
     "actions-pinned": check_actions_pinned,
 }
+
 
 def _is_applicable(filepath: str) -> bool:
     """Return True when a file falls in any golden-principle rule's file-type domain.
@@ -463,9 +551,7 @@ def _is_applicable(filepath: str) -> bool:
 
     if suffix in (".sh", ".bash"):
         return True
-    if name == "SKILL.md" and _has_path_parts(
-        filepath, _marker_parts(_SKILLS_PATH_MARKER)
-    ):
+    if name == "SKILL.md" and _has_path_parts(filepath, _marker_parts(_SKILLS_PATH_MARKER)):
         return True
     if (
         suffix == ".md"
@@ -478,6 +564,7 @@ def _is_applicable(filepath: str) -> bool:
     ):
         return True
     return False
+
 
 def run_scan(files: list[str], rules: tuple[str, ...]) -> ScanResult:
     """Run golden principle scan on the given files."""
@@ -500,6 +587,7 @@ def run_scan(files: list[str], rules: tuple[str, ...]) -> ScanResult:
                 result.violations.extend(checker(filepath, lines))
 
     return result
+
 
 def format_text(result: ScanResult) -> str:
     """Format results as human/agent-readable text."""
@@ -529,6 +617,7 @@ def format_text(result: ScanResult) -> str:
     output.append(summary)
     return "\n".join(output)
 
+
 def format_json(result: ScanResult) -> str:
     """Format results as JSON."""
     data = {
@@ -551,6 +640,7 @@ def format_json(result: ScanResult) -> str:
     }
     return json.dumps(data, indent=2)
 
+
 def parse_rules(rules_str: str) -> tuple[str, ...]:
     """Parse comma-separated rule names."""
     if not rules_str:
@@ -563,6 +653,7 @@ def parse_rules(rules_str: str) -> tuple[str, ...]:
         sys.exit(EXIT_ERROR)
     return rules
 
+
 def _find_repo_root() -> str | None:
     """Walk up from cwd to find .git directory."""
     current = Path.cwd()
@@ -571,15 +662,19 @@ def _find_repo_root() -> str | None:
             return str(parent)
     return None
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Golden principles scanner with agent-readable remediation",
     )
     parser.add_argument(
-        "files", nargs="*", help="Files to scan",
+        "files",
+        nargs="*",
+        help="Files to scan",
     )
     parser.add_argument(
-        "--directory", "-d",
+        "--directory",
+        "-d",
         help="Scan all files in directory (default: repo root)",
     )
     parser.add_argument(
@@ -588,7 +683,9 @@ def main() -> int:
         help="Scan only files changed in 'git diff --name-only BASE_BRANCH...HEAD'",
     )
     parser.add_argument(
-        "--format", choices=("text", "json"), default="text",
+        "--format",
+        choices=("text", "json"),
+        default="text",
         help="Output format (default: text)",
     )
     parser.add_argument(
@@ -596,7 +693,8 @@ def main() -> int:
         help=f"Comma-separated rules to run (default: all). Options: {','.join(ALL_RULES)}",
     )
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Write output to file instead of stdout",
     )
 
@@ -640,6 +738,7 @@ def main() -> int:
     if result.error_count > 0:
         return EXIT_VIOLATIONS
     return EXIT_SUCCESS
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/copilot-cli/skills/golden-principles/tests/test_scan_principles.py
+++ b/src/copilot-cli/skills/golden-principles/tests/test_scan_principles.py
@@ -77,9 +77,7 @@ def test_is_applicable_rejects_non_toolkit_files(tmp_path: Path) -> None:
 def test_path_markers_are_component_anchored(tmp_path: Path) -> None:
     fake_skill = _write(
         tmp_path,
-        "/".join(
-            ("my" + "." + "claude", "skills", "project", "demo", "SKILL.md")
-        ),
+        "/".join(("my" + "." + "claude", "skills", "project", "demo", "SKILL.md")),
         "---\n---\n",
     )
     real_skill = _write(tmp_path, _SKILL_DEMO, "---\n---\n")
@@ -89,11 +87,11 @@ def test_path_markers_are_component_anchored(tmp_path: Path) -> None:
 
 
 def test_applicable_clean_reports_no_violations(tmp_path: Path) -> None:
+    # model: field omitted -- correct default per ADR-080
     skill = _write(
         tmp_path,
         _SKILL_DEMO,
-        "---\nname: demo\nversion: 1.0.0\nmodel: claude-sonnet-4-6\n"
-        "description: demo\nlicense: MIT\n---\nBody.\n",
+        "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n---\nBody.\n",
     )
 
     result = _mod.run_scan([skill], _mod.ALL_RULES)
@@ -145,3 +143,110 @@ def test_format_json_includes_applicable_files(tmp_path: Path) -> None:
     assert data["files_scanned"] == 1
     assert data["applicable_files"] == 0
     assert data["violations"] == []
+
+
+# ADR-080: model field optional, rolling alias + rationale required when present.
+
+
+def test_skill_model_omitted_is_valid(tmp_path: Path) -> None:
+    """No model: field is the correct default per ADR-080 (inherit harness)."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n---\n",
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_valid_alias_with_rationale_is_valid(tmp_path: Path) -> None:
+    """Rolling alias + model-rationale: passes GP-003 per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: haiku\nmodel-rationale: Cost-sensitive scan.\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_versioned_id_fails_adr080(tmp_path: Path) -> None:
+    """Versioned model id (claude-opus-4-6) is forbidden for skills per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: claude-sonnet-4-6\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    v = result.violations[0]
+    assert v.rule == "skill-frontmatter"
+    assert "ADR-080" in v.message
+    assert "versioned" in v.message
+
+
+def test_skill_model_alias_without_rationale_fails_adr080(tmp_path: Path) -> None:
+    """Rolling alias without model-rationale: is forbidden per ADR-080."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        ("---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\nmodel: haiku\n---\n"),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    v = result.violations[0]
+    assert v.rule == "skill-frontmatter"
+    assert "ADR-080" in v.message
+    assert "model-rationale" in v.message
+
+
+def test_skill_model_sonnet_alias_valid_with_rationale(tmp_path: Path) -> None:
+    """sonnet alias with model-rationale: is a valid ADR-080 pin."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: sonnet\nmodel-rationale: Requires higher capability.\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert not result.violations
+
+
+def test_skill_model_unknown_value_fails_adr080(tmp_path: Path) -> None:
+    """Non-alias model value (e.g. gpt-4) fails ADR-080 versioned-id check."""
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        ("---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\nmodel: gpt-4\n---\n"),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    assert len(result.violations) == 1
+    assert "ADR-080" in result.violations[0].message
+
+
+def test_adr080_check_is_isolating_load_bearing(tmp_path: Path) -> None:
+    """Negative control: removing _ALLOWED_MODEL_ALIASES from the check would
+    mean a versioned id no longer raises a violation. This test fails if that
+    validation path is removed.
+    """
+    skill = _write(
+        tmp_path,
+        _SKILL_DEMO,
+        (
+            "---\nname: demo\nversion: 1.0.0\ndescription: demo\nlicense: MIT\n"
+            "model: claude-opus-4-6\n---\n"
+        ),
+    )
+    result = _mod.run_scan([skill], ["skill-frontmatter"])
+    # Must produce exactly one violation citing ADR-080; if zero violations
+    # are returned the ADR-080 check was stripped and the mutation survived.
+    assert result.violations, "ADR-080 versioned-id check must be present and triggered"
+    assert any("ADR-080" in v.message for v in result.violations)


### PR DESCRIPTION
## Summary

GP-003 required a `model` field in every `SKILL.md`. ADR-080 treats an omitted `model` field as the correct default for skills (inherit from the harness). The scanner was forcing agents to add a versioned model id that the ADR immediately forbids.

Issue #4000 was re-measured: the file is currently 355 lines, not 464 lines as stated. PR #3994 already moved the Copilot gotchas into the shared governance file, reducing the count by over 100 lines. At 355 lines there are 145 lines of buffer before the hard ceiling. The issue is closed with measured evidence.

## Root cause

`REQUIRED_SKILL_FIELDS` in `scan_principles.py` included `model`. ADR-080 was accepted after the scanner was written and was never reconciled with it. Any valid skill that followed ADR-080 by omitting `model` would trigger a GP-003 error, and the remediation template showed a versioned id (`claude-sonnet-4-6`) that ADR-080 forbids.

## Changes

- `.claude/skills/golden-principles/scripts/scan_principles.py`: removed `model` from `REQUIRED_SKILL_FIELDS`; added `_ALLOWED_MODEL_ALIASES` and `_MODEL_FIELD_RE`; added ADR-080 validation when `model` is present (must be a rolling alias with `model-rationale`; versioned ids are errors); fixed the missing-frontmatter remediation template to omit the versioned-id example.
- `.claude/skills/golden-principles/tests/test_scan_principles.py`: updated existing test to use a skill without `model`; added 7 new tests (positive, negative, edge, isolating negative control). 15 tests total, all passing, 5/5 mutants killed.
- `.agents/governance/golden-principles.md`: rewrote GP-003 to document that `model` is optional per ADR-080 and describe the valid states.
- `.claude/.claude-plugin/plugin.json`: version bumped to 0.6.5429.
- `src/copilot-cli/.claude-plugin/plugin.json`: version bumped to 0.6.5429.
- `src/copilot-cli/skills/golden-principles/scripts/scan_principles.py`: regenerated mirror.
- `src/copilot-cli/skills/golden-principles/tests/test_scan_principles.py`: regenerated mirror.
- `.agents/sessions/2026-07-30-session-4006-fix-golden-principles-governance.json`: session log.

## Verification

```
uv run --frozen ruff format .claude/skills/golden-principles/scripts/scan_principles.py .claude/skills/golden-principles/tests/test_scan_principles.py
uv run --frozen ruff check .claude/skills/golden-principles/scripts/scan_principles.py .claude/skills/golden-principles/tests/test_scan_principles.py
# All checks passed

uv run --frozen mypy .claude/skills/golden-principles/scripts/scan_principles.py .claude/skills/golden-principles/tests/test_scan_principles.py
# Success: no issues found in 2 source files

uv run --frozen python -m pytest .claude/skills/golden-principles/tests/test_scan_principles.py -q -p no:cacheprovider
# 15 passed in 0.15s

uv run --frozen python mut_gold.py
# 5 killed, 0 survived out of 5 mutants -- PASS
```

## References

See `.agents/architecture/ADR-080-model-pin-justification-policy.md` for the model pin policy this fix aligns with.

Fixes #4006
