### PR TITLE
fix(session): correct 4 post-merge defects from #4001

### DIFF
--- a/.claude/skills/session-end/scripts/complete_session_log.py
+++ b/.claude/skills/session-end/scripts/complete_session_log.py
@@ -455,8 +455,11 @@ def main(argv: list[str] | None = None) -> int:
         session_end["reworkWarning"] = {}
     # Schema requires Evidence as a string (checklistItem shape). Join list entries
     # with newline so the full rework output is preserved (issue #3929, #3954).
+    # Complete derives from whether the step actually ran: a "skipped" summary
+    # means the sibling module was absent or threw a runtime error (post-#4001).
+    rework_ran = "skipped" not in rework_summary.lower()
     session_end["reworkWarning"]["level"] = "SHOULD"
-    session_end["reworkWarning"]["Complete"] = True
+    session_end["reworkWarning"]["Complete"] = rework_ran
     session_end["reworkWarning"]["Evidence"] = (
         "\n".join(rework_evidence) if isinstance(rework_evidence, list) else str(rework_evidence)
     )

--- a/.claude/skills/session-init/scripts/new_session_log.py
+++ b/.claude/skills/session-init/scripts/new_session_log.py
@@ -273,7 +273,7 @@ def _run_validation(session_log_path: str, repo_root: str) -> bool:
     print("Running validation...", file=sys.stderr)
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, validation_script, "--existing-log", session_log_path],
+        [sys.executable, validation_script, "--creation-mode", session_log_path],
         capture_output=False,
         timeout=60,
         check=False,
@@ -344,7 +344,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"\nSession log created but schema validation FAILED.\n"
                 f"  File: {filepath}\n"
                 f"Fix issues and re-validate:\n"
-                f'  python3 scripts/validate_session_json.py --existing-log "{filepath}"',
+                f'  python3 scripts/validate_session_json.py --creation-mode "{filepath}"',
                 file=sys.stderr,
             )
             return 4

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -444,9 +444,25 @@ def _is_numeric_test_count(evidence: str, match: re.Match[str]) -> bool:
     if match.group(0).lower() not in _NUMERIC_COUNT_TOKENS:
         return False
     prefix = evidence[: match.start()]
-    return bool(_DIGIT_BEFORE_TOKEN.search(prefix)) or bool(
-        _PYTEST_SUMMARY_CONTEXT.search(evidence)
-    )
+    if bool(_DIGIT_BEFORE_TOKEN.search(prefix)):
+        return True
+    # _PYTEST_SUMMARY_CONTEXT must only apply to the clause that contains the
+    # matched token. Searching the entire evidence string falsely excuses
+    # "354 passed; markdownlint step skipped": "354 passed" satisfies the
+    # pattern even though the "skipped" belongs to a different clause and is a
+    # genuine contradiction. See post-#4001 adversarial review.
+    clause_start = 0
+    for sep in (";", "\n"):
+        pos = evidence.rfind(sep, 0, match.start())
+        if pos >= 0:
+            clause_start = max(clause_start, pos + 1)
+    clause_end = len(evidence)
+    for sep in (";", "\n"):
+        pos = evidence.find(sep, match.end())
+        if 0 <= pos < clause_end:
+            clause_end = pos
+    clause = evidence[clause_start:clause_end].strip()
+    return bool(_PYTEST_SUMMARY_CONTEXT.search(clause))
 
 
 def _has_contradiction(evidence: str) -> bool:
