### PR TITLE
fix(orchestrator): route by capability, not by a hand-copied model column

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5489",
+  "version": "0.6.5490",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5490",
+  "version": "0.6.5491",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5487",
+  "version": "0.6.5489",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -77,32 +77,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -339,7 +339,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -339,7 +339,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -95,7 +95,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -95,32 +95,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -329,7 +329,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -95,7 +95,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -95,7 +95,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -329,7 +329,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "Specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.59",
+  "version": "0.3.60",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "Specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.58",
+  "version": "0.3.59",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "Specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.60",
+  "version": "0.3.61",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/orchestrator.md
+++ b/src/claude/orchestrator.md
@@ -77,32 +77,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -339,7 +339,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/claude/orchestrator.md
+++ b/src/claude/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/claude/orchestrator.md
+++ b/src/claude/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/claude/orchestrator.md
+++ b/src/claude/orchestrator.md
@@ -77,7 +77,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -339,7 +339,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5490",
+  "version": "0.6.5491",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5489",
+  "version": "0.6.5490",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5487",
+  "version": "0.6.5489",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/agents/orchestrator.agent.md
+++ b/src/copilot-cli/agents/orchestrator.agent.md
@@ -90,32 +90,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -324,7 +324,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/copilot-cli/agents/orchestrator.agent.md
+++ b/src/copilot-cli/agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/copilot-cli/agents/orchestrator.agent.md
+++ b/src/copilot-cli/agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/copilot-cli/agents/orchestrator.agent.md
+++ b/src/copilot-cli/agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -324,7 +324,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/vs-code-agents/orchestrator.agent.md
+++ b/src/vs-code-agents/orchestrator.agent.md
@@ -90,32 +90,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -324,7 +324,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/src/vs-code-agents/orchestrator.agent.md
+++ b/src/vs-code-agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/vs-code-agents/orchestrator.agent.md
+++ b/src/vs-code-agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/src/vs-code-agents/orchestrator.agent.md
+++ b/src/vs-code-agents/orchestrator.agent.md
@@ -90,7 +90,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -324,7 +324,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/templates/agents/orchestrator.shared.md
+++ b/templates/agents/orchestrator.shared.md
@@ -88,7 +88,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/templates/agents/orchestrator.shared.md
+++ b/templates/agents/orchestrator.shared.md
@@ -88,7 +88,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides whichever default applies. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|

--- a/templates/agents/orchestrator.shared.md
+++ b/templates/agents/orchestrator.shared.md
@@ -88,7 +88,7 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
+This matrix routes work to an agent by capability; it does not set models. Each install carries its own copy of an agent definition, and the same agent can resolve to a different model in each one, because an agent that declares no tier takes its platform's default. The definition shipped in the install you are running sets the default model. Where the harness supports per-invocation model selection, the Model, Effort, and Cost Routing policy below overrides that default. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
 | Agent | Use For | Avoid When |
 |-------|---------|-----------|
@@ -322,7 +322,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only large async batches of bounded, structured tasks |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/templates/agents/orchestrator.shared.md
+++ b/templates/agents/orchestrator.shared.md
@@ -88,32 +88,32 @@ Use the classification to pick delegation depth. A clear, reversible, P3 task ne
 
 ## Agent Capability Matrix
 
-Model tiers: `opus` for deep strategy/analysis, `sonnet` for routine execution, `haiku` for lightweight operations. The Model column below is authoritative. Pair the tier with a reasoning effort and a cost posture per the Model, Effort, and Cost Routing section below.
+Each agent's definition file is the source of truth for the model it runs. This matrix routes work to an agent by capability; it does not set models. Where a harness supports per-invocation model selection, apply the Model, Effort, and Cost Routing policy below. Where it does not, the agent's own definition governs. Tier names used in that policy: `opus` for deep strategy and analysis, `sonnet` for routine execution, `haiku` for lightweight operations.
 
