### PR TITLE
test(ci): mirror the producer's citation-sum invariant in the memory health consumer

### DIFF
--- a/scripts/ci/parse_memory_health_results.py
+++ b/scripts/ci/parse_memory_health_results.py
@@ -74,6 +74,10 @@ def parse_report(payload: object) -> list[tuple[str, str]]:
     emits. A shape mismatch means the producer and this consumer have drifted
     apart, which is the failure issue #3971 was filed for, so it must not be
     absorbed into a default.
+
+    The citation-count sum is one of the invariants ``HealthReport`` enforces at
+    construction time. A report read from disk never passes through that
+    constructor, so the consumer re-checks it here rather than trusting the file.
     """
     if not isinstance(payload, dict):
         raise ValueError(f"expected a JSON object, got {type(payload).__name__}")
@@ -85,6 +89,18 @@ def parse_report(payload: object) -> list[tuple[str, str]]:
 
     counts = {field: _coerce_count(payload[field]) for field in COUNT_FIELDS}
     lengths = {field: _coerce_length(payload[field]) for field in LENGTH_FIELDS}
+
+    citation_sum = (
+        counts["valid_citations"]
+        + counts["stale_citations"]
+        + counts["broken_citations"]
+        + counts["unverified_citations"]
+    )
+    if citation_sum != counts["total_citations"]:
+        raise ValueError(
+            "citation counts must sum to total_citations: "
+            f"{citation_sum} != {counts['total_citations']}"
+        )
 
     pairs = [(field, str(counts[field])) for field in COUNT_FIELDS]
     pairs.extend((field, str(lengths[field])) for field in LENGTH_FIELDS)

--- a/tests/ci/test_parse_memory_health_invariants.py
+++ b/tests/ci/test_parse_memory_health_invariants.py
@@ -1,0 +1,122 @@
+"""Consumer-side invariant tests for the memory health result parser (#3971).
+
+Split out of ``test_parse_memory_health_results.py`` to keep both files under
+the 500-line taste-lint ceiling. The helpers are imported from that module
+rather than duplicated, matching the sibling-import convention already used by
+``test_adr006_scanner_heredoc.py`` and ``test_validation_scripts_are_reachable.py``.
+
+These classes exist because a report read from disk never passes through
+``HealthReport.__post_init__``. The producer enforces three invariants at
+construction; a consumer whose whole job is detecting drift has to re-check
+them itself or it will render broken parts as a plausible banner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.ci import parse_memory_health_results as parser
+from tests.ci.test_parse_memory_health_results import (
+    HEALTHY_REPORT,
+    _outputs,
+    _parsed,
+    _report,
+    _with,
+)
+
+
+class TestCitationSumIsChecked:
+    """The consumer mirrors the producer's citation-sum invariant.
+
+    A report read from disk never passes through ``HealthReport.__post_init__``,
+    so parts that do not add up would render as a plausible banner instead of
+    surfacing the drift this script exists to catch.
+    """
+
+    def test_matching_sum_is_accepted(self, tmp_path: Path, monkeypatch) -> None:
+        """Positive: a real report's parts add up and must still pass."""
+        out = _outputs(tmp_path, monkeypatch)
+        payload = _with(
+            total_citations=6,
+            valid_citations=3,
+            stale_citations=1,
+            broken_citations=1,
+            unverified_citations=1,
+        )
+        assert parser.main(["--results", str(_report(tmp_path, payload))]) == 0
+        assert _parsed(out)["total_citations"] == "6"
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"total_citations": 9},
+            {"valid_citations": 7},
+            {"broken_citations": 1},
+            {"stale_citations": 2, "valid_citations": 8},
+            {"unverified_citations": 4},
+        ],
+    )
+    def test_mismatched_sum_is_rejected(
+        self, tmp_path: Path, monkeypatch, capsys, overrides: dict[str, Any]
+    ) -> None:
+        """Negative: every part is load-bearing, so any one of them can break it."""
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(_report(tmp_path, _with(**overrides)))]) == 1
+        assert "sum to total_citations" in capsys.readouterr().out
+
+    def test_a_zero_citation_report_is_accepted(self, tmp_path: Path, monkeypatch) -> None:
+        """Edge: an empty corpus sums to zero and must not read as drift."""
+        _outputs(tmp_path, monkeypatch)
+        payload = _with(total_citations=0, valid_citations=0)
+        assert parser.main(["--results", str(_report(tmp_path, payload))]) == 0
+
+
+class TestProducerInvariantsAreMirrored:
+    """The consumer's guards must track the producer's, not a magic constant.
+
+    These construct the real ``HealthReport`` rather than asserting on a
+    literal. If the producer ever widens ``health_score`` past 0..1 or drops the
+    citation-sum rule, the consumer's stricter guard becomes a false failure and
+    these tests say so at that commit instead of in a red CI run months later.
+    """
+
+    @staticmethod
+    def _kwargs(**overrides: Any) -> dict[str, Any]:
+        return {**HEALTHY_REPORT, **overrides}
+
+    def test_the_producer_type_is_constructible(self) -> None:
+        """Negative control: if construction always raised, the rest is vacuous."""
+        from scripts.memory_enhancement.models import HealthReport
+
+        assert HealthReport(**self._kwargs()).health_score == 1.0
+
+    @pytest.mark.parametrize("score", [1.5, -0.1])
+    def test_the_producer_rejects_out_of_range_scores(self, score: float) -> None:
+        """Positive: proves the consumer's 0..1 bound is the producer's bound."""
+        from scripts.memory_enhancement.models import HealthReport
+
+        with pytest.raises(ValueError, match="health_score"):
+            HealthReport(**self._kwargs(health_score=score))
+
+    @pytest.mark.parametrize("score", [0.0, 1.0])
+    def test_the_producer_accepts_the_bounds(self, score: float) -> None:
+        """Edge: the producer's bound is inclusive, so the consumer's must be."""
+        from scripts.memory_enhancement.models import HealthReport
+
+        assert HealthReport(**self._kwargs(health_score=score)) is not None
+
+    def test_the_producer_rejects_a_mismatched_citation_sum(self) -> None:
+        """Positive: proves the consumer's sum check mirrors a real invariant."""
+        from scripts.memory_enhancement.models import HealthReport
+
+        with pytest.raises(ValueError, match="sum to total_citations"):
+            HealthReport(**self._kwargs(total_citations=9, valid_citations=1))
+
+    def test_the_shared_fixture_satisfies_the_producer(self) -> None:
+        """Negative control: an invalid fixture would make every test above weak."""
+        from scripts.memory_enhancement.models import HealthReport
+
+        assert HealthReport(**self._kwargs()) is not None