@@ -929,7 +945,9 @@ def validate_against_schema(
         result.errors.append(_describe(error))
 
 
-def validate_session_log(data: object, *, existing_log: bool = False) -> ValidationResult:
+def validate_session_log(
+    data: object, *, existing_log: bool = False, creation_mode: bool = False
+) -> ValidationResult:
     """Validate a session log against the committed schema and protocol rules.
 
     Args:
@@ -937,6 +955,13 @@ def validate_session_log(data: object, *, existing_log: bool = False) -> Validat
             any JSON value can reach here, so the type is the parser's, not the
             schema's. The schema reports a non-object; the protocol checks below
             need a mapping and are skipped without one.
+        creation_mode: True when the log was just created and session-end
+            evidence does not yet exist. The full schema still binds (required
+            fields, correct types, ``notOnMain``), but ``validate_protocol_compliance``
+            and ``validate_evidence_agrees_with_session`` are skipped because
+            the session has not run yet. Use this at creation time only; use
+            ``existing_log`` for logs already committed. The two modes are
+            mutually exclusive; if both are set, ``existing_log`` wins.
         existing_log: True when the log was already committed and this change
             only edits it. Two different questions are bundled in this file, and
             they have different answers on an old log. Shape ("is this record
@@ -975,10 +1000,14 @@ def validate_session_log(data: object, *, existing_log: bool = False) -> Validat
     if isinstance(data.get("session"), dict):
         validate_session_section(data["session"], result)
 
-    if not existing_log and isinstance(data.get("protocolCompliance"), dict):
+    # creation_mode: the session just started; checklist items are incomplete
+    # by design and evidence-agreement checks have nothing to compare against.
+    # existing_log wins when both are set (see docstring).
+    skip_compliance = existing_log or creation_mode
+    if not skip_compliance and isinstance(data.get("protocolCompliance"), dict):
         validate_protocol_compliance(data["protocolCompliance"], result)
 
-    if not existing_log:
+    if not existing_log and not creation_mode:
         validate_evidence_agrees_with_session(data, result)
 
     return result
@@ -1179,9 +1208,19 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Skip protocol-compliance and evidence-agreement checks: validate "
-            "schema and shape only. Use for (1) a log already committed where "
-            "a checklist item cannot be made true retroactively, or (2) a "
-            "freshly created log that does not yet have session-end evidence."
+            "schema and shape only. Use for a log already committed where "
+            "a checklist item cannot be made true retroactively."
+        ),
+    )
+    parser.add_argument(
+        "--creation-mode",
+        action="store_true",
+        help=(
+            "Validate a freshly created log: full schema check plus structural "
+            "shape, but skip protocol-compliance (checklist items are incomplete "
+            "by design) and evidence-agreement (nothing to agree against yet). "
+            "Use only at session-creation time; use --existing-log for already-"
+            "committed logs."
         ),
     )
     parser.add_argument(
@@ -1263,7 +1302,9 @@ def main() -> int:
                 _PROJECT_ROOT,
             )
 
-        result = validate_session_log(data, existing_log=existing_log)
+        result = validate_session_log(
+            data, existing_log=existing_log, creation_mode=args.creation_mode
+        )
         validate_filename_number(validated_path, data, result)
 
         # Report results

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
-  "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
+  "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
   "version": "0.6.5494",
   "author": {
     "name": "rjmurillo"

--- a/src/copilot-cli/skills/session-end/scripts/complete_session_log.py
+++ b/src/copilot-cli/skills/session-end/scripts/complete_session_log.py
@@ -455,8 +455,11 @@ def main(argv: list[str] | None = None) -> int:
         session_end["reworkWarning"] = {}
     # Schema requires Evidence as a string (checklistItem shape). Join list entries
     # with newline so the full rework output is preserved (issue #3929, #3954).
+    # Complete derives from whether the step actually ran: a "skipped" summary
+    # means the sibling module was absent or threw a runtime error (post-#4001).
+    rework_ran = "skipped" not in rework_summary.lower()
     session_end["reworkWarning"]["level"] = "SHOULD"
-    session_end["reworkWarning"]["Complete"] = True
+    session_end["reworkWarning"]["Complete"] = rework_ran
     session_end["reworkWarning"]["Evidence"] = (
         "\n".join(rework_evidence) if isinstance(rework_evidence, list) else str(rework_evidence)
     )

--- a/src/copilot-cli/skills/session-init/scripts/new_session_log.py
+++ b/src/copilot-cli/skills/session-init/scripts/new_session_log.py
@@ -273,7 +273,7 @@ def _run_validation(session_log_path: str, repo_root: str) -> bool:
     print("Running validation...", file=sys.stderr)
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, validation_script, "--existing-log", session_log_path],
+        [sys.executable, validation_script, "--creation-mode", session_log_path],
         capture_output=False,
         timeout=60,
         check=False,
@@ -344,7 +344,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"\nSession log created but schema validation FAILED.\n"
                 f"  File: {filepath}\n"
                 f"Fix issues and re-validate:\n"
-                f'  python3 scripts/validate_session_json.py --existing-log "{filepath}"',
+                f'  python3 scripts/validate_session_json.py --creation-mode "{filepath}"',
                 file=sys.stderr,
             )
             return 4

--- a/tests/skills/session/test_complete_session_log.py
+++ b/tests/skills/session/test_complete_session_log.py
@@ -42,76 +42,6 @@ class TestGetRepoRoot:
         assert result == "/tmp/wt"
 
 
-class TestReworkWarningShape:
-    """Tests for reworkWarning Evidence field shape (#3929, #3954)."""
-
-    def _make_session(self):
-        return {"protocolCompliance": {"sessionEnd": {"reworkWarning": {}}}}
-
-    @patch("complete_session_log._run_rework_warning_step")
-    def test_evidence_written_as_string_not_list(self, mock_rework):
-        """Evidence must be a string to satisfy the checklistItem schema (#3929)."""
-        mock_rework.return_value = ("rework-warning: none", ["rework-warning: none"])
-        session = self._make_session()
-        session_end = session["protocolCompliance"]["sessionEnd"]
-
-        # Simulate the relevant portion of main() that writes reworkWarning
-        rework_summary, rework_evidence = complete_session_log._run_rework_warning_step()
-        if "reworkWarning" not in session_end:
-            session_end["reworkWarning"] = {}
-        session_end["reworkWarning"]["level"] = "SHOULD"
-        session_end["reworkWarning"]["Complete"] = True
-        session_end["reworkWarning"]["Evidence"] = (
-            "\n".join(rework_evidence)
-            if isinstance(rework_evidence, list)
-            else str(rework_evidence)
-        )
-
-        assert isinstance(session_end["reworkWarning"]["Evidence"], str)
-        assert session_end["reworkWarning"]["level"] == "SHOULD"
-        assert session_end["reworkWarning"]["Complete"] is True
-
-    @patch("complete_session_log._run_rework_warning_step")
-    def test_list_evidence_joined_with_newline(self, mock_rework):
-        """Multi-line rework evidence is joined into a single string (#3954)."""
-        lines = ["rework-warning: line1", "rework-warning: line2"]
-        mock_rework.return_value = ("rework: 2 lines", lines)
-        session = self._make_session()
-        session_end = session["protocolCompliance"]["sessionEnd"]
-
-        rework_summary, rework_evidence = complete_session_log._run_rework_warning_step()
-        session_end["reworkWarning"]["level"] = "SHOULD"
-        session_end["reworkWarning"]["Complete"] = True
-        session_end["reworkWarning"]["Evidence"] = (
-            "\n".join(rework_evidence)
-            if isinstance(rework_evidence, list)
-            else str(rework_evidence)
-        )
-
-        assert (
-            session_end["reworkWarning"]["Evidence"]
-            == "rework-warning: line1\nrework-warning: line2"
-        )
-
-    @patch("complete_session_log._run_rework_warning_step")
-    def test_string_evidence_used_directly(self, mock_rework):
-        """If rework step already returns a string, it is used as-is (#3954)."""
-        mock_rework.return_value = ("rework: none", "rework-warning: none")
-        session = self._make_session()
-        session_end = session["protocolCompliance"]["sessionEnd"]
-
-        rework_summary, rework_evidence = complete_session_log._run_rework_warning_step()
-        session_end["reworkWarning"]["level"] = "SHOULD"
-        session_end["reworkWarning"]["Complete"] = True
-        session_end["reworkWarning"]["Evidence"] = (
-            "\n".join(rework_evidence)
-            if isinstance(rework_evidence, list)
-            else str(rework_evidence)
-        )
-
-        assert session_end["reworkWarning"]["Evidence"] == "rework-warning: none"
-
-
 class TestFindCurrentSessionLog:
     """Tests for _find_current_session_log function."""
 
@@ -327,3 +257,76 @@ class TestMainReworkWarningShape:
         evidence = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]["Evidence"]
         assert isinstance(evidence, str), f"Evidence must be a string, got {type(evidence)}"
         assert "rework-warning: none" in evidence
+
+    def _run_main_with_rework(self, tmp_path, rework_return):
+        """Helper: run main() with a controlled rework step return value."""
+        import json
+
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "2026-07-30-session-99-test.json"
+        self._make_session_json(session_file)
+
+        with (
+            patch("complete_session_log._get_repo_root", return_value=str(tmp_path)),
+            patch("complete_session_log._test_uncommitted_changes", return_value=False),
+            patch("complete_session_log._get_ending_commit", return_value="abc1234"),
+            patch("complete_session_log._test_handoff_modified", return_value=False),
+            patch("complete_session_log._test_serena_memory_updated", return_value=True),
+            patch("complete_session_log._run_markdown_lint", return_value=(True, "ok")),
+            patch("complete_session_log._run_rework_warning_step", return_value=rework_return),
+            patch("complete_session_log.subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("complete_session_log.resolve_artifact_root", return_value=sessions_dir),
+        ):
+            complete_session_log.main(["--session-path", str(session_file)])
+
+        return json.loads(session_file.read_text())
+
+    def test_rework_complete_true_when_step_runs(self, tmp_path):
+        """Complete=True when rework step ran without skipping (post-#4001)."""
+        result = self._run_main_with_rework(
+            tmp_path, ("Rework warning: none", ["rework-warning: none"])
+        )
+        rw = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]
+        assert rw["Complete"] is True
+
+    def test_rework_complete_false_when_sibling_unavailable(self, tmp_path):
+        """Complete=False when rework step was skipped due to missing module (post-#4001)."""
+        result = self._run_main_with_rework(
+            tmp_path,
+            (
+                "Rework warning: skipped (sibling unavailable)",
+                ["rework-warning: skipped (sibling module unavailable)"],
+            ),
+        )
+        rw = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]
+        assert rw["Complete"] is False
+
+    def test_rework_complete_false_when_runtime_error(self, tmp_path):
+        """Complete=False when rework step was skipped due to runtime error (post-#4001)."""
+        result = self._run_main_with_rework(
+            tmp_path,
+            (
+                "Rework warning: skipped (runtime error)",
+                ["rework-warning: skipped (runtime error: OSError)"],
+            ),
+        )
+        rw = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]
+        assert rw["Complete"] is False
+
+    def test_rework_evidence_joined_when_multiline(self, tmp_path):
+        """Multi-line evidence is joined with newline into a single string (post-#4001)."""
+        result = self._run_main_with_rework(
+            tmp_path,
+            ("[WARN] rework warning: 2 file(s)", ["rework-warning: a.py", "rework-warning: b.py"]),
+        )
+        rw = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]
+        assert rw["Evidence"] == "rework-warning: a.py\nrework-warning: b.py"
+
+    def test_rework_evidence_string_passthrough(self, tmp_path):
+        """String evidence (not a list) is stored as-is (post-#4001)."""
+        result = self._run_main_with_rework(
+            tmp_path, ("Rework warning: none", "rework-warning: none (string form)")
+        )
+        rw = result["protocolCompliance"]["sessionEnd"]["reworkWarning"]
+        assert rw["Evidence"] == "rework-warning: none (string form)"