-| Agent | Use For | Model | Avoid When |
-|-------|---------|-------|-----------|
-| **analyst** | Research, root cause, feasibility | sonnet | Already have enough context |
-| **architect** | ADRs, design review, patterns | sonnet | Implementation details |
-| **backlog-generator** | Proactive backlog discovery | sonnet | Existing PRD to decompose |
-| **critic** | Plan validation, pre-merge review | sonnet | No plan to review |
-| **debug** | Runtime failures, bug triage | sonnet | Requirements are unclear |
-| **dependency-auditor** | Dependency CVEs, package health | sonnet | First-party code risk |
-| **devops** | CI/CD, deployment, infra | sonnet | Business logic changes |
-| **explainer** | PRDs, documentation, onboarding | sonnet | Technical decisions |
-| **high-level-advisor** | Strategy, priorities, ruthless clarity | opus | Tactical work |
-| **implementer** | Code changes, tests | sonnet | Design decisions still open |
-| **independent-thinker** | Challenge consensus, devil's advocate | opus | Need validation, not challenge |
-| **issue-feature-review** | Triage feature requests | sonnet | Already prioritized |
-| **milestone-planner** | Epic → milestones with exit criteria | sonnet | Task-level decomposition |
-| **qa** | Test strategy, user-outcome validation | sonnet | Unit test details only |
-| **pr-test-analyzer** | PR test coverage gaps | sonnet | No PR or diff |
-| **quality-auditor** | Domain grading, gap analysis | sonnet | Single-file review |
-| **retrospective** | Post-mortem, learning extraction | sonnet | Real-time debugging |
-| **roadmap** | Strategic prioritization, outcome sequencing | opus | Tactical execution |
-| **security** | Threat modeling, vulnerability review | opus | Pure performance work |
-| **silent-failure-hunter** | Error suppression, unsafe fallbacks | sonnet | Loud failures already surface |
-| **skillbook** | Capture learnings as reusable skills | sonnet | One-off insights |
-| **task-decomposer** | Plan → atomic tasks | sonnet | Plan still vague |
+| Agent | Use For | Avoid When |
+|-------|---------|-----------|
+| **analyst** | Research, root cause, feasibility | Already have enough context |
+| **architect** | ADRs, design review, patterns | Implementation details |
+| **backlog-generator** | Proactive backlog discovery | Existing PRD to decompose |
+| **critic** | Plan validation, pre-merge review | No plan to review |
+| **debug** | Runtime failures, bug triage | Requirements are unclear |
+| **dependency-auditor** | Dependency CVEs, package health | First-party code risk |
+| **devops** | CI/CD, deployment, infra | Business logic changes |
+| **explainer** | PRDs, documentation, onboarding | Technical decisions |
+| **high-level-advisor** | Strategy, priorities, ruthless clarity | Tactical work |
+| **implementer** | Code changes, tests | Design decisions still open |
+| **independent-thinker** | Challenge consensus, devil's advocate | Need validation, not challenge |
+| **issue-feature-review** | Triage feature requests | Already prioritized |
+| **milestone-planner** | Epic → milestones with exit criteria | Task-level decomposition |
+| **qa** | Test strategy, user-outcome validation | Unit test details only |
+| **pr-test-analyzer** | PR test coverage gaps | No PR or diff |
+| **quality-auditor** | Domain grading, gap analysis | Single-file review |
+| **retrospective** | Post-mortem, learning extraction | Real-time debugging |
+| **roadmap** | Strategic prioritization, outcome sequencing | Tactical execution |
+| **security** | Threat modeling, vulnerability review | Pure performance work |
+| **silent-failure-hunter** | Error suppression, unsafe fallbacks | Loud failures already surface |
+| **skillbook** | Capture learnings as reusable skills | One-off insights |
+| **task-decomposer** | Plan → atomic tasks | Plan still vague |
 
 Every row above names an agent that is registered in this install. Delegate only to a name on this list, and confirm the agent is registered before routing: a delegation naming an agent that was renamed or retired fails silently, and the work is simply skipped rather than reported as an error. Cross-session retrieval and storage is not on this list because it is not an agent. Use the `memory` skill, or `mcp__serena__read_memory` and `mcp__serena__write_memory` directly.
 
