### PR TITLE
refactor(commit-limit): delete contains_base_merge dead code

### DIFF
--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -216,8 +216,7 @@ def _is_external_parent(parent: object, own_shas: set[str]) -> bool:
 def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
     """Collect SHAs of non-first parents that are not in the PR's own commit list.
 
-    Used by both contains_base_merge (backward-compat approximation) and
-    contains_main_merge (precise check verified against origin/main).
+    Used by contains_main_merge (precise check verified against origin/main).
     """
     own_shas: set[str] = set()
     for commit in commits:
@@ -235,20 +234,9 @@ def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
             continue
         for parent in parents[1:]:
             if _is_external_parent(parent, own_shas):
-                sha = parent.get("sha")
-                if isinstance(sha, str) and sha:
-                    shas.add(sha)
+                # _is_external_parent guarantees parent["sha"] is a non-empty str.
+                shas.add(parent.get("sha"))  # type: ignore[arg-type]
     return shas
-
-
-def contains_base_merge(commits: list[Any]) -> bool:
-    """Return True when the PR carries a merge commit from outside the branch.
-
-    BROADER APPROXIMATION: this grants relief for any external merge, not only
-    merges of origin/main's first-parent trunk. Use contains_main_merge when
-    a repo_root is available so the check matches the pre-push hook exactly.
-    """
-    return bool(_external_non_first_parent_shas(commits))
 
 
 def contains_main_merge(

--- a/tests/validation/test_commit_limit_parity.py
+++ b/tests/validation/test_commit_limit_parity.py
@@ -175,10 +175,11 @@ def test_both_gates_deny_relief_when_branch_merges_only_landed_side(tmp_path: Pa
     """NEGATIVE PARITY (the divergence case from issue #3997).
 
     A feature branch that merges a side branch already landed on main must NOT
-    receive the 40-commit relief from either gate. Before the fix, CI's
-    contains_base_merge granted relief (s1 was external to the PR commit list
-    because s1 is reachable from main), while the pre-push hook denied it (s1
-    is not on origin/main's first-parent history).
+    receive the 40-commit relief from either gate. Before the fix (PR #4030),
+    the broader contains_base_merge approximation granted relief (s1 was
+    external to the PR commit list because s1 is reachable from main), while
+    the pre-push hook denied it (s1 is not on origin/main's first-parent
+    history). Both gates now use contains_main_merge and agree.
     """
     repo, base, head = _repo_branch_merges_landed_side(tmp_path, "both-deny")
 

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -96,7 +96,7 @@ def test_the_block_boundary_agrees_with_the_local_hook(count: int, blocked: bool
 
     The hook widens ``limit`` to 40 when the update contains a merge of main,
     and CI applies the same widening: ``count_pr_commits`` reads the pull
-    request's own commit list through ``contains_base_merge``. A main-merge
+    request's own commit list through ``contains_main_merge``. A main-merge
     branch at 21 through 40 therefore needs no bypass label. This test pins
     only the default boundary; ``test_classify_count_honours_an_explicit_limit``
     pins the widened one.
@@ -366,24 +366,35 @@ def _merge_commits_json(n: int, external_parent: bool) -> str:
     return json.dumps(commits)
 
 
-def test_contains_base_merge_is_false_for_a_linear_branch() -> None:
+def test_external_non_first_parent_shas_empty_for_linear_branch() -> None:
     payload = json.loads(_merge_commits_json(5, external_parent=False))
-    assert mod.contains_base_merge(payload) is False
+    assert mod._external_non_first_parent_shas(payload) == set()
 
 
-def test_contains_base_merge_is_true_when_a_merge_parent_is_outside_the_branch() -> None:
+def test_external_non_first_parent_shas_nonempty_when_parent_outside_branch() -> None:
     payload = json.loads(_merge_commits_json(5, external_parent=True))
-    assert mod.contains_base_merge(payload) is True
+    assert mod._external_non_first_parent_shas(payload) != set()
 
 
-def test_contains_base_merge_ignores_a_merge_between_two_branch_commits() -> None:
+def test_external_non_first_parent_shas_returns_correct_sha() -> None:
+    """Returns the external parent's actual sha, not an arbitrary non-empty value."""
+    external_sha = "e" * 40
+    payload = [
+        {"sha": "a" * 40, "parents": [{"sha": "b" * 40}, {"sha": external_sha}]},
+        {"sha": "b" * 40, "parents": [{"sha": "0" * 40}]},
+    ]
+    result = mod._external_non_first_parent_shas(payload)
+    assert result == {external_sha}
+
+
+def test_external_non_first_parent_shas_empty_for_internal_merge() -> None:
     """An internal merge is the branch's own history, not a merge from main."""
     payload = [
         {"sha": "a" * 40, "parents": [{"sha": "0" * 40}]},
         {"sha": "b" * 40, "parents": [{"sha": "0" * 40}]},
         {"sha": "c" * 40, "parents": [{"sha": "a" * 40}, {"sha": "b" * 40}]},
     ]
-    assert mod.contains_base_merge(payload) is False
+    assert mod._external_non_first_parent_shas(payload) == set()
 
 
 @pytest.mark.parametrize(
@@ -397,11 +408,11 @@ def test_contains_base_merge_ignores_a_merge_between_two_branch_commits() -> Non
     ],
     ids=["empty", "non-dict", "no-parents", "parents-not-list", "parent-not-dict"],
 )
-def test_contains_base_merge_fails_closed_on_malformed_payloads(
+def test_external_non_first_parent_shas_fails_closed_on_malformed_payloads(
     payload: list[object],
 ) -> None:
-    """Malformed data must not grant the relief: False keeps the stricter 20."""
-    assert mod.contains_base_merge(payload) is False
+    """Malformed data must not grant the relief: empty set keeps the stricter 20."""
+    assert mod._external_non_first_parent_shas(payload) == set()
 
 
 def test_classify_count_honours_an_explicit_limit() -> None:
@@ -524,7 +535,7 @@ def test_the_drift_detector_ignores_unrelated_assignments() -> None:
 
 
 # ---------------------------------------------------------------------------
-# contains_base_merge: malformed parents must not grant the relaxed ceiling
+# _external_non_first_parent_shas: malformed parents must not grant the relaxed ceiling
 # ---------------------------------------------------------------------------
 
 
@@ -548,11 +559,11 @@ def test_malformed_parents_do_not_grant_the_relaxed_ceiling(
 ) -> None:
     """Malformed payloads fail closed, keeping the stricter 20-commit ceiling.
 
-    ``contains_base_merge`` gates an *exemption*: True raises the ceiling from
-    BLOCK_THRESHOLD to MAIN_MERGE_BLOCK_THRESHOLD. A parent entry we cannot
-    read is not evidence of a base merge, so it must not buy the relief.
+    ``_external_non_first_parent_shas`` feeds the exemption gate: an empty
+    return keeps the limit at BLOCK_THRESHOLD. A parent entry we cannot read
+    is not evidence of a main merge, so it must not buy the relief.
     """
-    assert mod.contains_base_merge(payload) is False, label
+    assert mod._external_non_first_parent_shas(payload) == set(), label
 
 
 @pytest.mark.parametrize(
@@ -568,9 +579,11 @@ def test_malformed_parents_do_not_grant_the_relaxed_ceiling(
         ("empty payload", [], False),
     ],
 )
-def test_contains_base_merge_controls(label: str, payload: list[object], expected: bool) -> None:
+def test_external_non_first_parent_shas_controls(
+    label: str, payload: list[object], expected: bool
+) -> None:
     """Behaviour that must survive the malformed-parent narrowing unchanged."""
-    assert mod.contains_base_merge(payload) is expected, label
+    assert bool(mod._external_non_first_parent_shas(payload)) == expected, label
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After PR #4030 unified the commit-limit predicate into `contains_main_merge`, `contains_base_merge` had zero production callers. Every reference was the function definition itself and a test suite. This PR deletes the dead function and repoints its tests to call `_external_non_first_parent_shas` directly, which is the underlying primitive both predicates shared.

## Root cause

PR #4030 extracted a shared `contains_main_merge` implementation. The older `contains_base_merge` was not deleted at that time. Leaving it shipped an unused abstraction and kept test coverage pointing at a function that could never affect production behavior.

## Changes

- `scripts/validation/pr_commit_count.py`: delete `contains_base_merge`; simplify `_external_non_first_parent_shas` by removing a redundant `isinstance` check that `_is_external_parent` already guarantees
- `tests/validation/test_pr_commit_count.py`: repoint all former `contains_base_merge` tests to call `_external_non_first_parent_shas` directly; add `test_external_non_first_parent_shas_returns_correct_sha` to assert the actual sha value (kills the sentinel-sha mutant)
- `tests/validation/test_commit_limit_parity.py`: update historical comment from `contains_base_merge` to `contains_main_merge`

## Verification

102 tests pass. 4/4 mutants killed:

- `always-empty-return`: replace `return shas` with `return set()`. Killed by the nonempty test.
- `skip-external-guard`: replace external-parent guard with `if True:`. Killed by the internal-merge empty test.
- `use-first-parent`: iterate `parents[:1]` instead of `parents[1:]`. Killed by the nonempty test.
- `sentinel-sha`: add `"__SENTINEL__"` instead of the real sha. Killed by the returns-correct-sha test.

## References

See PR #4030 for the unification that made `contains_base_merge` dead code.

Fixes #4047
