### PR TITLE
fix(skills): make retro-path re-verify command runnable from source

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5445",
+  "version": "0.6.5446",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/ai-agents-change-control/references/provenance.md
+++ b/.claude/skills/ai-agents-change-control/references/provenance.md
@@ -18,7 +18,7 @@ Verified against the working tree on 2026-07-03. Volatile facts and their re-ver
 | SHA-pin tension (Exceptions: None vs GP-006) | `.agents/governance/PROJECT-CONSTRAINTS.md:180`; `.agents/governance/golden-principles.md:63-69` | `grep -n "Exceptions" .agents/governance/PROJECT-CONSTRAINTS.md; sed -n 63,70p .agents/governance/golden-principles.md` |
 | ADR-066 proposed, ADR-071 accepted, #2230 rejected | Status sections of both ADR files | `sed -n 1,20p .agents/architecture/ADR-066-hook-fail-open-reconciliation.md; sed -n 1,10p .agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md` |
 | FM-9 and FM-10 sections; "neutral default" quote | `.agents/governance/FAILURE-MODES.md:284,315` | `grep -n "neutral default" .agents/governance/FAILURE-MODES.md` |
-| Incident retro paths (908, 1187, 1887, 1965, 2205) | `.agents/retrospective/` | `ls .agents/retrospective/ \| grep -E "908\|1187\|1887\|1965\|2205"` |
+| Incident retro paths (908, 1187, 1887, 1965, 2205) | `.agents/retrospective/` | `find .agents/retrospective \( -name "*908*" -o -name "*1187*" -o -name "*1887*" -o -name "*1965*" -o -name "*2205*" \)` |
 | `[skip-drift-check]` bypass contract | `.github/workflows/agent-drift-detection.yml:17,65-69` | `grep -n "skip-drift-check" .github/workflows/agent-drift-detection.yml` |
 | ai-pr-quality-gate authoritative blocker | `.github/workflows/ai-pr-quality-gate.yml:735` | `grep -n "check_critical_failures" .github/workflows/ai-pr-quality-gate.yml` |
 | ADR-006 amendment scope and conditions | `.agents/architecture/ADR-006-thin-workflows-testable-modules.md:255-309` | `grep -n "Amendment 2026-04-28" .agents/architecture/ADR-006-thin-workflows-testable-modules.md` |

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5445",
+  "version": "0.6.5446",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/ai-agents-change-control/references/provenance.md
+++ b/src/copilot-cli/skills/ai-agents-change-control/references/provenance.md
@@ -18,7 +18,7 @@ Verified against the working tree on 2026-07-03. Volatile facts and their re-ver
 | SHA-pin tension (Exceptions: None vs GP-006) | `.agents/governance/PROJECT-CONSTRAINTS.md:180`; `.agents/governance/golden-principles.md:63-69` | `grep -n "Exceptions" .agents/governance/PROJECT-CONSTRAINTS.md; sed -n 63,70p .agents/governance/golden-principles.md` |
 | ADR-066 proposed, ADR-071 accepted, #2230 rejected | Status sections of both ADR files | `sed -n 1,20p .agents/architecture/ADR-066-hook-fail-open-reconciliation.md; sed -n 1,10p .agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md` |
 | FM-9 and FM-10 sections; "neutral default" quote | `.agents/governance/FAILURE-MODES.md:284,315` | `grep -n "neutral default" .agents/governance/FAILURE-MODES.md` |
-| Incident retro paths (908, 1187, 1887, 1965, 2205) | `.agents/retrospective/` | `ls .agents/retrospective/ \| grep -E "908\|1187\|1887\|1965\|2205"` |
+| Incident retro paths (908, 1187, 1887, 1965, 2205) | `.agents/retrospective/` | `find .agents/retrospective \( -name "*908*" -o -name "*1187*" -o -name "*1887*" -o -name "*1965*" -o -name "*2205*" \)` |
 | `[skip-drift-check]` bypass contract | `.github/workflows/agent-drift-detection.yml:17,65-69` | `grep -n "skip-drift-check" .github/workflows/agent-drift-detection.yml` |
 | ai-pr-quality-gate authoritative blocker | `.github/workflows/ai-pr-quality-gate.yml:735` | `grep -n "check_critical_failures" .github/workflows/ai-pr-quality-gate.yml` |
 | ADR-006 amendment scope and conditions | `.agents/architecture/ADR-006-thin-workflows-testable-modules.md:255-309` | `grep -n "Amendment 2026-04-28" .agents/architecture/ADR-006-thin-workflows-testable-modules.md` |


### PR DESCRIPTION
## Summary

The `ai-agents-change-control` provenance table had one row whose re-verify
command could not work when copied from the file. Replaced it with a
pipe-free equivalent that needs no escaping at all.

## The defect

GFM renders `\|` as `|`, so a human reading the rendered table sees a working
command. Agents read raw markdown and copy the escaped form verbatim, which is
broken twice over:

1. `ls ... \| grep -E "..."` does not pipe. Bash strips the backslash during
   quote removal and hands `ls` a literal `|` argument, followed by `grep`,
   `-E`, and the pattern. `ls` rejects `-E` as an invalid option and exits 2
   having listed nothing. Stdout is empty, so an agent that reads stdout
   without checking the return code sees no retrospectives and concludes they
   are absent.
2. `grep -E "908\|1187\|..."` matches nothing. In POSIX ERE, `\|` is a literal
   pipe, not alternation. GNU and BusyBox grep do read `\|` as alternation in
   basic mode, but that is a GNU extension rather than a portable guarantee:
   POSIX defines no alternation operator for basic regular expressions.

## Evidence

Measured against the working tree:

```console
$ ls .agents/retrospective/ \| grep -E "908\|1187\|1887\|1965\|2205"
ls: invalid option -- 'E'
Try 'ls --help' for more information.
rc=2, stdout 0 bytes

$ ls .agents/retrospective/ | grep -E "908\|1187\|1887\|1965\|2205"
rc=1, no output

$ find .agents/retrospective \( -name "*908*" -o -name "*1187*" \
    -o -name "*1887*" -o -name "*1965*" -o -name "*2205*" \)
rc=0
.agents/retrospective/2026-01-15-pr-908-comprehensive-retrospective.md
.agents/retrospective/2026-02-08-session-1187-skip-prepush-abuse.md
.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md
.agents/retrospective/2026-05-10-pr-1965-review-axes-convergence.md
.agents/retrospective/2026-06-02-pr-2205-customer-wedge-incident.md
```

An agent following the old row would conclude the retrospectives do not exist.

## Why this remedy

Every other row in this table is already pipe-free. This was the only row that
needed an escape, which is why it was the only one that broke. Removing the
pipe makes the raw source and the rendered table byte-identical, so the class
of defect cannot recur in this row. `find` with `-name` and `-o` is POSIX, so
it does not depend on GNU `find` extensions.

## Verification

Extracted the command from the file itself, split the row on `|`, and executed
it: 3 cells (the table still renders) and all five retrospectives returned.
Negative control on the pre-fix line yields 8 cells, so the extraction test
discriminates rather than passing trivially.

## Scope

> [!NOTE]
> The Copilot CLI copy is generated from the Claude source by
> `build/scripts/generate_skills.py`. It was regenerated, not hand-edited.
> Both plugin manifests are bumped to the same version, as the parity gate
> requires. `src/claude/` is untouched, so its manifest is not bumped.

Refs #4079

