### PR TITLE
test(subprocess-encoding): bound wide-value scan by growth, not wall clock

### DIFF
--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -3847,6 +3847,35 @@ def test_one_value_reading_many_names_stays_linear() -> None:
     assert elapsed < 3.0, f"chain resolution took {elapsed:.1f}s for {depth} links"
 
 
+def _wide_value_source(width: int) -> str:
+    """One list literal reading ``width`` names that each resolve."""
+    lines = ["import subprocess"]
+    lines += [f"n{index} = subprocess.run" for index in range(width)]
+    lines.append("WIDE = [" + ", ".join(f"n{index}" for index in range(width)) + "]")
+    return "\n".join(lines)
+
+
+def _best_elapsed(source: str, repeats: int = 3) -> float:
+    """Fastest of several runs. Scheduler noise only ever adds time."""
+    best = float("inf")
+    for _ in range(repeats):
+        started = time.perf_counter()
+        flagged = unpinned_lines(source)
+        best = min(best, time.perf_counter() - started)
+        assert flagged == [], "no call is made, so nothing can decode"
+    return best
+
+
+# Quadrupling the width costs 4x under a linear scan and 16x under the
+# re-queueing one. Measured linear ratios ran 4.24 to 4.97 across three width
+# pairs and eighteen trials, so this sits about 1.6x above the worst linear
+# reading and 2x below what quadratic predicts.
+_LINEAR_SCALING_CEILING = 8.0
+
+_NARROW_WIDTH = 1000
+_WIDE_WIDTH = 4000
+
+
 def test_a_value_reading_many_names_stays_linear() -> None:
     """A value node that reads N names must be walked once, not once per name.
 
@@ -3857,19 +3886,51 @@ def test_a_value_reading_many_names_stays_linear() -> None:
     A group whose names are all settled cannot change an answer, so skipping
     it before the walk bounds the work. Unlike the wide-unpack case every
     name here does resolve, which is what drives the re-queue.
+
+    This one is bounded by how the cost grows rather than by a wall clock,
+    which its siblings can afford and this one cannot. Their two regimes sit
+    63x and 110x apart, so a fixed ceiling drops between them with room on
+    both sides. Here they sit about 11x apart: linear measured 0.30 seconds
+    against the docstring's 3.26 for the re-queueing version. The old ceiling
+    of 1.0 second was the midpoint of that narrow gap, which left only 3.6x
+    over linear, and a CI runner about 3.9x slower than a workstation failed
+    it at 1.078 seconds with the implementation behaving correctly. Raising
+    the ceiling instead is not available: any value high enough to stop
+    flaking on that runner sits above the 3.26 seconds quadratic already
+    costs, so the test would stop detecting the regression it exists for.
+
+    A ratio has neither problem. Both readings come off the same machine in
+    the same run, so a slow runner scales them together and cancels out.
+    Refs #4048.
     """
-    width = 4000
-    lines = ["import subprocess"]
-    lines += [f"n{index} = subprocess.run" for index in range(width)]
-    lines.append("WIDE = [" + ", ".join(f"n{index}" for index in range(width)) + "]")
-    source = "\n".join(lines)
+    narrow = _best_elapsed(_wide_value_source(_NARROW_WIDTH))
+    wide = _best_elapsed(_wide_value_source(_WIDE_WIDTH))
+    ratio = wide / narrow
 
-    started = time.perf_counter()
-    flagged = unpinned_lines(source)
-    elapsed = time.perf_counter() - started
+    assert ratio < _LINEAR_SCALING_CEILING, (
+        f"{_WIDE_WIDTH} names cost {ratio:.2f}x what {_NARROW_WIDTH} did "
+        f"({wide:.3f}s vs {narrow:.3f}s); linear predicts about "
+        f"{_WIDE_WIDTH / _NARROW_WIDTH:.0f}x and quadratic about "
+        f"{(_WIDE_WIDTH / _NARROW_WIDTH) ** 2:.0f}x"
+    )
 
-    assert flagged == [], "no call is made, so nothing can decode"
-    assert elapsed < 1.0, f"resolution took {elapsed:.1f}s for {width} names"
+
+def test_the_linear_scaling_ceiling_separates_the_two_regimes() -> None:
+    """The bound above proves nothing unless it can fail.
+
+    Pins both margins so a later edit cannot quietly widen the ceiling past
+    what quadratic costs, which would leave a bound that always passes, nor
+    tighten it under what linear measured, which is the flake being fixed.
+    """
+    width_factor = _WIDE_WIDTH / _NARROW_WIDTH
+    linear_predicts = width_factor
+    quadratic_predicts = width_factor**2
+    worst_measured_linear_ratio = 4.97
+
+    assert linear_predicts < _LINEAR_SCALING_CEILING < quadratic_predicts
+    assert worst_measured_linear_ratio < _LINEAR_SCALING_CEILING, (
+        "ceiling must clear the slowest linear reading actually observed"
+    )
 
 
 def test_return_bindings_stay_linear_in_a_deeply_nested_file() -> None:

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -53,10 +53,12 @@ from __future__ import annotations
 
 import ast
 import codecs
+import math
 import time
 from collections import Counter, deque
 from pathlib import Path
 from typing import NamedTuple
