### PR TITLE
fix(rules): replace a rotted bare count in plugin-self-containment with the command that computes it

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5441",
+  "version": "0.6.5442",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/rules/plugin-self-containment.md
+++ b/.claude/rules/plugin-self-containment.md
@@ -70,7 +70,26 @@ A file that legitimately depends on upstream paths declares it with an HTML comm
      contributors, not plugin consumers (issue #2050) -->
 ```
 
-170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+Files inside the plugin roots carry it in the low hundreds. Count them when the
+number matters rather than trusting a figure written here, because this line has
+already been wrong once:
+
+```bash
+git ls-files .claude src/copilot-cli src/claude | xargs grep -l "vendor-portability:" | wc -l
+```
+
+`git ls-files` rather than a bare `grep -r` on purpose: a recursive walk also
+descends into the nested checkouts under `.claude/worktrees/`, which is the same
+trap described below.
+
+Two structural facts hold regardless of the count. The declaration lives in skill
+files, so `.claude/skills/` and its `src/copilot-cli/skills/` mirror hold nearly
+all of them, and the two track each other because the mirror is generated.
+`src/claude/` holds none, because it ships agents and has no `skills/` directory
+at all.
+
+Use the declaration when the reference is real and intended. Do not use it to
+silence a reference you should have fixed.
 
 ## Known coverage gap
 

--- a/.github/instructions/plugin-self-containment.instructions.md
+++ b/.github/instructions/plugin-self-containment.instructions.md
@@ -64,7 +64,26 @@ A file that legitimately depends on upstream paths declares it with an HTML comm
      contributors, not plugin consumers (issue #2050) -->
 ```
 
-170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+Files inside the plugin roots carry it in the low hundreds. Count them when the
+number matters rather than trusting a figure written here, because this line has
+already been wrong once:
+
+```bash
+git ls-files .claude src/copilot-cli src/claude | xargs grep -l "vendor-portability:" | wc -l
+```
+
+`git ls-files` rather than a bare `grep -r` on purpose: a recursive walk also
+descends into the nested checkouts under `.claude/worktrees/`, which is the same
+trap described below.
+
+Two structural facts hold regardless of the count. The declaration lives in skill
+files, so `.claude/skills/` and its `src/copilot-cli/skills/` mirror hold nearly
+all of them, and the two track each other because the mirror is generated.
+`src/claude/` holds none, because it ships agents and has no `skills/` directory
+at all.
+
+Use the declaration when the reference is real and intended. Do not use it to
+silence a reference you should have fixed.
 
 ## Known coverage gap
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5441",
+  "version": "0.6.5442",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/instructions/plugin-self-containment.instructions.md
+++ b/src/copilot-cli/instructions/plugin-self-containment.instructions.md
@@ -64,7 +64,26 @@ A file that legitimately depends on upstream paths declares it with an HTML comm
      contributors, not plugin consumers (issue #2050) -->
 ```
 
-170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+Files inside the plugin roots carry it in the low hundreds. Count them when the
+number matters rather than trusting a figure written here, because this line has
+already been wrong once:
+
+```bash
+git ls-files .claude src/copilot-cli src/claude | xargs grep -l "vendor-portability:" | wc -l
+```
+
+`git ls-files` rather than a bare `grep -r` on purpose: a recursive walk also
+descends into the nested checkouts under `.claude/worktrees/`, which is the same
+trap described below.
+
+Two structural facts hold regardless of the count. The declaration lives in skill
+files, so `.claude/skills/` and its `src/copilot-cli/skills/` mirror hold nearly
+all of them, and the two track each other because the mirror is generated.
+`src/claude/` holds none, because it ships agents and has no `skills/` directory
+at all.
+
+Use the declaration when the reference is real and intended. Do not use it to
+silence a reference you should have fixed.
 
 ## Known coverage gap
 


### PR DESCRIPTION
Fixes #4076

## Problem

`.claude/rules/plugin-self-containment.md` asserted a bare file count with nothing bounding it. The number was written when the corpus was smaller and had drifted since. Because that rule loads into every session, a wrong number there teaches every agent a wrong fact.

## Three grades of count

1. **Bare unqualified count.** Claims to be current, nothing signals rot. Broken.
2. **Dated count.** Honest. Loses usefulness over time but never lies, because the date bounds the claim.
3. **Magnitude plus the command that reproduces it, plus structural invariants.** Durable.

The line was grade 1. It is now grade 3.

## The measurement discrepancy that made this worth writing up

Counting from the main checkout gave one answer. Counting from a clean worktree at `origin/main` gave a materially larger one. Two traps produce that gap:

- The main checkout sits on a **stale detached HEAD**, so any count taken there reflects an old tree.
- Four stale worktrees are present on disk (`.claude/worktrees`, `.cache/worktrees`, `.wt`, `pr3097-worktree`). A naive recursive scan walks all of them and double-counts.

The clean-worktree number is the correct one. The replacement command uses `git ls-files`, which is immune to both traps: it enumerates tracked paths in the current tree only, so it cannot walk an untracked stale worktree and cannot read a detached-HEAD checkout as if it were `main`.

That trap is not incidental. The same rule file documents the stale-worktree hazard two paragraphs below the line being fixed, so a count taken the naive way would have contradicted the file it lives in.

## What changed

The bare number is replaced by three things that do not rot together:

- The `git ls-files | xargs grep -l | wc -l` invocation that computes the current value.
- A magnitude ("low hundreds") so a reader can calibrate scale without running anything.
- Two structural facts about the reference pattern, which hold regardless of corpus size.

Two other counts in the same file were left alone deliberately. Each already names its measurement point and its matcher, which puts them at grade 3 by a different route. Rewriting them would be churn.

## Changes

- `.claude/rules/plugin-self-containment.md`: the declaration section now carries the relation form.
- `.github/instructions/plugin-self-containment.instructions.md`: regenerated.
- `src/copilot-cli/instructions/plugin-self-containment.instructions.md`: regenerated.
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json`: version bump, required because both plugin roots ship rule content.

## Verification

Push gates green: `plugin-load-e2e` 22.9s, `python-tests` 460.9s.