@@ -322,7 +322,7 @@ Investigation tools (WebSearch, WebFetch) are intentionally not included. If a t
 | Concatenating agent responses | Not synthesis, just noise | Extract, resolve conflicts, produce coherent output |
 | Relaying a worker's "done" without checking the artifact | The report states intent, not the actual change; a false "done" ships as success | Inspect the diff, created file, or command output before synthesizing |
 | Cheaper model on open-ended work to save tokens | Worse output; human fix-up time dwarfs the token savings | Default to the flagship; cost-route only batched bounded sub-tasks |
-| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Use a lighter tier for trivial ops and batched fan-out |
+| Opus for truly trivial single-step ops | Spends a flagship on a one-liner | Produce it directly per the triage table; cost-route only non-interactive batched fan-out |
 | Defaulting to xhigh/max effort | Burns latency and tokens for <=0.2 quality gain | Default high; reserve max for hard one-way doors |
 | Cheap model at max effort | Costs more all-in than a flagship, for worse output | Match effort to tier: light at low/med, flagship for hard reasoning |
 | Same-family self-verification | Correlated blind spots make it a weak check | Cross-check with a different model family |

--- a/tests/test_orchestrator_agent_routing_matrix.py
+++ b/tests/test_orchestrator_agent_routing_matrix.py
@@ -101,14 +101,15 @@ def test_realistic_request_resolves_to_installed_agent(
 
 @pytest.mark.parametrize("surface,path", ORCHESTRATOR_SURFACES.items())
 def test_matrix_routes_by_capability_not_by_model(surface: str, path: Path) -> None:
-    """The matrix selects an agent; each install's definition selects the model.
+    """The matrix selects an agent; the model comes from the install, not this table.
 
-    A hand-maintained Model column duplicated frontmatter that the build already
-    reads, across six byte-parity copies. One column cannot be right, because an
-    agent that declares no tier takes its platform's default and so resolves
-    differently per install. Measured before removal, the column disagreed with 7
-    of 22 Claude definitions, 13 of 22 GitHub definitions, and 15 of 22 Copilot
-    CLI and VS Code definitions. This test previously pinned three wrong values.
+    A hand-maintained Model column restated frontmatter the build already reads,
+    across six byte-parity copies. No column can be right: an installed definition
+    may declare a model, and when it declares none the harness supplies its own
+    platform default, so one agent resolves differently per install. Measured
+    before removal, the column disagreed with 7 of 22 Claude definitions, 13 of 22
+    GitHub definitions, and 15 of 22 Copilot CLI and VS Code definitions. This test
+    previously pinned three wrong values.
     """
     text = path.read_text(encoding="utf-8")
     matrix = _routing_matrix(path)

--- a/tests/test_orchestrator_agent_routing_matrix.py
+++ b/tests/test_orchestrator_agent_routing_matrix.py
@@ -104,12 +104,12 @@ def test_matrix_routes_by_capability_not_by_model(surface: str, path: Path) -> N
     """The matrix selects an agent; the model comes from the install, not this table.
 
     A hand-maintained Model column restated frontmatter the build already reads,
-    across six byte-parity copies. No single column can be right across installs: an installed definition
-    may declare a model, and when it declares none the harness supplies its own
-    platform default, so one agent resolves differently per install. Measured
-    before removal, the column disagreed with 7 of 22 Claude definitions, 13 of 22
-    GitHub definitions, and 15 of 22 Copilot CLI and VS Code definitions. This test
-    previously pinned three wrong values.
+    across six byte-parity copies. No single column can be right across installs:
+    an installed definition may declare a model, and when it declares none the
+    harness supplies its own platform default, so one agent resolves differently
+    per install. Measured before removal, the column disagreed with 7 of 22 Claude
+    definitions, 13 of 22 GitHub definitions, and 15 of 22 Copilot CLI and VS Code
+    definitions. This test previously pinned three wrong values.
     """
     text = path.read_text(encoding="utf-8")
     matrix = _routing_matrix(path)

--- a/tests/test_orchestrator_agent_routing_matrix.py
+++ b/tests/test_orchestrator_agent_routing_matrix.py
@@ -104,7 +104,7 @@ def test_matrix_routes_by_capability_not_by_model(surface: str, path: Path) -> N
     """The matrix selects an agent; the model comes from the install, not this table.
 
     A hand-maintained Model column restated frontmatter the build already reads,
-    across six byte-parity copies. No column can be right: an installed definition
+    across six byte-parity copies. No single column can be right across installs: an installed definition
     may declare a model, and when it declares none the harness supplies its own
     platform default, so one agent resolves differently per install. Measured
     before removal, the column disagreed with 7 of 22 Claude definitions, 13 of 22

--- a/tests/test_orchestrator_agent_routing_matrix.py
+++ b/tests/test_orchestrator_agent_routing_matrix.py
@@ -50,23 +50,35 @@ ROUTING_SCENARIOS = {
     ),
 }
 
