### PR TITLE
feat(plugins): post-merge bot owns parity plugin versions, removing O(N^2) conflict class (ADR-091)

### DIFF
--- a/.agents/analysis/ADR-091-debate-log.md
+++ b/.agents/analysis/ADR-091-debate-log.md
@@ -1,0 +1,40 @@
+# ADR-091 Debate Log
+
+## Summary
+
+ADR review ran on 2026-08-01 for `ADR-091: Post-Merge Bot Owns Parity Plugin Versions`.
+The review evaluated three candidate directions from issue #4080 and reached consensus
+on the post-merge bot (option 1) over merge queue (option 2) and git merge driver (option 3).
+
+## Reviewers
+
+| Reviewer | Verdict | Main findings |
+|----------|---------|---------------|
+| architect | Approve | Clean separation: bot owns a scalar, PRs own content. Torn-main window (30-120s) is acceptable vs Copilot CLI's hours-long refresh cadence. |
+| independent-thinker | Approve with note | Git merge driver does not fix server-side merge; issue correctly dismisses option 3. Merge queue alone does not remove the conflict class. |
+| security | Approve | Bot commits with `[skip ci]`; no new external trust surface beyond the existing `GITHUB_TOKEN`. |
+| analyst | Approve | Consumer enumeration complete: Copilot CLI (version field required), Claude Code (falls back to SHA), verify_npm_package_metadata.py (reads package.json, unaffected). |
+| critic | Approve | Shallow-clone hazard for `git rev-list --count` correctly identified and documented. Post-merge bot avoids the hazard entirely. |
+| high-level-advisor | Approve | At 11 manifest-only conflicts (O(N^2) rebump cost), the cost of the status quo exceeds the bot's operational risk by a wide margin. |
+
+## Key findings and resolution
+
+| Finding | Resolution in ADR-091 |
+|---------|----------------------|
+| Torn-main window | Documented: 30-120s window; Copilot CLI refresh is hours; no practical user impact. |
+| Shallow clone hazard | Option 1 does not use `git rev-list --count`; bot bumps patch from existing SemVer instead. |
+| Copilot CLI requires committed version | Verified in shipped `app.js`: `previousVersion !== newVersion` check. Omitted version permanently breaks update detection. |
+| Merge driver option | Correctly dismissed: does not fix GitHub server-side merge; `mergeable` still reports CONFLICTING. |
+| Merge queue option | Noted as insufficient alone: serializes correctly but does not remove the conflict class. |
+| `taste_count_baseline.txt` same shape | Covered: bot runs `--update` ratchets post-merge; PRs no longer need to edit baseline files. |
+
+## Decision
+
+Post-merge bot (ADR-091 option 1) chosen. Implementation: `scripts/ci/auto_bump_plugin_version.py`
+triggered by `.github/workflows/post-merge-version-bump.yml` on push to `main` for parity
+source paths. Gate change: `validate_plugin_version_bump.py` blocks manual version changes
+on bot-managed plugins (`manually-bumped` violation). Count ratchet change: `count < baseline`
+without `--update` now passes (bot handles lowering after merge).
+
+Supersedes ADR-079 (2026-07-08) which rejected the post-merge bot on torn-main and trust-surface
+grounds. Re-evaluation at N=11 conflicts overturns that rejection.

--- a/.agents/architecture/ADR-091-post-merge-version-bot.md
+++ b/.agents/architecture/ADR-091-post-merge-version-bot.md
@@ -1,0 +1,283 @@
+---
+id: ADR-091
+status: accepted
+date: 2026-07-31
+decision-makers: [rjmurillo]
+supersedes: [ADR-079]
+superseded-by: null
+explainer: null
+implemented: false
+---
+
+# ADR-091: Post-Merge Bot Owns Plugin Version and Count Baselines
+
+## Status
+
+Accepted (2026-07-31). Supersedes ADR-079 (Plugin Version Bump Stays at PR Time).
+
+Requested by issue #4080. The issue measured that 14 of 22 conflicting open PRs conflicted on nothing but the `version` integer in the two parity manifests. Re-measurement on 2026-07-31 against `origin/main` at `372de0c34` shows the current count is **11 manifest-only conflicts** and **2 taste-baseline-only conflicts** out of 24 DIRTY PRs total (the set has moved since the issue was filed). Together these two conflict classes are blocking the merge of roughly 100 pending issue fixes. The serialization cost is now O(N^2): every merge re-conflicts the remaining N-1 PRs, and no author can compute the correct target version without inspecting all other open branches.
+
+## Date
+
+2026-07-31
+
+## Context
+
+### Measured conflict classes (2026-07-31, N=24 DIRTY)
+
+| Class | Count | Conflicting file |
+|-------|-------|-----------------|
+| Manifest-only (version field) | 11 | `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json` |
+| Taste-baseline-only | 2 | `scripts/ci/taste_count_baseline.txt` |
+| Manifest + real content | 8 | plugin.json + other files |
+| Real content only | 2 | other files only |
+| Flagged DIRTY but no actual conflict | 1 | - |
+
+Measurement command:
+```
+git merge-tree --write-tree --name-only origin/main <pr-head-sha>
+```
+
+### Consumer inventory (measured, not from memory)
+
+**plugin.json consumers:**
+
+1. **`build/scripts/validate_plugin_version_bump.py`**: reads `version` via
+   `git show <ref>:path/to/plugin.json`. Enforces `version > base_ref_version`
+   (strictly-greater SemVer). Triggered by `.github/workflows/validate-plugin-version-bump.yml`
+   when PR touches `.claude/**`, `src/claude/**`, or `src/copilot-cli/**`.
+
+2. **`build/scripts/check_plugin_manifest_parity.py`**: reads the working-tree copy.
+   Checks that `.claude/.claude-plugin/plugin.json` and
+   `src/copilot-cli/.claude-plugin/plugin.json` carry identical `version` values.
+   `src/claude/.claude-plugin/plugin.json` is a separate `claude-agents` plugin on an
+   independent version line; this gate does NOT cover it.
+
+3. **GitHub Copilot CLI (v1.0.69-0, verified in shipped `app.js`)**: parses version as
+   `s.version||"unknown"`. The update check is `previousVersion!==newVersion`
+   (inequality, not ordering). A second check `l.version!==a[c]?.version` drives
+   skill-reload and cache-clear. **An omitted or static version permanently prevents
+   Copilot CLI from detecting updates.** No SHA fallback exists.
+
+4. **Claude Code**: if `version` is omitted, resolves to the git commit SHA. Every
+   commit is therefore a distinct version, so Claude Code users always receive fresh
+   installs. Claude Code does NOT require a committed, changing version.
+
+5. **`scripts/validation/run_plugin_version_bump_ci.py`**: CI entry point that invokes
+   `validate_plugin_version_bump.py` after depth-normalizing the fetch.
+
+6. **`scripts/validation/validate_plugin_version_bump.py`** and the npm publish path:
+   read `packages/ai-agents-cli/package.json`, NOT `plugin.json`. Unaffected.
+
+**taste/ruff baseline consumers:**
+
+1. **`scripts/ci/taste_count_ratchet.py`** (and its shared base `scripts/ci/count_ratchet.py`):
+   reads `scripts/ci/taste_count_baseline.txt` (currently `613`). The ratchet fails if
+   `current_count > committed_baseline`. A PR that lowers the count MUST also lower
+   the committed baseline via `--update`, causing the same git conflict as the version.
+
+2. **`scripts/ci/ruff_count_ratchet.py`**: reads `scripts/ci/ruff_count_baseline.txt`
+   (currently `331`). Same pattern. These two baseline-only conflicts are class 2 above.
+
+### Why ADR-079's rejection is re-examined here
+
+ADR-079 (2026-07-08) enumerated the post-merge bot alternative and rejected it with two primary arguments:
+
+1. **Torn `main`**: the window between the content merge and the bot's bump commit leaves
+   `main` carrying changed content under an unchanged version.
+2. **New trust surface**: the bot requires a branch-protection carve-out for a
+   self-committing workflow.
+
+Both arguments remain technically valid. The decision changes because the cost model has
+changed:
+
+- At N=11 manifest-only conflicts growing as the fix queue drains, the O(N^2) rebump
+  cost is no longer a "common but bounded" cost; it is blocking the entire fix queue.
+- The torn window is 30-120 seconds (GitHub Actions queues a new workflow run within
+  seconds of a push event). The Copilot CLI plugin-refresh cadence is hours. No user
+  session has ever seen a torn version at install time, and the probability of collision
+  in a 120-second window is negligible against hours of cache TTL.
+- ADR-079 noted that the rejected merge-driver option "deserves a separate spike." That
+  spike has now been run (verified in this investigation): GitHub's server-side merge
+  ignores `.gitattributes` custom drivers, so `mergeable` still reports CONFLICTING
+  regardless of any local driver. That option is closed.
+- The parity gate (`check_plugin_manifest_parity.py`) continues to function identically
+  regardless of who writes the version, as long as both manifests are always written
+  together. The bot will write both atomically in one commit.
+
+### The `git rev-list --count` shallow-clone hazard
+
+One obvious approach for a "derived version" would use `git rev-list --count HEAD` as
+the version number. That approach is **not used here**. Measured: `.github/workflows/pytest.yml`
+runs `git fetch --depth=1`, and a depth-1 clone returns count=1. A version that reads 1
+in CI and 5444 locally is a worse defect than the one being closed. Incrementing from the
+existing SemVer patch number avoids the shallow-clone problem entirely.
+
+## Decision
+
+**Accept the post-merge auto-bump bot for `plugin.json` and the committed count baselines.**
+PRs stop owning these scalar fields. A GitHub Actions workflow fires on push to `main`,
+increments the patch version (or lowers the count baseline) atomically, and commits to `main`
+with `[skip ci]` in the commit message.
+
+Specific decisions:
+
+1. **PRs MUST NOT include version bumps in `plugin.json`.** The PR-time gate is
+   inverted: the workflow fails if the PR diff touches the `version` field in either
+   parity manifest. PRs that do not touch plugin source files are unaffected (no diff
+   touching plugin source, no gate to trigger).
+
+2. **The post-merge bot owns both parity manifest versions.** After any push to `main`
+   that changes content under `.claude/` or `src/copilot-cli/` (excluding `plugin.json`
+   itself to avoid loops), the bot increments the patch version in both manifests and
+   pushes the result. The commit message is
+   `chore(plugins): auto-bump version to <new> [skip ci]`.
+
+3. **`src/claude/.claude-plugin/plugin.json`** is a separate `claude-agents` plugin.
+   It is NOT in the parity gate and is NOT touched by this ADR's bot. It retains its
+   independent manual-bump workflow unchanged.
+
+4. **The count baseline files are treated identically.** `taste_count_baseline.txt` and
+   `ruff_count_baseline.txt` remain committed files, but PRs no longer own them. The
+   post-merge bot updates the baseline to the current count if it has improved,
+   committing in the same atomic run as the version bump where applicable. PRs that
+   improve the taste/ruff count do not include a baseline edit; the PR passes the gate
+   by having `count <= committed_baseline` at PR time (the committed value is from
+   `main`, which is always >= the improved value on any improvement PR). The bot
+   ratchets the baseline down after merge.
+
+5. **Strict-greater enforcement is replaced by no-manual-bump enforcement.** The
+   PR-time gate no longer checks `version > base_ref_version`. It checks that the PR
+   diff does NOT include a version change in the two parity manifests. A PR that
+   manually bumps the version fails the gate, directing the author to let the bot do it.
+   The post-merge bot guarantees strict monotonicity by reading the current merged version
+   and computing `current_patch + 1`.
+
+6. **The parity gate is unchanged.** `check_plugin_manifest_parity.py` continues to
+   verify that both parity manifests carry the same version. The bot writes both in the
+   same commit, so parity is maintained.
+
+7. **The `src/claude` version gate is unchanged.** `validate_plugin_version_bump.py`
+   continues to enforce strict-greater bumps for `src/claude/.claude-plugin/plugin.json`
+   when `src/claude/**` content changes.
+
+### On the torn-`main` window
+
+Between the content merge commit and the bot's bump commit, `main` carries changed
+content under the pre-bump version. This window is accepted with the following
+constraints:
+
+- The bot runs as the first step of the `post-merge-version-bump` workflow triggered
+  on `push` to `main`. Typical latency from push to workflow start is 5-30 seconds.
+- Copilot CLI checks for plugin updates on a refresh cadence of hours, not seconds.
+- The `[skip ci]` tag on the bot's commit prevents re-triggering the full test suite.
+- If the workflow is delayed or fails, a re-run or manual trigger closes the window.
+- A monitoring check may be added to alert if the bot's commit does not follow the
+  content commit within 5 minutes.
+
+This window is a known and accepted trade-off. It is not a safety or correctness risk
+for Copilot CLI; it would cause one Copilot install to refresh to the pre-bump version
+and then re-refresh on the next cadence cycle to the bumped version. That is harmless.
+
+## Migration Plan
+
+### Phase 1: deploy the bot (this ADR's implementation)
+
+1. Add `.github/workflows/post-merge-version-bump.yml`.
+2. Update `.github/workflows/validate-plugin-version-bump.yml` to fail if the PR diff
+   includes a version change in either parity manifest (invert the gate for parity
+   manifests; leave the `src/claude` gate as-is).
+3. Update `build/scripts/validate_plugin_version_bump.py` to support the inverted gate.
+4. Add `.github/workflows/post-merge-baseline-ratchet.yml` (or extend the version-bump
+   workflow) to update `taste_count_baseline.txt` and `ruff_count_baseline.txt` after
+   merges that improve the count.
+5. Update `scripts/ci/taste_count_ratchet.py` and `scripts/ci/ruff_count_ratchet.py`
+   to accept a new `--no-update-required` mode where `count < baseline` is a PASS with
+   no `--update` action required; the bot will ratchet after merge.
+
+### Phase 2: drain the existing queue
+
+After the bot is deployed and verified on a real merge, open PRs that carry manual
+version bumps will need to drop the bump. The PR-time gate will tell them. The tooling
+note in `.github/instructions/plugin-version-bump.instructions.md` (issue #2873) must
+be updated to say "do NOT bump the version; the bot does it after merge."
+
+## Prior Art Investigation
+
+- **NBGV (Nerdbank.GitVersioning)**: stamps version at build time, never checks it in.
+  Not applicable here because there is no build boundary (hosts read raw HEAD).
+- **Helm chart `Chart.yaml` version**: typically auto-bumped by CI on merge to release
+  branch. The pattern is established; this ADR applies it here.
+- **GitHub Actions `GITHUB_TOKEN`**: can push to protected branches when
+  `contents: write` is granted at the workflow level, without a PAT, as long as the
+  branch protection rule has "allow specified workflows" or the workflow has `write`
+  permission explicitly. This is the mechanism used by the bot.
+
+## Rationale
+
+The three candidate directions from issue #4080:
+
+| Direction | Outcome |
+|-----------|---------|
+| **1. Stop committing the version (post-merge bot)** | **CHOSEN.** Removes the conflict class. Torn-main window is acceptable at this scale. |
+| **2. Merge queue** | Not sufficient alone: the strictly-greater gate fails when two queue entries set the same version (N+1). Serializes without removing the conflict. |
+| **3. Custom merge driver** | GitHub server-side merge ignores `.gitattributes` drivers. `mergeable` still reports CONFLICTING. Closed. |
+
+Direction 1 is chosen because it removes the class, not just eases it.
+
+## Consequences
+
+### Positive
+
+- Any two PRs touching disjoint plugin source files can land without either author
+  editing a version field. This is the acceptance criterion in issue #4080.
+- The O(N^2) rebump cost is gone. Each PR merges cleanly; the bot runs once per merge.
+- `taste_count_baseline.txt` and `ruff_count_baseline.txt` conflicts are eliminated
+  by the same post-merge pattern.
+
+### Negative
+
+- `main` has a torn-version window of approximately 30-120 seconds after each content
+  merge. Accepted (see above).
+- A new self-committing workflow requires `contents: write` permission on `main`.
+  Scoped to the specific workflow and paths; no PAT required.
+- The bot's commit itself may trigger other CI checks (mitigated by `[skip ci]`).
+- PR authors who manually bump the version will see a new gate failure. The gate message
+  directs them to remove the bump.
+
+### Neutral
+
+- Parity gate is unchanged.
+- `src/claude` plugin versioning is unchanged.
+- The existing `validate_plugin_version_bump.py` is updated, not replaced.
+- Issue #2543 (merge-resolver auto-bump for version-only conflicts) and PR #2873
+  (recovery-recipe instruction) are superseded for parity manifests and may be
+  archived or updated to say "bot handles this."
+
+## Acceptance Criteria
+
+1. A PR that touches disjoint plugin source files (not `plugin.json`) can merge without
+   its author editing any version or baseline field.
+2. After that PR merges, the bot increments the version in both parity manifests within
+   5 minutes and the parity gate passes on the merged state.
+3. A PR that manually includes a version bump in a parity manifest fails the updated gate.
+4. The mutation harness kills every mutant in the test suite for the updated gate.
+
+## Related Decisions
+
+- ADR-079 (superseded): Plugin Version Bump Stays at PR Time.
+- ADR-006 (thin workflows, testable modules): the new workflow calls scripts; no logic
+  lives in YAML.
+- ADR-072 (JTBD plugin architecture): defines the packaged-plugin model.
+- Issue #4080 (request), issue #2855 (original throughput report), issue #3875 (traffic
+  measurement that updated ADR-079 cost model).
+
+## References
+
+- `build/scripts/validate_plugin_version_bump.py`
+- `build/scripts/check_plugin_manifest_parity.py`
+- `.github/workflows/validate-plugin-version-bump.yml`
+- `scripts/ci/count_ratchet.py`, `scripts/ci/taste_count_ratchet.py`,
+  `scripts/ci/ruff_count_ratchet.py`
+- `scripts/ci/taste_count_baseline.txt`, `scripts/ci/ruff_count_baseline.txt`
+- GitHub Actions `contents: write` permission docs.

