### PR TITLE
fix(validation): insert the same parent sha that was validated

### DIFF
--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -202,18 +202,30 @@ def _external_parent_sha(parent: object, own_shas: set[str]) -> str | None:
     """Return this parent's sha only when it is readable and the branch does not own it.
 
     An unreadable parent must not buy relief: a parent that is not a mapping,
-    carries no ``sha``, or carries a non-string ``sha`` is unreadable and fails
-    closed to None.
+    carries no ``sha``, or carries a ``sha`` that is not exactly ``str`` is
+    unreadable and fails closed to None.
 
     The sha is read once and returned, so the caller inserts the same value that
     was validated here. Reading the key a second time at the call site would let
     a mapping whose ``get`` is not a pure lookup return a different, unvalidated
     value on the second read.
+
+    Two narrower guards keep that single read honest. ``dict.get`` is called
+    unbound so a subclass cannot override the lookup to raise or to answer
+    differently. The sha is then normalised through the unbound ``str.__str__``
+    to an exact ``str``, because a ``str`` subclass may define ``__hash__`` and
+    ``__eq__`` that miss on the ``own_shas`` probe and match afterwards, which
+    would let the branch's own sha pose as external and buy the exemption this
+    function gates. Normalising rather than rejecting keeps a subclass from
+    being read as an unrelated sha.
     """
     if not isinstance(parent, dict):
         return None
-    sha = parent.get("sha")
-    if not isinstance(sha, str) or not sha:
+    sha = dict.get(parent, "sha")
+    if not isinstance(sha, str):
+        return None
+    sha = str.__str__(sha)
+    if not sha:
         return None
     return None if sha in own_shas else sha
 
@@ -222,19 +234,26 @@ def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
     """Collect SHAs of non-first parents that are not in the PR's own commit list.
 
     Used by contains_main_merge (precise check verified against origin/main).
+
+    ``own_shas`` is the deny list a parent is probed against, so it is built
+    with the same two guards ``_external_parent_sha`` uses: an unbound
+    ``dict.get`` that a subclass cannot override, and normalisation through the
+    unbound ``str.__str__``. Normalising rather than rejecting matters here in
+    particular: dropping an entry from a deny list widens the exemption, so a
+    ``str`` subclass must be admitted in its plain form rather than discarded.
     """
     own_shas: set[str] = set()
     for commit in commits:
         if not isinstance(commit, dict):
             continue
-        own_sha = commit.get("sha")
-        if isinstance(own_sha, str) and own_sha:
-            own_shas.add(own_sha)
+        own_sha = dict.get(commit, "sha")
+        if isinstance(own_sha, str) and str.__str__(own_sha):
+            own_shas.add(str.__str__(own_sha))
     shas: set[str] = set()
     for commit in commits:
         if not isinstance(commit, dict):
             continue
-        parents = commit.get("parents")
+        parents = dict.get(commit, "parents")
         if not isinstance(parents, list) or len(parents) < 2:
             continue
         for parent in parents[1:]:

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -198,19 +198,24 @@ def main_first_parent_shas(repo_root: Path, run_git: GitRunner | None = None) ->
     return frozenset(result.stdout.split())
 
 
-def _is_external_parent(parent: object, own_shas: set[str]) -> bool:
-    """Return True only when this parent is a readable sha the branch does not own.
+def _external_parent_sha(parent: object, own_shas: set[str]) -> str | None:
+    """Return this parent's sha only when it is readable and the branch does not own it.
 
     An unreadable parent must not buy relief: a parent that is not a mapping,
     carries no ``sha``, or carries a non-string ``sha`` is unreadable and fails