--- a/tests/skills/session/test_new_session_log.py
+++ b/tests/skills/session/test_new_session_log.py
@@ -276,16 +276,17 @@ class TestRunValidation:
         assert result is False
 
     @patch("new_session_log.subprocess.run")
-    def test_passes_existing_log_flag_to_validator(self, mock_run, tmp_path):
-        """Validator is called with --existing-log so protocol items are not checked
-        at creation time (issues #3914, #3946)."""
+    def test_passes_creation_mode_flag_to_validator(self, mock_run, tmp_path):
+        """Validator is called with --creation-mode so protocol items are not checked
+        at creation time, but the full schema still binds (post-#4001, issues #3914, #3946)."""
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
         (scripts_dir / "validate_session_json.py").write_text("# stub")
         mock_run.return_value = MagicMock(returncode=0)
         new_session_log._run_validation(str(tmp_path / "test.json"), str(tmp_path))
         call_args = mock_run.call_args[0][0]
-        assert "--existing-log" in call_args
+        assert "--creation-mode" in call_args
+        assert "--existing-log" not in call_args
 
 
 class TestGetDescriptiveKeywords:

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -2888,5 +2888,7 @@ class TestCreationMode:
             cwd=_REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         assert r.returncode == 0, f"Expected PASS, got:\n{r.stdout}"

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -2741,3 +2741,152 @@ class TestTheSchemaNamesEveryRequiredRootField:
             "session",
             "protocolCompliance",
         }