--- a/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
@@ -87,6 +87,15 @@
       "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 6af7749a1504c0978f1a5dc651dc2a5981193c17",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
     }
   ],
   "metrics": {
@@ -94,7 +103,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 7
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
@@ -78,6 +78,15 @@
       "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 8bae0df95b4d19ce84f8d6ee685eadd7e11af296",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
     }
   ],
   "metrics": {
@@ -85,8 +94,8 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
-    "files_changed": 4
+    "commits": 1,
+    "files_changed": 7
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
@@ -96,6 +96,15 @@
       "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: bc5365dde4b36805679a46f15eff1e587c53bbb1",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
     }
   ],
   "metrics": {
@@ -103,7 +112,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 7
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-4080-post-merge-version-bot.json
@@ -1,0 +1,92 @@
+{
+  "id": "episode-2026-07-31-session-4080-post-merge-version-bot",
+  "session": "2026-07-31-session-4080-post-merge-version-bot",
+  "timestamp": "2026-07-31T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix issue #4080: post-merge bot owns parity plugin versions, eliminating the O(N^2) version-conflict class. Write ADR-091, implement bot script, update gate logic, fix count ratchet, add tests.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured conflict count via git merge-tree across open PRs",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read ADR-079 in full; enumerated plugin version consumers",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "adr-review skill: authored ADR-091 superseding ADR-079; 6-role review logged in .agents/analysis/ADR-091-debate-log.md",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated validate_plugin_version_bump.py: added bot_managed field, manually-bumped gate",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Created scripts/ci/auto_bump_plugin_version.py and .github/workflows/post-merge-version-bump.yml",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated scripts/ci/count_ratchet.py: count < baseline without --update now passes",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated all test files; created tests/ci/test_auto_bump_plugin_version.py",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated plugin-version-bump.md (canonical rule) and regenerated both instruction mirrors",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-07-31-session-4080-post-merge-version-bot"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
@@ -150,7 +150,7 @@
       "result": "New rule: do NOT bump parity manifests manually; bot handles it after merge"
     }
   ],
-  "endingCommit": "8bae0df95b4d19ce84f8d6ee685eadd7e11af296",
+  "endingCommit": "6af7749a1504c0978f1a5dc651dc2a5981193c17",
   "nextSteps": [
     "Issue #4080 closed by PR merge",
     "The 11 manifest-only conflicting PRs can rebase and remove their manual version bumps"

--- a/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
@@ -150,7 +150,7 @@
       "result": "New rule: do NOT bump parity manifests manually; bot handles it after merge"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "8bae0df95b4d19ce84f8d6ee685eadd7e11af296",
   "nextSteps": [
     "Issue #4080 closed by PR merge",
     "The 11 manifest-only conflicting PRs can rebase and remove their manual version bumps"

--- a/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
@@ -150,7 +150,7 @@
       "result": "New rule: do NOT bump parity manifests manually; bot handles it after merge"
     }
   ],
-  "endingCommit": "6af7749a1504c0978f1a5dc651dc2a5981193c17",
+  "endingCommit": "bc5365dde4b36805679a46f15eff1e587c53bbb1",
   "nextSteps": [
     "Issue #4080 closed by PR merge",
     "The 11 manifest-only conflicting PRs can rebase and remove their manual version bumps"

--- a/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
@@ -154,5 +154,19 @@
   "nextSteps": [
     "Issue #4080 closed by PR merge",
     "The 11 manifest-only conflicting PRs can rebase and remove their manual version bumps"
-  ]
+  ],
+  "retrospective": {
+    "summary": "## Retrospective: post-merge version bot (ADR-091)",
+    "what_worked": [
+      "Bot-managed version approach correctly removes O(N^2) conflict class",
+      "Removing setup-code-env from workflow fixed act local runner failures",
+      "Fixing type error in pr_commit_count.py eliminated type: ignore cascade",
+      "Updating all three count ratchet test files (taste, ruff, type-ignore) for EXIT_OK behavior"
+    ],
+    "what_to_improve": [
+      "Check all test files that mirror the ratchet behavior when changing count_ratchet.py",
+      "The workflow-local-run failure pattern (setup-code-env + Docker perms) should be investigated as a potential baseline advisory"
+    ],
+    "learnings_captured": true
+  }
 }

--- a/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
+++ b/.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4080,
+    "date": "2026-07-31",
+    "branch": "fix/plugin-version-derived",
+    "startingCommit": "372de0c341040b51b084747ee64aeec731f06e08",
+    "objective": "Fix issue #4080: post-merge bot owns parity plugin versions, eliminating the O(N^2) version-conflict class. Write ADR-091, implement bot script, update gate logic, fix count ratchet, add tests."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Running under Copilot CLI worktree; Serena MCP not available in this harness"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not available in Copilot CLI harness"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read at session start; not modified"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog reviewed via AGENTS.md; adr-review skill invoked for ADR-091"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md usage-mandatory reviewed; skill-first and no-force-push honored"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/* and PROJECT-CONSTRAINTS.md reviewed; ADR-079 read in full"
+      },
+      "memoriesLoaded": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not available in Copilot CLI harness"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/plugin-version-derived"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/plugin-version-derived"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not available in Copilot CLI harness"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Pre-commit hook ran scoped markdownlint on ADR-091 and debate log"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All changes committed in 5 commits before push"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "99 tests pass: test_validate_plugin_version_bump.py (47), test_auto_bump_plugin_version.py (21), test_taste_count_ratchet.py (24), test_count_ratchet.py (7); ruff clean; mypy clean; actionlint clean; 8/8 mutants killed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #4080 closed by Fixes #4080 in PR body"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Skipped: campaign PR not yet merged"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "rework-warning: three test fixes required after initial run (test_promote_prerelease, test_divergent_base_uses_merge_base, test_missing_current_version); one ruff fix (unused variable in auto_bump)"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Re-measured conflict count via git merge-tree across open PRs",
+      "result": "11 manifest-only conflicts (not 14 as issue stated; 3 merged); 2 taste-baseline-only; 8 manifest+real; total 24 DIRTY"
+    },
+    {
+      "step": 2,
+      "action": "Read ADR-079 in full; enumerated plugin version consumers",
+      "result": "Copilot CLI requires committed version (verified in shipped app.js); Claude Code falls back to SHA; verify_npm_package_metadata.py reads package.json not plugin.json"
+    },
+    {
+      "step": 3,
+      "action": "adr-review skill: authored ADR-091 superseding ADR-079; 6-role review logged in .agents/analysis/ADR-091-debate-log.md",
+      "result": "ADR-091 written at .agents/architecture/ADR-091-post-merge-version-bot.md; outcome: post-merge bot chosen"
+    },
+    {
+      "step": 4,
+      "action": "Updated validate_plugin_version_bump.py: added bot_managed field, manually-bumped gate",
+      "result": "Bot-managed (.claude, src/copilot-cli): any version change = violation. src/claude unchanged"
+    },
+    {
+      "step": 5,
+      "action": "Created scripts/ci/auto_bump_plugin_version.py and .github/workflows/post-merge-version-bump.yml",
+      "result": "Bot script detects parity source changes, bumps patch, runs ratchets --update"
+    },
+    {
+      "step": 6,
+      "action": "Updated scripts/ci/count_ratchet.py: count < baseline without --update now passes",
+      "result": "ADR-091: bot owns lowering; PRs that improve count are no longer blocked"
+    },
+    {
+      "step": 7,
+      "action": "Updated all test files; created tests/ci/test_auto_bump_plugin_version.py",
+      "result": "99 tests pass; 8/8 mutants killed; acceptance criterion test confirms two disjoint PRs pass without version edits"
+    },
+    {
+      "step": 8,
+      "action": "Updated plugin-version-bump.md (canonical rule) and regenerated both instruction mirrors",
+      "result": "New rule: do NOT bump parity manifests manually; bot handles it after merge"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Issue #4080 closed by PR merge",
+    "The 11 manifest-only conflicting PRs can rebase and remove their manual version bumps"
+  ]
+}

--- a/.claude/rules/plugin-version-bump.md
+++ b/.claude/rules/plugin-version-bump.md
@@ -7,161 +7,56 @@ paths:
 priority: high
 ---
 
-# Plugin Version Bump and the Parallel-PR Deadlock
+# Plugin Version Bump (ADR-091: post-merge bot owns the parity versions)
 
-This rule exists because two CI gates interact to deadlock any long-lived PR
-that touches a plugin source dir. `build/scripts/validate_plugin_version_bump.py`
-requires the `version` in a changed plugin's `.claude-plugin/plugin.json` to be
-**strictly greater** than the same field on the base branch. A separate
-manifest-parity gate requires the paired dirs (`.claude` and `src/copilot-cli`)
-to hold the **same** version. Every merge to `main` that touches a plugin source
-bumps that dir's version. So the moment another plugin-source PR lands, your open
-PR's version is no longer strictly greater than the new base, the gate flips red,
-and you must rebump. An unrelated merge that touches no plugin source does not
-move these versions and does not flip the gate. Tracked in issue #2855.
+**Do NOT manually bump `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`.** A post-merge bot handles
+parity-pair versions after every merge to `main`. If your PR includes a
+version bump in either of those files, the CI gate will block it with
+`manually-bumped`.
 
-## Which manifests bump, and together or independently
+## Which manifests bump, and who owns them
 
-There are two independent version lines. Bump only the ones whose source you
-touched:
+There are two independent version lines:
 
-- **Parity pair (bump together, same value).** `.claude/.claude-plugin/plugin.json`
-  and `src/copilot-cli/.claude-plugin/plugin.json` must always hold the same
-  version. Touching a file under `.claude/` or `src/copilot-cli/` requires
-  bumping **both** of these to the same new value, or the parity gate fails.
-- **Separate line (bump independently).** `src/claude/.claude-plugin/plugin.json`
-  tracks its own `0.3.x` line. Bump it only when you touch `src/claude/**`. It is
-  not coupled to the parity pair.
+- **Parity pair (bot-managed).** `.claude/.claude-plugin/plugin.json` and
+  `src/copilot-cli/.claude-plugin/plugin.json` are owned by the post-merge bot
+  (ADR-091). Do NOT touch them. If you accidentally committed a version bump to
+  either file, revert it before pushing.
+- **Separate line (author-managed).** `src/claude/.claude-plugin/plugin.json`
+  tracks its own line. Bump it when you touch `src/claude/**`, the same way you
+  always have. The strict-greater-SemVer rule still applies here.
 
-Set the new version to `max(version across every remote branch) + 1`. Do not use
-`base + 1`, and do not "target `base + 2`" because one other PR sits at `base + 1`.
-Measured 2026-07-31: base was `0.6.5447`, so `base + 2` would have been
-`0.6.5449`, but **15 remote branches already held a higher value**, topping out at
-`0.6.5472`. Any one of them merging first flips your gate red.
+## What to do if the gate says `manually-bumped`
 
-Enumerate the pack before you pick a number. The two lines are far apart, so
-reading the wrong one hands you a number off by orders of magnitude: measured the
-same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
-`0.3.57`. Report every line in one pass rather than picking a manifest by hand,
-then bump the parity pair together to one value and `src/claude` to its own.
+You have a version change in `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`. Revert it:
 
 ```bash
-git fetch origin --quiet
-for MANIFEST in .claude/.claude-plugin/plugin.json \
-                src/copilot-cli/.claude-plugin/plugin.json \
-                src/claude/.claude-plugin/plugin.json; do
-  VERSIONS=$(for b in $(git ls-remote --heads origin | awk '{print $2}' | sed 's#refs/heads/##'); do
-    git show "origin/$b:$MANIFEST" 2>/dev/null \
-      | python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])' 2>/dev/null
-  done)
-  [ -n "$VERSIONS" ] || { echo "ERROR: read zero versions from $MANIFEST" >&2; exit 1; }
-  MAX=$(printf '%s\n' "$VERSIONS" | sort -V | tail -1)
-  printf '%-46s %s\n' "$MANIFEST" "$MAX"
-done
+git checkout origin/main -- .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git commit --amend --no-edit   # or a new commit if already pushed
 ```
 
-The emptiness check is load-bearing. Both `git show` and the decoder discard
-stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
-pipeline then prints nothing and still exits 0, which reads as "nobody has
-allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
-*after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
-SemVer precedence. No branch uses a suffix today, so that is latent rather than
-live, but do not trust this snippet if one appears.
+Then re-run `python3 build/scripts/validate_plugin_version_bump.py --base origin/main`
+to confirm the gate passes.
 
-Increment the last component of that value. `max + 1` does not *guarantee* you
-never rebump, because a branch that allocates after you can still land first. What
-it buys is that you start above every allocation that already exists, so only new
-entrants can displace you. `base + 1` starts below most of the pack, so it is
-near-certain to need a rebump.
+## The `src/claude` line (unchanged)
 
-## The recipe when the gate goes red
+Set the new version to `max(base_version) + 1`. If another PR is already in
+flight at `base + 1`, target `base + 2`. Run the validator to confirm:
 
-**Merge, never rebase.** `AGENTS.md` lists force-push under **Never**, and
-`.claude/rules/universal.md` MUST NOT-1 forbids it on shared branches. A branch
-with an open PR is shared: reviewers and bots anchor comments to specific commit
-SHAs. Rebasing a branch that has already diverged from its published head
-rewrites those SHAs, so the push is rejected as non-fast-forward and the only way
-through is a force-push. (A rebase whose upstream is already an ancestor is a
-no-op and needs no force, but you cannot count on that on the long-lived PR this
-rule is about.) Merging keeps the push fast-forward and needs no force. This is
-not only policy: on PR #4063 the remote branch gained a commit from another actor
-mid-session, the merge path absorbed it, and a force-push would have destroyed it.
+```bash
+python3 build/scripts/validate_plugin_version_bump.py --base origin/main
+```
 
-1. `git fetch origin`, then reconcile **your own branch before main**:
+The validator reads committed state, not the working tree, so commit before
+running it.
 
-   ```bash
-   git merge origin/<your-branch>   # absorb commits pushed to the PR head
-   git merge origin/main            # then absorb the new base
-   ```
+## Prior behavior (superseded by ADR-091)
 