+MATRIX_HEADER = "| Agent | Use For | Avoid When |"
+
 _MATRIX_ROW = re.compile(
-    r"^\| \*\*(?P<agent>[^*]+)\*\* \| (?P<use_for>[^|]+) "
-    r"\| (?P<model>[^|]+) \| (?P<avoid>[^|]+) \|$",
+    r"^\| \*\*(?P<agent>[^*]+)\*\* \| (?P<use_for>[^|]+) \| (?P<avoid>[^|]+) \|$",
     re.MULTILINE,
 )
 
 
-def _routing_matrix(path: Path) -> dict[str, tuple[str, str, str]]:
+def _routing_matrix(path: Path) -> dict[str, tuple[str, str]]:
     text = path.read_text(encoding="utf-8")
     return {
         match.group("agent"): (
             match.group("use_for").strip().lower(),
-            match.group("model").strip().lower(),
             match.group("avoid").strip().lower(),
         )
         for match in _MATRIX_ROW.finditer(text)
     }
+
+
+def _matrix_block(text: str) -> list[str]:
+    """Raw data rows of the capability matrix, header and delimiter excluded."""
+    lines = text.split("\n")
+    start = lines.index(MATRIX_HEADER)
+    block: list[str] = []
+    for line in lines[start + 2 :]:
+        if not line.startswith("|"):
+            break
+        block.append(line)
+    return block
 
 
 @pytest.mark.parametrize("surface,path", ORCHESTRATOR_SURFACES.items())