+from unittest import mock
 
 import pytest
 
@@ -3863,6 +3865,13 @@ def _best_elapsed(source: str, repeats: int = 3) -> float:
         flagged = unpinned_lines(source)
         best = min(best, time.perf_counter() - started)
         assert flagged == [], "no call is made, so nothing can decode"
+    assert math.isfinite(best) and best > 0.0, (
+        f"the timer returned {best!r} over {repeats} repeats, so this reading "
+        "carries no duration and any ratio built on it is meaningless. That is "
+        "a measurement failure, not a regression in the code under test. "
+        "Without this check a zero reading reaches the divide below and raises "
+        "ZeroDivisionError, which reads as a crash instead of naming the cause."
+    )
     return best
 
 
@@ -3931,6 +3940,30 @@ def test_the_linear_scaling_ceiling_separates_the_two_regimes() -> None:
     assert worst_measured_linear_ratio < _LINEAR_SCALING_CEILING, (
         "ceiling must clear the slowest linear reading actually observed"
     )
+
+
+def test_a_zero_duration_reading_is_named_as_a_measurement_failure() -> None:
+    """The zero-reading guard proves nothing unless it can fire.
+
+    A coarse timer handing back two identical stamps yields an elapsed time of
+    zero. That reading reached the divide in the ratio test above and raised
+    ``ZeroDivisionError``, which reads as a crash in the code under test rather
+    than as the measurement failure it is. Guarding at the reading rather than
+    at the one divide covers both readings and every future caller. Refs #4048.
+    """
+    with mock.patch.object(time, "perf_counter", side_effect=[1.0, 1.0]):
+        with pytest.raises(AssertionError, match="carries no duration"):
+            _best_elapsed("x = 1", repeats=1)
+
+
+def test_a_positive_reading_passes_the_zero_duration_guard() -> None:
+    """Negative control for the guard above.
+
+    A guard that rejected every reading would also make the test above pass, so
+    pin that a normal reading survives it.
+    """
+    with mock.patch.object(time, "perf_counter", side_effect=[1.0, 1.25]):
+        assert _best_elapsed("x = 1", repeats=1) == pytest.approx(0.25)
 
 
 def test_return_bindings_stay_linear_in_a_deeply_nested_file() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

Replaces the wall-clock ceiling in one performance test with a bound on how the cost grows, and adds a guard test that pins the margins on both sides.

### Why

The test failed on a shared runner at 1.078s against a 1.0s ceiling, on a pull request whose diff contained no Python at all. The implementation was correct. The runner was about 3.9x slower than the workstation the ceiling was calibrated on.

Raising the ceiling is not available. This test's two regimes sit only about 11x apart: linear measured 0.30s against the 3.26s the docstring records for the re-queueing version. Its siblings sit 63x and 110x apart and can drop a fixed ceiling between them with room on both sides. Here, any ceiling high enough to stop flaking on that runner lands above what quadratic already costs, so the test would keep passing while the regression it exists to catch went straight through. That is a worse outcome than the flake.

A growth ratio has neither problem. Both readings come off the same machine in the same run, so a slow runner scales them together and cancels out.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4048 | Wall-clock ceiling flakes on CI at 3.6x headroom |

## Changes

- `tests/test_subprocess_text_encoding.py`: the wide-value scan test now quadruples the width and asserts the cost grows by less than 8x. Added a guard test that pins the ceiling between what linear measures and what quadratic predicts. Extracted the source builder and a best-of-N timer as module-level helpers.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether 8.0 is the right separator. Linear predicts 4x, quadratic predicts 16x, and measurement put the real linear readings at 4.24 to 4.97.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed

Measurements taken on a developer workstation:

1. **Baseline that explains the flake.** Timed the region the old assertion measured, five repeats: 0.282, 0.277, 0.294, 0.276, 0.275, median 0.277s against a 1.0s ceiling. That is 3.6x headroom. The CI observation of 1.078s is 3.9x the median, so an ordinarily slow runner reaches the ceiling with a correct implementation.
2. **Ratio stability.** Three width pairs, six trials each, eighteen readings total. Ratios ran 4.24 to 4.97 with medians of 4.45, 4.46, and 4.54. All three pairs agree, so the smallest was chosen and the test cost fell from 2.35s to 1.05s.
3. **Negative control on the guard.** Moved the ceiling under linear (3.0) and over quadratic (20.0). The guard test failed in both directions and passes at 8.0. A bound that cannot fail proves nothing, so this is the part that makes the rest of the numbers mean something.
4. **Whole file green.** 308 passed in 9.21s. Ruff clean on the changed file.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

Two things worth knowing.

The numerically tightest ceiling in this file is not the risky one. The `< 0.3` bound has about 20x headroom because its two regimes sit 63x apart. Ranking these tests by the size of the constant is misleading; the ratio to the measured linear cost is what matters. That is why only one test is changed here.

This file already fails the taste-lint module size target on main, at 3922 lines against a 300-line target. This change adds 61 net lines and does not fix that. Splitting a 3900-line test file is not something to bundle into a flake fix, and the lint result is identical before and after, which was verified rather than assumed.

The remaining four timing tests in this file were not characterized. Refs #4048 records that as open.

## Related Issues

Fixes #4048
