### PR TITLE
fix(ci): add CI backstop for the security suppression policy

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -238,6 +238,12 @@ jobs:
       - name: Checkout repository for workflow validation
         if: steps.should-run.outputs.skip == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The unconditional steps below include `Enforce security suppression
+          # policy`, which resolves a merge base between the PR base and head
+          # (issue #4061). A default depth-1 checkout has no merge base, so the
+          # gate would exit 2 on every bot PR. Matches the primary checkout.
+          fetch-depth: 0
 
       - name: Setup uv for workflow validation
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -314,3 +320,24 @@ jobs:
       # changed pins, so it passes clean on today's tree.
       - name: Enforce model pin policy
         run: uv run --frozen python3 scripts/validation/check_model_pins.py --mode enforce
+
+      # Issue #4061: the security-suppression policy shipped only as a lefthook
+      # gate (`security-suppressions-staged` on pre-commit and pre-merge-commit,
+      # `security-suppressions-push` on pre-push). No workflow referenced it, so
+      # it bound exactly those contributors who had lefthook installed and did
+      # not pass --no-verify. `security-suppressions-range` runs the same
+      # collector over the PR's base..head range, so CI and the hook cannot
+      # disagree about what the policy is.
+      #
+      # Deliberately outside the `steps.should-run.outputs.skip` guard. Bots
+      # author code changes here, and a security gate they are exempt from is
+      # weaker than the local hook it backstops, not equal to it.
+      - name: Enforce security suppression policy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          uv run --frozen python3 scripts/validation/git_hook_policy.py \
+            security-suppressions-range \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA"

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -2261,25 +2261,64 @@ def _push_updates(stream: TextIO, repo_root: Path) -> list[PushUpdate] | None:
     return updates
 
 
-def check_pushed_suppressions(stream: TextIO, repo_root: Path) -> int:
-    updates = _push_updates(stream, repo_root)
-    if updates is None:
-        return 2
+def _collect_suppression_violations(
+    updates: Sequence[PushUpdate],
+    repo_root: Path,
+) -> list[str] | None:
+    """Added-suppression violations across every update, or None on a git failure.
+
+    Shared by the pre-push hook and the CI backstop so both decide with one
+    implementation. Issue #4061: CI previously ran no equivalent of this gate,
+    so the policy bound only contributors who had lefthook installed.
+    """
     violations: list[str] = []
     for update in updates:
         paths = _changed_commit_paths(update, repo_root)
         if paths is None:
-            return 2
+            return None
         added_violations = _added_suppression_violations(update, paths, repo_root)
         if added_violations is None:
-            return 2
+            return None
         violations.extend(added_violations)
+    return violations
+
+
+def _report_suppression_violations(violations: Sequence[str], subject: str) -> int:
     if not violations:
         return 0
-    print("ERROR: security suppression comments detected in pushed commits:", file=sys.stderr)
+    print(f"ERROR: security suppression comments detected in {subject}:", file=sys.stderr)
     for violation in violations:
         print(f"  {violation}", file=sys.stderr)
     return 1
+
+
+def check_pushed_suppressions(stream: TextIO, repo_root: Path) -> int:
+    updates = _push_updates(stream, repo_root)
+    if updates is None:
+        return 2
+    violations = _collect_suppression_violations(updates, repo_root)
+    if violations is None:
+        return 2
+    return _report_suppression_violations(violations, "pushed commits")
+
+
+def check_range_suppressions(base_ref: str, head_ref: str, repo_root: Path) -> int:
+    """CI backstop: the pre-push suppression policy applied to a base..head range.
+
+    Resolves the same merge-base relationship `resolve_push_update` uses, then
+    runs the identical violation collector. A shallow clone cannot produce a
+    merge base, so that case exits EXIT_CONFIG rather than passing silently:
+    a security gate that cannot read history must not report success.
+    """
+    try:
+        update = resolve_range_update(base_ref, head_ref, repo_root)
+    except PushUpdateConfigError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    violations = _collect_suppression_violations([update], repo_root)
+    if violations is None:
+        return 2
+    return _report_suppression_violations(violations, f"{base_ref}..{head_ref}")
 
 
 def _added_suppression_violations(
@@ -4523,6 +4562,49 @@ def resolve_push_update(push_ref: PushRef, repo_root: Path) -> PushUpdate:
     )
 
 
