### PR TITLE
fix(pr-comment-responder): match the real **Status** field so the unaddressed-comment gate can fire

### DIFF
--- a/.claude/agents/pr-comment-responder.md
+++ b/.claude/agents/pr-comment-responder.md
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.claude/agents/pr-comment-responder.md
+++ b/.claude/agents/pr-comment-responder.md
@@ -359,7 +359,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -389,7 +389,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1320,15 +1320,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.claude/agents/pr-comment-responder.md
+++ b/.claude/agents/pr-comment-responder.md
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.claude/agents/pr-comment-responder.md
+++ b/.claude/agents/pr-comment-responder.md
@@ -359,7 +359,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -389,7 +389,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1328,7 +1328,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/.claude/skills/pr-comment-responder/references/gates.md
+++ b/.claude/skills/pr-comment-responder/references/gates.md
@@ -74,7 +74,7 @@ fi
 
 ```bash
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
-PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: \[NEW\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"

--- a/.claude/skills/pr-comment-responder/references/gates.md
+++ b/.claude/skills/pr-comment-responder/references/gates.md
@@ -74,7 +74,7 @@ fi
 
 ```bash
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
-PENDING=$(grep -c "Status: pending\|Status: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -89,8 +89,8 @@ echo "[PASS] All gates cleared"
 ### Phase 8.1: Comment Status Verification
 
 ```bash
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"

--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1135,7 +1135,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1127,15 +1127,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -1217,7 +1217,7 @@ echo "[PASS] All CI checks passing ($passed checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -318,7 +318,7 @@ fi
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
 
 # Artifact state
-PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: \[NEW\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1090,7 +1090,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -B5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: pending" .agents/pr-comments/PR-[number]/comments.md
+  grep -B5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[NEW\]" .agents/pr-comments/PR-[number]/comments.md
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -318,7 +318,7 @@ fi
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
 
 # Artifact state
-PENDING=$(grep -c "Status: pending\|Status: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1082,15 +1082,15 @@ gh pr edit [number] --body "[updated body]"
 
 ```bash
 # Count addressed vs total
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -B5 "Status: \[ACKNOWLEDGED\]\|Status: pending" .agents/pr-comments/PR-[number]/comments.md
+  grep -B5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: pending" .agents/pr-comments/PR-[number]/comments.md
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1217,7 +1217,7 @@ echo "[PASS] All CI checks passing ($passed checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -1217,7 +1217,7 @@ echo "[PASS] All CI checks passing ($passed checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/claude/pr-comment-responder.md
+++ b/src/claude/pr-comment-responder.md
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/claude/pr-comment-responder.md
+++ b/src/claude/pr-comment-responder.md
@@ -359,7 +359,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -389,7 +389,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1320,15 +1320,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/claude/pr-comment-responder.md
+++ b/src/claude/pr-comment-responder.md
@@ -1460,7 +1460,7 @@ echo "[PASS] All CI checks passing ($(echo "$checks" | jq '.Data.PassedCount') c
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/claude/pr-comment-responder.md
+++ b/src/claude/pr-comment-responder.md
@@ -359,7 +359,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -389,7 +389,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1328,7 +1328,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/src/copilot-cli/agents/pr-comment-responder.agent.md
+++ b/src/copilot-cli/agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/copilot-cli/agents/pr-comment-responder.agent.md
+++ b/src/copilot-cli/agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/copilot-cli/agents/pr-comment-responder.agent.md
+++ b/src/copilot-cli/agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1135,7 +1135,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/src/copilot-cli/agents/pr-comment-responder.agent.md
+++ b/src/copilot-cli/agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1127,15 +1127,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/copilot-cli/skills/pr-comment-responder/references/gates.md
+++ b/src/copilot-cli/skills/pr-comment-responder/references/gates.md
@@ -74,7 +74,7 @@ fi
 
 ```bash
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
-PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]\|^\*\*Status\*\*: \[NEW\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"

--- a/src/copilot-cli/skills/pr-comment-responder/references/gates.md
+++ b/src/copilot-cli/skills/pr-comment-responder/references/gates.md
@@ -74,7 +74,7 @@ fi
 
 ```bash
 REMAINING=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
-PENDING=$(grep -c "Status: pending\|Status: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
+PENDING=$(grep -c "^\*\*Status\*\*: pending\|^\*\*Status\*\*: \[ACKNOWLEDGED\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -89,8 +89,8 @@ echo "[PASS] All gates cleared"
 ### Phase 8.1: Comment Status Verification
 
 ```bash
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" .agents/pr-comments/PR-[number]/comments.md)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" .agents/pr-comments/PR-[number]/comments.md)
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1135,7 +1135,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -310,7 +310,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -340,7 +340,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1127,15 +1127,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1271,7 +1271,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/templates/agents/pr-comment-responder.shared.md
+++ b/templates/agents/pr-comment-responder.shared.md
@@ -317,7 +317,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -347,7 +347,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1142,7 +1142,7 @@ echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```

--- a/templates/agents/pr-comment-responder.shared.md
+++ b/templates/agents/pr-comment-responder.shared.md
@@ -1278,7 +1278,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/templates/agents/pr-comment-responder.shared.md
+++ b/templates/agents/pr-comment-responder.shared.md
@@ -1278,7 +1278,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"` equals total | [ ] |
+| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "\[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |

--- a/templates/agents/pr-comment-responder.shared.md
+++ b/templates/agents/pr-comment-responder.shared.md
@@ -317,7 +317,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true)
 
 # Count unresolved review threads separately
 UNRESOLVED_API=$(gh api graphql -f query='...' --jq '.data...unresolved.length')
@@ -347,7 +347,7 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-PENDING=$(grep -Ec "Status: pending|Status: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
+PENDING=$(grep -Ec "^\*\*Status\*\*: pending|^\*\*Status\*\*: \[ACKNOWLEDGED\]" "$COMMENT_MAP" || true)
 
 if [ "$REMAINING" -ne 0 ] || [ "$PENDING" -ne 0 ]; then
   echo "[BLOCKED] API unresolved: $REMAINING, Artifact pending: $PENDING"
@@ -1134,15 +1134,15 @@ if [ ! -f "$COMMENT_MAP" ]; then
   echo "[BLOCKED] Comment map missing: $COMMENT_MAP"
   exit 1
 fi
-ADDRESSED=$(grep -c "Status: \[COMPLETE\]" "$COMMENT_MAP" || true)
-WONTFIX=$(grep -c "Status: \[WONTFIX\]" "$COMMENT_MAP" || true)
+ADDRESSED=$(grep -c "^\*\*Status\*\*: \[COMPLETE\]" "$COMMENT_MAP" || true)
+WONTFIX=$(grep -c "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP" || true)
 TOTAL=$TOTAL_COMMENTS
 
 echo "Verification: $((ADDRESSED + WONTFIX)) / $TOTAL comments addressed"
 
 if [ "$((ADDRESSED + WONTFIX))" -lt "$TOTAL" ]; then
   echo "[WARNING] INCOMPLETE: $((TOTAL - ADDRESSED - WONTFIX)) comments remaining"
-  grep -E -B 5 "Status: \[ACKNOWLEDGED\]|Status: pending" "$COMMENT_MAP" || true
+  grep -E -B 5 "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" "$COMMENT_MAP" || true
   # Return to Phase 3 for unaddressed comments
 fi
 ```
@@ -1278,7 +1278,7 @@ echo "[PASS] All CI checks passing ($PASSED_COUNT checks)"
 
 | Criterion | Check | Status |
 |-----------|-------|--------|
-| All comments resolved | `grep -c -e "Status: \[COMPLETE\]" -e "Status: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
+| All comments resolved | `grep -c -e "^\*\*Status\*\*: \[COMPLETE\]" -e "^\*\*Status\*\*: \[WONTFIX\]" "$COMMENT_MAP"` equals total | [ ] |
 | No new comments | Re-check returned 0 new | [ ] |
 | CI checks pass | `get_pr_checks.py --pull-request [number]` MergeRefUsable = true and AllPassing = true | [ ] |
 | No unresolved threads | `gh pr view --json reviewThreads` all resolved | [ ] |


### PR DESCRIPTION
## Summary

### What

Anchors every `pr-comment-responder` verification grep to the status field the comment map actually emits. Also removes an escaped regex pipe from a table-cell command and supplies a missing file argument.

### Why

The comment map template writes the status in bold at line start. Every check searched for an unbolded, unanchored form. The two never match, so all six checks were dead.

The serious direction is fail-open. The Phase 8 gates block when the pending count is non-zero, and the pending count was always zero, so the gate whose only job is to stop work with unaddressed reviewer comments never fired.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #4034 | Verification greps match a field the template never emits |

## Verification

Reproduced against a real historical comment map before and after:

```bash
git show c0c8698e2:.agents/pr-comments/PR-225/comments.md |
  grep -c -e 'Status: \[COMPLETE\]' -e 'Status: \[WONTFIX\]'
# 0, exit 1

git show c0c8698e2:.agents/pr-comments/PR-225/comments.md |
  grep -c -e '^\*\*Status\*\*: \[COMPLETE\]' -e '^\*\*Status\*\*: \[WONTFIX\]'
# 5, exit 0
```

Fail-open direction, on a fixture holding two unaddressed comments:

```bash
grep -Ec "Status: \[ACKNOWLEDGED\]|Status: pending" f.md          # 0, gate passes
grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" f.md  # 2, gate blocks
```

Renderer check. The pattern lives in a table cell, so it had to survive GitHub's table parsing. Confirmed byte-identical after rendering with markdown-it in `gfm-like` mode, then executed the rendered string against the real map to prove it works after rendering and not only in source. Only `\|` is stripped by that renderer, because the pipe is the cell delimiter; `\*` and `\[` are preserved.

Gates run locally:

```text
build/generate_agents.py --validate   VALIDATION PASSED
validate_install_parity.py            install-parity: OK
check_plugin_manifest_parity.py       versions match 0.6.5436
pre-push python-tests                 pass (450s)
```

## Notes for Reviewers

Nine carriers change together (shared template, four hand-maintained agent copies, two skill references, two generated mirrors). A partial fix would leave the trees disagreeing. The generator validate step confirms the hand-patched mirrors match generator output.

One earlier commit on this branch, `bd3293b43`, anchored `[WONTFIX]` to a prefix that does not exist in generated maps. Its severity claim rested on a hand-written fixture using the unbolded field. On real data the direction is fail-closed, not fail-open. That commit is superseded here. The correction came from a GPT-5.6 Sol adversarial review that reproduced the mismatch and supplied the anchored pattern.

## Second Defect Found In Review

An adversarial review on GPT-5.6 Sol found the gate still fails open for a status this same template creates. Phase 8.3 instructs the agent to record newly arrived comments with status `[NEW]`, and no pending check counted it:

```bash
printf '%s\n' '**Status**: [ACKNOWLEDGED]' '**Status**: [NEW]' '**Status**: [COMPLETE]' \
  '**Status**: [WONTFIX]' '**Status**: pending' > m.md

# before: 2, so a map holding a real unaddressed comment underreports
grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending" m.md

# after: 3
grep -Ec "^\*\*Status\*\*: \[ACKNOWLEDGED\]|^\*\*Status\*\*: pending|^\*\*Status\*\*: \[NEW\]" m.md
```

Added to all 22 pending patterns. Sites invoking `grep -c` keep BRE alternation and sites invoking `grep -Ec` keep ERE alternation, because the two syntaxes assign opposite meanings to a bare and an escaped pipe. A terminal-only map still counts 0, confirming the change did not invert the gate.

The same review found the completion command in the pr-review-007 Serena memory searched for a bare `Status:` prefix the map never emits, and sat in a table cell where GFM strips the escaped pipe. It is now an anchored command in a fenced block.

### Out of Scope

Real maps also carry `[DEFERRED]` and `[DUPLICATE]` statuses that no check treats as terminal, so those comments block completion forever. Reproduced on real data and filed as #4054, which shows the two gate families enumerate different status sets and fail in opposite directions. Fixing that requires defining a status vocabulary, which is a design change rather than a pattern correction.

