### PR TITLE
fix(memories): make piped commands in Serena memories runnable

### DIFF
--- a/.serena/memories/git/git-worktree-worktrunk-hooks.md
+++ b/.serena/memories/git/git-worktree-worktrunk-hooks.md
@@ -65,14 +65,18 @@ test = "npm test"
 
 ## Template Variables
 
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Current branch name |
-| `{{ repo }}` | Repository name |
-| `{{ worktree_path }}` | Absolute worktree path |
-| `{{ default_branch }}` | Default branch name |
-| `{{ branch \| sanitize }}` | Branch with `/` replaced by `-` |
-| `{{ branch \| hash_port }}` | Unique port (10000-19999) |
+Template variables, including the filter forms, are shown in a fenced block
+because a markdown table cannot carry a bare `|`, and the escaped `\|` a table
+would need is a template syntax error rather than a filter.
+
+```text
+{{ branch }}                Current branch name
+{{ repo }}                  Repository name
+{{ worktree_path }}         Absolute worktree path
+{{ default_branch }}        Default branch name
+{{ branch | sanitize }}     Branch with / replaced by -
+{{ branch | hash_port }}    Unique port (10000-19999)
+```
 
 ## ai-agents Configuration Pattern
 

--- a/.serena/memories/jq/jq-010-handling-pagination-results.md
+++ b/.serena/memories/jq/jq-010-handling-pagination-results.md
@@ -100,47 +100,9 @@ echo '{"a": 1, "b": 2}' | jq 'keys'
 
 ## Quick Reference
 
-### Basic Operators
-
-| Operator | Purpose | Example |
-|----------|---------|---------|
-| `.field` | Access field | `.name` |
-| `.[]` | Iterate array | `.[].id` |
-| `.[n]` | Index array | `.[0]` |
-| `\|` | Pipe | `.[] \| .name` |
-| `,` | Multiple outputs | `.name, .id` |
-
-### Filters
-
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `select()` | Filter | `select(.state == "open")` |
-| `map()` | Transform | `map(.name)` |
-| `sort_by()` | Sort | `sort_by(.date)` |
-| `group_by()` | Group | `group_by(.author)` |
-| `unique` | Dedupe | `unique` |
-| `flatten` | Flatten arrays | `flatten` |
-
-### String Functions
-
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `contains()` | Substring match | `select(.name \| contains("api"))` |
-| `startswith()` | Prefix match | `select(.name \| startswith("test"))` |
-| `split()` | Split string | `split(",")` |
-| `join()` | Join array | `join(", ")` |
-| `@csv` | CSV format | `[.a, .b] \| @csv` |
-| `@tsv` | TSV format | `[.a, .b] \| @tsv` |
-
-### Type Functions
-
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `type` | Get type | `type` |
-| `tonumber` | To number | `.count \| tonumber` |
-| `tostring` | To string | `.id \| tostring` |
-| `length` | Array/string length | `length` |
-| `keys` | Object keys | `keys` |
+The operator, filter, string, and type tables live in one place:
+[jq-quick-reference](jq-quick-reference.md). They used to be duplicated here,
+which let the two copies drift and forced every fix to be applied twice.
 
 ---
 
@@ -151,3 +113,4 @@ echo '{"a": 1, "b": 2}' | jq 'keys'
 - [jq-003-object-construction](jq-003-object-construction.md)
 - [jq-004-filtering-with-select](jq-004-filtering-with-select.md)
 - [jq-005-array-operations](jq-005-array-operations.md)
+- [jq-quick-reference](jq-quick-reference.md)

--- a/.serena/memories/jq/jq-010-handling-pagination-results.md
+++ b/.serena/memories/jq/jq-010-handling-pagination-results.md
@@ -33,19 +33,35 @@ gh api graphql --paginate -f query='...' \
 
 ## Common jq Pitfalls
 
-### Pitfall-JQ-001: Forgetting Raw Mode
+### Pitfall-JQ-001: Raw Mode Belongs to External jq, Not `--jq`
 