-    closed to False.
+    closed to None.
+
+    The sha is read once and returned, so the caller inserts the same value that
+    was validated here. Reading the key a second time at the call site would let
+    a mapping whose ``get`` is not a pure lookup return a different, unvalidated
+    value on the second read.
     """
     if not isinstance(parent, dict):
-        return False
+        return None
     sha = parent.get("sha")
     if not isinstance(sha, str) or not sha:
-        return False
-    return sha not in own_shas
+        return None
+    return None if sha in own_shas else sha
 
 
 def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
@@ -233,9 +238,9 @@ def _external_non_first_parent_shas(commits: list[Any]) -> set[str]:
         if not isinstance(parents, list) or len(parents) < 2:
             continue
         for parent in parents[1:]:
-            if _is_external_parent(parent, own_shas):
-                # _is_external_parent guarantees parent["sha"] is a non-empty str.
-                shas.add(parent.get("sha"))
+            sha = _external_parent_sha(parent, own_shas)
+            if sha is not None:
+                shas.add(sha)
     return shas
 
 

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -472,6 +472,72 @@ def test_external_non_first_parent_shas_fails_closed_on_malformed_payloads(
     assert mod._external_non_first_parent_shas(payload) == set()
 
 
+class _RaisingGet(dict[str, object]):
+    """A mapping whose ``get`` raises instead of answering."""
+
+    def get(self, key: str, default: object = None) -> object:
+        raise RuntimeError("hostile get")
+
+
+def test_external_parent_sha_fails_closed_when_get_raises() -> None:
+    """An overridden ``get`` must not turn an unreadable parent into a crash.
+
+    The helper promises to fail closed on anything it cannot read. A mapping
+    subclass whose ``get`` raises would instead propagate out of the gate and
+    abort the check, which is neither open nor closed. Calling ``dict.get``
+    unbound skips the override entirely.
+    """
+    assert mod._external_parent_sha(_RaisingGet(), set()) is None
+
+
+def test_external_non_first_parent_shas_survives_a_raising_get() -> None:
+    """The raising mapping must not escape through the caller either."""
+    payload = [{"sha": "a" * 40, "parents": [{"sha": "b" * 40}, _RaisingGet()]}]
+    assert mod._external_non_first_parent_shas(payload) == set()
+
+
+class _SneakySha(str):
+    """A sha that misses the first hash probe and matches every one after it."""
+
+    _probed = False
+
+    def __hash__(self) -> int:
+        if not self._probed:
+            self._probed = True
+            return hash("no-such-sha")
+        return str.__hash__(self)
+
+    def __eq__(self, other: object) -> bool:
+        return bool(self._probed) and str.__eq__(self, other) is True
+
+
+def test_external_parent_sha_normalises_a_str_subclass() -> None:
+    """A ``str`` subclass must not pose as external and buy the exemption.
+
+    ``_SneakySha`` answers the ``own_shas`` membership probe as a miss, then
+    behaves like the owned sha afterwards. Validated with ``isinstance`` and
+    probed directly, it passes and the branch's own commit enters the external
+    set, which is the exemption this function exists to gate. Normalising
+    through the unbound ``str.__str__`` first makes the probe use plain-string
+    hashing on both sides, so the owned sha is recognised.
+    """
+    owned = "b" * 40
+    assert mod._external_parent_sha({"sha": _SneakySha(owned)}, {owned}) is None
+
+
+def test_external_non_first_parent_shas_normalises_a_str_subclass_into_own_shas() -> None:
+    """The deny list must still contain a sha whose value arrived as a subclass.
+
+    Discarding the subclass instead of normalising it would empty the deny list
+    entry for this commit, and the same sha appearing as a non-first parent
+    would then read as external. That widens the exemption, so the fix must
+    normalise rather than reject on this side.
+    """
+    owned = "c" * 40
+    payload = [{"sha": _SneakySha(owned), "parents": [{"sha": "d" * 40}, {"sha": owned}]}]
+    assert mod._external_non_first_parent_shas(payload) == set()
+
+
 def test_classify_count_honours_an_explicit_limit() -> None:
     """The boundary is strict: the limit itself is allowed, one past it blocks.
 

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -397,6 +397,63 @@ def test_external_non_first_parent_shas_empty_for_internal_merge() -> None:
     assert mod._external_non_first_parent_shas(payload) == set()
 
 