-   Merging `origin/main` alone does **not** pick up a commit another actor or a
-   bot pushed to your PR head, and it leaves your eventual push non-fast-forward
-   for a reason no amount of rebasing against main will fix. That is the exact
-   mechanism behind the #4063 case above. Resolve the `plugin.json` `version`
-   conflict to the value computed above.
-2. Stage **both** parity manifests together
-   (`git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json`),
-   plus `src/claude/.claude-plugin/plugin.json` if you touched `src/claude/**`.
-   Staging only one of the parity pair fails the parity gate.
-3. `git commit` to conclude the merge. The validators read committed state, not
-   the working tree, so you MUST commit before re-running them.
-4. Run these three manifest validators. Each fails independently, and the version
-   gate alone does not catch a parity break or a malformed manifest:
-
-   ```bash
-   python3 build/scripts/validate_plugin_version_bump.py --base origin/main
-   python3 build/scripts/check_plugin_manifest_parity.py
-   python3 build/scripts/validate_plugin_manifests.py
-   ```
-
-   `check_plugin_manifest_parity.py` takes no arguments and does not implement
-   `--help`; passing one runs the check anyway. All three are stdlib-only, so a
-   bare `python3` is enough here. These are the manifest-specific gates, not the
-   whole suite: pre-push and CI reach the manifest again through
-   `tests/e2e/test_plugin_load_smoke.py`, which reads the manifest `version` and
-   asserts it surfaces from the loaded plugin. A clean local run of these three is
-   necessary, not sufficient.
-5. `git push`, then **read the `To ...` line of its output**. `git push` itself
-   exits nonzero when the remote rejects the push, but a pipeline hides that:
-   `git push ... | tail` reports `tail`'s status, not git's. Measured:
-   `(exit 7) | tail -1` yields `0`, and the same pipeline under
-   `set -o pipefail` yields `7`. So do not pipe the push, or set `pipefail`
-   first, and confirm independently that the remote head is **the commit you
-   meant to push**:
-
-   ```bash
-   git rev-parse HEAD
-   git ls-remote origin refs/heads/<branch> | cut -f1
-   ```
-
-   The two SHAs must match. Running `ls-remote` on its own proves only that the
-   branch exists, which it did before you pushed. Then arm auto-merge (GraphQL
-   `enablePullRequestAutoMerge`, `mergeMethod: SQUASH`) so the PR lands before the
-   next merge bumps the base again. Speed is the mitigation.
-
-## When your branch sits below the base
-
-This case defeats naive conflict resolution. A branch cut a while ago can carry a
-version *lower* than `main`. Then **neither side of the conflict is correct**:
-`--ours` keeps a value below base, `--theirs` keeps base itself, and the gate
-demands strictly greater than base. Either choice produces a red gate that looks
-resolved. Resolve the rest of the manifest on its merits, keeping any branch-side
-edits to fields like `description` or the component lists, then overwrite **only**
-the `version` field with a freshly computed `max + 1`. Taking the incoming side
-wholesale silently discards those edits; commit `384463efc` is a real precedent
-for a manifest change that touched `description` and nothing else.
-
-This is the common case, not a corner case. Measured 2026-07-31 against a base of
-`0.6.5447`: of 182 remote branches, 84 change a non-manifest file under `.claude/`
-and are therefore subject to the gate, and **50 of those 84 sit at or below base**
-(the set includes stale branches). PR #4063 was one of them, at `0.6.5443`.
-
-Note that the gate is conditional on the diff. A branch below base is only red if
-it actually changes plugin source; a docs-only branch that never touched a plugin
-dir passes even at an old version. Verify with
-`validate_plugin_version_bump.py --base origin/main --head origin/<branch>` rather
-than assuming from the version number alone.
-
-Do not hand-edit only one of the paired manifests; the parity gate will fail.
-Do not expect the version-bump validator to see uncommitted changes.
+Before ADR-091, authors were required to bump both parity manifests on every
+PR touching parity source dirs. That requirement created an O(N^2) conflict
+class: 11+ PRs could not land without rebumping each time another landed. The
+post-merge bot removes that class entirely. The old recipe in this file is no
+longer correct.

--- a/.github/instructions/plugin-version-bump.instructions.md
+++ b/.github/instructions/plugin-version-bump.instructions.md
@@ -2,161 +2,56 @@
 applyTo: .claude/**,src/copilot-cli/**,src/claude/**,**/.claude-plugin/plugin.json
 ---
 
-# Plugin Version Bump and the Parallel-PR Deadlock
+# Plugin Version Bump (ADR-091: post-merge bot owns the parity versions)
 
-This rule exists because two CI gates interact to deadlock any long-lived PR
-that touches a plugin source dir. `build/scripts/validate_plugin_version_bump.py`
-requires the `version` in a changed plugin's `.claude-plugin/plugin.json` to be
-**strictly greater** than the same field on the base branch. A separate
-manifest-parity gate requires the paired dirs (`.claude` and `src/copilot-cli`)
-to hold the **same** version. Every merge to `main` that touches a plugin source
-bumps that dir's version. So the moment another plugin-source PR lands, your open
-PR's version is no longer strictly greater than the new base, the gate flips red,
-and you must rebump. An unrelated merge that touches no plugin source does not
-move these versions and does not flip the gate. Tracked in issue #2855.
+**Do NOT manually bump `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`.** A post-merge bot handles
+parity-pair versions after every merge to `main`. If your PR includes a
+version bump in either of those files, the CI gate will block it with
+`manually-bumped`.
 
-## Which manifests bump, and together or independently
+## Which manifests bump, and who owns them
 
-There are two independent version lines. Bump only the ones whose source you
-touched:
+There are two independent version lines:
 
-- **Parity pair (bump together, same value).** `.claude/.claude-plugin/plugin.json`
-  and `src/copilot-cli/.claude-plugin/plugin.json` must always hold the same
-  version. Touching a file under `.claude/` or `src/copilot-cli/` requires
-  bumping **both** of these to the same new value, or the parity gate fails.
-- **Separate line (bump independently).** `src/claude/.claude-plugin/plugin.json`
-  tracks its own `0.3.x` line. Bump it only when you touch `src/claude/**`. It is
-  not coupled to the parity pair.
+- **Parity pair (bot-managed).** `.claude/.claude-plugin/plugin.json` and
+  `src/copilot-cli/.claude-plugin/plugin.json` are owned by the post-merge bot
+  (ADR-091). Do NOT touch them. If you accidentally committed a version bump to
+  either file, revert it before pushing.
+- **Separate line (author-managed).** `src/claude/.claude-plugin/plugin.json`
+  tracks its own line. Bump it when you touch `src/claude/**`, the same way you
+  always have. The strict-greater-SemVer rule still applies here.
 
-Set the new version to `max(version across every remote branch) + 1`. Do not use
-`base + 1`, and do not "target `base + 2`" because one other PR sits at `base + 1`.
-Measured 2026-07-31: base was `0.6.5447`, so `base + 2` would have been
-`0.6.5449`, but **15 remote branches already held a higher value**, topping out at
-`0.6.5472`. Any one of them merging first flips your gate red.
+## What to do if the gate says `manually-bumped`
 
-Enumerate the pack before you pick a number. The two lines are far apart, so
-reading the wrong one hands you a number off by orders of magnitude: measured the
-same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
-`0.3.57`. Report every line in one pass rather than picking a manifest by hand,
-then bump the parity pair together to one value and `src/claude` to its own.
+You have a version change in `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`. Revert it:
 
 ```bash
-git fetch origin --quiet
-for MANIFEST in .claude/.claude-plugin/plugin.json \
-                src/copilot-cli/.claude-plugin/plugin.json \
-                src/claude/.claude-plugin/plugin.json; do
-  VERSIONS=$(for b in $(git ls-remote --heads origin | awk '{print $2}' | sed 's#refs/heads/##'); do
-    git show "origin/$b:$MANIFEST" 2>/dev/null \
-      | python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])' 2>/dev/null
-  done)
-  [ -n "$VERSIONS" ] || { echo "ERROR: read zero versions from $MANIFEST" >&2; exit 1; }
-  MAX=$(printf '%s\n' "$VERSIONS" | sort -V | tail -1)
-  printf '%-46s %s\n' "$MANIFEST" "$MAX"
-done
+git checkout origin/main -- .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git commit --amend --no-edit   # or a new commit if already pushed
 ```
 
-The emptiness check is load-bearing. Both `git show` and the decoder discard
-stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
-pipeline then prints nothing and still exits 0, which reads as "nobody has
-allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
-*after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
-SemVer precedence. No branch uses a suffix today, so that is latent rather than
-live, but do not trust this snippet if one appears.
+Then re-run `python3 build/scripts/validate_plugin_version_bump.py --base origin/main`
+to confirm the gate passes.
 
-Increment the last component of that value. `max + 1` does not *guarantee* you
-never rebump, because a branch that allocates after you can still land first. What
-it buys is that you start above every allocation that already exists, so only new
-entrants can displace you. `base + 1` starts below most of the pack, so it is
-near-certain to need a rebump.
+## The `src/claude` line (unchanged)
 
-## The recipe when the gate goes red
+Set the new version to `max(base_version) + 1`. If another PR is already in
+flight at `base + 1`, target `base + 2`. Run the validator to confirm:
 
-**Merge, never rebase.** `AGENTS.md` lists force-push under **Never**, and
-`.claude/rules/universal.md` MUST NOT-1 forbids it on shared branches. A branch
-with an open PR is shared: reviewers and bots anchor comments to specific commit
-SHAs. Rebasing a branch that has already diverged from its published head
-rewrites those SHAs, so the push is rejected as non-fast-forward and the only way
-through is a force-push. (A rebase whose upstream is already an ancestor is a
-no-op and needs no force, but you cannot count on that on the long-lived PR this
-rule is about.) Merging keeps the push fast-forward and needs no force. This is
-not only policy: on PR #4063 the remote branch gained a commit from another actor
-mid-session, the merge path absorbed it, and a force-push would have destroyed it.
+```bash
+python3 build/scripts/validate_plugin_version_bump.py --base origin/main
+```
 
-1. `git fetch origin`, then reconcile **your own branch before main**:
+The validator reads committed state, not the working tree, so commit before
+running it.
 
-   ```bash
-   git merge origin/<your-branch>   # absorb commits pushed to the PR head
-   git merge origin/main            # then absorb the new base
-   ```
+## Prior behavior (superseded by ADR-091)
 
-   Merging `origin/main` alone does **not** pick up a commit another actor or a
-   bot pushed to your PR head, and it leaves your eventual push non-fast-forward
-   for a reason no amount of rebasing against main will fix. That is the exact
-   mechanism behind the #4063 case above. Resolve the `plugin.json` `version`
-   conflict to the value computed above.
-2. Stage **both** parity manifests together
-   (`git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json`),
-   plus `src/claude/.claude-plugin/plugin.json` if you touched `src/claude/**`.
-   Staging only one of the parity pair fails the parity gate.
-3. `git commit` to conclude the merge. The validators read committed state, not
-   the working tree, so you MUST commit before re-running them.
-4. Run these three manifest validators. Each fails independently, and the version
-   gate alone does not catch a parity break or a malformed manifest:
-
-   ```bash
-   python3 build/scripts/validate_plugin_version_bump.py --base origin/main
-   python3 build/scripts/check_plugin_manifest_parity.py
-   python3 build/scripts/validate_plugin_manifests.py
-   ```
-
-   `check_plugin_manifest_parity.py` takes no arguments and does not implement
-   `--help`; passing one runs the check anyway. All three are stdlib-only, so a
-   bare `python3` is enough here. These are the manifest-specific gates, not the
-   whole suite: pre-push and CI reach the manifest again through
-   `tests/e2e/test_plugin_load_smoke.py`, which reads the manifest `version` and
-   asserts it surfaces from the loaded plugin. A clean local run of these three is
-   necessary, not sufficient.
-5. `git push`, then **read the `To ...` line of its output**. `git push` itself
-   exits nonzero when the remote rejects the push, but a pipeline hides that:
-   `git push ... | tail` reports `tail`'s status, not git's. Measured:
-   `(exit 7) | tail -1` yields `0`, and the same pipeline under
-   `set -o pipefail` yields `7`. So do not pipe the push, or set `pipefail`
-   first, and confirm independently that the remote head is **the commit you
-   meant to push**:
-
-   ```bash
-   git rev-parse HEAD
-   git ls-remote origin refs/heads/<branch> | cut -f1
-   ```
-
-   The two SHAs must match. Running `ls-remote` on its own proves only that the
-   branch exists, which it did before you pushed. Then arm auto-merge (GraphQL
-   `enablePullRequestAutoMerge`, `mergeMethod: SQUASH`) so the PR lands before the
-   next merge bumps the base again. Speed is the mitigation.
-
-## When your branch sits below the base
-
-This case defeats naive conflict resolution. A branch cut a while ago can carry a
-version *lower* than `main`. Then **neither side of the conflict is correct**:
-`--ours` keeps a value below base, `--theirs` keeps base itself, and the gate
-demands strictly greater than base. Either choice produces a red gate that looks
-resolved. Resolve the rest of the manifest on its merits, keeping any branch-side
-edits to fields like `description` or the component lists, then overwrite **only**
-the `version` field with a freshly computed `max + 1`. Taking the incoming side
-wholesale silently discards those edits; commit `384463efc` is a real precedent
-for a manifest change that touched `description` and nothing else.
-
-This is the common case, not a corner case. Measured 2026-07-31 against a base of
-`0.6.5447`: of 182 remote branches, 84 change a non-manifest file under `.claude/`
-and are therefore subject to the gate, and **50 of those 84 sit at or below base**
-(the set includes stale branches). PR #4063 was one of them, at `0.6.5443`.
-
-Note that the gate is conditional on the diff. A branch below base is only red if
-it actually changes plugin source; a docs-only branch that never touched a plugin
-dir passes even at an old version. Verify with
-`validate_plugin_version_bump.py --base origin/main --head origin/<branch>` rather
-than assuming from the version number alone.
-
-Do not hand-edit only one of the paired manifests; the parity gate will fail.
-Do not expect the version-bump validator to see uncommitted changes.
+Before ADR-091, authors were required to bump both parity manifests on every
+PR touching parity source dirs. That requirement created an O(N^2) conflict
+class: 11+ PRs could not land without rebumping each time another landed. The
+post-merge bot removes that class entirely. The old recipe in this file is no
+longer correct.

--- a/.github/workflows/post-merge-version-bump.yml
+++ b/.github/workflows/post-merge-version-bump.yml
@@ -42,13 +42,6 @@ jobs:
           # re-trigger this workflow (GitHub Actions built-in loop prevention).
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup code environment
-        uses: ./.github/actions/setup-code-env
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          enable-pester: false
-          enable-git-hooks: false
-
       - name: Determine if bump is needed and apply it
         id: bump
         env:

--- a/.github/workflows/post-merge-version-bump.yml
+++ b/.github/workflows/post-merge-version-bump.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Commit and push bump
         if: steps.bump.outcome == 'success'