-**Problem**: Quotes in output break shell scripts.
+**Problem**: Quotes in output break shell scripts, but the fix depends on which
+jq is doing the work.
+
+`gh`'s built-in `--jq` already emits raw output for string results, and it takes
+exactly one argument, so passing `-r` to it is a syntax error rather than an
+improvement. External `jq` is the one that quotes strings by default and needs
+`-r`.
 
 ```bash
-# BAD
+# gh's built-in --jq: already raw
 TITLE=$(gh pr view 123 --json title --jq '.title')
-# TITLE="My PR" (with quotes)
+# TITLE=My PR
 
-# GOOD
-TITLE=$(gh pr view 123 --json title --jq -r '.title')
-# TITLE=My PR (without quotes)
+# ...and -r is a syntax error, not a fix
+gh pr view 123 --json title --jq -r '.title'
+# accepts at most 1 arg(s), received 2
+
+# External jq: quotes by default
+gh pr view 123 --json title | jq '.title'
+# "My PR"
+
+# External jq: -r strips them
+gh pr view 123 --json title | jq -r '.title'
+# My PR
 ```
+
+All four forms measured against gh 2.96.0.
 
 ### Pitfall-JQ-002: Null Values in Pipelines
 

--- a/.serena/memories/jq/jq-quick-reference.md
+++ b/.serena/memories/jq/jq-quick-reference.md
@@ -4,8 +4,7 @@
 
 Examples are shown in fenced blocks, not table cells, so the `|` characters
 are the real jq pipe operator. A markdown table cell cannot hold a bare `|`,
-and the escaped `\|` a table would need is a jq syntax error: `jq '.count \|
-tonumber'` exits 3 with `syntax error, unexpected INVALID_CHARACTER`.
+and the escaped `\|` a table would need is a jq syntax error. Running `jq '.count \| tonumber'` exits 3 with `syntax error, unexpected INVALID_CHARACTER`.
 
 ```text
 Operator  Purpose           Example

--- a/.serena/memories/jq/jq-quick-reference.md
+++ b/.serena/memories/jq/jq-quick-reference.md
@@ -2,45 +2,54 @@
 
 ## Basic Operators
 
-| Operator | Purpose | Example |
-|----------|---------|---------|
-| `.field` | Access field | `.name` |
-| `.[]` | Iterate array | `.[].id` |
-| `.[n]` | Index array | `.[0]` |
-| `\|` | Pipe | `.[] \| .name` |
-| `,` | Multiple outputs | `.name, .id` |
+Examples are shown in fenced blocks, not table cells, so the `|` characters
+are the real jq pipe operator. A markdown table cell cannot hold a bare `|`,
+and the escaped `\|` a table would need is a jq syntax error: `jq '.count \|
+tonumber'` exits 3 with `syntax error, unexpected INVALID_CHARACTER`.
+
+```text
+Operator  Purpose           Example
+.field    Access field      .name
+.[]       Iterate array     .[].id
+.[n]      Index array       .[0]
+|         Pipe              .[] | .name
+,         Multiple outputs  .name, .id
+```
 
 ## Filters
 
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `select()` | Filter | `select(.state == "open")` |
-| `map()` | Transform | `map(.name)` |
-| `sort_by()` | Sort | `sort_by(.date)` |
-| `group_by()` | Group | `group_by(.author)` |
-| `unique` | Dedupe | `unique` |
-| `flatten` | Flatten arrays | `flatten` |
+```text
+Function    Purpose         Example
+select()    Filter          select(.state == "open")
+map()       Transform       map(.name)
+sort_by()   Sort            sort_by(.date)
+group_by()  Group           group_by(.author)
+unique      Dedupe          unique
+flatten     Flatten arrays  flatten
+```
 
 ## String Functions
 
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `contains()` | Substring match | `select(.name \| contains("api"))` |
-| `startswith()` | Prefix match | `select(.name \| startswith("test"))` |
-| `split()` | Split string | `split(",")` |
-| `join()` | Join array | `join(", ")` |
-| `@csv` | CSV format | `[.a, .b] \| @csv` |
-| `@tsv` | TSV format | `[.a, .b] \| @tsv` |
+```text
+Function      Purpose          Example
+contains()    Substring match  select(.name | contains("api"))
+startswith()  Prefix match     select(.name | startswith("test"))
+split()       Split string     split(",")
+join()        Join array       join(", ")
+@csv          CSV format       [.a, .b] | @csv
+@tsv          TSV format       [.a, .b] | @tsv
+```
 
 ## Type Functions
 
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `type` | Get type | `type` |
-| `tonumber` | To number | `.count \| tonumber` |
-| `tostring` | To string | `.id \| tostring` |
-| `length` | Array/string length | `length` |
-| `keys` | Object keys | `keys` |
+```text
+Function  Purpose              Example
+type      Get type             type
+tonumber  To number            .count | tonumber
+tostring  To string            .id | tostring
+length    Array/string length  length
+keys      Object keys          keys
+```
 
 ## References
 