--- a/tests/ci/test_parse_memory_health_invariants.py
+++ b/tests/ci/test_parse_memory_health_invariants.py
@@ -88,10 +88,16 @@ class TestProducerInvariantsAreMirrored:
         return {**HEALTHY_REPORT, **overrides}
 
     def test_the_producer_type_is_constructible(self) -> None:
-        """Negative control: if construction always raised, the rest is vacuous."""
+        """Negative control: if construction always raised, the rest is vacuous.
+
+        Asserts only that a valid payload yields an instance. Asserting a
+        particular ``health_score`` here would couple the control to the
+        fixture's value, so a producer that changed the healthy score while
+        staying constructible would fail this test for the wrong reason.
+        """
         from scripts.memory_enhancement.models import HealthReport
 
-        assert HealthReport(**self._kwargs()).health_score == 1.0
+        assert isinstance(HealthReport(**self._kwargs()), HealthReport)
 
     @pytest.mark.parametrize("score", [1.5, -0.1])
     def test_the_producer_rejects_out_of_range_scores(self, score: float) -> None:

--- a/tests/ci/test_parse_memory_health_results.py
+++ b/tests/ci/test_parse_memory_health_results.py
@@ -100,10 +100,10 @@ class TestHasIssues:
         ("overrides", "expected"),
         [
             ({}, "false"),
-            ({"broken_citations": 1}, "true"),
-            ({"stale_citations": 1}, "true"),
+            ({"broken_citations": 1, "valid_citations": 7}, "true"),
+            ({"stale_citations": 1, "valid_citations": 7}, "true"),
             ({"stale_memories": ["a.md"]}, "true"),
-            ({"unverified_citations": 5}, "false"),
+            ({"unverified_citations": 5, "valid_citations": 3}, "false"),
             ({"recommendations": ["do a thing"]}, "false"),
         ],
     )


### PR DESCRIPTION
## Summary

The memory health consumer renders a report it reads from disk. The producer enforces three invariants at construction time, but a report loaded from JSON never passes through that constructor, so the consumer had no idea whether the numbers it was rendering were internally consistent.

PR #3977 repaired the same script's workflow rot and added a range guard on the score. It did not carry the citation-sum guard or the producer-coupling tests, because a concurrent push to that branch won the race and the PR merged without this delta. This ships the remainder against current main.

## What was wrong

The producer requires that valid, stale, broken, and unverified citation counts sum to the reported total. Nothing re-checked that on the reading side. A report whose parts did not add up rendered as a perfectly plausible banner, which is the exact failure mode this script exists to detect.

## What changed

The parser now re-checks the sum and exits non-zero with a named reason when it does not hold.

The tests are anchored to the live producer rather than to magic constants. They construct a real report object and assert the producer rejects an out-of-range score and a mismatched sum. If the producer ever widens those rules, the consumer's stricter guard becomes a false failure and these tests say so at that commit rather than in a red CI run months later. Three negative controls guard against the tests becoming vacuous.

Adding the check immediately exposed three existing fixtures as invalid: they set a broken-citation count without adjusting the total. Fixture breakage after adding a producer-derived check is evidence the check has teeth, so the fixtures were corrected rather than the check weakened.

## Verification

All 87 tests pass. A seven-mutant harness covers the new guard: deleting it, inverting its comparison, dropping each of the four terms from the sum, and comparing against the wrong field. Seven of seven mutants died. Each of the four sum terms has its own isolating negative control, so every term is individually load-bearing. Ruff and mypy are clean on all three files.

## Note on the file split

The new tests pushed the existing test module past the 500-line taste-lint ceiling, which raised the repo-wide taste count and failed the count ratchet. Rather than suppress the rule or raise the baseline, the two new classes moved into their own module. The shared helpers are imported from the sibling test module, matching the convention already used elsewhere in that directory. The repo-wide count is back at the baseline of 615.

## Changes

- `scripts/ci/parse_memory_health_results.py`: re-check the citation-sum invariant when parsing a report, and document why a report read from disk needs it
- `tests/ci/test_parse_memory_health_results.py`: correct three fixtures that violated the sum invariant, and move the two new classes out to stay under the file-size ceiling
- `tests/ci/test_parse_memory_health_invariants.py`: new module holding the sum-guard tests and the producer-coupling tests

## References

Producer invariants live in `scripts/memory_enhancement/models.py`. Filed separately from this work: issue #4041, covering why the ratchet failure above took 400 seconds to surface instead of 2.

Refs #3971