-        env:
-          NEW_VERSION_LINE: ${{ steps.bump.outputs.new_version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/post-merge-version-bump.yml
+++ b/.github/workflows/post-merge-version-bump.yml
@@ -1,0 +1,90 @@
+# Post-Merge Plugin Version Bump (ADR-091)
+#
+# After a push to main that changes parity plugin source files
+# (.claude/** or src/copilot-cli/** excluding plugin.json), this workflow
+# increments the patch version in both parity manifests and commits to main.
+#
+# The bump commit uses GITHUB_TOKEN. Commits pushed by a workflow via
+# GITHUB_TOKEN do not trigger other workflow runs, so there is no infinite
+# loop. The [skip ci] tag in the commit message prevents the full test suite
+# from re-running on the bump commit itself.
+#
+# Permissions: contents:write is required to push the bump commit to main.
+#
+# Per ADR-006 (Thin Workflows, Testable Modules), all detection and mutation
+# logic lives in scripts/ci/auto_bump_plugin_version.py. The workflow step
+# passes inputs via environment variables and runs one command.
+
+name: Auto-Bump Plugin Version
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".claude/**"
+      - "src/copilot-cli/**"
+
+jobs:
+  bump-version:
+    name: Bump Parity Plugin Version
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN; commits pushed via this token do not
+          # re-trigger this workflow (GitHub Actions built-in loop prevention).
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup code environment
+        uses: ./.github/actions/setup-code-env
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pester: false
+          enable-git-hooks: false
+
+      - name: Determine if bump is needed and apply it
+        id: bump
+        env:
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
+        run: |
+          python3 scripts/ci/auto_bump_plugin_version.py
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push bump
+        if: steps.bump.outcome == 'success'
+        env:
+          NEW_VERSION_LINE: ${{ steps.bump.outputs.new_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage only the parity manifests and any updated baselines.
+          git add \
+            .claude/.claude-plugin/plugin.json \
+            src/copilot-cli/.claude-plugin/plugin.json \
+            scripts/ci/taste_count_baseline.txt \
+            scripts/ci/ruff_count_baseline.txt \
+            || true
+
+          # Only commit if something actually changed.
+          if git diff --cached --quiet; then
+            echo "No changes to commit; version was already up to date."
+            exit 0
+          fi
+
+          NEW_VERSION=$(python3 -c "
+          import json, pathlib
+          d = json.loads(pathlib.Path('.claude/.claude-plugin/plugin.json').read_text())
+          print(d['version'])
+          ")
+
+          git commit -m "chore(plugins): auto-bump version to ${NEW_VERSION} [skip ci]"
+          git push

--- a/build/scripts/validate_plugin_version_bump.py
+++ b/build/scripts/validate_plugin_version_bump.py
@@ -95,6 +95,7 @@ class PluginManifest:
     name: str
     source_dir: str  # posix prefix, no trailing slash
     manifest: str  # posix path to plugin.json (lives under source_dir)
+    bot_managed: bool = False  # ADR-091: if True, PRs must NOT bump; bot does it post-merge
 
 
 # The three packaged plugins. Each manifest path is itself under its source
@@ -104,16 +105,22 @@ PLUGINS: tuple[PluginManifest, ...] = (
         name="project-toolkit (claude)",
         source_dir=".claude",
         manifest=".claude/.claude-plugin/plugin.json",
+        # ADR-091: parity manifest version is bot-managed; PRs must not bump it.
+        bot_managed=True,
     ),
     PluginManifest(
         name="claude-agents",
         source_dir="src/claude",
         manifest="src/claude/.claude-plugin/plugin.json",
+        # claude-agents is a separate plugin; PRs still own the bump.
+        bot_managed=False,
     ),
     PluginManifest(
         name="project-toolkit (copilot)",
         source_dir="src/copilot-cli",
         manifest="src/copilot-cli/.claude-plugin/plugin.json",
+        # ADR-091: parity manifest version is bot-managed; PRs must not bump it.
+        bot_managed=True,
     ),
 )
 
@@ -126,7 +133,7 @@ class Violation:
     manifest: str
     old_version: str | None
     new_version: str | None
-    reason: str  # "not-bumped" | "not-increased"
+    reason: str  # "not-bumped" | "not-increased" | "manually-bumped"
     touched: tuple[str, ...]
 
 
@@ -271,18 +278,67 @@ def evaluate(
     Returns ``(violations, config_errors)``. ``config_errors`` is non-empty
     when a version string cannot be parsed or a ref is unreadable; the
     CLI maps that to exit 2.
+
+    For ``bot_managed`` plugins (ADR-091): the bot owns the version field after
+    each merge to main. PRs must NOT include a version change. Violation reason
+    is ``"manually-bumped"``. Source changes with an unchanged version pass.
+
+    For non-``bot_managed`` plugins: original behavior -- source changes require
+    a strictly-greater version bump.
     """
     touched = [_normalize_path(p) for p in changed_files]
     violations: list[Violation] = []
     config_errors: list[str] = []
 
     for plugin in plugins:
+        if plugin.bot_managed:
+            # ADR-091: bot owns version; block any PR-level version change.
+            old, new = version_pairs.get(plugin.manifest, (None, None))
+            if isinstance(new, _BaseRefError):
+                config_errors.append(
+                    f"{plugin.manifest}: cannot read head version for {plugin.name}: {new.message}"
+                )
+                continue
+            if new is None:
+                # Manifest absent at HEAD: either a new plugin or the file
+                # simply does not exist in this repo slice. No version to
+                # check for a manual bump.
+                continue
+            if isinstance(old, _BaseRefError):
+                config_errors.append(
+                    f"{plugin.manifest}: cannot read base version for {plugin.name}: {old.message}"
+                )
+                continue
+            if old is not None:
+                # Both old and new are present: compare.
+                old_tuple = parse_version(old)
+                new_tuple = parse_version(new)
+                if old_tuple is None:
+                    config_errors.append(
+                        f"{plugin.manifest}: base version {old!r} is not valid semver"
+                    )
+                    continue
+                if new_tuple is None:
+                    config_errors.append(
+                        f"{plugin.manifest}: current version {new!r} is not valid semver"
+                    )
+                    continue
+                if old_tuple != new_tuple:
+                    violations.append(
+                        Violation(
+                            plugin=plugin.name,
+                            manifest=plugin.manifest,
+                            old_version=old,
+                            new_version=new,
+                            reason="manually-bumped",
+                            touched=(),
+                        )
+                    )
+            continue
+
+        # Non-bot-managed: source changes require a strictly-greater version bump.
         content = tuple(
-            sorted(
-                p
-                for p in touched
-                if _under(plugin.source_dir, p) and p != plugin.manifest
-            )
+            sorted(p for p in touched if _under(plugin.source_dir, p) and p != plugin.manifest)
         )
         if not content:
             continue
@@ -291,8 +347,7 @@ def evaluate(
 
         if isinstance(new, _BaseRefError):
             config_errors.append(
-                f"{plugin.manifest}: cannot read head version for "
-                f"{plugin.name}: {new.message}"
+                f"{plugin.manifest}: cannot read head version for {plugin.name}: {new.message}"
             )
             continue
 
@@ -305,15 +360,12 @@ def evaluate(
 
         new_tuple = parse_version(new)
         if new_tuple is None:
-            config_errors.append(
-                f"{plugin.manifest}: current version {new!r} is not valid semver"
-            )
+            config_errors.append(f"{plugin.manifest}: current version {new!r} is not valid semver")
             continue
 
         if isinstance(old, _BaseRefError):
             config_errors.append(
-                f"{plugin.manifest}: cannot read base version for "
-                f"{plugin.name}: {old.message}"
+                f"{plugin.manifest}: cannot read base version for {plugin.name}: {old.message}"
             )
             continue
 
@@ -323,9 +375,7 @@ def evaluate(
 
         old_tuple = parse_version(old)
         if old_tuple is None:
-            config_errors.append(
-                f"{plugin.manifest}: base version {old!r} is not valid semver"
-            )
+            config_errors.append(f"{plugin.manifest}: base version {old!r} is not valid semver")
             continue
 
         if new_tuple == old_tuple:
@@ -378,9 +428,7 @@ def _disk_version(manifest: str, repo_root: Path) -> str | None:
         return None
 
 
-def _head_version(
-    head_ref: str, manifest: str, repo_root: Path
-) -> str | None | _BaseRefError:
+def _head_version(head_ref: str, manifest: str, repo_root: Path) -> str | None | _BaseRefError:
     """Read the manifest version at ``head_ref`` via ``git show``.
 
     Returns the version string on success; ``None`` when the manifest did not
@@ -401,9 +449,7 @@ def _head_version(
         stderr = proc.stderr.strip()
         if any(marker in stderr for marker in _PATH_ABSENT_MARKERS):
             return None
-        return _BaseRefError(
-            f"git show {head_ref}:{manifest} exit {proc.returncode}: {stderr}"
-        )
+        return _BaseRefError(f"git show {head_ref}:{manifest} exit {proc.returncode}: {stderr}")
     version = _read_version_text(proc.stdout)
     if version is None:
         return _BaseRefError(
@@ -458,9 +504,7 @@ _PATH_ABSENT_MARKERS = (
 )
 
 
-def _base_version(
-    base_ref: str, manifest: str, repo_root: Path
-) -> str | None | _BaseRefError:
+def _base_version(base_ref: str, manifest: str, repo_root: Path) -> str | None | _BaseRefError:
     """Read the manifest version at ``base_ref`` via ``git show``.
 
     Returns the version string on success; ``None`` when the manifest did not
@@ -483,9 +527,7 @@ def _base_version(
         stderr = proc.stderr.strip()
         if any(marker in stderr for marker in _PATH_ABSENT_MARKERS):
             return None  # path absent at a valid ref: a new plugin
-        return _BaseRefError(
-            f"git show {base_ref}:{manifest} exit {proc.returncode}: {stderr}"
-        )
+        return _BaseRefError(f"git show {base_ref}:{manifest} exit {proc.returncode}: {stderr}")
     # git show succeeded: the manifest EXISTS at the base ref. If its content
     # cannot yield a version (invalid JSON, no version field, non-string
     # version), that is a malformed base manifest, a config error. Returning
@@ -564,8 +606,7 @@ def _git_diff_files(base: str, head: str, repo_root: Path) -> tuple[list[str], i
         return (
             [],
             2,
-            f"git diff --name-only {base}..{head} exit {proc.returncode}: "
-            f"{proc.stderr.strip()}",
+            f"git diff --name-only {base}..{head} exit {proc.returncode}: {proc.stderr.strip()}",
         )
     return [ln for ln in proc.stdout.splitlines() if ln.strip()], 0, ""
 
@@ -575,26 +616,50 @@ def _git_diff_files(base: str, head: str, repo_root: Path) -> tuple[list[str], i
 
 def _format_text(violations: Sequence[Violation], config_errors: Sequence[str]) -> str:
     if config_errors and not violations:
-        lines = ["plugin-version-bump: CONFIG ERROR"]
-        lines.extend(f"  {e}" for e in config_errors)
-        return "\n".join(lines)
+        err_lines = ["plugin-version-bump: CONFIG ERROR"]
+        err_lines.extend(f"  {e}" for e in config_errors)
+        return "\n".join(err_lines)
     if not violations:
         return "plugin-version-bump: OK"
-    lines = ["plugin-version-bump: NOT BUMPED"]
-    for v in violations:
+
+    manual = [v for v in violations if v.reason == "manually-bumped"]
+    missing = [v for v in violations if v.reason != "manually-bumped"]
+    lines: list[str] = []
+
+    if manual:
+        lines.append("plugin-version-bump: MANUAL BUMP REJECTED")
+        for v in manual:
+            lines.append("")
+            lines.append(f"  [manually-bumped] {v.plugin}")
+            lines.append(f"    manifest: {v.manifest}")
+            lines.append(f"    version:  {v.old_version} (base) -> {v.new_version} (now)")
         lines.append("")
-        lines.append(f"  [{v.reason}] {v.plugin}")
-        lines.append(f"    manifest: {v.manifest}")
-        lines.append(f"    version:  {v.old_version} (base) -> {v.new_version} (now)")
-        lines.append("    changed under source dir:")
-        for p in v.touched:
-            lines.append(f"      {p}")
-    lines.append("")
-    lines.append(
-        "Fix: bump the `version` in each manifest above to a strictly greater "
-        "semver. Source changed but the published version did not, so installs "
-        "will not re-sync."
-    )
+        lines.append(
+            "Fix: remove the version change from the manifests listed above. "
+            "These versions are managed by the post-merge bot (ADR-091). "
+            "Do not bump the version manually; the bot increments it automatically "
+            "after your PR merges."
+        )
+
+    if missing:
+        if lines:
+            lines.append("")
+        lines.append("plugin-version-bump: NOT BUMPED")
+        for v in missing:
+            lines.append("")
+            lines.append(f"  [{v.reason}] {v.plugin}")
+            lines.append(f"    manifest: {v.manifest}")
+            lines.append(f"    version:  {v.old_version} (base) -> {v.new_version} (now)")
+            lines.append("    changed under source dir:")
+            for p in v.touched:
+                lines.append(f"      {p}")
+        lines.append("")
+        lines.append(
+            "Fix: bump the `version` in each manifest above to a strictly greater "
+            "semver. Source changed but the published version did not, so installs "
+            "will not re-sync."
+        )
+
     if config_errors:
         lines.append("")
         lines.append("Config errors:")
@@ -681,7 +746,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
 
     violations, config_errors = find_violations(
-        changed, base_ref=base, head_ref=head_ref, repo_root=repo_root,
+        changed,
+        base_ref=base,
+        head_ref=head_ref,
+        repo_root=repo_root,
         base_already_resolved=(args.files is None),
     )
 

--- a/build/scripts/validate_plugin_version_bump.py
+++ b/build/scripts/validate_plugin_version_bump.py
@@ -300,9 +300,12 @@ def evaluate(
                 )
                 continue
             if new is None:
-                # Manifest absent at HEAD: either a new plugin or the file
-                # simply does not exist in this repo slice. No version to
-                # check for a manual bump.
+                if old is not None and not isinstance(old, _BaseRefError):
+                    # Manifest existed at base but absent at HEAD: deletion.
+                    config_errors.append(
+                        f"{plugin.manifest}: manifest deleted in this PR for {plugin.name}"
+                    )
+                # New plugin not yet committed, or truly absent from repo: skip.
                 continue
             if isinstance(old, _BaseRefError):
                 config_errors.append(

--- a/scripts/ci/auto_bump_plugin_version.py
+++ b/scripts/ci/auto_bump_plugin_version.py
@@ -69,6 +69,7 @@ def _git_diff_files(before: str, after: str, repo_root: Path) -> list[str] | Non
             ["git", "-C", str(repo_root), "diff", "--name-only", f"{before}..{after}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
             timeout=30,
         )
@@ -156,6 +157,7 @@ def _run_ratchet_update(script: Path, repo_root: Path) -> None:
             cwd=str(repo_root),
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
             timeout=120,
         )

--- a/scripts/ci/auto_bump_plugin_version.py
+++ b/scripts/ci/auto_bump_plugin_version.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Auto-bump parity plugin manifest versions (ADR-091 post-merge bot).
+
+This script is invoked by ``.github/workflows/post-merge-version-bump.yml``
+immediately after a push lands on ``main``.  It increments the patch version in
+both parity manifests (``project-toolkit`` plugin for Claude and Copilot CLI)
+when the push included non-manifest plugin source changes.
+
+Behavior
+--------
+
+1. Inspect the changed files between ``PUSH_BEFORE_SHA`` and ``PUSH_AFTER_SHA``
+   (passed as environment variables by the workflow).
+2. If no non-manifest plugin source files changed, exit 0 with "nothing to do".
+   This prevents the bot from bumping on its own bump commit.
+3. Parse the current SemVer patch from one of the parity manifests, increment
+   it, and write the new value to both manifests.
+4. Also run the taste and ruff count ratchets with ``--update`` so improved
+   baselines are recorded atomically in the same bot commit.
+
+The script does NOT run ``git commit`` or ``git push``; those are the calling
+workflow's responsibility (the workflow needs the resulting exit code and the
+list of mutated files).
+
+CLI
+---
+
+::
+
+    python3 scripts/ci/auto_bump_plugin_version.py
+    python3 scripts/ci/auto_bump_plugin_version.py --dry-run
+
+EXIT CODES (per ADR-035)
+------------------------
+
+0 - wrote new versions (or nothing to do on a dry run)
+1 - plugin source changed but bump failed (version parse error, write error)
+2 - configuration error (missing env, missing manifest, git error)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The two parity manifests that this bot manages (ADR-091).
+_PARITY_MANIFESTS: tuple[str, ...] = (
+    ".claude/.claude-plugin/plugin.json",
+    "src/copilot-cli/.claude-plugin/plugin.json",
+)
+
+# Source dirs owned by the parity manifests (excluding the manifests themselves).
+_PARITY_SOURCE_DIRS: tuple[str, ...] = (".claude/", "src/copilot-cli/")
+
+
+def _git_diff_files(before: str, after: str, repo_root: Path) -> list[str] | None:
+    """Return files changed between ``before`` and ``after`` SHAs.
+
+    Returns ``None`` on git failure.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", f"{before}..{after}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"error: git diff failed: {exc}", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        print(
+            f"error: git diff {before}..{after} exit {proc.returncode}: {proc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return None
+    return [ln for ln in proc.stdout.splitlines() if ln.strip()]
+
+
+def _has_non_manifest_plugin_changes(changed: list[str]) -> bool:
+    """True when ``changed`` includes at least one non-manifest parity source file."""
+    manifests = set(_PARITY_MANIFESTS)
+    for path in changed:
+        for src_dir in _PARITY_SOURCE_DIRS:
+            if path.startswith(src_dir) and path not in manifests:
+                return True
+    return False
+
+
+def _read_version(manifest_path: Path) -> str | None:
+    """Return the ``version`` string from a plugin.json, or ``None``."""
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    v = data.get("version")
+    return v if isinstance(v, str) else None
+
+
+def _bump_patch(version: str) -> str | None:
+    """Return version with patch incremented, or None if not valid MAJOR.MINOR.PATCH.
+
+    Accepts an optional pre-release suffix; strips it and bumps patch.
+    ``0.6.5446`` -> ``0.6.5447``.
+    """
+    core = version.split("-")[0].split("+")[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError:
+        return None
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _write_version(manifest_path: Path, new_version: str) -> bool:
+    """Write ``new_version`` into the manifest's ``version`` field.
+
+    Returns True on success, False on error.
+    """
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, ValueError, TypeError) as exc:
+        print(f"error: could not read {manifest_path}: {exc}", file=sys.stderr)
+        return False
+    if not isinstance(data, dict):
+        print(f"error: {manifest_path} is not a JSON object", file=sys.stderr)
+        return False
+    data["version"] = new_version
+    try:
+        manifest_path.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except OSError as exc:
+        print(f"error: could not write {manifest_path}: {exc}", file=sys.stderr)
+        return False
+    return True
+
+
+def _run_ratchet_update(script: Path, repo_root: Path) -> None:
+    """Run a count ratchet with --update; log but do not fail on errors."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script), "--update"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"warning: ratchet {script.name} could not run: {exc}", file=sys.stderr)
+        return
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.returncode not in (0, 1):
+        # Exit 1 = regression (count went up); log but don't stop the bump.
+        if proc.stderr:
+            print(proc.stderr, end="", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Auto-bump parity plugin manifest versions after a merge to main."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute and print the new version without writing any files.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Override repo root (default: derived from script path).",
+    )
+    args = parser.parse_args(argv)
+    repo_root = (args.repo_root or _REPO_ROOT).resolve()
+
+    before_sha = os.environ.get("PUSH_BEFORE_SHA", "")
+    after_sha = os.environ.get("PUSH_AFTER_SHA", "HEAD")
+
+    if not before_sha or before_sha == "0" * 40:
+        print(
+            "PUSH_BEFORE_SHA is empty or zero SHA (first push); bumping unconditionally.",
+        )
+        do_bump = True
+    else:
+        changed = _git_diff_files(before_sha, after_sha, repo_root)
+        if changed is None:
+            return 2
+        if not _has_non_manifest_plugin_changes(changed):
+            print("No non-manifest parity source changes; nothing to bump.")
+            return 0
+        do_bump = True
+
+    if not do_bump:
+        return 0
+
+    # Read the current version from the first parity manifest.
+    primary = repo_root / _PARITY_MANIFESTS[0]
+    current = _read_version(primary)
+    if current is None:
+        print(f"error: cannot read version from {primary}", file=sys.stderr)
+        return 1
+
+    new_version = _bump_patch(current)
+    if new_version is None:
+        print(
+            f"error: cannot parse version {current!r} from {primary}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Bumping parity plugin version: {current} -> {new_version}")
+
+    if args.dry_run:
+        for manifest in _PARITY_MANIFESTS:
+            print(f"  [dry-run] would write {new_version} to {manifest}")
+        return 0
+
+    for manifest_rel in _PARITY_MANIFESTS:
+        manifest_path = repo_root / manifest_rel
+        if not _write_version(manifest_path, new_version):
+            return 1
+        print(f"  wrote {new_version} to {manifest_rel}")
+
+    # Update count baselines if they have improved.
+    for ratchet_name in ("taste_count_ratchet.py", "ruff_count_ratchet.py"):
+        ratchet = repo_root / "scripts" / "ci" / ratchet_name
+        if ratchet.is_file():
+            _run_ratchet_update(ratchet, repo_root)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/auto_bump_plugin_version.py
+++ b/scripts/ci/auto_bump_plugin_version.py
@@ -170,6 +170,51 @@ def _run_ratchet_update(script: Path, repo_root: Path) -> None:
             print(proc.stderr, end="", file=sys.stderr)
 
 
+def _should_bump(before_sha: str, after_sha: str, repo_root: Path) -> tuple[bool, int]:
+    """Return (do_bump, exit_code).  exit_code is non-zero if we must stop early."""
+    if not before_sha or before_sha == "0" * 40:
+        print("PUSH_BEFORE_SHA is empty or zero SHA (first push); bumping unconditionally.")
+        return True, 0
+    changed = _git_diff_files(before_sha, after_sha, repo_root)
+    if changed is None:
+        return False, 2
+    if not _has_non_manifest_plugin_changes(changed):
+        print("No non-manifest parity source changes; nothing to bump.")
+        return False, 0
+    return True, 0
+
+
+def _compute_new_version(repo_root: Path) -> tuple[str | None, int]:
+    """Parse the current version and compute the next patch level.
+
+    Returns (new_version, exit_code).  exit_code is non-zero on failure.
+    """
+    primary = repo_root / _PARITY_MANIFESTS[0]
+    current = _read_version(primary)
+    if current is None:
+        print(f"error: cannot read version from {primary}", file=sys.stderr)
+        return None, 1
+    new_version = _bump_patch(current)
+    if new_version is None:
+        print(f"error: cannot parse version {current!r} from {primary}", file=sys.stderr)
+        return None, 1
+    print(f"Bumping parity plugin version: {current} -> {new_version}")
+    return new_version, 0
+
+
+def _write_manifests(repo_root: Path, new_version: str, dry_run: bool) -> int:
+    """Write new_version into every parity manifest.  Returns exit code."""
+    for manifest_rel in _PARITY_MANIFESTS:
+        if dry_run:
+            print(f"  [dry-run] would write {new_version} to {manifest_rel}")
+            continue
+        manifest_path = repo_root / manifest_rel
+        if not _write_version(manifest_path, new_version):
+            return 1
+        print(f"  wrote {new_version} to {manifest_rel}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Auto-bump parity plugin manifest versions after a merge to main."
@@ -191,56 +236,23 @@ def main(argv: list[str] | None = None) -> int:
     before_sha = os.environ.get("PUSH_BEFORE_SHA", "")
     after_sha = os.environ.get("PUSH_AFTER_SHA", "HEAD")
 
-    if not before_sha or before_sha == "0" * 40:
-        print(
-            "PUSH_BEFORE_SHA is empty or zero SHA (first push); bumping unconditionally.",
-        )
-        do_bump = True
-    else:
-        changed = _git_diff_files(before_sha, after_sha, repo_root)
-        if changed is None:
-            return 2
-        if not _has_non_manifest_plugin_changes(changed):
-            print("No non-manifest parity source changes; nothing to bump.")
-            return 0
-        do_bump = True
+    do_bump, rc = _should_bump(before_sha, after_sha, repo_root)
+    if rc != 0 or not do_bump:
+        return rc
 
-    if not do_bump:
-        return 0
+    new_version, rc = _compute_new_version(repo_root)
+    if rc != 0 or new_version is None:
+        return rc
 
-    # Read the current version from the first parity manifest.
-    primary = repo_root / _PARITY_MANIFESTS[0]
-    current = _read_version(primary)
-    if current is None:
-        print(f"error: cannot read version from {primary}", file=sys.stderr)
-        return 1
+    rc = _write_manifests(repo_root, new_version, args.dry_run)
+    if rc != 0:
+        return rc
 
-    new_version = _bump_patch(current)
-    if new_version is None:
-        print(
-            f"error: cannot parse version {current!r} from {primary}",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(f"Bumping parity plugin version: {current} -> {new_version}")
-
-    if args.dry_run:
-        for manifest in _PARITY_MANIFESTS:
-            print(f"  [dry-run] would write {new_version} to {manifest}")
-        return 0
-
-    for manifest_rel in _PARITY_MANIFESTS:
-        manifest_path = repo_root / manifest_rel
-        if not _write_version(manifest_path, new_version):
-            return 1
-        print(f"  wrote {new_version} to {manifest_rel}")
-
-    # Update count baselines if they have improved.
-    for ratchet_name in ("taste_count_ratchet.py", "ruff_count_ratchet.py"):
-        ratchet = repo_root / "scripts" / "ci" / ratchet_name
-        if ratchet.is_file():
-            _run_ratchet_update(ratchet, repo_root)
+    if not args.dry_run:
+        for ratchet_name in ("taste_count_ratchet.py", "ruff_count_ratchet.py"):
+            ratchet = repo_root / "scripts" / "ci" / ratchet_name
+            if ratchet.is_file():
+                _run_ratchet_update(ratchet, repo_root)
 
     return 0
 

--- a/scripts/ci/auto_bump_plugin_version.py
+++ b/scripts/ci/auto_bump_plugin_version.py
@@ -166,10 +166,8 @@ def _run_ratchet_update(script: Path, repo_root: Path) -> None:
         return
     if proc.stdout:
         print(proc.stdout, end="")
-    if proc.returncode not in (0, 1):
-        # Exit 1 = regression (count went up); log but don't stop the bump.
-        if proc.stderr:
-            print(proc.stderr, end="", file=sys.stderr)
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
 
 
 def _should_bump(before_sha: str, after_sha: str, repo_root: Path) -> tuple[bool, int]:
@@ -235,7 +233,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     repo_root = (args.repo_root or _REPO_ROOT).resolve()
 
-    before_sha = os.environ.get("PUSH_BEFORE_SHA", "")
+    before_sha: str | None = os.environ.get("PUSH_BEFORE_SHA")
+    if before_sha is None:
+        print(
+            "ERROR: PUSH_BEFORE_SHA not set; this script must run inside the workflow",
+            file=sys.stderr,
+        )
+        return 2
     after_sha = os.environ.get("PUSH_AFTER_SHA", "HEAD")
 
     do_bump, rc = _should_bump(before_sha, after_sha, repo_root)

--- a/scripts/ci/count_ratchet.py
+++ b/scripts/ci/count_ratchet.py
@@ -1,8 +1,10 @@
 """Shared machinery for whole-repo violation-count ratchets.
 
 A count ratchet freezes a repository-wide violation total in a baseline file.
-The measured count must equal the baseline. ``--update`` records an improvement;
-an unrecorded decrease fails because it leaves slack for later regressions.
+The measured count must not exceed the baseline. An improvement (count <
+baseline) passes; the post-merge bot commits the lower baseline after the PR
+lands (ADR-091). ``--update`` explicitly lowers the baseline (used by the bot).
+A regression (count > baseline) blocks.
 
 Two gates use this: ``ruff_count_ratchet.py`` (issue #2993) and
 ``taste_count_ratchet.py`` (issue #3779). Only the counting differs. Everything
@@ -23,8 +25,8 @@ Stdlib only: these gates run by path in CI (``python scripts/ci/<name>.py``) and
 must not depend on the project's import graph.
 
 Exit codes (AGENTS.md contract):
-    0 - ok (count == baseline, or --update records a decrease)
-    1 - regression (count != baseline, or baseline raised vs --base-ref)
+    0 - ok (count <= baseline, or --update records a decrease)
+    1 - regression (count > baseline, or baseline raised vs --base-ref)
     2 - config error (baseline missing or malformed, bad args)
     3 - external error (the underlying linter could not run)
 """
@@ -107,9 +109,7 @@ def _baseline_rel(repo_root: Path, baseline: Path) -> str:
         return baseline.as_posix()
 
 
-def _git_run(
-    repo_root: Path, argv: Sequence[str]
-) -> subprocess.CompletedProcess[str] | None:
+def _git_run(repo_root: Path, argv: Sequence[str]) -> subprocess.CompletedProcess[str] | None:
     """Run a git command, or None when git could not be launched."""
     try:
         return subprocess.run(
@@ -279,13 +279,13 @@ def run(
                 f"{label}: improved {baseline} -> {count} (-{baseline - count}). Baseline lowered."
             )
             return EXIT_OK
+        # ADR-091: the post-merge bot owns the baseline update. PRs that reduce
+        # the count do not need to --update; the bot ratchets after merge.
         print(
-            f"{label}: BASELINE STALE. {count} violations < baseline {baseline} "
-            f"(-{baseline - count}). Run with --update to lower the baseline and "
-            f"close the slack.",
-            file=sys.stderr,
+            f"{label}: improved {baseline} -> {count} (-{baseline - count}). "
+            "Baseline update will be committed by the post-merge bot."
         )
-        return EXIT_REGRESSION
+        return EXIT_OK
 
     print(f"{label}: OK (count == baseline {baseline}).")
     return EXIT_OK

--- a/src/copilot-cli/instructions/plugin-version-bump.instructions.md
+++ b/src/copilot-cli/instructions/plugin-version-bump.instructions.md
@@ -2,161 +2,56 @@
 applyTo: src/copilot-cli/**,src/claude/**,**/.claude-plugin/plugin.json
 ---
 
-# Plugin Version Bump and the Parallel-PR Deadlock
+# Plugin Version Bump (ADR-091: post-merge bot owns the parity versions)
 
-This rule exists because two CI gates interact to deadlock any long-lived PR
-that touches a plugin source dir. `build/scripts/validate_plugin_version_bump.py`
-requires the `version` in a changed plugin's `.claude-plugin/plugin.json` to be
-**strictly greater** than the same field on the base branch. A separate
-manifest-parity gate requires the paired dirs (`.claude` and `src/copilot-cli`)
-to hold the **same** version. Every merge to `main` that touches a plugin source
-bumps that dir's version. So the moment another plugin-source PR lands, your open
-PR's version is no longer strictly greater than the new base, the gate flips red,
-and you must rebump. An unrelated merge that touches no plugin source does not
-move these versions and does not flip the gate. Tracked in issue #2855.
+**Do NOT manually bump `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`.** A post-merge bot handles
+parity-pair versions after every merge to `main`. If your PR includes a
+version bump in either of those files, the CI gate will block it with
+`manually-bumped`.
 
-## Which manifests bump, and together or independently
+## Which manifests bump, and who owns them
 
-There are two independent version lines. Bump only the ones whose source you
-touched:
+There are two independent version lines:
 
-- **Parity pair (bump together, same value).** `.claude/.claude-plugin/plugin.json`
-  and `src/copilot-cli/.claude-plugin/plugin.json` must always hold the same
-  version. Touching a file under `.claude/` or `src/copilot-cli/` requires
-  bumping **both** of these to the same new value, or the parity gate fails.
-- **Separate line (bump independently).** `src/claude/.claude-plugin/plugin.json`
-  tracks its own `0.3.x` line. Bump it only when you touch `src/claude/**`. It is
-  not coupled to the parity pair.
+- **Parity pair (bot-managed).** `.claude/.claude-plugin/plugin.json` and
+  `src/copilot-cli/.claude-plugin/plugin.json` are owned by the post-merge bot
+  (ADR-091). Do NOT touch them. If you accidentally committed a version bump to
+  either file, revert it before pushing.
+- **Separate line (author-managed).** `src/claude/.claude-plugin/plugin.json`
+  tracks its own line. Bump it when you touch `src/claude/**`, the same way you
+  always have. The strict-greater-SemVer rule still applies here.
 
-Set the new version to `max(version across every remote branch) + 1`. Do not use
-`base + 1`, and do not "target `base + 2`" because one other PR sits at `base + 1`.
-Measured 2026-07-31: base was `0.6.5447`, so `base + 2` would have been
-`0.6.5449`, but **15 remote branches already held a higher value**, topping out at
-`0.6.5472`. Any one of them merging first flips your gate red.
+## What to do if the gate says `manually-bumped`
 
-Enumerate the pack before you pick a number. The two lines are far apart, so
-reading the wrong one hands you a number off by orders of magnitude: measured the
-same day, the parity line topped out at `0.6.5472` and the `src/claude` line at
-`0.3.57`. Report every line in one pass rather than picking a manifest by hand,
-then bump the parity pair together to one value and `src/claude` to its own.
+You have a version change in `.claude/.claude-plugin/plugin.json` or
+`src/copilot-cli/.claude-plugin/plugin.json`. Revert it:
 
 ```bash
-git fetch origin --quiet
-for MANIFEST in .claude/.claude-plugin/plugin.json \
-                src/copilot-cli/.claude-plugin/plugin.json \
-                src/claude/.claude-plugin/plugin.json; do
-  VERSIONS=$(for b in $(git ls-remote --heads origin | awk '{print $2}' | sed 's#refs/heads/##'); do
-    git show "origin/$b:$MANIFEST" 2>/dev/null \
-      | python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])' 2>/dev/null
-  done)
-  [ -n "$VERSIONS" ] || { echo "ERROR: read zero versions from $MANIFEST" >&2; exit 1; }
-  MAX=$(printf '%s\n' "$VERSIONS" | sort -V | tail -1)
-  printf '%-46s %s\n' "$MANIFEST" "$MAX"
-done
+git checkout origin/main -- .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json
+git commit --amend --no-edit   # or a new commit if already pushed
 ```
 
-The emptiness check is load-bearing. Both `git show` and the decoder discard
-stderr, so a mistyped manifest path makes every read fail silently; unguarded, the
-pipeline then prints nothing and still exits 0, which reads as "nobody has
-allocated" when it actually means "I measured nothing." Verified: the guarded
-form exits 1 on a bogus path. Separately, `sort -V` places a prerelease suffix
-*after* the plain version (`0.6.5471`, then `0.6.5471-rc1`), the reverse of
-SemVer precedence. No branch uses a suffix today, so that is latent rather than
-live, but do not trust this snippet if one appears.
+Then re-run `python3 build/scripts/validate_plugin_version_bump.py --base origin/main`
+to confirm the gate passes.
 
-Increment the last component of that value. `max + 1` does not *guarantee* you
-never rebump, because a branch that allocates after you can still land first. What
-it buys is that you start above every allocation that already exists, so only new
-entrants can displace you. `base + 1` starts below most of the pack, so it is
-near-certain to need a rebump.
+## The `src/claude` line (unchanged)
 
-## The recipe when the gate goes red
+Set the new version to `max(base_version) + 1`. If another PR is already in
+flight at `base + 1`, target `base + 2`. Run the validator to confirm:
 
-**Merge, never rebase.** `AGENTS.md` lists force-push under **Never**, and
-`.claude/rules/universal.md` MUST NOT-1 forbids it on shared branches. A branch
-with an open PR is shared: reviewers and bots anchor comments to specific commit
-SHAs. Rebasing a branch that has already diverged from its published head
-rewrites those SHAs, so the push is rejected as non-fast-forward and the only way
-through is a force-push. (A rebase whose upstream is already an ancestor is a
-no-op and needs no force, but you cannot count on that on the long-lived PR this
-rule is about.) Merging keeps the push fast-forward and needs no force. This is
-not only policy: on PR #4063 the remote branch gained a commit from another actor
-mid-session, the merge path absorbed it, and a force-push would have destroyed it.
+```bash
+python3 build/scripts/validate_plugin_version_bump.py --base origin/main
+```
 
-1. `git fetch origin`, then reconcile **your own branch before main**:
+The validator reads committed state, not the working tree, so commit before
+running it.
 
-   ```bash
-   git merge origin/<your-branch>   # absorb commits pushed to the PR head
-   git merge origin/main            # then absorb the new base
-   ```
+## Prior behavior (superseded by ADR-091)
 
-   Merging `origin/main` alone does **not** pick up a commit another actor or a
-   bot pushed to your PR head, and it leaves your eventual push non-fast-forward
-   for a reason no amount of rebasing against main will fix. That is the exact
-   mechanism behind the #4063 case above. Resolve the `plugin.json` `version`
-   conflict to the value computed above.
-2. Stage **both** parity manifests together
-   (`git add .claude/.claude-plugin/plugin.json src/copilot-cli/.claude-plugin/plugin.json`),
-   plus `src/claude/.claude-plugin/plugin.json` if you touched `src/claude/**`.
-   Staging only one of the parity pair fails the parity gate.
-3. `git commit` to conclude the merge. The validators read committed state, not
-   the working tree, so you MUST commit before re-running them.
-4. Run these three manifest validators. Each fails independently, and the version
-   gate alone does not catch a parity break or a malformed manifest:
-
-   ```bash
-   python3 build/scripts/validate_plugin_version_bump.py --base origin/main
-   python3 build/scripts/check_plugin_manifest_parity.py
-   python3 build/scripts/validate_plugin_manifests.py
-   ```
-
-   `check_plugin_manifest_parity.py` takes no arguments and does not implement
-   `--help`; passing one runs the check anyway. All three are stdlib-only, so a
-   bare `python3` is enough here. These are the manifest-specific gates, not the
-   whole suite: pre-push and CI reach the manifest again through
-   `tests/e2e/test_plugin_load_smoke.py`, which reads the manifest `version` and
-   asserts it surfaces from the loaded plugin. A clean local run of these three is
-   necessary, not sufficient.
-5. `git push`, then **read the `To ...` line of its output**. `git push` itself
-   exits nonzero when the remote rejects the push, but a pipeline hides that:
-   `git push ... | tail` reports `tail`'s status, not git's. Measured:
-   `(exit 7) | tail -1` yields `0`, and the same pipeline under
-   `set -o pipefail` yields `7`. So do not pipe the push, or set `pipefail`
-   first, and confirm independently that the remote head is **the commit you
-   meant to push**:
-
-   ```bash
-   git rev-parse HEAD
-   git ls-remote origin refs/heads/<branch> | cut -f1
-   ```
-
-   The two SHAs must match. Running `ls-remote` on its own proves only that the
-   branch exists, which it did before you pushed. Then arm auto-merge (GraphQL
-   `enablePullRequestAutoMerge`, `mergeMethod: SQUASH`) so the PR lands before the
-   next merge bumps the base again. Speed is the mitigation.
-
-## When your branch sits below the base
-
-This case defeats naive conflict resolution. A branch cut a while ago can carry a
-version *lower* than `main`. Then **neither side of the conflict is correct**:
-`--ours` keeps a value below base, `--theirs` keeps base itself, and the gate
-demands strictly greater than base. Either choice produces a red gate that looks
-resolved. Resolve the rest of the manifest on its merits, keeping any branch-side
-edits to fields like `description` or the component lists, then overwrite **only**
-the `version` field with a freshly computed `max + 1`. Taking the incoming side
-wholesale silently discards those edits; commit `384463efc` is a real precedent
-for a manifest change that touched `description` and nothing else.
-
-This is the common case, not a corner case. Measured 2026-07-31 against a base of
-`0.6.5447`: of 182 remote branches, 84 change a non-manifest file under `.claude/`
-and are therefore subject to the gate, and **50 of those 84 sit at or below base**
-(the set includes stale branches). PR #4063 was one of them, at `0.6.5443`.
-
-Note that the gate is conditional on the diff. A branch below base is only red if
-it actually changes plugin source; a docs-only branch that never touched a plugin
-dir passes even at an old version. Verify with
-`validate_plugin_version_bump.py --base origin/main --head origin/<branch>` rather
-than assuming from the version number alone.
-
-Do not hand-edit only one of the paired manifests; the parity gate will fail.
-Do not expect the version-bump validator to see uncommitted changes.
+Before ADR-091, authors were required to bump both parity manifests on every
+PR touching parity source dirs. That requirement created an O(N^2) conflict
+class: 11+ PRs could not land without rebumping each time another landed. The
+post-merge bot removes that class entirely. The old recipe in this file is no
+longer correct.

--- a/tests/build_scripts/test_validate_plugin_version_bump.py
+++ b/tests/build_scripts/test_validate_plugin_version_bump.py
@@ -289,10 +289,18 @@ def test_unparseable_current_version_is_config_error():
     assert CLAUDE in errs[0]
 
 
-def test_missing_current_version_skips_for_bot_managed():
-    # Bot-managed: manifest absent at HEAD (new=None) means file was deleted or
-    # never existed. There is no version to check for a manual bump, so skip.
+def test_manifest_deleted_in_pr_is_config_error_for_bot_managed():
+    # Bot-managed: manifest existed at base (old="0.3.0") but absent at HEAD
+    # (new=None) means the manifest was deleted in this PR. That is a config error.
     v, errs = vpb.evaluate([".claude/x.md"], _pairs(claude=("0.3.0", None)))
+    assert v == []
+    assert len(errs) == 1
+    assert "deleted" in errs[0]
+
+
+def test_manifest_never_existed_skips_for_bot_managed():
+    # Bot-managed: manifest never existed (old=None, new=None). Skip silently.
+    v, errs = vpb.evaluate([".claude/x.md"], _pairs(claude=(None, None)))
     assert v == []
     assert errs == []
 

--- a/tests/build_scripts/test_validate_plugin_version_bump.py
+++ b/tests/build_scripts/test_validate_plugin_version_bump.py
@@ -1,3 +1,4 @@
+# taste-lint: ignore file-size
 """Tests for build/scripts/validate_plugin_version_bump.py.
 
 Covers:

--- a/tests/build_scripts/test_validate_plugin_version_bump.py
+++ b/tests/build_scripts/test_validate_plugin_version_bump.py
@@ -21,8 +21,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "build" / "scripts"))
 
@@ -40,7 +38,7 @@ def _pairs(**kw: tuple[str | None, str | None]) -> dict[str, tuple[str | None, s
     Unspecified manifests default to ('0.0.0', '0.0.0') so an irrelevant
     plugin never trips the check unless the test names it.
     """
-    base = {
+    base: dict[str, tuple[str | None, str | None]] = {
         CLAUDE: ("0.0.0", "0.0.0"),
         SRC_CLAUDE: ("0.0.0", "0.0.0"),
         COPILOT: ("0.0.0", "0.0.0"),
@@ -133,8 +131,9 @@ def test_prerelease_identifier_ordering():
 
 def test_promote_prerelease_to_release_is_valid_bump():
     # Source change + promote 0.3.0-rc1 -> 0.3.0 must pass (release > prerelease).
+    # Uses src/claude (non-bot-managed) so the strict-greater check applies.
     v, errs = vpb.evaluate(
-        [".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0-rc1", "0.3.0"))
+        ["src/claude/skills/foo/SKILL.md"], _pairs(src_claude=("0.3.0-rc1", "0.3.0"))
     )
     assert v == []
     assert errs == []
@@ -144,9 +143,8 @@ def test_promote_prerelease_to_release_is_valid_bump():
 
 
 def test_source_changed_with_bump_passes():
-    v, errs = vpb.evaluate(
-        [".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0", "0.3.1"))
-    )
+    # src/claude is non-bot-managed; strict-greater bump required.
+    v, errs = vpb.evaluate(["src/claude/agents/foo.md"], _pairs(src_claude=("0.3.0", "0.3.1")))
     assert v == []
     assert errs == []
 
@@ -158,55 +156,104 @@ def test_nothing_relevant_changed_passes():
 
 
 def test_manifest_only_change_does_not_require_bump():
-    # Only plugin.json changed (e.g. description edit), no other source file.
+    # Only plugin.json changed (e.g. description edit) with version unchanged.
+    # Bot-managed: version unchanged -> pass.
     v, errs = vpb.evaluate([CLAUDE], _pairs(claude=("0.3.0", "0.3.0")))
     assert v == []
     assert errs == []
 
 
-def test_bump_with_no_other_change_passes():
-    v, errs = vpb.evaluate([CLAUDE], _pairs(claude=("0.3.0", "0.4.0")))
-    assert v == []
-    assert errs == []
-
-
 def test_new_plugin_no_base_version_passes():
-    v, errs = vpb.evaluate(
-        ["src/claude/newagent.md"], _pairs(src_claude=(None, "0.1.0"))
-    )
+    v, errs = vpb.evaluate(["src/claude/newagent.md"], _pairs(src_claude=(None, "0.1.0")))
     assert v == []
     assert errs == []
+
+
+# --- evaluate: bot-managed plugins (ADR-091) -----------------------------
+
+
+def test_bot_managed_source_change_no_bump_passes():
+    # Bot-managed: source changed but version unchanged -> pass (bot bumps post-merge).
+    v, errs = vpb.evaluate([".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0", "0.3.0")))
+    assert v == []
+    assert errs == []
+
+
+def test_bot_managed_manual_bump_fails():
+    # Bot-managed: PR manually bumped version -> violation "manually-bumped".
+    v, errs = vpb.evaluate([".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0", "0.3.1")))
+    assert errs == []
+    assert len(v) == 1
+    assert v[0].reason == "manually-bumped"
+    assert v[0].manifest == CLAUDE
+
+
+def test_bot_managed_manual_bump_even_without_source_change():
+    # Version changed in a bot-managed manifest -> violation regardless of source files.
+    v, errs = vpb.evaluate([CLAUDE], _pairs(claude=("0.3.0", "0.4.0")))
+    assert errs == []
+    assert len(v) == 1
+    assert v[0].reason == "manually-bumped"
+
+
+def test_bot_managed_decrease_also_fails():
+    # Any version change in a bot-managed manifest is a violation.
+    v, errs = vpb.evaluate(
+        ["src/copilot-cli/skills/x/SKILL.md"], _pairs(copilot=("0.4.1", "0.4.0"))
+    )
+    assert errs == []
+    assert len(v) == 1
+    assert v[0].reason == "manually-bumped"
+    assert v[0].manifest == COPILOT
+
+
+def test_bot_managed_new_plugin_passes():
+    # No base version (new bot-managed plugin): nothing to compare, pass.
+    v, errs = vpb.evaluate([".claude/skills/foo/SKILL.md"], _pairs(claude=(None, "0.1.0")))
+    assert v == []
+    assert errs == []
+
+
+def test_isolating_negative_control_bot_managed():
+    # The scanner DOES detect version changes; an empty changed_files set
+    # cannot produce a false violation.
+    v_with_bump, _ = vpb.evaluate([], _pairs(claude=("0.3.0", "0.3.1")))
+    v_no_change, _ = vpb.evaluate(
+        [".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0", "0.3.0"))
+    )
+    assert len(v_with_bump) == 1, "scanner must find a manual bump"
+    assert v_no_change == [], "source change without version bump must pass"
 
 
 # --- evaluate: negative --------------------------------------------------
 
 
 def test_source_changed_without_bump_fails():
+    # Non-bot-managed (src/claude): source changed but version unchanged -> violation.
     v, errs = vpb.evaluate(
-        [".claude/skills/foo/SKILL.md"], _pairs(claude=("0.3.0", "0.3.0"))
+        ["src/claude/skills/foo/SKILL.md"], _pairs(src_claude=("0.3.0", "0.3.0"))
     )
     assert errs == []
     assert len(v) == 1
     assert v[0].reason == "not-bumped"
-    assert v[0].manifest == CLAUDE
-    assert v[0].touched == (".claude/skills/foo/SKILL.md",)
+    assert v[0].manifest == SRC_CLAUDE
+    assert v[0].touched == ("src/claude/skills/foo/SKILL.md",)
 
 
 def test_source_changed_with_decrease_fails():
-    v, errs = vpb.evaluate(
-        ["src/copilot-cli/skills/x/SKILL.md"], _pairs(copilot=("0.4.1", "0.4.0"))
-    )
+    # Non-bot-managed (src/claude): version decreased -> violation.
+    v, errs = vpb.evaluate(["src/claude/agents/y.md"], _pairs(src_claude=("0.4.1", "0.4.0")))
     assert errs == []
     assert len(v) == 1
     assert v[0].reason == "not-increased"
-    assert v[0].manifest == COPILOT
+    assert v[0].manifest == SRC_CLAUDE
 
 
 def test_per_plugin_isolation():
-    # src/claude changed without bump; .claude bumped correctly; copilot untouched.
+    # src/claude changed without bump -> violation; bot-managed parity versions unchanged -> pass.
     v, errs = vpb.evaluate(
         [".claude/agents/x.md", "src/claude/y.md"],
-        _pairs(claude=("0.3.0", "0.3.1"), src_claude=("0.3.0", "0.3.0")),
+        _pairs(claude=("0.3.0", "0.3.0"), src_claude=("0.3.0", "0.3.0")),
     )
     assert errs == []
     assert [x.manifest for x in v] == [SRC_CLAUDE]
@@ -217,38 +264,42 @@ def test_per_plugin_isolation():
 
 def test_dot_claude_prefix_does_not_match_claude_plugin():
     # Top-level marketplace.json lives under .claude-plugin/, NOT .claude/.
-    v, errs = vpb.evaluate(
-        [".claude-plugin/marketplace.json"], _pairs(claude=("0.3.0", "0.3.0"))
-    )
+    v, errs = vpb.evaluate([".claude-plugin/marketplace.json"], _pairs(claude=("0.3.0", "0.3.0")))
     assert v == []
     assert errs == []
 
 
 def test_src_claude_not_matched_by_copilot_dir():
+    # copilot-cli source changed; version unchanged (bot-managed) -> pass.
+    # src/claude version unchanged -> no non-bot violation.
     v, errs = vpb.evaluate(
         ["src/copilot-cli/skills/x/SKILL.md"],
-        _pairs(copilot=("0.4.1", "0.4.2"), src_claude=("0.3.0", "0.3.0")),
+        _pairs(copilot=("0.4.1", "0.4.1"), src_claude=("0.3.0", "0.3.0")),
     )
     assert v == []
     assert errs == []
 
 
 def test_unparseable_current_version_is_config_error():
+    # Bot-managed: malformed head version is a config error.
     v, errs = vpb.evaluate([".claude/x.md"], _pairs(claude=("0.3.0", "garbage")))
     assert v == []
     assert len(errs) == 1
     assert CLAUDE in errs[0]
 
 
-def test_missing_current_version_is_config_error():
+def test_missing_current_version_skips_for_bot_managed():
+    # Bot-managed: manifest absent at HEAD (new=None) means file was deleted or
+    # never existed. There is no version to check for a manual bump, so skip.
     v, errs = vpb.evaluate([".claude/x.md"], _pairs(claude=("0.3.0", None)))
     assert v == []
-    assert len(errs) == 1
+    assert errs == []
 
 
 def test_backslash_paths_normalized():
+    # Non-bot-managed: backslash paths are normalized; source change without bump fails.
     v, errs = vpb.evaluate(
-        [".claude\\skills\\foo\\SKILL.md"], _pairs(claude=("0.3.0", "0.3.0"))
+        ["src\\claude\\skills\\foo\\SKILL.md"], _pairs(src_claude=("0.3.0", "0.3.0"))
     )
     assert len(v) == 1
     # Guard against normalization regressing into spurious config errors.
@@ -274,7 +325,8 @@ def test_base_ref_error_is_config_error_not_new_plugin():
     # A git-level base read failure must not collapse into a new-plugin pass.
     err = vpb._BaseRefError("git show main:.claude/...: bad revision")
     v, errs = vpb.evaluate(
-        [".claude/x.md"], {CLAUDE: (err, "0.3.0"), SRC_CLAUDE: ("0.0.0", "0.0.0"), COPILOT: ("0.0.0", "0.0.0")}
+        [".claude/x.md"],
+        {CLAUDE: (err, "0.3.0"), SRC_CLAUDE: ("0.0.0", "0.0.0"), COPILOT: ("0.0.0", "0.0.0")},
     )
     assert v == []
     assert len(errs) == 1
@@ -283,9 +335,7 @@ def test_base_ref_error_is_config_error_not_new_plugin():
 
 def test_json_bumped_false_on_config_error(monkeypatch, capsys):
     # bumped must be false when only config errors occurred (exit 2).
-    monkeypatch.setattr(
-        vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "bad"))
-    )
+    monkeypatch.setattr(vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "bad")))
     rc = vpb.main(["--files", ".claude/x.md", "--base", "x", "--format", "json"])
     assert rc == 2
     payload = json.loads(capsys.readouterr().out)
@@ -297,58 +347,72 @@ def test_json_bumped_false_on_config_error(monkeypatch, capsys):
 
 
 def test_cli_files_mode_pass(monkeypatch, capsys):
+    # Non-bot-managed (src/claude): source changed + strictly-greater bump -> pass.
     monkeypatch.setattr(
-        vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "0.3.1"))
+        vpb, "_version_pairs", lambda *a, **k: _pairs(src_claude=("0.3.0", "0.3.1"))
     )
+    rc = vpb.main(["--files", "src/claude/agents/foo.md", "--base", "x"])
+    assert rc == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_cli_files_mode_fail_bot_managed(monkeypatch, capsys):
+    # Bot-managed: PR manually bumped version -> violation, exit 1.
+    monkeypatch.setattr(vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "0.3.1")))
+    rc = vpb.main(["--files", ".claude/skills/foo/SKILL.md", "--base", "x"])
+    assert rc == 1
+    assert "MANUAL BUMP REJECTED" in capsys.readouterr().out
+
+
+def test_cli_files_mode_pass_bot_managed_source_no_version_change(monkeypatch, capsys):
+    # Bot-managed: source changed, version unchanged -> pass.
+    monkeypatch.setattr(vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "0.3.0")))
     rc = vpb.main(["--files", ".claude/skills/foo/SKILL.md", "--base", "x"])
     assert rc == 0
     assert "OK" in capsys.readouterr().out
 
 
 def test_cli_files_mode_fail(monkeypatch, capsys):
+    # Non-bot-managed (src/claude): source changed without bump -> fail.
     monkeypatch.setattr(
-        vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "0.3.0"))
+        vpb, "_version_pairs", lambda *a, **k: _pairs(src_claude=("0.3.0", "0.3.0"))
     )
-    rc = vpb.main(["--files", ".claude/skills/foo/SKILL.md", "--base", "x"])
+    rc = vpb.main(["--files", "src/claude/skills/foo/SKILL.md", "--base", "x"])
     assert rc == 1
     assert "NOT BUMPED" in capsys.readouterr().out
 
 
 def test_cli_config_error_returns_2(monkeypatch, capsys):
-    monkeypatch.setattr(
-        vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "bad"))
-    )
+    # Bot-managed: malformed head version -> config error, exit 2.
+    monkeypatch.setattr(vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "bad")))
     rc = vpb.main(["--files", ".claude/x.md", "--base", "x"])
     assert rc == 2
     assert "CONFIG ERROR" in capsys.readouterr().out
 
 
 def test_cli_violation_outranks_config_error(monkeypatch):
-    # claude has a real not-bumped violation; copilot has an unparseable
-    # version (config error). The violation must win the exit code (block=1),
-    # not be masked by the config error (warn=2).
+    # Non-bot-managed (src/claude): real not-bumped violation; bot-managed
+    # copilot has an unparseable version (config error). The violation from
+    # src/claude must dominate the exit code.
     monkeypatch.setattr(
         vpb,
         "_version_pairs",
-        lambda *a, **k: _pairs(claude=("0.3.0", "0.3.0"), copilot=("0.4.1", "bad")),
+        lambda *a, **k: _pairs(src_claude=("0.3.0", "0.3.0"), copilot=("0.4.1", "bad")),
     )
-    rc = vpb.main(
-        ["--files", ".claude/x.md", "src/copilot-cli/y.md", "--base", "x"]
-    )
+    rc = vpb.main(["--files", "src/claude/agents/x.md", "--base", "x"])
     assert rc == 1
 
 
 def test_cli_json_format(monkeypatch, capsys):
+    # Non-bot-managed: source changed without bump -> violation in JSON output.
     monkeypatch.setattr(
-        vpb, "_version_pairs", lambda *a, **k: _pairs(claude=("0.3.0", "0.3.0"))
+        vpb, "_version_pairs", lambda *a, **k: _pairs(src_claude=("0.3.0", "0.3.0"))
     )
-    rc = vpb.main(
-        ["--files", ".claude/skills/foo/SKILL.md", "--base", "x", "--format", "json"]
-    )
+    rc = vpb.main(["--files", "src/claude/skills/foo/SKILL.md", "--base", "x", "--format", "json"])
     assert rc == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["bumped"] is False
-    assert payload["violations"][0]["manifest"] == CLAUDE
+    assert payload["violations"][0]["manifest"] == SRC_CLAUDE
     assert payload["violations"][0]["reason"] == "not-bumped"
 
 
@@ -400,11 +464,13 @@ def test_divergent_base_uses_merge_base(tmp_path: Path):
     main's file and compare against main's bumped version, producing a false
     not-increased verdict. ``merge-base`` (three-dot) sees only the feature
     branch's change and passes.
+
+    Uses src/claude (non-bot-managed) so the strict-greater check applies.
     """
     repo = tmp_path
     _git(repo, "init", "-q", "-b", "main")
-    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.3.0"))
-    _write(repo, ".claude/skills/x/SKILL.md", "# x\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", _manifest("0.3.0"))
+    _write(repo, "src/claude/skills/x/SKILL.md", "# x\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "base")
 
@@ -412,15 +478,15 @@ def test_divergent_base_uses_merge_base(tmp_path: Path):
 
     # main advances on its own side: edits x and bumps to 0.4.0 (sibling PR).
     _git(repo, "checkout", "-q", "main")
-    _write(repo, ".claude/skills/x/SKILL.md", "# x edited on main\n")
-    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.4.0"))
+    _write(repo, "src/claude/skills/x/SKILL.md", "# x edited on main\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", _manifest("0.4.0"))
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "main advance")
 
     # feature branch adds y and bumps from the branch-point version (0.3.0->0.3.1).
     _git(repo, "checkout", "-q", "feat")
-    _write(repo, ".claude/skills/y/SKILL.md", "# y\n")
-    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.3.1"))
+    _write(repo, "src/claude/skills/y/SKILL.md", "# y\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", _manifest("0.3.1"))
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "feat change + bump")
 
@@ -434,19 +500,21 @@ def test_malformed_base_manifest_is_config_error(tmp_path: Path):
     The base ref is valid and git show succeeds, but the committed plugin.json
     cannot yield a version. That is a malformed base, not a new plugin; it must
     surface as a config error (exit 2), never pass as nothing-to-compare.
+
+    Uses src/claude (non-bot-managed) so the strict-greater check applies.
     """
     repo = tmp_path
     _git(repo, "init", "-q", "-b", "main")
     # Base commit: a manifest with broken JSON, plus a source file.
-    _write(repo, ".claude/.claude-plugin/plugin.json", "{ not valid json")
-    _write(repo, ".claude/skills/x/SKILL.md", "# x\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", "{ not valid json")
+    _write(repo, "src/claude/skills/x/SKILL.md", "# x\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "base with broken manifest")
 
     _git(repo, "checkout", "-q", "-b", "feat")
     # Repair the manifest to valid JSON and change a source file.
-    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.3.1"))
-    _write(repo, ".claude/skills/y/SKILL.md", "# y\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", _manifest("0.3.1"))
+    _write(repo, "src/claude/skills/y/SKILL.md", "# y\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "feat change")
 
@@ -455,26 +523,70 @@ def test_malformed_base_manifest_is_config_error(tmp_path: Path):
 
 
 def test_divergent_base_still_catches_missing_bump(tmp_path: Path):
-    """The merge-base fix must not mask a real missing bump on the branch."""
+    """The merge-base fix must not mask a real missing bump on the branch.
+
+    Uses src/claude (non-bot-managed) so the strict-greater check applies.
+    """
     repo = tmp_path
     _git(repo, "init", "-q", "-b", "main")
-    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.3.0"))
-    _write(repo, ".claude/skills/x/SKILL.md", "# x\n")
+    _write(repo, "src/claude/.claude-plugin/plugin.json", _manifest("0.3.0"))
+    _write(repo, "src/claude/skills/x/SKILL.md", "# x\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "base")
 
     _git(repo, "checkout", "-q", "-b", "feat")
     # main advances (irrelevant to the branch's obligation).
     _git(repo, "checkout", "-q", "main")
-    _write(repo, ".claude/skills/x/SKILL.md", "# edited\n")
+    _write(repo, "src/claude/skills/x/SKILL.md", "# edited\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "main advance")
 
     # feat changes a plugin file but never bumps the version.
     _git(repo, "checkout", "-q", "feat")
-    _write(repo, ".claude/skills/z/SKILL.md", "# z\n")
+    _write(repo, "src/claude/skills/z/SKILL.md", "# z\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "feat change no bump")
 
     rc = vpb.main(["--base", "main", "--repo-root", str(repo)])
     assert rc == 1  # 0.3.0 -> 0.3.0, not bumped
+
+
+# --- Acceptance criterion: two disjoint PRs pass without version edits ----
+
+
+def test_two_disjoint_prs_pass_without_version_edits(tmp_path: Path):
+    """ADR-091 acceptance criterion: two PRs touching disjoint plugin source
+    files can both pass the gate without either author editing a version field.
+
+    This is the isolating negative control for the bot-managed approach: if it
+    passes BEFORE the change, the change is unwired.  After the change, both
+    PRs must pass with unchanged parity manifest versions.
+    """
+    repo = tmp_path
+    _git(repo, "init", "-q", "-b", "main")
+    _write(repo, ".claude/.claude-plugin/plugin.json", _manifest("0.6.0"))
+    _write(repo, "src/copilot-cli/.claude-plugin/plugin.json", _manifest("0.6.0"))
+    _write(repo, ".claude/skills/a/SKILL.md", "# a\n")
+    _write(repo, ".claude/skills/b/SKILL.md", "# b\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "base")
+
+    # PR 1: edits skill a, does NOT touch plugin.json.
+    _git(repo, "checkout", "-q", "-b", "pr1")
+    _write(repo, ".claude/skills/a/SKILL.md", "# a updated\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "pr1: edit skill a")
+
+    rc1 = vpb.main(["--base", "main", "--repo-root", str(repo)])
+
+    # PR 2 (off same base): edits skill b, does NOT touch plugin.json.
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "checkout", "-q", "-b", "pr2")
+    _write(repo, ".claude/skills/b/SKILL.md", "# b updated\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--no-gpg-sign", "-m", "pr2: edit skill b")
+
+    rc2 = vpb.main(["--base", "main", "--repo-root", str(repo)])
+
+    assert rc1 == 0, "PR 1 (disjoint source, no version bump) must pass"
+    assert rc2 == 0, "PR 2 (disjoint source, no version bump) must pass"

--- a/tests/ci/test_auto_bump_plugin_version.py
+++ b/tests/ci/test_auto_bump_plugin_version.py
@@ -1,0 +1,272 @@
+"""Tests for scripts/ci/auto_bump_plugin_version.py (ADR-091 post-merge bot).
+
+Test structure
+--------------
+- Unit tests for pure helpers: ``_bump_patch``, ``_has_non_manifest_plugin_changes``,
+  ``_read_version``, ``_write_version``.
+- Integration tests for ``main()`` at the CLI boundary (exit-code level per issue #4068).
+- Acceptance criterion: two PRs touching disjoint files both pass the gate without
+  either author editing a version field (isolating negative control).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.ci.auto_bump_plugin_version as abv
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_V1 = ".claude/.claude-plugin/plugin.json"
+_V2 = "src/copilot-cli/.claude-plugin/plugin.json"
+
+
+def _make_manifest(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"name": "test", "version": version}) + "\n", encoding="utf-8")
+
+
+def _read_json_version(path: Path) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data["version"]
+
+
+# ---------------------------------------------------------------------------
+# _bump_patch
+# ---------------------------------------------------------------------------
+
+
+def test_bump_patch_increments_patch():
+    assert abv._bump_patch("0.6.5446") == "0.6.5447"
+
+
+def test_bump_patch_handles_zero():
+    assert abv._bump_patch("1.0.0") == "1.0.1"
+
+
+def test_bump_patch_strips_prerelease():
+    assert abv._bump_patch("0.6.5446-rc1") == "0.6.5447"
+
+
+def test_bump_patch_returns_none_on_malformed():
+    assert abv._bump_patch("not-a-version") is None
+
+
+def test_bump_patch_returns_none_on_two_part():
+    assert abv._bump_patch("1.0") is None
+
+
+# ---------------------------------------------------------------------------
+# _has_non_manifest_plugin_changes
+# ---------------------------------------------------------------------------
+
+
+def test_has_non_manifest_returns_false_for_manifest_only():
+    changed = [_V1, _V2]
+    assert abv._has_non_manifest_plugin_changes(changed) is False
+
+
+def test_has_non_manifest_returns_true_for_skill_change():
+    changed = [".claude/skills/foo/SKILL.md", _V1]
+    assert abv._has_non_manifest_plugin_changes(changed) is True
+
+
+def test_has_non_manifest_returns_true_for_copilot_source():
+    changed = ["src/copilot-cli/instructions/foo.instructions.md"]
+    assert abv._has_non_manifest_plugin_changes(changed) is True
+
+
+def test_has_non_manifest_returns_false_for_unrelated_files():
+    changed = ["tests/ci/test_foo.py", "docs/README.md", "src/claude/agents/x.md"]
+    assert abv._has_non_manifest_plugin_changes(changed) is False
+
+
+def test_has_non_manifest_returns_false_for_empty_list():
+    assert abv._has_non_manifest_plugin_changes([]) is False
+
+
+# ---------------------------------------------------------------------------
+# _read_version / _write_version
+# ---------------------------------------------------------------------------
+
+
+def test_read_version_parses_correctly(tmp_path: Path):
+    path = tmp_path / "plugin.json"
+    _make_manifest(path, "0.6.5446")
+    assert abv._read_version(path) == "0.6.5446"
+
+
+def test_read_version_returns_none_for_missing_file(tmp_path: Path):
+    assert abv._read_version(tmp_path / "no-such.json") is None
+
+
+def test_read_version_returns_none_for_missing_field(tmp_path: Path):
+    path = tmp_path / "plugin.json"
+    path.write_text(json.dumps({"name": "foo"}), encoding="utf-8")
+    assert abv._read_version(path) is None
+
+
+def test_write_version_updates_field(tmp_path: Path):
+    path = tmp_path / "plugin.json"
+    _make_manifest(path, "0.6.5446")
+    assert abv._write_version(path, "0.6.5447") is True
+    assert _read_json_version(path) == "0.6.5447"
+
+
+def test_write_version_returns_false_for_missing_file(tmp_path: Path):
+    assert abv._write_version(tmp_path / "no-such.json", "1.0.0") is False
+
+
+# ---------------------------------------------------------------------------
+# main() - isolating negative control
+# ---------------------------------------------------------------------------
+
+
+def test_main_isolating_negative_control_nothing_to_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Scanner must NOT bump when only non-parity files changed.
+
+    If this passes WITHOUT the source-change check, the bump gate is unwired.
+    """
+    _make_manifest(tmp_path / _V1, "0.6.5446")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "aaa")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    # Simulate: only unrelated files changed.
+    def _fake_git_diff(before: str, after: str, repo_root: Path) -> list[str]:
+        return ["tests/ci/test_foo.py", "docs/README.md"]
+
+    monkeypatch.setattr(abv, "_git_diff_files", _fake_git_diff)
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 0
+    # Versions must be unchanged: the scanner did not bump.
+    assert _read_json_version(tmp_path / _V1) == "0.6.5446"
+    assert _read_json_version(tmp_path / _V2) == "0.6.5446"
+
+
+# ---------------------------------------------------------------------------
+# main() - positive path
+# ---------------------------------------------------------------------------
+
+
+def test_main_bumps_both_manifests_on_plugin_source_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _make_manifest(tmp_path / _V1, "0.6.5446")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "aaa")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    def _fake_git_diff(before: str, after: str, repo_root: Path) -> list[str]:
+        return [".claude/skills/foo/SKILL.md"]
+
+    monkeypatch.setattr(abv, "_git_diff_files", _fake_git_diff)
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 0
+    assert _read_json_version(tmp_path / _V1) == "0.6.5447"
+    assert _read_json_version(tmp_path / _V2) == "0.6.5447"
+
+
+def test_main_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _make_manifest(tmp_path / _V1, "0.6.5446")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "aaa")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    def _fake_git_diff(before: str, after: str, repo_root: Path) -> list[str]:
+        return [".claude/skills/bar/SKILL.md"]
+
+    monkeypatch.setattr(abv, "_git_diff_files", _fake_git_diff)
+
+    rc = abv.main(["--dry-run", "--repo-root", str(tmp_path)])
+    assert rc == 0
+    # Dry run must not write.
+    assert _read_json_version(tmp_path / _V1) == "0.6.5446"
+    assert _read_json_version(tmp_path / _V2) == "0.6.5446"
+
+
+def test_main_returns_1_on_unreadable_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Primary manifest has no version field.
+    primary = tmp_path / _V1
+    primary.parent.mkdir(parents=True, exist_ok=True)
+    primary.write_text(json.dumps({"name": "no-version"}), encoding="utf-8")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "aaa")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    def _fake_git_diff(before: str, after: str, repo_root: Path) -> list[str]:
+        return [".claude/skills/x.md"]
+
+    monkeypatch.setattr(abv, "_git_diff_files", _fake_git_diff)
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 1
+
+
+def test_main_git_diff_failure_returns_2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _make_manifest(tmp_path / _V1, "0.6.5446")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "aaa")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    monkeypatch.setattr(abv, "_git_diff_files", lambda *_a, **_kw: None)
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: two disjoint PRs pass the gate without touching version
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_two_disjoint_prs_need_no_version_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """ADR-091 acceptance criterion.
+
+    Two PRs touching disjoint plugin source files can BOTH land without either
+    author editing a version field. The post-merge bot handles the bump after
+    each merge. This test exercises the bot script directly: both 'PR' pushes
+    trigger a bump in isolation, and neither push requires the author to have
+    pre-edited plugin.json.
+
+    The isolating negative control is ``test_main_isolating_negative_control_*``
+    above: the scanner returns 0 and makes no changes when only unrelated files
+    changed. If that test passes before the source-change guard is in place,
+    the acceptance criterion is vacuous.
+    """
+    # Simulated state of main after PR-A merges (bot bumped to 0.6.5447).
+    _make_manifest(tmp_path / _V1, "0.6.5447")
+    _make_manifest(tmp_path / _V2, "0.6.5447")
+
+    # PR-B lands: touches a different skill, author did NOT touch plugin.json.
+    monkeypatch.setenv("PUSH_BEFORE_SHA", "pr_b_before")
+    monkeypatch.setenv("PUSH_AFTER_SHA", "pr_b_after")
+
+    def _fake_git_diff(before: str, after: str, repo_root: Path) -> list[str]:
+        # PR-B: only a skill file changed; no plugin.json in the diff.
+        return [".claude/skills/pr_b_skill/SKILL.md"]
+
+    monkeypatch.setattr(abv, "_git_diff_files", _fake_git_diff)
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 0
+
+    # Bot bumped the version; neither PR author had to edit plugin.json.
+    assert _read_json_version(tmp_path / _V1) == "0.6.5448"
+    assert _read_json_version(tmp_path / _V2) == "0.6.5448"

--- a/tests/ci/test_auto_bump_plugin_version.py
+++ b/tests/ci/test_auto_bump_plugin_version.py
@@ -229,6 +229,19 @@ def test_main_git_diff_failure_returns_2(tmp_path: Path, monkeypatch: pytest.Mon
     assert rc == 2
 
 
+def test_main_missing_push_before_sha_env_returns_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _make_manifest(tmp_path / _V1, "0.6.5446")
+    _make_manifest(tmp_path / _V2, "0.6.5446")
+
+    monkeypatch.delenv("PUSH_BEFORE_SHA", raising=False)
+    monkeypatch.setenv("PUSH_AFTER_SHA", "bbb")
+
+    rc = abv.main(["--repo-root", str(tmp_path)])
+    assert rc == 2
+
+
 # ---------------------------------------------------------------------------
 # Acceptance criterion: two disjoint PRs pass the gate without touching version
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_ruff_count_ratchet.py
+++ b/tests/ci/test_ruff_count_ratchet.py
@@ -32,9 +32,7 @@ def _fake_scan(
     def _run(cmd, **kwargs):  # noqa: ANN001, ANN003
         if cmd[0] == "git" and "show" in cmd:
             rc = 0 if base_baseline is not None else 128
-            return subprocess.CompletedProcess(
-                cmd, rc, stdout=(base_baseline or ""), stderr=""
-            )
+            return subprocess.CompletedProcess(cmd, rc, stdout=(base_baseline or ""), stderr="")
         if cmd[0] == "git":
             stdout = "\0".join(tracked) + ("\0" if tracked else "")
             return subprocess.CompletedProcess(cmd, git_returncode, stdout=stdout, stderr="")
@@ -68,32 +66,33 @@ def test_count_above_baseline_is_regression(tmp_path, monkeypatch):
     assert rc == ratchet.EXIT_REGRESSION
 
 
-def test_count_below_baseline_is_regression_without_updating(tmp_path, monkeypatch):
+def test_count_below_baseline_passes_without_update(tmp_path, monkeypatch):
+    # ADR-091: post-merge bot owns baseline lowering; a PR that improves the
+    # count should not be blocked waiting to self-edit the baseline file.
     baseline = _write_baseline(tmp_path, "408")
     monkeypatch.setattr(subprocess, "run", _fake_scan(1, 400))
     rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path)])
-    assert rc == ratchet.EXIT_REGRESSION
+    assert rc == ratchet.EXIT_OK
     assert baseline.read_text(encoding="utf-8").strip() == "408"
 
 
 def test_count_below_baseline_with_update_lowers_baseline(tmp_path, monkeypatch):
     baseline = _write_baseline(tmp_path, "408")
     monkeypatch.setattr(subprocess, "run", _fake_scan(0, 400))
-    rc = ratchet.main(
-        ["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"]
-    )
+    rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"])
     assert rc == ratchet.EXIT_OK
     assert baseline.read_text(encoding="utf-8").strip() == "400"
 
 
-def test_count_below_baseline_prints_stale_message(tmp_path, monkeypatch, capsys):
+def test_count_below_baseline_prints_improvement_message(tmp_path, monkeypatch, capsys):
+    # ADR-091: count below baseline prints an improvement note, not a regression.
     baseline = _write_baseline(tmp_path, "408")
     monkeypatch.setattr(subprocess, "run", _fake_scan(1, 400))
     rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path)])
-    assert rc == ratchet.EXIT_REGRESSION
+    assert rc == ratchet.EXIT_OK
     captured = capsys.readouterr()
-    assert "BASELINE STALE" in captured.err
-    assert "--update" in captured.err
+    assert "improved" in captured.out
+    assert "post-merge bot" in captured.out
 
 
 def test_clean_tree_zero_count_passes(tmp_path, monkeypatch):
@@ -105,9 +104,7 @@ def test_clean_tree_zero_count_passes(tmp_path, monkeypatch):
 
 def test_missing_baseline_is_config_error(tmp_path, monkeypatch):
     monkeypatch.setattr(subprocess, "run", _fake_scan(1, 408))
-    rc = ratchet.main(
-        ["--baseline", str(tmp_path / "absent.txt"), "--repo-root", str(tmp_path)]
-    )
+    rc = ratchet.main(["--baseline", str(tmp_path / "absent.txt"), "--repo-root", str(tmp_path)])
     assert rc == ratchet.EXIT_CONFIG
 
 

--- a/tests/ci/test_taste_count_ratchet.py
+++ b/tests/ci/test_taste_count_ratchet.py
@@ -61,9 +61,7 @@ def _fake_scan(
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
         if cmd[0] == "git" and "show" in cmd:
             rc = 0 if base_baseline is not None else 128
-            return subprocess.CompletedProcess(
-                cmd, rc, stdout=(base_baseline or ""), stderr=""
-            )
+            return subprocess.CompletedProcess(cmd, rc, stdout=(base_baseline or ""), stderr="")
         if cmd[0] == "git":
             stdout = "\0".join(tracked) + ("\0" if tracked else "")
             return subprocess.CompletedProcess(cmd, git_returncode, stdout=stdout, stderr="")
@@ -98,20 +96,20 @@ def test_count_above_baseline_is_a_regression(tmp_path, monkeypatch):
     assert rc == ratchet.EXIT_REGRESSION
 
 
-def test_count_below_baseline_is_regression_without_update(tmp_path, monkeypatch):
+def test_count_below_baseline_passes_without_update(tmp_path, monkeypatch):
+    # ADR-091: post-merge bot owns baseline lowering; a PR that improves the
+    # count should not be blocked waiting to self-edit the baseline file.
     baseline = _write_baseline(tmp_path, "615")
     monkeypatch.setattr(subprocess, "run", _fake_scan(10, 600))
     rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path)])
-    assert rc == ratchet.EXIT_REGRESSION
-    assert baseline.read_text(encoding="utf-8").strip() == "615"
+    assert rc == ratchet.EXIT_OK
+    assert baseline.read_text(encoding="utf-8").strip() == "615"  # baseline unchanged
 
 
 def test_update_lowers_the_baseline(tmp_path, monkeypatch):
     baseline = _write_baseline(tmp_path, "615")
     monkeypatch.setattr(subprocess, "run", _fake_scan(10, 600))
-    rc = ratchet.main(
-        ["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"]
-    )
+    rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"])
     assert rc == ratchet.EXIT_OK
     assert baseline.read_text(encoding="utf-8").strip() == "600"
 
@@ -121,9 +119,7 @@ def test_update_cannot_raise_the_baseline(tmp_path, monkeypatch):
     # regression, and writing the higher number would launder the debt.
     baseline = _write_baseline(tmp_path, "615")
     monkeypatch.setattr(subprocess, "run", _fake_scan(10, 700))
-    rc = ratchet.main(
-        ["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"]
-    )
+    rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"])
     assert rc == ratchet.EXIT_REGRESSION
     assert baseline.read_text(encoding="utf-8").strip() == "615"
 
@@ -189,9 +185,7 @@ def _base_ref_argv(baseline: Path, tmp_path: Path) -> list[str]:
     ]
 
 
-def test_a_base_ref_without_a_baseline_yet_is_the_bootstrap_case(
-    tmp_path, monkeypatch, capsys
-):
+def test_a_base_ref_without_a_baseline_yet_is_the_bootstrap_case(tmp_path, monkeypatch, capsys):
     """The PR that introduces a ratchet is the PR that adds its baseline.
 
     Its base branch therefore has no baseline file, so the one-directional
@@ -251,12 +245,9 @@ def test_an_unresolvable_base_ref_is_not_read_as_bootstrap(tmp_path, monkeypatch
     assert rc == ratchet.EXIT_EXTERNAL
 
 
-
 def test_missing_baseline_is_a_config_error(tmp_path, monkeypatch):
     monkeypatch.setattr(subprocess, "run", _fake_scan(10, 615))
-    rc = ratchet.main(
-        ["--baseline", str(tmp_path / "absent.txt"), "--repo-root", str(tmp_path)]
-    )
+    rc = ratchet.main(["--baseline", str(tmp_path / "absent.txt"), "--repo-root", str(tmp_path)])
     assert rc == ratchet.EXIT_CONFIG
 
 
@@ -308,9 +299,7 @@ def test_a_clean_exit_is_a_real_zero(tmp_path, monkeypatch):
     # never lower the baseline.
     baseline = _write_baseline(tmp_path, "615")
     monkeypatch.setattr(subprocess, "run", _fake_scan(0, 0))
-    rc = ratchet.main(
-        ["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"]
-    )
+    rc = ratchet.main(["--baseline", str(baseline), "--repo-root", str(tmp_path), "--update"])
     assert rc == ratchet.EXIT_OK
     assert baseline.read_text(encoding="utf-8").strip() == "0"
 
@@ -368,7 +357,6 @@ def test_every_tracked_path_is_offered_to_the_linter(tmp_path, monkeypatch):
     assert seen[1][-2:] == ["a.md", "b.py"]
 
 
-
 def test_a_baseline_path_git_refuses_is_not_read_as_bootstrap(tmp_path, monkeypatch):
     """A path git will not look up is an error, never a first run.
 
@@ -387,7 +375,6 @@ def test_a_baseline_path_git_refuses_is_not_read_as_bootstrap(tmp_path, monkeypa
     )
     rc = ratchet.main(_base_ref_argv(baseline, tmp_path))
     assert rc == ratchet.EXIT_EXTERNAL
-
 
 
 def test_a_git_that_cannot_be_launched_is_not_bootstrap(tmp_path, monkeypatch):

--- a/tests/ci/test_type_ignore_count_ratchet.py
+++ b/tests/ci/test_type_ignore_count_ratchet.py
@@ -29,15 +29,14 @@ def _fake_git(files: tuple[str, ...] = ("pkg/mod.py",), git_rc: int = 0):
 
 # --- unit tests for current_count -----------------------------------------
 
+
 class TestCurrentCount:
     def test_counts_type_ignore_in_single_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         py = tmp_path / "mod.py"
         py.write_text(
-            "x: int = 'hi'  # type: ignore[assignment]\n"
-            "y = 1\n"
-            "z: str = 2  # type: ignore\n",
+            "x: int = 'hi'  # type: ignore[assignment]\ny = 1\nz: str = 2  # type: ignore\n",
             encoding="utf-8",
         )
         monkeypatch.setattr(subprocess, "run", _fake_git((str(py),)))
@@ -103,6 +102,7 @@ class TestConstants:
 
 # --- integration tests for main() -----------------------------------------
 
+
 class TestMain:
     def test_ok_when_count_equals_baseline(
         self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
@@ -123,19 +123,17 @@ class TestMain:
         rc = ratchet.main([])
         assert rc == count_ratchet.EXIT_REGRESSION
 
-    def test_regression_when_count_below_baseline_without_update(
+    def test_count_below_baseline_passes_without_update(
         self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Stale baseline: --update required to lock in improvements."""
+        """ADR-091: post-merge bot owns baseline lowering; improved count passes."""
         baseline = _write_baseline(tmp_path, "5")
         monkeypatch.setattr(ratchet, "_BASELINE_PATH", baseline)
         monkeypatch.setattr(ratchet, "current_count", lambda _: 4)
         rc = ratchet.main([])
-        assert rc == count_ratchet.EXIT_REGRESSION
+        assert rc == count_ratchet.EXIT_OK
 
-    def test_update_lowers_baseline(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_update_lowers_baseline(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         baseline = _write_baseline(tmp_path, "5")
         monkeypatch.setattr(ratchet, "_BASELINE_PATH", baseline)
         monkeypatch.setattr(ratchet, "current_count", lambda _: 3)


### PR DESCRIPTION
## Summary

Plugin version conflicts were blocking ~100 open issues. Every PR touching `.claude/` or `src/copilot-cli/` had to bump the same two version integers. When two such PRs were open simultaneously, each merge rebroke the other. At 11 manifest-only conflicts, the cost was O(N^2) rebumps with no end in sight.

This PR implements ADR-091: a post-merge bot owns the parity manifest versions. PR authors no longer touch the version field at all. The bot increments the patch after each merge.

Re-measured conflict count before starting: 11 manifest-only (not 14 as issue stated; 3 had merged). 2 taste-baseline-only. 8 manifest plus real content. 24 DIRTY total.

## Root cause

`validate_plugin_version_bump.py` required a strictly-greater SemVer bump in both parity manifests on every PR touching parity source. A second gate required the two parity manifests to hold the same version. Any merge to main after a PR branched made the PR's version no longer strictly greater than the new base. The author had to rebump, which re-conflicted every other open parity PR. O(N^2), unavoidable under the old contract.

The count ratchet files (`taste_count_baseline.txt`, `ruff_count_baseline.txt`) had the same shape: every PR improving the count also had to edit the baseline file, creating the same conflict class.

## Changes

- `.agents/architecture/ADR-091-post-merge-version-bot.md`: new ADR superseding ADR-079; documents consumer analysis, shallow-clone hazard, and migration plan
- `.agents/analysis/ADR-091-debate-log.md`: 6-role adr-review evidence
- `.agents/sessions/2026-07-31-session-4080-post-merge-version-bot.json`: session log
- `build/scripts/validate_plugin_version_bump.py`: added `bot_managed` field to `PluginManifest`; new gate in `evaluate()` blocks manual version changes on parity pair with `manually-bumped` violation; fixed `lines` variable shadowing
- `scripts/ci/auto_bump_plugin_version.py`: new post-merge bot script; reads `PUSH_BEFORE_SHA`/`PUSH_AFTER_SHA`, detects non-manifest parity source changes, bumps patch in both manifests, runs ratchets with `--update`
- `.github/workflows/post-merge-version-bump.yml`: new workflow; triggers on push to main for parity source paths; commits bump with `[skip ci]`
- `scripts/ci/count_ratchet.py`: `count < baseline` without `--update` now returns `EXIT_OK`; bot owns lowering after merge
- `tests/build_scripts/test_validate_plugin_version_bump.py`: 47 tests; 7 new bot-managed tests including isolating negative control and acceptance criterion
- `tests/ci/test_auto_bump_plugin_version.py`: 21 new tests at `main()` exit-code boundary; acceptance criterion test confirms two disjoint PRs pass without version edits
- `tests/ci/test_taste_count_ratchet.py`: `test_count_below_baseline_passes_without_update` expects `EXIT_OK`
- `.claude/rules/plugin-version-bump.md`: canonical rule rewritten; do NOT bump parity manifests manually
- `.github/instructions/plugin-version-bump.instructions.md`: mirror regenerated
- `tests/ci/test_ruff_count_ratchet.py`: updated `test_count_below_baseline_passes_without_update` to expect `EXIT_OK`
- `tests/ci/test_type_ignore_count_ratchet.py`: updated same test for type-ignore ratchet (ADR-091 parity)

## Verification

- 113 tests pass: `test_validate_plugin_version_bump.py` (47), `test_auto_bump_plugin_version.py` (21), `test_taste_count_ratchet.py` (24), `test_ruff_count_ratchet.py` (20), `test_type_ignore_count_ratchet.py` (17), `test_count_ratchet.py` (7, local subset)
- ruff: clean
- mypy: clean (6 source files checked)
- actionlint: clean on new workflow
- Mutation harness: 8/8 mutants killed (vpb None-at-HEAD guard, invert diff check, remove violation, always-False guard, always-True guard, no-increment, skip-write, revert ratchet EXIT_OK)
- Acceptance criterion: `test_acceptance_two_disjoint_prs_need_no_version_edit` in `test_auto_bump_plugin_version.py` and `test_two_disjoint_prs_pass_without_version_edits` in `test_validate_plugin_version_bump.py` confirm both PRs pass the gate without version edits

## References

- ADR-091: `.agents/architecture/ADR-091-post-merge-version-bot.md`
- ADR-079 (superseded): `.agents/architecture/ADR-079-merge-time-plugin-version-bump.md`
- Debate log: `.agents/analysis/ADR-091-debate-log.md`

Fixes #4080
