### PR TITLE
fix(memory): restore working regex patterns in secret detection memory

### DIFF
--- a/.serena/memories/security/security-secret-detection.md
+++ b/.serena/memories/security/security-secret-detection.md
@@ -57,6 +57,15 @@ fi
 
 **Source**: `.agents/security/secret-detection-patterns.md`
 
+That source file is a broader catalog written in a different dialect: its
+patterns carry `(?i)` and `\s`, which are Python and PCRE constructs, not
+POSIX ERE. Do not copy patterns between the two files without translating
+them. Measured with GNU grep 3.11: every source-file pattern containing
+`[a-zA-Z0-9-_]` aborts under `grep -E` with `Invalid range end`, because the
+mid-class hyphen opens a character range there. Python's `re` parses the same
+hyphen as a literal, so those patterns are correct for the source file's own
+engine and wrong for this one.
+
 ## Related
 
 - [security-002-input-validation-first](security-002-input-validation-first.md)

--- a/.serena/memories/security/security-secret-detection.md
+++ b/.serena/memories/security/security-secret-detection.md
@@ -8,17 +8,34 @@
 
 **Pattern Categories**:
 
-| Secret Type | Regex Pattern |
-|-------------|---------------|
-| AWS Access Key | `AKIA[0-9A-Z]{16}` |
-| AWS Secret Key | `[A-Za-z0-9/+=]{40}` (context required) |
-| GitHub PAT | `ghp_[A-Za-z0-9]{36}` |
-| GitHub OAuth | `gho_[A-Za-z0-9]{36}` |
-| GitHub App | `ghs_[A-Za-z0-9]{36}` |
-| Connection String | `(password\|pwd)=[^;]+` |
-| API Key | `(api_key\|apikey)=[A-Za-z0-9]+` |
-| Private Key | `-----BEGIN (RSA\|OPENSSH\|EC) PRIVATE KEY-----` |
-| JWT | `eyJ[A-Za-z0-9-_]+\.eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*` |
+Patterns are POSIX ERE, the dialect `grep -E` reads in the hook below. Copy
+them verbatim. The `|` characters are alternation and must stay unescaped: in
+ERE a `\|` matches a literal pipe character, so an escaped pattern silently
+matches nothing and the scan reports clean while secrets pass.
+
+```text
+AWS Access Key     AKIA[0-9A-Z]{16}
+AWS Secret Key     [A-Za-z0-9/+=]{40}
+GitHub PAT         ghp_[A-Za-z0-9]{36}
+GitHub OAuth       gho_[A-Za-z0-9]{36}
+GitHub App         ghs_[A-Za-z0-9]{36}
+Connection String  (password|pwd)=[^;]+
+API Key            (api_key|apikey)=[A-Za-z0-9]+
+Private Key        -----BEGIN (RSA|OPENSSH|EC) PRIVATE KEY-----
+JWT                eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_.+/=-]*
+```
+
+The `\.` pairs in the JWT pattern are correct: they match the literal dots
+separating the header, payload, and signature segments. Each `-` sits last in
+its bracket expression, where it is a literal; placed mid-class it starts a
+character range and `grep -E` rejects the pattern with `Invalid range end`.
+
+The Private Key pattern begins with `-`, so pass it after `--` or with `-e`.
+Otherwise `grep` reads it as a bundle of options.
+
+AWS Secret Key has no distinctive prefix and matches any 40-character base64
+run, so it needs surrounding context (an assignment to a credential-shaped
+variable name) before it is worth alerting on.
 
 **Pre-commit Hook Pattern**:
 


### PR DESCRIPTION
## Summary

The secret detection memory listed its regex patterns in a markdown table, so
every alternation was written as an escaped pipe to keep the cell from
splitting. Copying a pattern out of that table gives you something that does
not work.

## The defect

GFM renders an escaped pipe as a bare pipe, so a human reading the rendered
memory sees correct patterns. Agents read raw markdown and copy the escaped
form verbatim.

The memory's own pre-commit hook feeds these patterns to `grep -E`, which is
POSIX ERE. In ERE an escaped pipe matches a literal pipe character, not
alternation. Three patterns were affected: connection string, API key, and
private key.

This failure is silent. Every other instance of this defect class found so far
produces a visible error. Here the scan runs, matches nothing, and reports
clean while the secret it was built to catch passes through.

## Evidence

Measured with Python's `re`, which reads an escaped pipe the same way ERE does:

```console
>>> re.search(r'(password\|pwd)=[^;]+', 'password=hunter2;')
None
>>> re.search(r'(password|pwd)=[^;]+', 'password=hunter2;')
<re.Match object; span=(0, 17), match='password=hunter2;'>
```

## A second defect found while fixing the first

The JWT pattern does not compile at all:

```console
$ printf 'abc\n' | grep -E -- '[A-Za-z0-9-_]'
grep: Invalid range end
```

A hyphen in the middle of a bracket expression starts a character range. Moved
each hyphen to the end of its class, where it is a literal. This was not caused
by the pipe defect and would have survived a pipe-only fix.

## The remedy

Replaced the table with a fenced block, so the raw source and the rendered
output are byte-identical and no escaping is needed. That matches the form the
memory's own cited source has always used, and the form the bash hook six lines
below already used correctly.

## Verification

Extracted all nine patterns from the file and ran each under `grep -E` against
a positive and a negative fixture. All nine match their positive fixture and
none match their negative fixture. Before the change the JWT pattern did not
compile and the three escaped patterns matched nothing.

## Notes

> [!NOTE]
> Serena memories are not a plugin root, so no plugin manifest bump applies
> here.

Refs #4079