--- a/.serena/memories/powershell/powershell-observations.md
+++ b/.serena/memories/powershell/powershell-observations.md
@@ -66,7 +66,7 @@ These are observations that may become patterns:
 | 2026-01-16 | 2026-01-16-session-07 | HIGH | Test both positive and negative cases |
 | 2026-01-16 | 2026-01-16-session-07 | HIGH | Pattern matching: most specific first |
 | 2026-01-16 | 2026-01-16-session-07 | HIGH | Use $() subexpression for arrays, never += in loops |
-| 2026-01-16 | Session 07 | HIGH | Filter nulls with `@($raw) \| Where-Object { $_ }` before `-contains` |
+| 2026-01-16 | Session 07 | HIGH | Filter nulls through `Where-Object { $_ }` before `-contains` |
 | 2026-01-16 | Session 07 | HIGH | Wrap single strings with `@()` before `-contains` |
 | 2026-01-16 | Session 07 | HIGH | Use `.ToLowerInvariant()` for case-insensitive `-contains` |
 | 2026-01-16 | Session 01, PR #845 | HIGH | YAML + PowerShell here-strings conflict - use array-join pattern |

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -79,11 +79,21 @@ Before claiming PR review complete, ALL must be true:
 
 | Criterion | Verification Command | Required |
 |-----------|---------------------|----------|
-| All comments resolved | `grep -c "Status: \\[COMPLETE\\]\\|\\[WONTFIX\\]"` equals total | Yes |
+| All comments resolved | count of resolved markers equals total, see command below | Yes |
 | No new comments | Re-check after 45s wait returned 0 new | Yes |
 | **CI checks pass** | **`gh pr checks` all success/skipped** | **Yes** |
 | No unresolved threads | GraphQL query for unresolved reviewThreads | Yes |
 | Commits pushed | `git status` shows "up to date with origin" | Yes |
+
+The resolved-marker count uses a basic regular expression, where `\|` is
+alternation. It is shown outside the table because a table cell would need
+`\\|`, which BRE reads as an escaped backslash followed by a literal pipe. That
+form matches nothing and reports 0, so the criterion fails even when every
+comment is resolved.
+
+```bash
+grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"
+```
 
 ## Implementation
 

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -131,7 +131,7 @@ So neither "double quotes work" nor "no shell means it breaks" holds on its
 own. Fencing the command removes the ambiguity.
 
 ```bash
-grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"
+grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]" review-threads.md
 ```
 
 ## Implementation

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -108,10 +108,15 @@ the table form of the pattern:
 - bash ANSI-C quoting, `$'...'`: collapses, reports 2
 - Python non-raw string literal: collapses, reports 2
 - Python raw string literal: preserves, reports 0