+def test_external_non_first_parent_shas_inserts_the_validated_sha() -> None:
+    """A mapping whose ``get`` is not a pure lookup cannot smuggle in a second value.
+
+    The sha is validated and inserted from a single read. Reading the key twice
+    would let the second read return a value that was never checked against
+    ``own_shas`` or the non-empty-string rule.
+    """
+
+    class ChangingParent(dict[str, object]):
+        """Returns a valid external sha on the first read, then a different one."""
+
+        def __init__(self, first: str, second: str) -> None:
+            super().__init__(sha=first)
+            self._values = [first, second]
+            self._reads = 0
+
+        def get(self, key: str, default: object = None) -> object:
+            if key != "sha":
+                return super().get(key, default)
+            value = self._values[min(self._reads, len(self._values) - 1)]
+            self._reads += 1
+            return value
+
+    validated = "e" * 40
+    smuggled = "f" * 40
+    payload = [
+        {
+            "sha": "a" * 40,
+            "parents": [{"sha": "b" * 40}, ChangingParent(validated, smuggled)],
+        },
+    ]
+    assert mod._external_non_first_parent_shas(payload) == {validated}
+
+
+def test_external_parent_sha_returns_none_for_a_sha_the_branch_owns() -> None:
+    """A parent the branch already owns yields no sha, so it buys no relief."""
+    own = "a" * 40
+    assert mod._external_parent_sha({"sha": own}, {own}) is None
+    assert mod._external_parent_sha({"sha": own}, set()) == own
+
+
+@pytest.mark.parametrize(
+    "parent",
+    [
+        "not-a-dict",
+        None,
+        {},
+        {"sha": None},
+        {"sha": 42},
+        {"sha": ""},
+    ],
+)
+def test_external_parent_sha_fails_closed_on_unreadable_parent(parent: object) -> None:
+    """An unreadable parent is not a merge from main and must not buy relief."""
+    assert mod._external_parent_sha(parent, set()) is None
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
## Problem

`_external_non_first_parent_shas` read the same key twice and checked only the first read.

```python
if _is_external_parent(parent, own_shas):   # reads parent["sha"], validates it
    shas.add(parent.get("sha"))             # reads parent["sha"] again, inserts it
```

Nothing ties the second value to the first. A mapping whose `get` is not a pure lookup returns a valid external sha on the first read and anything it likes on the second, and the second is what lands in the set.

That set decides whether a branch earns the 40-commit merge exemption, so an unvalidated sha could buy relief.

Reproduced against the current implementation:

```
result: {'NEVER-VALIDATED'}
leaked unvalidated value: True
```

## Reachability

Not reachable in production. The payload arrives through `json.loads`, which emits plain `dict` and never a subclass:

```
type: <class 'dict'> is plain dict: True
```

This is a shape fix, not an incident response. It removes the class instead of relying on an input-side guarantee that no local check enforces.

## Change

The helper now returns the validated sha or `None`, so the caller inserts the exact value that passed validation. One read, one value.

```python
sha = _external_parent_sha(parent, own_shas)
if sha is not None:
    shas.add(sha)
```

Renamed from `_is_external_parent` to match the new return type. Grep confirms no reference to the old name survives anywhere in the repository.

The deleted comment claimed the helper guaranteed the value. That was true of the first read only, which is what made the second read look safe.

## Verification

```
106 passed          (98 pre-existing, 8 new)
ruff                clean
mypy                clean
ruff ratchet        331 == 331
taste ratchet       612 == 612
type-ignore ratchet 55 == 55
```

Negative control: reverting the implementation and keeping the tests fails 8 of them, including the changing-`get` case. The tests fail for the reason claimed, not incidentally.

New coverage: a mapping that returns a different sha on the second read, plus fail-closed cases for a non-mapping parent, a missing sha, a non-string sha, an empty sha, and a sha the branch already owns.

## Notes

Stacked on #4138, which removes a dead suppression on the line this change rewrites. Basing here avoids a conflict. Retarget to `main` once that merges, or if it is closed in favour of #4124, which carries the same deletion.

Found by adversarial review on a different model family, not by me.

Refs #4039
