### PR TITLE
docs(governance): correct the portability checker count and paths

### DIFF
--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -18,16 +18,20 @@ workspace budget covers only `CLAUDE.md`, `AGENTS.md`, and `.claude/CLAUDE.md`,
 and `instruction_budget.py` covers only `.github/instructions/*.instructions.md`.
 New always-on guidance therefore belongs here, not there (Refs #3991).
 
-## Three portability checkers exist and their names do not tell you the scope
+## Four portability checkers exist and their names do not tell you the scope
 
-Running two of them is not running the third, and only the third reads
-Markdown.
+Running three of them is not running the fourth. Two read scripts and two read
+Markdown, and the two Markdown checkers are inverses of each other: one counts
+prose references and deliberately ignores `.claude/skills/`, the other looks
+for executable invocations of exactly that tree. All four live in
+`scripts/validation/`, not `build/scripts/`.
 
 | Script | Scans | Catches |
 |---|---|---|
-| `build/scripts/check_vendor_portability.py` | skill scripts | code that reads an upstream-only path |
-| `build/scripts/check_skill_portability.py` | skill scripts | drift against the script baseline |
+| `scripts/validation/check_vendor_portability.py` | skill scripts | code that reads an upstream-only path |
+| `scripts/validation/check_skill_portability.py` | skill scripts | drift against the script baseline |
 | `scripts/validation/check_skill_md_portability.py` | skill `.md` | an upstream path cited in **prose** |
+| `scripts/validation/check_skill_md_exec_portability.py` | skill `.md` | a bare `.claude/skills/...` script **invocation** |
 
 Symptom: the first two pass, you commit, and the push is rejected by
 `pre_pr.py` with `[FAIL] Skill Markdown Portability` naming a reference file

--- a/.agents/memory/episodes/episode-2026-07-30-session-4039-fix-portability-checker-gotcha.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-4039-fix-portability-checker-gotcha.json
@@ -1,0 +1,44 @@
+{
+  "id": "episode-2026-07-30-session-4039-fix-portability-checker-gotcha",
+  "session": "2026-07-30-session-4039-fix-portability-checker-gotcha",
+  "timestamp": "2026-07-30T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Correct the portability checker count and paths in the shared gotchas file",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verify objective deliverables landed on main",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Audit the portability checker gotcha",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Audit every path cited in the document",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-30-session-4039-fix-portability-checker-gotcha.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-4039-fix-portability-checker-gotcha.json
@@ -30,6 +30,14 @@
       "content": "Audit every path cited in the document",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 9f795dc333060451ed52249ad73ac46ef989312e",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -37,7 +45,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/sessions/2026-07-30-session-4039-fix-portability-checker-gotcha.json
+++ b/.agents/sessions/2026-07-30-session-4039-fix-portability-checker-gotcha.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4039,
+    "date": "2026-07-30",
+    "branch": "rjmurillo/fix-portability-gotcha",
+    "startingCommit": "55d09173",
+    "objective": "Correct the portability checker count and paths in the shared gotchas file"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Copilot CLI harness exposes no serena/ or mcp__serena__ tools, so context came through the AGENTS.md file fallback: read .serena/memories/ci/deployment-001-agent-self-containment.md directly"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md Serena Init section read in context; file fallback path exercised as that section directs"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md is read-only per ADR-014 and carries no gotchas-file carryover"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current reports rjmurillo/fix-portability-gotcha in worktree /tmp/gotchawt"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Worktree branch is rjmurillo/fix-portability-gotcha, created from origin/main; the main checkout holds main and was never switched"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All items in this section carry evidence"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md untouched; git status shows it unmodified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No memory write needed: .serena/memories/ci/deployment-001-agent-self-containment.md already records that all four checkers live in scripts/validation/. The memory was correct and the gotchas file had drifted from it, so this change moves the document toward the memory rather than the reverse"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 invoked on the file and reported 'Linting: 0 files, 0 issues in 0 files' because .agents/** is in the config ignore list. That green is the silent false pass this very document warns about, so it is recorded as a no-op rather than as a passing lint. The checks that do apply were run: taste-lints on the file, and an existence audit of every path it cites"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Single commit correcting the checker table"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Every file-like path cited in GOTCHAS.md audited for existence, with a negative control against the pre-fix file that flags exactly the two absent build/scripts/ paths"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Verify objective deliverables landed on main",
+      "outcome": "GOTCHAS.md present and referenced from AGENTS.md and .github/copilot-instructions.md; CLAUDE.md inherits through its @AGENTS.md import, so the gotchas reach all three entry points without duplication"
+    },
+    {
+      "task": "Audit the portability checker gotcha",
+      "outcome": "Found three claimed checkers against four real ones, with build/scripts/ paths for two that resolve nowhere. Corrected the count, the paths, and added the missing exec-path checker with the inverse relationship the names hide"
+    },
+    {
+      "task": "Audit every path cited in the document",
+      "outcome": "13 file-like paths cited, 0 missing after the fix. Negative control against the pre-fix file flags exactly the two absent paths, so the check can fail"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-07-30-session-4039-fix-portability-checker-gotcha.json
+++ b/.agents/sessions/2026-07-30-session-4039-fix-portability-checker-gotcha.json
@@ -87,6 +87,6 @@
       "outcome": "13 file-like paths cited, 0 missing after the fix. Negative control against the pre-fix file flags exactly the two absent paths, so the check can fail"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "9f795dc333060451ed52249ad73ac46ef989312e",
   "nextSteps": []
 }


### PR DESCRIPTION
# Pull Request

## Summary

### What

Corrects the plugin-portability section of `.agents/governance/GOTCHAS.md`. It claimed three portability checkers and gave paths for two of them that do not exist. There are four checkers and they all live in one directory.

### Why

That file is the shared gotchas document both entry points route an agent to. Two of the three commands it handed an agent would fail with "no such file or directory". An agent that runs a documented command and gets a missing-file error learns the gate is imaginary and skips it. A wrong path is worse than an absent one.

The fourth checker was missing entirely, so the gate it enforces was invisible to any reader of the document.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4043 | GOTCHAS.md documents three portability checkers at wrong paths |

## Changes

- `.agents/governance/GOTCHAS.md`: count corrected from three to four, all paths repointed to the directory that actually holds them, and the previously unmentioned skill-exec checker added with a note on the inverse relationship its name hides.
- `.agents/sessions/2026-07-30-session-4039-fix-portability-checker-gotcha.json`: session log, validator reports PASS.
- `.agents/memory/episodes/episode-2026-07-30-session-4039-fix-portability-checker-gotcha.json`: episode record.

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether every path now cited in the document resolves. That is the whole point of the change, and it is the property the previous version failed.

## Testing

Deliverables in this PR:

- [x] Manual testing completed
- [x] No testing required (documentation only)

Verification performed:

1. **Full path audit.** Extracted every file-like path cited anywhere in the document, not just the ones in the section I touched, and resolved each against the working tree. Thirteen paths cited, zero missing after the fix.
2. **Negative control.** The audit is only evidence if it can fail. Ran the same audit against the pre-fix version of the file: it flagged exactly the two absent paths and nothing else. Against the fixed version it flags zero. A detector that cannot fail has not been run.
3. **Session log validator** reports PASS.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] Self-review completed

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

The correct four-checker fact was already recorded in a Serena CI memory. See `.serena/memories/ci/deployment-001-agent-self-containment.md` lines 89 through 94. The governance document had drifted away from it, so two documents disagreed and the one an agent is instructed to read carried the wrong answer. Worth knowing when weighing whether other governance prose has drifted from the memories that back it.

The ending commit was recorded in a follow-up commit rather than an amend, per the rule against rewriting a pushed session log.

## Related Issues

Fixes #4043
Refs #4038