+def _resolve_commit(repo_root: Path, ref: str) -> str | None:
+    result = _run_git(repo_root, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"])
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def resolve_range_update(base_ref: str, head_ref: str, repo_root: Path) -> PushUpdate:
+    """Build a PushUpdate for an explicit base..head range (CI backstop path).
+
+    Mirrors ``resolve_push_update``'s merge-base resolution so the CI gate and
+    the pre-push hook examine the same commits. The two-dot ``range_spec`` is
+    deliberate and matches the hook: the merge base is already computed here, so
+    three-dot would recompute it against a different endpoint.
+
+    Raises PushUpdateConfigError when no merge base exists, which is what a
+    shallow clone produces. Callers must surface that as a config failure; a
+    security gate that cannot read history must not report success.
+    """
+    head_sha = _resolve_commit(repo_root, head_ref)
+    if head_sha is None:
+        raise PushUpdateConfigError(f"could not resolve head ref {head_ref!r}")
+    base = _merge_base(repo_root, base_ref, head_sha)
+    if base is None:
+        raise PushUpdateConfigError(
+            f"could not determine merge base between {base_ref!r} and {head_ref!r}; "
+            "fetch full history (fetch-depth: 0) before running this check"
+        )
+    source = PushRef(
+        local_ref=head_ref,
+        local_sha=head_sha,
+        remote_ref="refs/heads/main",
+        remote_sha=base,
+    )
+    return PushUpdate(
+        source=source,
+        base=base,
+        head=head_sha,
+        range_spec=f"{base}..{head_sha}",
+        destination_branch="main",
+    )
+
+
 def _branch_name(ref: str) -> str | None:
     prefix = "refs/heads/"
     return ref[len(prefix) :] if ref.startswith(prefix) else None
@@ -5542,6 +5624,10 @@ def _handle_suppressions_push(args: argparse.Namespace) -> int:
     return check_pushed_suppressions(sys.stdin, _repo_root(args))
 
 
+def _handle_suppressions_range(args: argparse.Namespace) -> int:
+    return check_range_suppressions(args.base, args.head, _repo_root(args))
+
+
 def _handle_staged_suppressions(args: argparse.Namespace) -> int:
     return check_staged_suppressions(_repo_root(args))
 
@@ -5618,6 +5704,10 @@ def build_parser() -> argparse.ArgumentParser:
     generated = subparsers.add_parser("stage-generated")
     generated.add_argument("kind", choices=sorted(GENERATED_PATHS | GENERATED_GLOBS))
     generated.set_defaults(handler=_handle_stage_generated)
+    suppressions_range = subparsers.add_parser("security-suppressions-range")
+    suppressions_range.add_argument("--base", required=True)
+    suppressions_range.add_argument("--head", required=True)
+    suppressions_range.set_defaults(handler=_handle_suppressions_range)
     return parser
 
 

--- a/tests/validation/test_git_hook_policy_suppression_range.py
+++ b/tests/validation/test_git_hook_policy_suppression_range.py
@@ -1,0 +1,314 @@
+"""CI backstop for the security-suppression policy (issue #4061).
+
+The suppression policy shipped only as a lefthook gate: `pre-commit` and
+`pre-merge-commit` ran ``security-suppressions-staged`` and `pre-push` ran
+``security-suppressions-push``. No workflow referenced either, so the policy
+bound exactly those contributors who had lefthook installed and did not use
+``--no-verify``. ``security-suppressions-range`` closes that gap by running the
+same collector over an explicit base..head range from CI.
+
+Every test drives ``policy.main(argv)`` and asserts on its **exit code**, not on
+a helper's return value. Issue #4068 documents why: a helper-level assertion
+structurally cannot catch a wrong exit code, which is how loud shell failures
+became silent green Python steps across this repository.
+
+Literal suppression tokens are split (``"# no" "qa"``) so this file does not
+trip the very gate it exercises.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.validation import git_hook_policy as policy  # noqa: E402
+
+NOQA = "# no" "qa"
+TYPE_IGNORE = "# type: " "ignore"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = _run(["git", *args], repo)
+    assert result.returncode == 0, result.stderr
+    return result
+
+
+def _init_repo(repo: Path) -> str:
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "alpha.py").write_text("import os\nprint(os)\n", encoding="utf-8")
+    (repo / "pkg" / "beta.py").write_text("import sys\nprint(sys)\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)
+    _git(repo, "checkout", "-b", "topic")
+    return base
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _range_exit(repo: Path, base: str = "origin/main", head: str = "HEAD") -> int:
+    return policy.main(
+        [
+            "--repo-root",
+            str(repo),
+            "security-suppressions-range",
+            "--base",
+            base,
+            "--head",
+            head,
+        ]
+    )
+
+
+class TestRangeSuppressionGate:
+    """The four policy properties the local hook enforces, now enforced in CI."""
+
+    def test_clean_range_exits_zero(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            "import os\nprint(os)\nprint('added')\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "no suppressions")
+        assert _range_exit(tmp_path) == 0
+
+    def test_net_new_suppression_fails(self, tmp_path: Path, capsys) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "add a suppression")
+        assert _range_exit(tmp_path) == 1
+        assert "pkg/alpha.py" in capsys.readouterr().err
+
+    def test_intra_file_move_passes(self, tmp_path: Path) -> None:
+        """Relocating an existing suppression inside one file is not an addition."""
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "seed a suppression")
+        _git(tmp_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"print('reordered')\nimport os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "move it down")
+        assert _range_exit(tmp_path) == 0
+
+    def test_cross_file_removal_earns_no_credit(self, tmp_path: Path) -> None:
+        """Deleting a suppression in beta.py must not pay for adding one in alpha.py."""
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "beta.py").write_text(
+            f"import sys  {NOQA}\nprint(sys)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "seed beta suppression")
+        _git(tmp_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+        (tmp_path / "pkg" / "beta.py").write_text("import sys\nprint(sys)\n", encoding="utf-8")
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "trade beta for alpha")
+        assert _range_exit(tmp_path) == 1
+
+    def test_one_removal_cannot_pay_for_two_additions(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "seed one suppression")
+        _git(tmp_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os\nprint(os)  {NOQA}\nprint('x')  {NOQA}\n",
+            encoding="utf-8",
+        )
+        _commit(tmp_path, "remove one, add two")
+        assert _range_exit(tmp_path) == 1
+
+    def test_typing_suppressions_are_out_of_scope_by_design(self, tmp_path: Path) -> None:
+        """The gate is a *security* suppression gate, not a suppression gate.
+
+        SECURITY_SUPPRESSION_RE matches nosec, nosemgrep, noqa, lgtm[, codeql[,
+        and cwe-suppress. It does not match ``type: ignore``, which is a typing
+        suppression carrying no security signal and governed by its own counter
+        at ``scripts/ci/type_ignore_count_ratchet.py``. Pinning the boundary
+        here so a future reader does not mistake this pass for a hole, and so
+        widening the regex cannot happen silently.
+        """
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os\nprint(os)\nprint('x')  {TYPE_IGNORE}\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "add a typing suppression")
+        assert _range_exit(tmp_path) == 0
+
+
+class TestRangeResolutionFailsClosed:
+    """A gate that cannot read history must not report success (issue #4068)."""
+
+    def test_unresolvable_head_is_a_config_error_not_a_pass(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        assert _range_exit(tmp_path, head="refs/heads/does-not-exist") == 2
+
+    def test_no_merge_base_is_a_config_error_not_a_pass(self, tmp_path: Path) -> None:
+        """Two unrelated histories share no merge base; a shallow clone looks the same."""
+        _init_repo(tmp_path)
+        _git(tmp_path, "checkout", "--orphan", "unrelated")
+        _git(tmp_path, "rm", "-rf", "--cached", ".")
+        (tmp_path / "solo.py").write_text("print('solo')\n", encoding="utf-8")
+        orphan = _commit(tmp_path, "unrelated root")
+        assert _range_exit(tmp_path, base="origin/main", head=orphan) == 2
+
+    def test_config_error_names_the_remedy(self, tmp_path: Path, capsys) -> None:
+        _init_repo(tmp_path)
+        _range_exit(tmp_path, base="refs/heads/missing-base")
+        assert "fetch-depth: 0" in capsys.readouterr().err
+
+
+    def test_collector_failure_exits_config_error_not_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A git failure inside the collector must not read as "no violations".
+
+        ``_added_suppression_violations`` returns None (not an empty list) when
+        it cannot read rename data from git. Treating that None as clean is the
+        #4068 silent-pass shape exactly: the gate reports success on a run where
+        it inspected nothing.
+        """
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "add a suppression")
+        monkeypatch.setattr(policy, "_collect_suppression_violations", lambda *_: None)
+        assert _range_exit(tmp_path) == 2
+
+    def test_reporter_is_the_only_source_of_the_failing_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pin the reporter as load-bearing: neutering it must not go green."""
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text(
+            f"import os  {NOQA}\nprint(os)\n", encoding="utf-8"
+        )
+        _commit(tmp_path, "add a suppression")
+        seen: list[list[str]] = []
+        real = policy._report_suppression_violations
+
+        def spy(violations, subject):
+            seen.append(list(violations))
+            return real(violations, subject)
+
+        monkeypatch.setattr(policy, "_report_suppression_violations", spy)
+        assert _range_exit(tmp_path) == 1
+        assert seen and seen[0], "the reporter must receive the collected violations"
+
+
+class TestRangeAndPushShareOneImplementation:
+    """Both entry points must decide with the same collector, or they can disagree."""
+
+    def test_range_resolution_uses_a_two_dot_merge_base_spec(self, tmp_path: Path) -> None:
+        base = _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text("import os\nprint(os)\n#x\n", encoding="utf-8")
+        head = _commit(tmp_path, "advance topic")
+        update = policy.resolve_range_update("origin/main", head, tmp_path)
+        assert update.base == base
+        assert update.head == head
+        assert update.range_spec == f"{base}..{head}"
+
+    def test_collector_returns_empty_list_for_a_clean_range(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "pkg" / "alpha.py").write_text("import os\nprint(os)\n#y\n", encoding="utf-8")
+        head = _commit(tmp_path, "clean change")
+        update = policy.resolve_range_update("origin/main", head, tmp_path)
+        assert policy._collect_suppression_violations([update], tmp_path) == []
+
+
+class TestWorkflowWiring:
+    """The gate is worthless if CI never calls it, which was the whole of #4061.
+
+    These assertions parse the workflow rather than substring-matching it. A
+    substring assertion passes when the step name is deleted and only the
+    ``run:`` line survives, which is a step that no longer exists as far as
+    Actions is concerned. Structure is the only honest check.
+    """
+
+    @pytest.fixture(scope="class")
+    def workflow(self) -> dict:
+        text = (_ROOT / ".github" / "workflows" / "pr-validation.yml").read_text(encoding="utf-8")
+        return yaml.safe_load(text)
+
+    @staticmethod
+    def _gate_steps(workflow: dict) -> list[dict]:
+        steps = workflow["jobs"]["validate-pr"]["steps"]
+        return [
+            step
+            for step in steps
+            if "security-suppressions-range" in str(step.get("run", ""))
+        ]
+
+    def test_validate_pr_runs_the_range_subcommand(self, workflow: dict) -> None:
+        gate_steps = self._gate_steps(workflow)
+        assert len(gate_steps) == 1, "expected exactly one suppression-range step"
+        assert gate_steps[0].get("name"), "a step with no name is not a step"
+
+    def test_gate_passes_both_pull_request_shas_via_env(self, workflow: dict) -> None:
+        """A range gate given the wrong endpoints silently scans nothing.
+
+        The SHAs bind through ``env:`` rather than interpolating into the shell.
+        ``scripts/validate_workflows.py`` rejects the inline form as an
+        expression-injection risk, and it is right to: the uniform rule is
+        cheaper to enforce than case-by-case reasoning about which context
+        values happen to be hex today.
+        """
+        step = self._gate_steps(workflow)[0]
+        env = step.get("env") or {}
+        assert env.get("BASE_SHA") == "${{ github.event.pull_request.base.sha }}"
+        assert env.get("HEAD_SHA") == "${{ github.event.pull_request.head.sha }}"
+        run = step["run"]
+        assert '--base "$BASE_SHA"' in run
+        assert '--head "$HEAD_SHA"' in run
+        assert "${{" not in run, "interpolating into the run block reopens the injection path"
+
+    def test_gate_runs_outside_the_bot_skip_guard(self, workflow: dict) -> None:
+        """Bots push code too; exempting them would defeat the gate."""
+        step = self._gate_steps(workflow)[0]
+        assert "should-run" not in str(step.get("if", ""))
+
+    def test_every_checkout_in_the_job_fetches_full_history(self, workflow: dict) -> None:
+        """A merge base needs history; depth-1 makes the gate exit 2 on every PR."""
+        checkouts = [
+            step
+            for step in workflow["jobs"]["validate-pr"]["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        assert checkouts, "validate-pr must check out the repository"
+        for checkout in checkouts:
+            depth = (checkout.get("with") or {}).get("fetch-depth")
+            assert depth == 0, f"checkout {checkout.get('name')!r} has fetch-depth {depth!r}"


### PR DESCRIPTION
## Summary

The security-suppression policy shipped as a lefthook gate only. `pre-commit` and `pre-merge-commit` ran `security-suppressions-staged`; `pre-push` ran `security-suppressions-push`. No workflow referenced either subcommand, so the policy bound exactly those contributors who had lefthook installed locally and did not pass `--no-verify`.

This adds a `security-suppressions-range --base --head` subcommand that runs the identical collector over an explicit range, and wires it into the `validate-pr` job.

Fixes #4061
Refs #4068

## Why validate-pr and not a new job

`validate-pr` reports the required context "Validate PR", one of the 17 the branch ruleset requires. A new job would create a context that is not in the required set, so the gate could be bypassed by never running it.

The step sits in the unconditional section of the job, alongside `Enforce model pin policy`. Steps guarded by `steps.should-run.outputs.skip` are skipped for `dependabot[bot]`, `github-actions[bot]`, and `renovate[bot]`. Bots author code, so a gate they are exempt from is weaker than the local hook it backstops, not equal to it. Placing it unconditionally makes the CI gate strictly stronger than the hook.

## Fails closed

A shallow clone yields no merge base. That case exits 2 (config error), never 0. A security gate that cannot read history must not report success. Both checkouts in the job now request full history for that reason.

## Verification

17 tests, all driving `main(argv)` and asserting on its exit code rather than on a helper return value, which is the #4068 failure shape.

A 7-mutant harness, all dead:

| Mutant | Result |
|---|---|
| Delete the CI step from the workflow | DEAD |
| Revert full history on the bot-fallback checkout | DEAD |
| Fail open when the range cannot be resolved | DEAD |
| Swallow the collector's `None` sentinel | DEAD |
| Ignore `--base`, merge-base against head itself | DEAD |
| Reporter always reports clean | DEAD |
| Subcommand ignores `--head` | DEAD |

The first harness run had four survivors. Two mutations had silently failed to apply, and the workflow assertion was a bare substring match that passed with the step name deleted and only the `run:` line surviving. Both were fixed; the wiring assertions now parse the workflow and check step structure.

## Two premises corrected while building this

**A test I wrote was wrong, not the policy.** `test_one_removal_cannot_pay_for_two_additions` originally paid for one removed `noqa` with one added `noqa` plus one added `type: ignore`, and expected a failure. It got a pass. Probing the shipped `security-suppressions-push` hook showed it returns 0 on that same input, so the new range check was faithful to the shipped policy. `SECURITY_SUPPRESSION_RE` matches `nosec`, `nosemgrep`, `noqa`, `lgtm[`, `codeql[`, and `cwe-suppress`. `type: ignore` is a typing suppression with no security signal, governed by its own counter. The test now uses two same-class tokens, and a second test pins the scope boundary explicitly so widening the regex cannot happen silently.

**The inline SHA form was an injection risk.** `actionlint` passed it. The repo's own `scripts/validate_workflows.py` rejected it. Both SHAs now bind through `env:`, and a test asserts the run block contains no `${{` at all.

## Out of scope, filed separately

Security-relevant steps in `validate-pr` that sit behind the bot-skip guard remain exempt for the three bot actors. This change does not alter that; it only declines to add to it.
