### PR TITLE
refactor(validation): narrow sha type instead of type-ignore in _external_non_first_parent_shas

### DIFF
--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -234,8 +234,9 @@ def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
             continue
         for parent in parents[1:]:
             if _is_external_parent(parent, own_shas):
-                # _is_external_parent guarantees parent["sha"] is a non-empty str.
-                shas.add(parent.get("sha"))  # type: ignore[arg-type]
+                sha = parent.get("sha")
+                if isinstance(sha, str) and sha:
+                    shas.add(sha)
     return shas
 
 


### PR DESCRIPTION
## Summary

Removes the `# type: ignore[arg-type]` suppression in `_external_non_first_parent_shas` and replaces it with an explicit `isinstance(sha, str) and sha` guard. The guard narrows the type so mypy can track it without a suppression comment.

## Root cause

`_is_external_parent` already validates that `parent["sha"]` is a non-empty string before returning `True`. Any code inside the `if _is_external_parent(...)` branch therefore has a guaranteed `str`. mypy could not see through that guarantee, so a `# type: ignore[arg-type]` was added. An explicit local variable with an isinstance check gives mypy the same information without suppressing the checker.

## Changes

- `scripts/validation/pr_commit_count.py`: replace suppression with local variable + isinstance guard

## Verification

102 tests pass:

```
uv run --frozen python -m pytest tests/validation/test_pr_commit_count.py tests/validation/test_commit_limit_parity.py -q
```

mypy reports no issues:

```
uv run --frozen mypy scripts/validation/pr_commit_count.py
```

## References

Follows up on PR #4091 (reviewer thread PRRT_kwDOQoWRls6VW7GL on `scripts/validation/pr_commit_count.py`).