-- `xargs` default mode: strips every backslash, including the ones guarding
-  `[`, so grep receives bracket expressions where literals were written. It
-  reports 2 for a pattern that no longer means what the author wrote, which is
-  the right answer for the wrong reason. `xargs -d '\n'` preserves, reports 0.
+- `xargs` default mode: treats backslash as an escape, which mangles the pattern
+  without flattening it. `\[` and `\]` lose their shields and become bracket
+  expressions, while `\\` collapses to a single `\`, so the GNU BRE `\|`
+  alternation survives. grep receives `Status: [COMPLETE]\|[WONTFIX]` and reports
+  2, but the hits are single characters drawn from the class `[WONTFIX]`, not the
+  literal markers: the right answer for the wrong reason. Do not restate this as
+  "strips every backslash"; a full strip yields `Status: [COMPLETE]|[WONTFIX]`,
+  whose bare pipe is literal in BRE and reports 0. `xargs -d '\n'` preserves,
+  reports 0.
 
 Second, the dialect flag. Argv bytes are necessary but not sufficient, because
 `-E` inverts the escaping. Against the same fixture: `grep` with one backslash

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -89,12 +89,21 @@ Before claiming PR review complete, ALL must be true:
 
 The resolved-marker count uses a basic regular expression, where `\|` is
 alternation. It is shown outside the table because a table cell would need
-`\\|`, and what grep then receives depends on the caller's quoting. Inside
-double quotes the shell collapses the pair back to `\|` and the match works.
-Inside single quotes, or when the pattern is passed as an argument with no
-shell between the author and grep, grep receives `\\|` and reads an escaped
-backslash followed by a literal pipe, which matches nothing and reports 0.
-Fencing the command removes that ambiguity.
+`\\|`, and whether that still matches depends on how many literal-processing
+layers sit between the author and grep's argv. Only the bytes grep receives
+decide it: one backslash is alternation and matches, two is an escaped
+backslash followed by a literal pipe and matches nothing. Each layer either
+collapses the pair or preserves it. Measured against a two-line fixture
+holding both markers, using the table form of the pattern:
+
+- bash inline double quotes: collapses, reports 2
+- bash single quotes: preserves, reports 0
+- bash double-quoted variable expansion: preserves, reports 0
+- Python non-raw string literal: collapses, reports 2
+- Python raw string literal: preserves, reports 0
+
+So neither "double quotes work" nor "no shell means it breaks" holds on its
+own. Fencing the command removes the ambiguity.
 
 ```bash
 grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"
@@ -133,7 +142,7 @@ if [ "$failed_count" -gt 0 ]; then
   # Parse actionable items from failures
   echo ""
   echo "Actionable items:"
-  echo "$failed_checks" | jq -r '.[] | "  - \(.name): Review logs at \(.link // "N/A")"'
+  echo "$failed_checks" | jq -r '.[] | "  - \(.name): Review logs at \(.link | select(length > 0) // "N/A")"'
 
   # Return to Phase 6 for fixes
   exit 1

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -60,10 +60,12 @@ gh pr view 199 --json state,mergeable,reviewDecision
 checks_file=$(mktemp)
 trap 'rm -f "$checks_file"' EXIT
 
-gh pr checks 199 --json name,state,conclusion,detailsUrl > "$checks_file"
+gh pr checks 199 --json name,bucket,link > "$checks_file"
 