@@ -80,9 +92,31 @@ def test_realistic_request_resolves_to_installed_agent(
     """A realistic request has a concrete row and installed prompt."""
     request, required_terms = scenario
     matrix = _routing_matrix(path)
-    use_for, model, _avoid = matrix[agent]
+    use_for, _avoid = matrix[agent]
     route_text = f"{agent} {use_for} {request}".lower()
 
-    assert model == "sonnet"
     assert all(term in route_text for term in required_terms)
     assert Path(str(AGENT_SURFACES[surface]).format(agent=agent)).is_file()
+
+
+@pytest.mark.parametrize("surface,path", ORCHESTRATOR_SURFACES.items())
+def test_matrix_routes_by_capability_not_by_model(surface: str, path: Path) -> None:
+    """The matrix selects an agent; each agent definition selects its own model.
+
+    A hand-maintained Model column duplicated frontmatter that the build already
+    reads, across six byte-parity copies. It drifted to 32 percent wrong before
+    removal, and this test previously pinned three of those wrong values.
+    """
+    text = path.read_text(encoding="utf-8")
+    matrix = _routing_matrix(path)
+    rows = _matrix_block(text)
+
+    assert "Model column" not in text
+    assert "| Agent | Use For | Model | Avoid When |" not in text
+    assert matrix, f"{surface}: capability matrix parsed zero rows"
+    assert len(matrix) == len(rows), (
+        f"{surface}: {len(rows)} matrix rows present but {len(matrix)} parsed"
+    )
+    for agent, (use_for, avoid) in matrix.items():
+        assert use_for, f"{surface}: {agent} has an empty Use For cell"
+        assert avoid, f"{surface}: {agent} has an empty Avoid When cell"

--- a/tests/test_orchestrator_agent_routing_matrix.py
+++ b/tests/test_orchestrator_agent_routing_matrix.py
@@ -101,11 +101,14 @@ def test_realistic_request_resolves_to_installed_agent(
 
 @pytest.mark.parametrize("surface,path", ORCHESTRATOR_SURFACES.items())
 def test_matrix_routes_by_capability_not_by_model(surface: str, path: Path) -> None:
-    """The matrix selects an agent; each agent definition selects its own model.
+    """The matrix selects an agent; each install's definition selects the model.
 
     A hand-maintained Model column duplicated frontmatter that the build already
-    reads, across six byte-parity copies. It drifted to 32 percent wrong before
-    removal, and this test previously pinned three of those wrong values.
+    reads, across six byte-parity copies. One column cannot be right, because an
+    agent that declares no tier takes its platform's default and so resolves
+    differently per install. Measured before removal, the column disagreed with 7
+    of 22 Claude definitions, 13 of 22 GitHub definitions, and 15 of 22 Copilot
+    CLI and VS Code definitions. This test previously pinned three wrong values.
     """
     text = path.read_text(encoding="utf-8")
     matrix = _routing_matrix(path)


### PR DESCRIPTION
## Summary

The orchestrator's Agent Capability Matrix carried a `Model` column restating model data the build already derives. No single column can be right across installs, because each surface keeps its own copy of an agent definition and those copies declare different models. `analyst` is the clearest case: its five copies declare `sonnet`, `claude-opus-4.6`, `sonnet`, `claude-opus-4.6`, and `Claude Opus 4.6 (copilot)`. Where a copy declares no model at all, the harness supplies that platform's default instead.

Measured against every surface, the column was wrong in:

| Surface | Rows wrong |
| --- | --- |
| Claude agents | 7 of 22 |
| src claude | 7 of 22 |
| GitHub agents | 13 of 22 (plus 2 declaring no model) |
| Copilot CLI agents | 15 of 22 |
| VS Code agents | 15 of 22 |

The seven Claude rows, every one in the same direction (matrix said `sonnet`, definition said `opus`):

| Agent | Matrix said | Definition says |
| --- | --- | --- |
| architect | sonnet | opus |
| critic | sonnet | opus |
| debug | sonnet | opus |
| implementer | sonnet | opus |
| qa | sonnet | opus |
| pr-test-analyzer | sonnet | opus |
| silent-failure-hunter | sonnet | opus |

The build already derives models from frontmatter. The column was a hand-typed projection of that data into a second location, locked byte-identical across six copies, so every correction cost 6x and every edit was a chance to desync. That is what drifted.

## What changed

**Removed the column** from all six parity copies. The two generated copies were regenerated, not hand-edited.

**Replaced the authority claim.** The old text said "The Model column below is authoritative." It now states the actual rule: the matrix routes by capability and does not set models; an installed definition may declare a model, and when it declares none the harness supplies its platform default; where the harness supports per-invocation model selection, request a model according to the routing policy and let harness precedence and availability rules determine which model actually runs.

**Fixed a contradicting remedy.** The anti-pattern row for trivial single-step ops said to use a lighter tier. That contradicted the "lesser models, never interactively" bullet *and* the file's own triage table, which already says to produce trivial work directly rather than delegate it. The remedy now points at the triage table.

**Rewrote the routing test.** It asserted `model == "sonnet"` for five agents. Three of those five (debug, pr-test-analyzer, silent-failure-hunter) were among the wrong rows, so the test was pinning falsehoods and actively blocking the correction. It now asserts routing integrity: no stale Model column text, every raw table row parses, no empty cells.

## Verification

Negative controls, not just green checks.

| Control | Expected | Actual |
| --- | --- | --- |
| Phantom agent row injected into the now-3-column matrix | matrix-ref validator exits 1 | exit 1, caught at the right line |
| Stale 4-column header reintroduced | new test fails | 1 failed |
| `Use For` cell emptied | new test fails | 1 failed |
| Table row made unparseable | new test fails (count mismatch) | 1 failed |

`validate_agent_matrix_refs.py` still parses the 3-column table (192 rows cited across 20 files), so column removal did not silently disable it. Gates on the committed tree: `build_all.py --check` exit 0, `install-parity: OK`, `plugin-version-bump: OK`. `pytest -k "parity or agent"`: 1601 passed.

Every figure was re-derived independently from the pre-removal matrix at `7df0924c42` against each surface's own frontmatter, resolving tier aliases per platform.

## Adversarial review

Three passes, each off-family (this branch was authored on Opus; reviewers ran on GPT-5.6 Sol and Gemini 3.1 Pro). All three returned BLOCK. Every finding was verified first-hand against the cited source before any edit was made.

**First pass.** Two required findings.

1. **The principle sentence was false.** It claimed an agent's definition file is the source of truth for its model. It is not. The rewrite from this pass was itself rejected by the second pass, so it is recorded here only as history; what actually shipped is quoted under *Current wording* below.
2. **The 32% figure was Claude-only, presented as global.** Re-measured per surface (table above). It understated the drift. Corrected in the test docstring and in this description. The original commit message keeps the old figure because the PR is open and history is not being rewritten; the follow-up commit records the correction.

One optional finding was also taken: the trivial-op remedy said "non-interactive batched fan-out", broader than the routing policy's own "large async batches of bounded, structured tasks". It now uses the policy's wording.

**Second pass.** The first fix had over-corrected in the mirror direction, claiming the installed definition sets the default model. Rejected. The reviewer also caught two paragraphs of this description still carrying the original claim. This pass independently reproduced all five per-surface figures and confirmed the allowlist reading of the drift detector described below.

**Third pass.** Two required findings, both accepted.

1. **The override claim was too absolute.** The text said the routing policy "overrides whichever default applies". The registry schema (see `src/agent-registry-schema.ts`) declares a required `default_model` property and an optional `model_override` property, but both are TypeScript interface property declarations, not runtime enforcement, so neither can support a claim about what wins at resolution time. Harness precedence and org allowlists decide that. Reworded so the text says what this repository does, which is issue a request, and leaves the outcome to the harness.
2. **This description still carried stale claims.** The commit reference for the pre-removal matrix was relative and had gone stale as commits were added to the branch; it is now a fixed SHA. The summary paragraph still described the first pass's rejected framing.

**A further correction, found while fixing the third pass.** Re-measuring the frontmatter directly across all five surfaces showed that the summary's mechanism claim was wrong in a way none of the three passes had caught. `analyst` does not "declare no tier": it declares a model on every surface, with three distinct values between them. Divergent declared values, not absent ones, are the main reason a single column cannot be right. Two agents do lack a model, but on one surface only, not "at all" as the second pass recorded. The summary above now states the measured mechanism. This strengthens the case for removal rather than weakening it.

**Current wording**, identical in all six copies:

> This matrix routes work to an agent by capability; it does not set models. An installed agent definition may declare a model; when it declares none, the harness supplies its own platform default. The same agent can therefore resolve to a different model in each install, which is why no column here can state one. Where the harness supports per-invocation model selection, request a model according to the Model, Effort, and Cost Routing policy below; harness precedence and availability rules determine which model actually runs.

## Decision provenance

Removal versus correction went to `llm-council` (Opus 4.8, GPT-5.5, Sonnet 4.6, chaired off-family by GPT-5.5). All three converged on removal through different framings, which is a stronger signal than shared-frame unanimity. Two of five councillors failed on a GitHub Models brownout, so vendor diversity was weaker than intended.

The council chairman proposed letting trivial ops use a lighter tier. That was **not** adopted: the triage table already says to produce trivial work directly, so the chairman's wording would have introduced a new contradiction.

## Observation, out of scope

While building a negative control I found that agent content parity is advisory rather than enforced. `detect_agent_drift.py` compares `.claude/agents` against `.github/agents` (and `src-claude` against `src-vscode`, never canonical-template against install) using an **80% similarity threshold**, and the workflow captures its exit code and exits 0. A one-cell edit reports "OK (100.0% similar)". That is how a wrong column survived six byte-parity copies. Not changed here; flagging it.

Stacked on #4114 because it edits the same file region.

Refs #4114

