### PR TITLE
fix(rules): guard the unchecked git fetch in the version-enumeration recipe

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5486",
+  "version": "0.6.5488",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/rules/plugin-version-bump.md
+++ b/.claude/rules/plugin-version-bump.md
@@ -46,7 +46,7 @@ same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
 then bump the parity pair together to one value and `src/claude` to its own.
 
 ```bash
-git fetch origin --quiet
+git fetch origin --quiet || { echo "ERROR: git fetch failed; refs may be stale" >&2; exit 1; }
 for MANIFEST in .claude/.claude-plugin/plugin.json \
                 src/copilot-cli/.claude-plugin/plugin.json \
                 src/claude/.claude-plugin/plugin.json; do
@@ -64,7 +64,13 @@ The emptiness check is load-bearing. Both `git show` and the decoder discard
 stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
 pipeline then prints nothing and still exits 0, which reads as "nobody has
 allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
+form exits 1 on a bogus path. The fetch guard is load-bearing for the same
+reason, one step earlier. `git show` reads local remote-tracking refs, not the
+network, so an unchecked fetch failure does not empty the output; it silently
+answers from whatever those refs held last. Verified: with the fetch failing
+(exit 128) and the return value discarded, the loop still printed a maximum and
+exited 0. That is worse than reading nothing, because a stale answer understates
+the pack and looks exactly like a fresh one. Separately, `sort -V` places a prerelease suffix
 *after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
 SemVer precedence. No branch uses a suffix today, so that is latent rather than
 live, but do not trust this snippet if one appears.

--- a/.github/instructions/plugin-version-bump.instructions.md
+++ b/.github/instructions/plugin-version-bump.instructions.md
@@ -41,7 +41,7 @@ same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
 then bump the parity pair together to one value and `src/claude` to its own.
 
 ```bash
-git fetch origin --quiet
+git fetch origin --quiet || { echo "ERROR: git fetch failed; refs may be stale" >&2; exit 1; }
 for MANIFEST in .claude/.claude-plugin/plugin.json \
                 src/copilot-cli/.claude-plugin/plugin.json \
                 src/claude/.claude-plugin/plugin.json; do
@@ -59,7 +59,13 @@ The emptiness check is load-bearing. Both `git show` and the decoder discard
 stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
 pipeline then prints nothing and still exits 0, which reads as "nobody has
 allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
+form exits 1 on a bogus path. The fetch guard is load-bearing for the same
+reason, one step earlier. `git show` reads local remote-tracking refs, not the
+network, so an unchecked fetch failure does not empty the output; it silently
+answers from whatever those refs held last. Verified: with the fetch failing
+(exit 128) and the return value discarded, the loop still printed a maximum and
+exited 0. That is worse than reading nothing, because a stale answer understates
+the pack and looks exactly like a fresh one. Separately, `sort -V` places a prerelease suffix
 *after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
 SemVer precedence. No branch uses a suffix today, so that is latent rather than
 live, but do not trust this snippet if one appears.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5486",
+  "version": "0.6.5488",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/instructions/plugin-version-bump.instructions.md
+++ b/src/copilot-cli/instructions/plugin-version-bump.instructions.md
@@ -41,7 +41,7 @@ same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
 then bump the parity pair together to one value and `src/claude` to its own.
 
 ```bash
-git fetch origin --quiet
+git fetch origin --quiet || { echo "ERROR: git fetch failed; refs may be stale" >&2; exit 1; }
 for MANIFEST in .claude/.claude-plugin/plugin.json \
                 src/copilot-cli/.claude-plugin/plugin.json \
                 src/claude/.claude-plugin/plugin.json; do
@@ -59,7 +59,13 @@ The emptiness check is load-bearing. Both `git show` and the decoder discard
 stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
 pipeline then prints nothing and still exits 0, which reads as "nobody has
 allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
+form exits 1 on a bogus path. The fetch guard is load-bearing for the same
+reason, one step earlier. `git show` reads local remote-tracking refs, not the
+network, so an unchecked fetch failure does not empty the output; it silently
+answers from whatever those refs held last. Verified: with the fetch failing
+(exit 128) and the return value discarded, the loop still printed a maximum and
+exited 0. That is worse than reading nothing, because a stale answer understates
+the pack and looks exactly like a fresh one. Separately, `sort -V` places a prerelease suffix
 *after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
 SemVer precedence. No branch uses a suffix today, so that is latent rather than
 live, but do not trust this snippet if one appears.


### PR DESCRIPTION
## Summary

The version-enumeration recipe in `.claude/rules/plugin-version-bump.md` runs `git fetch origin --quiet` without checking its exit status. When the fetch fails (no network, auth expired, remote unreachable), the recipe silently continues against stale remote-tracking refs and still prints a maximum version. The caller gets a plausible number that is wrong, and every downstream guard passes.

An adversarial review flagged the recipe's atomicity. This fixes the one sub-claim that was genuinely uncovered.

## What changed

Guarded the fetch:

```
git fetch origin --quiet || { echo "ERROR: git fetch failed; refs may be stale" >&2; exit 1; }
```

Added a prose paragraph explaining why the existing emptiness guard cannot catch this: `git show` reads local remote-tracking refs, so a failed fetch yields a stale but non-empty answer, which the emptiness check accepts.

## What this does NOT change

The `sort -V` prerelease-ordering caveat. The rule already documents it, with the same worked example and a "latent rather than live" judgment. Re-fixing it would be a duplicate.

## Verification

Extracted the fixed snippet verbatim from the committed markdown and ran it both ways:

| Case | Expected | Actual |
| --- | --- | --- |
| Fetch fails (unreachable remote) | non-zero exit, no version printed | exit 1 |
| Fetch succeeds (real remote) | exit 0, three version lines | exit 0, all three printed |

Gates: `build_all.py --check` exit 0. `plugin-version-bump: OK`. Negative control on the version gate run with the revert **committed** (a working-tree revert passes vacuously because the validator diffs `origin/main`): exit 1 with a precise message.

Both instruction mirrors regenerated with `build/scripts/generate_rules.py`. Parity pair bumped to `0.6.5488`, enumerated with the rule's own recipe.

Refs #4114