-# Parse results
-failed_checks=$(jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' "$checks_file")
+# Parse results. `bucket` is gh's normalized category: pass, fail, pending,
+# skipping, cancel. Prefer it over `state`, which reports NEUTRAL separately
+# even though gh already buckets NEUTRAL as skipping.
+failed_checks=$(jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")]' "$checks_file")
 
 if [ "$(echo "$failed_checks" | jq 'length')" -gt 0 ]; then
   echo "[BLOCKED] CI checks not passing:"
@@ -87,9 +89,12 @@ Before claiming PR review complete, ALL must be true:
 
 The resolved-marker count uses a basic regular expression, where `\|` is
 alternation. It is shown outside the table because a table cell would need
-`\\|`, which BRE reads as an escaped backslash followed by a literal pipe. That
-form matches nothing and reports 0, so the criterion fails even when every
-comment is resolved.
+`\\|`, and what grep then receives depends on the caller's quoting. Inside
+double quotes the shell collapses the pair back to `\|` and the match works.
+Inside single quotes, or when the pattern is passed as an argument with no
+shell between the author and grep, grep receives `\\|` and reads an escaped
+backslash followed by a literal pipe, which matches nothing and reports 0.
+Fencing the command removes that ambiguity.
 
 ```bash
 grep -c "Status: \[COMPLETE\]\|\[WONTFIX\]"
@@ -115,20 +120,20 @@ checks_file=$(mktemp)
 trap 'rm -f "$checks_file"' EXIT
 
 # Fetch all fields in one call, reuse for both waiting and verification
-gh pr checks [number] --json name,state,conclusion,detailsUrl > "$checks_file"
+gh pr checks [number] --json name,bucket,link > "$checks_file"
 
-# Parse for failures
-failed_checks=$(jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' "$checks_file")
+# Parse for failures. `bucket` is gh's normalized category.
+failed_checks=$(jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")]' "$checks_file")
 failed_count=$(echo "$failed_checks" | jq 'length')
 
 if [ "$failed_count" -gt 0 ]; then
   echo "[BLOCKED] $failed_count CI checks not passing:"
-  echo "$failed_checks" | jq -r '.[] | "  - \(.name): \(.conclusion)"'
+  echo "$failed_checks" | jq -r '.[] | "  - \(.name): \(.bucket)"'
 
   # Parse actionable items from failures
   echo ""
   echo "Actionable items:"
-  echo "$failed_checks" | jq -r '.[] | "  - \(.name): Review logs at \(.detailsUrl // "N/A")"'
+  echo "$failed_checks" | jq -r '.[] | "  - \(.name): Review logs at \(.link // "N/A")"'
 
   # Return to Phase 6 for fixes
   exit 1

--- a/.serena/memories/pr-review/pr-review-007-ci-verification.md
+++ b/.serena/memories/pr-review/pr-review-007-ci-verification.md
@@ -87,20 +87,40 @@ Before claiming PR review complete, ALL must be true:
 | No unresolved threads | GraphQL query for unresolved reviewThreads | Yes |
 | Commits pushed | `git status` shows "up to date with origin" | Yes |
 
-The resolved-marker count uses a basic regular expression, where `\|` is
-alternation. It is shown outside the table because a table cell would need
-`\\|`, and whether that still matches depends on how many literal-processing
-layers sit between the author and grep's argv. Only the bytes grep receives
-decide it: one backslash is alternation and matches, two is an escaped
-backslash followed by a literal pipe and matches nothing. Each layer either
-collapses the pair or preserves it. Measured against a two-line fixture
-holding both markers, using the table form of the pattern:
+The resolved-marker count uses a GNU basic regular expression, where `\|` is
+alternation. That spelling is a GNU extension, not portable POSIX BRE.
+`man 7 regex` says of obsolete ("basic") REs: "'|', '+', and '?' are ordinary
+characters and there is no equivalent for their functionality." Measured here
+on GNU grep 3.11.
+
+It is shown outside the table because a table cell would need `\\|`, and
+whether that still matches depends on two things, not one.
+
+First, the bytes grep receives. One backslash is alternation and matches, two
+is an escaped backslash followed by a literal pipe and matches nothing. Each
+layer between the author and grep's argv either collapses the pair or
+preserves it. Measured against a two-line fixture holding both markers, using
+the table form of the pattern:
 
 - bash inline double quotes: collapses, reports 2
 - bash single quotes: preserves, reports 0
 - bash double-quoted variable expansion: preserves, reports 0
+- bash ANSI-C quoting, `$'...'`: collapses, reports 2
 - Python non-raw string literal: collapses, reports 2
 - Python raw string literal: preserves, reports 0
+- `xargs` default mode: strips every backslash, including the ones guarding
+  `[`, so grep receives bracket expressions where literals were written. It
+  reports 2 for a pattern that no longer means what the author wrote, which is
+  the right answer for the wrong reason. `xargs -d '\n'` preserves, reports 0.
+
+Second, the dialect flag. Argv bytes are necessary but not sufficient, because
+`-E` inverts the escaping. Against the same fixture: `grep` with one backslash
+reports 2; `grep -E` with one backslash reports 0, because that is a literal
+pipe in ERE; `grep -E` with a bare pipe reports 2; `grep -E` with the table
+form reports 1, reading it as a literal backslash alternated with the second
+marker. A reader who copies the pattern and adds `-E` gets a silent zero, so
+any claim about this pattern has to name both the dialect and the
+implementation.
 
 So neither "double quotes work" nor "no shell means it breaks" holds on its
 own. Fencing the command removes the ambiguity.

--- a/.serena/memories/quality/quality-test-criteria-patterns.md
+++ b/.serena/memories/quality/quality-test-criteria-patterns.md
@@ -26,9 +26,18 @@
 |-------------|--------------|---------|
 | Function execution | Test calls the function under test | `$result = Get-Something` |
 | Mock isolation | External dependencies mocked | `Mock gh { ... }` |
-| Output validation | Return values checked | `$result \| Should -Be $expected` |
-| Error conditions | Exception paths tested | `{ Bad-Input } \| Should -Throw` |
+| Output validation | Return values checked | see assertions below |
+| Error conditions | Exception paths tested | see assertions below |
 | Edge cases | Boundary values covered | null, empty, max values |
+
+Assertion forms are shown outside the table. A markdown table cannot carry a
+bare `|`, and the escaped `\|` a table would need is a PowerShell parse error,
+so a copied assertion would fail with `ParserError` rather than run.
+
+```powershell
+$result | Should -Be $expected
+{ Bad-Input } | Should -Throw
+```
 
 ## Test Review Checklist
 


### PR DESCRIPTION
## Summary

Fixes 21 escaped pipe defects across 6 Serena memory files. An escaped pipe is valid Markdown, but a raw reader gets the bytes intact, so every command in these cells reached the shell as a literal argument instead of a pipeline.

Refs #4081

## Why this is a defect and not a style nit

Three dialects, three different failure modes, all measured on this branch.

```
jq    escaped   jq '.count \| tonumber'      rc 3, syntax error, unexpected INVALID_CHARACTER
jq    bare      jq '.count | tonumber'       rc 0, prints 5
pwsh  escaped   $result \| Should -Be $e      ParserError, rc 1
pwsh  bare      $result | Should -Be $e       parses clean
grep  raw       "Status: \\[C\\]\\|\\[W\\]"    0 matches, a silent wrong answer
grep  rendered  "Status: \[C\]\|\[W\]"         2 matches, correct
```

The grep case is inverted from the other two. For a shell pipeline the raw bytes are broken and the rendered form is right. For a POSIX basic regular expression alternation the author wrote a doubled escape so that it renders as a single one, which means the rendered form is correct and the raw form silently matches nothing.

That inversion is why the remedy is to fence the content. A fenced block makes the raw bytes and the rendered bytes identical, so both audiences read the same thing and neither dialect is guessed at.

## What changed

Four tables became fenced text blocks with aligned columns. Pester assertions moved into a fenced powershell block. One grep command moved into a fenced bash block. One table cell was reworded so it no longer needs a pipe at all.

## The deletion

One file carried a byte identical 45 line copy of another file's quick reference and did not link to it. Duplicating the fix into a verbatim copy would have doubled the maintenance surface for no reader benefit, so the copy was replaced with a pointer to the canonical file plus an entry in the Related list. That removed 7 of the 21 sites by deletion rather than by editing them twice.

## Evidence

Positive and negative controls, 12 assertions, all passing. Each jq expression runs against a real fixture and the escaped form is asserted to fail while the bare form is asserted to succeed. Each PowerShell snippet is written to a `.ps1` file and parsed, because passing a snippet containing a dollar sign through `pwsh -c` from bash mangles it before the parser ever sees it.

Three assertions failed on the first run and all three turned out to be harness bugs rather than artifact bugs. A jq expression beginning with a bracket iterator needs an array fixture, not an object. The two PowerShell cases were the dollar sign mangling described above. The harness was corrected and the artifacts were unchanged.

Dash count is 0 across all 6 files. Serena paths are excluded from the markdownlint configuration, so a scoped lint run reports 0 files checked, which means not linted rather than clean.

## Notes

One escaped pipe is intentionally retained in `jq/jq-quick-reference.md` because the surrounding prose quotes the broken form in order to name it. One escaped pipe is intentionally retained in `pr-review/pr-review-007-ci-verification.md` because it is a basic regular expression alternation where the escape is correct.