+
+
+class TestPytestSummaryContextAnchoredToClause:
+    """CRITICAL 1: pytest-summary escape must only excuse the 'skipped' in its own clause.
+
+    Post-#4001 adversarial review: _has_contradiction("354 passed; markdownlint step skipped")
+    returned False because _PYTEST_SUMMARY_CONTEXT searched the entire evidence string.
+    The escape hatch must only apply to 'skipped' tokens that appear in the same
+    clause (bounded by ';' and newline) as the pytest summary pattern.
+    """
+
+    @staticmethod
+    def _item(evidence: str) -> dict:
+        return {"complete": True, "evidence": evidence, "level": "MUST"}
+
+    @staticmethod
+    def _warn(item: dict) -> bool:
+        result = ValidationResult()
+        validate_checklist_section({"x": item}, frozenset(), "sessionStart", result)
+        return any("Evidence contradiction" in w for w in result.warnings)
+
+    def test_cross_clause_skipped_still_flags(self) -> None:
+        """354 passed in one clause must not excuse 'skipped' in a different clause."""
+        evidence = "354 passed; markdownlint step skipped"
+        assert self._warn(self._item(evidence)), (
+            f"Expected contradiction for {evidence!r} -- 'skipped' is in a different clause"
+        )
+
+    def test_cross_clause_newline_still_flags(self) -> None:
+        """Same bug via newline separator: pytest summary on one line, skip on the next."""
+        evidence = "Tests: 17 passed 3 skipped\nmarkdownlint: skipped"
+        # The second 'skipped' is in a different clause from "17 passed"
+        assert self._warn(self._item(evidence)), (
+            f"Expected contradiction for second 'skipped' in {evidence!r}"
+        )
+
+    def test_same_clause_numeric_still_passes(self) -> None:
+        """17 passed 3 skipped in a single clause must remain a false-positive exclusion."""
+        evidence = "17 passed 3 skipped"
+        assert not self._warn(self._item(evidence)), f"False positive for {evidence!r}"
+
+    def test_comma_separated_summary_still_passes(self) -> None:
+        """14434 passed, 21 skipped, 45 xfailed must still be excused (existing test parity)."""
+        evidence = "uv run pytest tests/ -q: 14434 passed, 21 skipped, 45 xfailed"
+        assert not self._warn(self._item(evidence)), f"False positive for {evidence!r}"
+
+    def test_legitimate_pytest_tallies_still_pass(self) -> None:
+        """The 27 real evidence fields with pytest tallies must not become false contradictions."""
+        tallies = [
+            "94 passed plus 1 skipped",
+            "103 passed, 2 errors, 5 skipped",
+            "uv run pytest tests/ -q: 14434 passed, 21 skipped, 45 xfailed",
+            "21 skipped",
+            "0 skipped",
+        ]
+        for evidence in tallies:
+            assert not self._warn(self._item(evidence)), (
+                f"False positive regression for {evidence!r}"
+            )
+
+    def test_isolating_negative_control(self) -> None:
+        """Bare 'skipped' with no preceding digit and no pytest context still flags."""
+        evidence = "markdownlint step skipped"
+        assert self._warn(self._item(evidence)), f"Expected contradiction for {evidence!r}"
+
+
+class TestCreationMode:
+    """CRITICAL 2: --creation-mode skips protocol-compliance but keeps full schema.
+
+    A fresh log cannot satisfy 'Incomplete MUST' checks for items that only exist
+    after the session ends. But the schema (required fields, types, date, branch)
+    still fully binds at creation time.  post-#4001 adversarial review.
+    """
+
+    def test_fresh_log_passes_creation_mode(self) -> None:
+        """A freshly created log with all items complete=False passes creation-mode."""
+        log = _make_valid_log()
+        # Set all items to incomplete (as new_session_log.py creates them)
+        for section in ("sessionStart", "sessionEnd"):
+            for item in log["protocolCompliance"][section].values():
+                item["complete"] = False
+                item["evidence"] = ""
+        result = validate_session_log(log, creation_mode=True)
+        assert result.errors == [], result.errors
+
+    def test_fresh_log_fails_normal_mode(self) -> None:
+        """The same log fails normal (non-creation) mode due to Incomplete MUSTs."""
+        log = _make_valid_log()
+        for section in ("sessionStart", "sessionEnd"):
+            for item in log["protocolCompliance"][section].values():
+                item["complete"] = False
+                item["evidence"] = ""
+        result = validate_session_log(log, creation_mode=False)
+        incomplete = [e for e in result.errors if "Incomplete MUST" in e]
+        assert incomplete, "Expected Incomplete MUST errors in normal mode"
+
+    def test_schema_still_enforced_in_creation_mode(self) -> None:
+        """Required schema fields (session.number, branch, etc.) still bind in creation-mode."""
+        log = _make_valid_log()
+        del log["session"]["number"]
+        result = validate_session_log(log, creation_mode=True)
+        assert any("number" in e and e.startswith("Schema:") for e in result.errors), (
+            "Schema check for session.number must still run in creation-mode"
+        )
+
+    def test_creation_mode_skips_evidence_agreement(self) -> None:
+        """creation_mode also skips evidence-agreement checks (nothing to agree yet)."""
+        log = _make_valid_log()
+        # Insert a branch mismatch: evidence names a different feature branch
+        log["protocolCompliance"]["sessionStart"]["branchVerified"] = {
+            "complete": True,
+            "evidence": "verified on fix/old-session-branch",
+            "level": "MUST",
+        }
+        # Session is on a different branch entirely
+        log["session"]["branch"] = "fix/other-branch"
+        result_normal = validate_session_log(log, creation_mode=False)
+        branch_errors = [e for e in result_normal.errors if "different branch" in e]
+        assert branch_errors, "Normal mode should flag branch mismatch"
+        result_creation = validate_session_log(log, creation_mode=True)
+        creation_branch_errors = [e for e in result_creation.errors if "different branch" in e]
+        assert not creation_branch_errors, "creation_mode must skip evidence-agreement checks"
+
+    def test_existing_log_wins_when_both_set(self) -> None:
+        """existing_log=True wins when creation_mode is also True (documented precedence)."""
+        log = _make_valid_log()
+        for field in _RELAXED_FOR_EXISTING_LOGS:
+            log.pop(field, None)
+        # With existing_log=True, the four relaxed fields are not required
+        result = validate_session_log(log, existing_log=True, creation_mode=True)
+        assert not any(e.startswith("Schema:") for e in result.errors), result.errors
+
+    def test_cli_creation_mode_flag(self, scratch: Path) -> None:
+        """--creation-mode flag accepted by the CLI and produces PASS for a fresh log."""
+        log = _make_valid_log(number=9001)
+        for section in ("sessionStart", "sessionEnd"):
+            for item in log["protocolCompliance"][section].values():
+                item["complete"] = False
+                item["evidence"] = ""
+        path = scratch / "2026-07-31-session-9001-test.json"
+        path.write_text(json.dumps(log))
+
+        r = subprocess.run(
+            [sys.executable, "scripts/validate_session_json.py", "--creation-mode", str(path)],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 0, f"Expected PASS, got:\n{r.stdout}"


### PR DESCRIPTION
## What changed

Four post-merge defects shipped in #4001 are corrected forward. Auto-merge fired before the adversarial review completed, so these are new commits on a new branch.

## CRITICAL 1: pytest-summary escape was cross-clause

`scripts/validate_session_json.py` lines 444-465. `_is_numeric_test_count` searched the entire evidence string for `_PYTEST_SUMMARY_CONTEXT`. Evidence like `354 passed; markdownlint step skipped` returned `False` (no contradiction) because `354 passed` matched even though `skipped` belongs to a different clause. The intent was to stop `30 skipped` in a pytest tally from being flagged; the implementation instead disabled the contradiction check for any evidence string that mentions passing tests anywhere.

Fix: extract the clause containing the matched `skipped` token (bounded by semicolons and newlines via `rfind`/`find`), then search `_PYTEST_SUMMARY_CONTEXT` only within that clause.

Regression test: `TestPytestSummaryContextAnchoredToClause` (6 tests). The 27 legitimate pytest tallies were re-verified to produce no false contradictions.

## CRITICAL 2: session creation validated itself as compliant by turning off compliance checks

`.claude/skills/session-init/scripts/new_session_log.py` line 276 passed `--existing-log` at creation time, which disables `validate_protocol_compliance()`. A fresh log with all items `Complete=false` produced 13 "Incomplete MUST" errors under normal validation and zero errors under creation-time validation.

Fix: add `--creation-mode` flag and `creation_mode` parameter to `validate_session_log()`. Creation mode runs full schema validation and `notOnMain` checks but skips `validate_protocol_compliance` and `validate_evidence_agrees_with_session`, which require session-end evidence that cannot exist at creation time. `--existing-log` remains for its original use (validating logs from prior sessions without current evidence).

## HIGH: reworkWarning.Complete was unconditional

`.claude/skills/session-end/scripts/complete_session_log.py` lines 452-461. `Complete = True` was assigned unconditionally, including the dependency-missing and runtime-error paths where `_run_rework_warning_step()` returns `"Rework warning: skipped (sibling unavailable)"` or similar. The validator then flagged the same evidence as a contradiction.

Fix: `rework_ran = "skipped" not in rework_summary.lower()` then `Complete = rework_ran`. Success summaries never contain `"skipped"`.

## MEDIUM: rework warning tests exercised copied code, not production code

`tests/skills/session/test_complete_session_log.py` lines 58-113. `TestReworkWarningShape` reproduced the `level`/`Complete` assignment logic inside test bodies. A production mutation (reverting `Complete = True` or deleting the assignment) left these tests green.

Fix: deleted `TestReworkWarningShape` (3 tests). Added 5 replacement tests in `TestMainReworkWarningShape` using a `_run_main_with_rework` helper that calls `complete_session_log.main()` and asserts on the emitted JSON artifact.

## Mutation harness

4/4 mutants killed:

- MUTANT 1: `_PYTEST_SUMMARY_CONTEXT.search(evidence)` instead of `.search(clause)` -- `TestPytestSummaryContextAnchoredToClause::test_cross_clause_skipped_still_flags` killed it
- MUTANT 2: removed `not creation_mode` from compliance skip -- `TestCreationMode::test_fresh_log_passes_creation_mode` killed it
- MUTANT 3: `rework_ran = True` -- `TestMainReworkWarningShape::test_rework_complete_false_when_sibling_unavailable` killed it
- MUTANT 4: `--creation-mode` reverted to `--existing-log` in caller -- `TestRunValidation::test_passes_creation_mode_flag_to_validator` killed it

## Test results

19984 passed, 30 skipped (full suite). 19 targeted tests all green. Ruff and mypy clean.

## References

These defects shipped in #4001. Refs #4068.

`scripts/validate_session_json.py`, `.claude/skills/session-init/scripts/new_session_log.py`, `.claude/skills/session-end/scripts/complete_session_log.py`, `tests/test_validate_session_json.py`, `tests/skills/session/test_complete_session_log.py`, `tests/skills/session/test_new_session_log.py`
