### PR TITLE
fix(eval): keep judge failure evidence, gate on exact averages and salvage rate

### DIFF
--- a/.agents/analysis/ADR-091-debate-log.md
+++ b/.agents/analysis/ADR-091-debate-log.md
@@ -1,0 +1,38 @@
+# ADR-091 Debate Log
+
+## What ran, and what did not
+
+The `adr-review` skill's six-agent debate did not run against `ADR-091: Judge Verdict Recovery Bounds`. The sessions that authored and reviewed it ran as isolated worktree subagents with no Task tool, so no subagent could be spawned. This file records the review that did happen and names the gap, rather than reporting a consensus nobody reached.
+
+Read every verdict below as coming from a reviewer that examined the branch, not from the six-role panel the skill would have convened. Nothing here should be read as a 6/6 accept.
+
+## Reviewers
+
+| Reviewer | Basis | Verdict on the decision | Verdict on the artifact |
+|----------|-------|-------------------------|--------------------------|
+| Reviewer 1 (independent, branch diff) | Read the whole diff plus `git status`, `git ls-files`, `git diff main HEAD --stat` | Not contested | BLOCKING: four committed references to a file that does not exist in the repo |
+| Reviewer 3 (independent, branch diff) | Same diff, plus the orphan-ref-validator and `evals/architect-spike/fixtures/A001.json` | Not contested | MAJOR: three #3988 sub-claims stay open without this file; the repo's own eval plants `ADR-091` as the canonical fabricated citation |
+| Reviewer 5 (independent, branch diff) | Same diff, plus `pre_pr.py` run to confirm no gate catches it | Not contested | MAJOR: the 0.15 default's rationale is unrecoverable while the ADR is untracked |
+| Round 16 measurement (`.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md`) | 288 archived judge payloads replayed | Supports keeping the recovery path | Retracts the zero-marker inference issue #3988 rested on |
+
+All three independent reviewers reached the same conclusion from the same evidence and none disputed the decision the ADR records. That is agreement about a missing file, not a debate about the architecture.
+
+## Findings and resolution
+
+| Finding | Resolution |
+|---------|------------|
+| ADR-091 cited four times, tracked nowhere | Committed alongside the four citing files. |
+| Decision item 6 claimed every salvaged record keeps `judge_raw`, and the prefix recovery in `score_response` kept none | Fixed in `scripts/eval/eval-rule-activation.py`; item 6 now names all three salvage paths. |
+| The `--max-salvaged-fraction` bound moved the exit code and the rendered report disclosed nothing | Salvage rate added to `_render_caveats`; decision item 5 records it. |
+
+## What the decision rests on, and what would overturn it
+
+The ADR keeps the recovery path because deleting it drops 24 of 288 archived samples, 8.3%, measured after issue #3988 was filed and against a retracted zero. Two facts would overturn it:
+
+- A provider-enforced structured-output schema (`response_format` or a tool-call schema) lands anywhere in `scripts/eval/`. Recovery becomes dead code and deletion is free. Named as the exit path in the ADR and out of scope there.
+- A re-measurement showing the 8.3% figure is itself an artifact of the replay rather than of the run. The 288 payloads are archived at `.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/recovered-judge-payloads.json`, so this is checkable.
+
+## Accepted risks
+
+- Two residuals ship live. An exemplar object at offset 0 followed by a prose refusal still grades 5/5/5, and adjacent string literals are undetected. Both are recorded in the ADR and pinned by tests. Both now retain the payload under `judge_raw`, so a reader can find them in the artifact.
+- The six-agent debate is unrun. An agent that can spawn subagents should run `adr-review` against this ADR and replace this file with its output. Until then the ADR's status stays `proposed`.

--- a/.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/README.md
+++ b/.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/README.md
@@ -72,12 +72,16 @@ Two limits on what this archive can support:
   marked until rounds 9 and 10 added `judge_salvaged` to them. That gap is the
   reason the marker exists, and the reason no claim about tightening the
   parser can be validated here.
-- **Re-walking the 24 failures is weaker than it looks.** Only 200 characters
-  of each payload survive (#3975), so a re-parse exercises the stored prefix,
-  not the payload the judge actually emitted. A duplicate score field in the
-  discarded tail would refuse under the current guard and is invisible here.
-  All 24 prefixes recover; that shows the hardening did not make the parser
-  worse on what was kept, not that it matches on what was not.
+- **Re-walking the 24 failures needs the recovered payloads, not the run
+  artifacts.** The run stored only a 200-character prefix of each payload
+  (#3975), so a re-parse against these files exercises the prefix, not what the
+  judge emitted. `recovered-judge-payloads.json` in this directory carries the
+  full raw for all 288 samples, recovered from the Copilot CLI session
+  transcripts rather than from the eval, so the 24 failures can be re-parsed
+  against the real thing. The eval now stores the whole payload under
+  `judge_raw`, so a future run needs no recovery step. All 24 prefixes recover;
+  that shows the hardening did not make the parser worse on what was kept, not
+  that it matches on what was not.
 
 A third figure that was published as free is not. Of the 264 graded samples,
 none has a `reasoning` string naming a score field. That was read as evidence

--- a/.agents/architecture/ADR-091-judge-verdict-recovery-bounds.md
+++ b/.agents/architecture/ADR-091-judge-verdict-recovery-bounds.md
@@ -1,0 +1,104 @@
+---
+id: ADR-091
+status: proposed
+date: 2026-07-30
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
+# ADR-091: Judge Verdict Recovery Bounds
+
+## Status
+
+Proposed. Implemented in the same change for issue #3988. The recovery path and its bound both ship in `scripts/eval/eval-rule-activation.py`.
+
+## Date
+
+2026-07-30
+
+## Context
+
+`scripts/eval/eval-rule-activation.py` scores model responses with an LLM judge that is told to answer with a JSON object holding three integers and one `reasoning` string. Some payloads do not parse. The judge quotes the response it is grading, an unescaped quote inside that prose invalidates the object, and the three numbers the eval actually needs sit before the damage.
+
+The script recovers those numbers. Twenty-three rounds of adversarial review found sixteen defects of one class in that recovery: a search picking the wrong candidate object and reporting it as the judge's answer with `judge_failed` false. Each round fixed the instance. Issue #3988 argued the class is the problem and proposed deleting the path outright.
+
+Two facts decided against deletion, and both were measured after the issue was filed.
+
+The zero the deletion argument rested on is a serialization artifact. Issue #3988 reported 0 of 288 archived samples carrying a salvage marker and inferred that recovery had never moved a published number. `.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md` retracts that inference: the artifacts store the state before recovery was applied, so the marker count says when the files were written, not what recovery did. Recovery moved one published cell. Round 16 recovered all 288 raw payloads from the Copilot CLI session transcripts and measured that 24 of 288 cells, 8.3%, would change if the run were re-scored today.
+
+Deleting the path therefore drops 8.3% of samples for a benefit the measurement no longer supports. At three judge samples per cell, that takes 17 Opus cells down to one or two graded samples.
+
+What issue #3988 was right about is that the decision has never been written down. There is no ADR. `judge_salvaged` was written at two sites and read at none, so option 3 of the issue, bounding the run on the marker, did not exist as code. And the round-9 residual is still live: an exemplar object at offset 0 followed by an explicit English refusal still grades 5/5/5.
+
+## Decision
+
+Keep the recovery path. Bound it, mark it, and record the residuals.
+
+1. **Anchor at offset 0.** A payload's verdict is its leading object, ignoring leading whitespace. Position does not establish provenance, but it is cheap, auditable, and it replaced the search that produced every one of the sixteen defects.
+2. **Refuse on a second named verdict.** Any payload naming a score field twice is refused rather than resolved. Picking one of two candidates is a guess.
+3. **Unwrap a fence only when nothing but whitespace sits outside it.** One fence is not a selection.
+4. **Mark every recovery.** A recovered sample carries `judge_salvaged: True`. The marker now survives `_reduce_score_samples` as `salvaged_sample_count` and reaches the run summary as `salvaged_sample_count`, `graded_sample_count`, and `salvaged_sample_fraction`.
+5. **Bound the run on the marker.** `--max-salvaged-fraction` defaults to 0.15 and fails the run with exit code 1 when the observed fraction exceeds it. 0.15 sits above the 8.3% the reference run would salvage today, so that run still reproduces, and below the rate a provider that started wrapping verdicts in prose would produce. The rate is disclosed in the rendered report whenever recovery moved anything, so the exit code never contradicts a table that says nothing.
+6. **Store the whole payload.** Every failed and every salvaged record keeps `judge_raw` and `judge_model` (issue #3975), so a recovery decision can be re-examined from the artifact instead of from a transcript that may not survive. All three salvage paths do this, not only the two inside `_salvaged_or_failed_judge`: the prefix recovery in `score_response` marked the sample and kept nothing, so the gate counted evidence it had discarded.
+
+### Accepted residuals
+
+Both are recorded rather than fixed, because the fix for each is a search, and the search is the defect class this ADR exists to bound.
+
+- **Exemplar at offset 0 followed by a prose refusal.** `{"activation_score": 5, ...}\nI cannot score the response.` grades 5/5/5. Reproduced at HEAD. Distinguishing a quoted exemplar from an answer requires reading meaning out of a payload already known to be malformed. The refusal text is now retained under `judge_raw`, so the residual is auditable from the artifact even though it is not detected.
+- **Adjacent string literals.** Pinned by `test_adjacent_string_literals_are_a_known_undetected_shape` in `tests/eval/test_eval_rule_activation.py`.
+
+### The asymmetry this rests on
+
+A refused sample costs one of three judge samples and is recorded as a failure, so it moves the median visibly through `judge_failed` and the graded sample count. A fabricated sample corrupts a published number and is recorded as a success. The bound above is calibrated to that asymmetry: recovery is allowed, but a run that leans on it more than its reference did fails rather than absorbing the change.
+
+### Exit path
+
+Provider-enforced structured output, a `response_format` or tool-call schema that makes the payload parseable by construction, is the durable answer. No such schema exists anywhere in `scripts/eval/` today, and the Copilot CLI path needs checking. That is out of scope here and belongs in its own issue.
+
+## Rationale
+
+The alternative considered and rejected was option 1 of issue #3988: delete the recovery path and require strict JSON. It is the simplest option and it eliminates the class rather than the instance. It was rejected because its supporting measurement was retracted in-repo before this decision was made, and the replacement measurement (24 of 288 cells would change) says deletion costs 8.3% of the sample pool.
+
+Option 2, provider-enforced structured output, is the right long-term answer and is named above as the exit path. It is not available today without a provider change.
+
+Option 3, bounding the run on the marker, is what this ADR adopts. It preserves samples, makes the reliance measurable rather than assumed, and turns a silent accommodation into a failed run.
+
+## Consequences
+
+Positive:
+
+- A run that starts depending on recovery fails loudly instead of publishing numbers that rest on it.
+- `judge_raw` makes every recovery decision re-examinable from the artifact.
+- The decision stops being re-litigated implicitly. Round 24 starts here.
+
+Negative:
+
+- The bound can fail a run that a provider hiccup pushed over 15%. The flag is the escape hatch and the failure names the observed fraction, so the operator can decide.
+- The two residuals above are live. A payload of either shape still publishes a score the judge did not give.
+- The emitted artifact grows by the raw payload on every failed and salvaged sample. Bounded by the judge call's `max_tokens`, and failures are rare (24 of 288 in the reference run).
+
+## Impact on Dependent Components
+
+- `scripts/eval/eval-rule-activation.py`: owns all of it.
+- `scripts/eval/_optimizer_adapters.py` and `scripts/eval/optimize-artifact.py` read `score_samples` by key and never enumerate keys, so the additive fields pass through.
+- Archived artifacts predate `salvaged_sample_count`. Every reader defaults it rather than requiring it, so the archive replay in `tests/eval/test_eval_rule_activation.py` stays green.
+
+## Rollback and Kill Criteria
+
+Set `--max-salvaged-fraction 1.0` to disable the bound without reverting anything. Roll the ADR back if provider-enforced structured output lands, at which point recovery becomes dead code and deletion is free.
+
+## Related Decisions
+
+- Issue #3988: the argument this ADR settles.
+- Issue #3975: full payload retention and model identity on the sample record.
+- Issue #4031: the record builder is now named `_salvaged_or_failed_judge` for both branches it produces.
+- Issue #3999: the two recovery entry points that disagreed in strictness. Closed.
+
+## References
+
+- `.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md`: rounds 1 through 23 and the retraction of the zero-marker inference.
+- `.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/recovered-judge-payloads.json`: the 288 raw payloads.

--- a/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -13,9 +13,7 @@
       "type": "milestone",
       "content": "Reproduced all four defects against the worktree base and re-read the code rather than trusting the triage fix plans",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e002",
@@ -23,9 +21,7 @@
       "type": "milestone",
       "content": "Stored the whole judge payload and the model on every judge sample; renamed _judge_parse_failure to _salvaged_or_failed_judge",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e003",
@@ -33,9 +29,7 @@
       "type": "milestone",
       "content": "Split the published average from the gated average at _mechanism_summary and routed the restraint, activation, and delta gates through avg_score_exact",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e004",
@@ -43,9 +37,7 @@
       "type": "milestone",
       "content": "Carried judge_salvaged through _reduce_score_samples to the run summary and added --max-salvaged-fraction",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e005",
@@ -53,9 +45,7 @@
       "type": "milestone",
       "content": "Revived test_dry_run_counts_repeated_judge_calls, found dead on the path",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e006",
@@ -63,22 +53,33 @@
       "type": "milestone",
       "content": "Drafted ADR-091 for the recovery bounds and updated the two skill references plus the archive README",
       "caused_by": [],
-      "leads_to": [
-        "e007"
-      ]
+      "leads_to": []
     },
     {
       "id": "e007",
-      "timestamp": "2026-07-31T04:20:22+00:00",
+      "timestamp": "2026-07-31T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: a3bf87800",
+      "caused_by": [],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Review round: committed ADR-091, stored judge_raw on the third salvage path in score_response, ranked best_mechanism on the unrounded average, disclosed the salvage rate in the rendered report, corrected the _delta_exact docstring, and kept the whole judge payload in eval-agents.py and eval-knowledge-integration.py",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "test",
+      "content": "Review round: committed ADR-091, stored judge_raw on the third salvage path in score_response, ranked best_mechanism on the unrounded average, disclosed the salvage rate in the rendered report, corrected the _delta_exact docstring, and kept the whole judge payload in eval-agents.py and eval-knowledge-integration.py      1728 passed, 3 skipped in tests/eval; ruff clean on every changed file. Mutation checks confirm each new test fails against the pre-fix code",
       "caused_by": [
-        "e001",
-        "e002",
-        "e003",
-        "e004",
-        "e005",
-        "e006"
+        "e007"
       ],
       "leads_to": []
     }
@@ -89,7 +90,7 @@
     "errors": 0,
     "recoveries": 0,
     "commits": 1,
-    "files_changed": 3
+    "files_changed": 4
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -1,0 +1,95 @@
+{
+  "id": "episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating",
+  "session": "2026-07-31-session-3975-eval-recovery-evidence-and-gating",
+  "timestamp": "2026-07-31T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix the eval judge recovery cluster: payload evidence (#3975), exact-average gates (#4070), salvage marker propagation and bound (#3988), and the inverted helper name (#4031)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced all four defects against the worktree base and re-read the code rather than trusting the triage fix plans",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Stored the whole judge payload and the model on every judge sample; renamed _judge_parse_failure to _salvaged_or_failed_judge",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Split the published average from the gated average at _mechanism_summary and routed the restraint, activation, and delta gates through avg_score_exact",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Carried judge_salvaged through _reduce_score_samples to the run summary and added --max-salvaged-fraction",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Revived test_dry_run_counts_repeated_judge_calls, found dead on the path",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Drafted ADR-091 for the recovery bounds and updated the two skill references plus the archive README",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-31T04:20:22+00:00",
+      "type": "commit",
+      "content": "Commit: a3bf87800",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/memory/episodes/episode-2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -62,7 +62,7 @@
       "content": "Commit: a3bf87800",
       "caused_by": [],
       "leads_to": [
-        "e009"
+        "e010"
       ]
     },
     {
@@ -79,9 +79,21 @@
       "type": "test",
       "content": "Review round: committed ADR-091, stored judge_raw on the third salvage path in score_response, ranked best_mechanism on the unrounded average, disclosed the salvage rate in the rendered report, corrected the _delta_exact docstring, and kept the whole judge payload in eval-agents.py and eval-knowledge-integration.py      1728 passed, 3 skipped in tests/eval; ruff clean on every changed file. Mutation checks confirm each new test fails against the pre-fix code",
       "caused_by": [
-        "e007"
+        "e010"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-31T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a64060730",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
     }
   ],
   "metrics": {
@@ -89,7 +101,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/retrospective/2026-08-01-eval-judge-recovery-evidence.md
+++ b/.agents/retrospective/2026-08-01-eval-judge-recovery-evidence.md
@@ -1,0 +1,95 @@
+# Truncated Evidence Made Four Eval Defects Look Like One
+
+Date: 2026-08-01
+Branch: `fix/eval-recovery-evidence-and-gating`
+Issues: #3975, #4070, #4031, #3988
+
+## Summary
+
+`scripts/eval/eval-rule-activation.py` stored a 200-character prefix of every
+judge payload that failed to parse. Measured failure offsets across the 24
+archived failures run 162 to 421, so the window cut the damage out. Re-parsing
+the stored prefixes yields "Unterminated string starting at" 19 times while the
+real payloads yield "Expecting ',' delimiter" 24 times. The archive recorded
+the truncation instead of the judge.
+
+That single storage decision hid three more defects, each filed as its own
+issue. Fixing them together was not scope creep; the same record is the input
+to all four.
+
+## What the four issues turned out to share
+
+| Issue | Surface defect | Shared root |
+|-------|----------------|-------------|
+| #3975 | 200-character prefix on the failure record | The record is the only evidence, and it was lossy |
+| #4070 | Gates compared display-rounded averages against their floors | The published number and the gated number came from one `round(..., 2)` call |
+| #3988 | `judge_salvaged` written twice, read nowhere | The marker never reached a cell result, so no gate could read it |
+| #4031 | `_judge_parse_failure` returned `judge_failed: False` | The name described the trigger, not the two branches it takes |
+
+Reading all four issue threads before editing is what surfaced the overlap. The
+triage verdict for #3988 explicitly warned against the obvious fix (delete the
+recovery path) because the measurement that motivated deletion had already been
+retracted in-repo. Acting on the issue title alone would have deleted working
+recovery code.
+
+## What went wrong during the work
+
+Two new tests were wrong on the first pass, and both failures had the same
+shape: the test asserted the right claim against a fixture that could not
+exercise it.
+
+1. The fabricated-parse-error test led its payload with prose. That made the
+   200-character prefix fail at character 0 rather than mid-string, so the test
+   passed for the wrong reason. A prefix that fails at offset 0 does not
+   demonstrate that truncation fabricates a cause.
+2. The salvage-gate pass test used a scenario whose verdict was already
+   `FAIL_NO_DELTA`. Exit 1 proved nothing about the new
+   `--max-salvaged-fraction` bound, because the run would have exited 1 anyway.
+
+Both were caught by asking what the test would do against the pre-fix code.
+Every new test on this branch was run against pre-fix code and required to fail
+there. That check is cheap and it caught both.
+
+## Tooling defects found on the path
+
+`.claude/skills/session-end/scripts/complete_session_log.py:76` resolves the
+repository root with `git rev-parse --git-common-dir`. In a linked worktree
+that points at the main checkout, so the script auto-detected an unrelated
+session log belonging to another branch and wrote to it. Passing
+`--session-path` with a path inside the worktree then failed with
+"Session path must be inside '<main checkout>/.agents/sessions'". The stray
+write had to be reverted by hand.
+
+This is the issue #3402 class (worktree identity) reaching a skill script. The
+rule at `.claude/rules/ci-scripts.md` MUST 7 already requires a script that
+resolves a root and writes to it to confirm the current directory is inside
+that root. This script does neither.
+
+## What changed
+
+Every failed and salvaged judge record now carries the whole payload under
+`judge_raw`, on all three salvage paths, in `eval-rule-activation.py` and in
+both sibling scorers. Every judge sample carries `judge_model`, including the
+RuntimeError path, so a per-model claim is checkable from the record rather
+than the artifact filename. `_mechanism_summary` emits `avg_score_exact` beside
+the rounded `avg_score`, and every gate reads the exact value while the table
+keeps publishing the rounded one. `judge_salvaged` survives reduction as
+`salvaged_sample_count`, reaches the run summary as
+`salvaged_sample_fraction`, and `--max-salvaged-fraction` fails the run when
+recovery carried more of it than the bound allows.
+
+ADR-091 records the decision to keep the hand-written recovery path, the
+round-9 residual it accepts, and provider-enforced structured output as the
+exit path.
+
+## What to carry forward
+
+- When several issues name the same file, read all their threads before
+  editing. The overlap is usually the root cause and the separate fixes are
+  usually symptoms.
+- Run every new regression test against pre-fix code. A test that passes there
+  is measuring something else.
+- Evidence a gate reads must be stored whole. A truncation applied for
+  readability turns the archive into a record of the truncation.
+- A skill script that resolves a repository root needs the worktree-identity
+  check before its first write, not after a stray file lands in another branch.

--- a/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -94,12 +94,12 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Code and tests at a3bf87800; docs and manifests staged with this log"
+        "Evidence": "All work committed through a64060730, which sets the parity pair to the reserved 0.6.5482 slot"
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "1328 tests pass across tests/eval and tests/test_eval_optimizer_adapters.py; ruff clean on both touched files; uv run python scripts/validation/pre_pr.py reports all validations passed"
+        "Evidence": "uv run pytest tests/eval/test_eval_rule_activation.py tests/eval/test_eval_agents_dry_run.py tests/eval/test_eval_knowledge_integration.py -q reports 396 passed in 4.35s; ruff clean on all six changed files; uv run python scripts/validation/pre_pr.py reports All validations passed"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -154,7 +154,7 @@
       "result": "1728 passed, 3 skipped in tests/eval; ruff clean on every changed file. Mutation checks confirm each new test fails against the pre-fix code"
     }
   ],
-  "endingCommit": "a3bf87800",
+  "endingCommit": "a64060730",
   "nextSteps": [
     "ADR-091 is committed and stays status proposed. The adr-review skill's six-agent debate has not run against it: this harness exposes no Task tool. An agent that can spawn subagents should run adr-review on .agents/architecture/ADR-091-judge-verdict-recovery-bounds.md and replace .agents/analysis/ADR-091-debate-log.md with its output",
     "Issue #3988's remaining ask, provider-enforced structured output for the judge, needs its own issue. No response_format or tool schema exists anywhere in scripts/eval today",

--- a/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -1,0 +1,159 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3975,
+    "date": "2026-07-31",
+    "branch": "fix/eval-recovery-evidence-and-gating",
+    "startingCommit": "284372561",
+    "objective": "Fix the eval judge recovery cluster: payload evidence (#3975), exact-average gates (#4070), salvage marker propagation and bound (#3988), and the inverted helper name (#4031)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Running as an isolated worktree subagent with no MCP reach (demotion: Serena tools are not callable from this harness; used grep and direct reads instead)"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not reachable from this harness (demotion: same as serenaActivated)"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Task brief plus the triage verdicts and full issue discourse for #3975, #4070, #4031, #3988 read before any edit"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog reviewed via AGENTS.md and the harness skill listing"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md usage-mandatory reviewed"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/universal.md, code-quality.md, python.md, testing.md, ci-scripts.md, plugin-version-bump.md reviewed"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/eval-recovery-evidence-and-gating"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/eval-recovery-evidence-and-gating in an isolated worktree"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status clean at worktree creation"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "284372561"
+      },
+      "memoriesLoaded": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not reachable from this harness (demotion: triage verdicts carried the prior findings this session needed)"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not reachable from this harness (demotion: findings recorded in this log and in ADR-091's draft instead)"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "lefthook markdown-check ran on the staged markdown; pre_pr.py reports all validations passed"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Code and tests at a3bf87800; docs and manifests staged with this log"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "1328 tests pass across tests/eval and tests/test_eval_optimizer_adapters.py; ruff clean on both touched files; uv run python scripts/validation/pre_pr.py reports all validations passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Refs #3975, #4070, #3988, #4031. ADR-091 drafted but left uncommitted: the adr-review gate needs a multi-agent debate log this subagent cannot honestly produce"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Skipped: PR not yet merged"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "rework-warning: two new tests were wrong on the first pass. The fabricated-parse-error test led its payload with prose, which made the 200-character prefix fail at char 0 rather than mid-string; and the salvage-gate pass test used a scenario whose verdict was FAIL_NO_DELTA, so exit 1 proved nothing about the gate"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Reproduced all four defects against the worktree base and re-read the code rather than trusting the triage fix plans",
+      "result": "All four live. Confirmed 24 archived failures re-parse differently from their full payloads, judge_salvaged is written twice and read nowhere, and round(avg, 2) feeds both the table and the gates"
+    },
+    {
+      "step": 2,
+      "action": "Stored the whole judge payload and the model on every judge sample; renamed _judge_parse_failure to _salvaged_or_failed_judge",
+      "result": "judge_raw and judge_model on the failed, salvaged, clean, and judge-API-failure records. Reason strings became short labels. 14 existing tests updated for the new signature, none of their assertions weakened"
+    },
+    {
+      "step": 3,
+      "action": "Split the published average from the gated average at _mechanism_summary and routed the restraint, activation, and delta gates through avg_score_exact",
+      "result": "A 35-cell pool measuring 3.49524 now returns FAIL_OVER_ACTIVATION while the table still prints 3.5. Falsified by reverting the one line: the new tests went red, then green again on restore. All 8 archived artifacts still replay field for field"
+    },
+    {
+      "step": 4,
+      "action": "Carried judge_salvaged through _reduce_score_samples to the run summary and added --max-salvaged-fraction",
+      "result": "salvaged_sample_count, graded_sample_count, and salvaged_sample_fraction on the summary; exit 1 with the observed fraction when the bound is exceeded. Default 0.15 sits above the 8.3 percent the 2026-07-29 reference run would salvage"
+    },
+    {
+      "step": 5,
+      "action": "Revived test_dry_run_counts_repeated_judge_calls, found dead on the path",
+      "result": "It skipped on every run since its pinned rule file left the repository, and its call still passed a bare Path where _process_one_rule unpacks a tuple. Repointed at .claude/rules/testing.md and fixed the call"
+    },
+    {
+      "step": 6,
+      "action": "Drafted ADR-091 for the recovery bounds and updated the two skill references plus the archive README",
+      "result": "Skill mirrors regenerated with build/scripts/generate_skills.py; both plugin manifests bumped to 0.6.5445. ADR-091 left uncommitted for an agent that can run adr-review"
+    }
+  ],
+  "endingCommit": "a3bf87800",
+  "nextSteps": [
+    "ADR-091 is drafted at .agents/architecture/ADR-091-judge-verdict-recovery-bounds.md but uncommitted. Landing it needs the adr-review skill plus a debate log in .agents/analysis, which this subagent cannot produce",
+    "Issue #3988's remaining ask, provider-enforced structured output for the judge, needs its own issue. No response_format or tool schema exists anywhere in scripts/eval today",
+    "eval_one_scenario is at cyclomatic complexity 11, which predates this change and stays over the repo ceiling of 10"
+  ]
+}

--- a/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -84,7 +84,7 @@
       "serenaMemoryUpdated": {
         "level": "SHOULD",
         "Complete": false,
-        "Evidence": "Serena not reachable from this harness (demotion: findings recorded in this log and in ADR-091's draft instead)"
+        "Evidence": "Serena not reachable from this harness (demotion: findings recorded in this log and in ADR-091 instead)"
       },
       "markdownLintRun": {
         "level": "MUST",
@@ -104,7 +104,7 @@
       "tasksUpdated": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "Refs #3975, #4070, #3988, #4031. ADR-091 drafted but left uncommitted: the adr-review gate needs a multi-agent debate log this subagent cannot honestly produce"
+        "Evidence": "Refs #3975, #4070, #3988, #4031. ADR-091 committed in the same change as the four files that cite it. The adr-review skill's six-agent debate did not run because this harness exposes no Task tool; .agents/analysis/ADR-091-debate-log.md records the review that did happen and names the gap"
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
@@ -147,13 +147,18 @@
     {
       "step": 6,
       "action": "Drafted ADR-091 for the recovery bounds and updated the two skill references plus the archive README",
-      "result": "Skill mirrors regenerated with build/scripts/generate_skills.py; both plugin manifests bumped to 0.6.5445. ADR-091 left uncommitted for an agent that can run adr-review"
+      "result": "Skill mirrors regenerated with build/scripts/generate_skills.py; both plugin manifests bumped to 0.6.5445. ADR-091 committed alongside its four citations"
+    },
+    {
+      "action": "Review round: committed ADR-091, stored judge_raw on the third salvage path in score_response, ranked best_mechanism on the unrounded average, disclosed the salvage rate in the rendered report, corrected the _delta_exact docstring, and kept the whole judge payload in eval-agents.py and eval-knowledge-integration.py",
+      "result": "1728 passed, 3 skipped in tests/eval; ruff clean on every changed file. Mutation checks confirm each new test fails against the pre-fix code"
     }
   ],
   "endingCommit": "a3bf87800",
   "nextSteps": [
-    "ADR-091 is drafted at .agents/architecture/ADR-091-judge-verdict-recovery-bounds.md but uncommitted. Landing it needs the adr-review skill plus a debate log in .agents/analysis, which this subagent cannot produce",
+    "ADR-091 is committed and stays status proposed. The adr-review skill's six-agent debate has not run against it: this harness exposes no Task tool. An agent that can spawn subagents should run adr-review on .agents/architecture/ADR-091-judge-verdict-recovery-bounds.md and replace .agents/analysis/ADR-091-debate-log.md with its output",
     "Issue #3988's remaining ask, provider-enforced structured output for the judge, needs its own issue. No response_format or tool schema exists anywhere in scripts/eval today",
-    "eval_one_scenario is at cyclomatic complexity 11, which predates this change and stays over the repo ceiling of 10"
+    "eval_one_scenario is at cyclomatic complexity 11, which predates this change and stays over the repo ceiling of 10",
+    "tests/eval/test_anthropic_model_default.py:35 fails ruff UP037 on main, unrelated to this branch and left alone"
   ]
 }

--- a/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
+++ b/.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json
@@ -108,8 +108,8 @@
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": "Skipped: PR not yet merged"
+        "Complete": true,
+        "Evidence": ".agents/retrospective/2026-08-01-eval-judge-recovery-evidence.md records the shared root across the four issues, the two tests that were wrong on the first pass, and the session-end worktree-identity defect"
       },
       "reworkWarning": {
         "level": "SHOULD",

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5445",
+  "version": "0.6.5482",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5444",
+  "version": "0.6.5445",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/context-optimizer/references/rule-audit-measurement-discipline.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-measurement-discipline.md
@@ -107,8 +107,10 @@ correct. Both were about a different question than the one being asked.
 The entry point returns `judge_failed=False` and `judge_salvaged=True` for all
 24. `_recover_verdict` returning `None` means no *embedded complete object* was
 found, which is one route among several; the three top-level integers are still
-extractable, and the function named `_judge_parse_failure` extracts them. Its
-name asserts an outcome it does not produce, which is now issue #4031.
+extractable, and the entry point's record builder extracts them. At the time
+that builder was named `_judge_parse_failure`, a name asserting an outcome its
+primary path does not produce (issue #4031). It is now
+`_salvaged_or_failed_judge`, which names both branches.
 
 Two correct measurements pointed the opposite way from the real behaviour, and
 the reason was reading a name instead of a return value. Had the claim been

--- a/.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md
@@ -72,7 +72,9 @@ this function and each missed what the next found, so "it survived review" is
 weaker evidence here than the round count suggests. Sixteen defects of one
 class is evidence against hand-writing the parser at all (issue #3988, which
 tracks the argument; its round log stops at nine and is not the history of
-record. This document is).
+record. This document is). ADR-091 records what was decided: the bound salvage
+runs under, the residuals accepted, and provider-enforced structured output as
+the exit path.
 
 Round 12 found no defect of that class and was aimed at the two least-tested
 surfaces: the duplicate guard's paired-quote alternation, and the strict-parse

--- a/scripts/eval/eval-agents.py
+++ b/scripts/eval/eval-agents.py
@@ -635,12 +635,19 @@ Respond in JSON only, no other text:
         # Note: if appropriateness is missing, we leave it out and _avg_scores will exclude it
     except json.JSONDecodeError:
         print(f"WARNING: Failed to parse LLM response: {text[:100]}", file=sys.stderr)
+        # `judge_raw` holds the payload whole. A 200-character prefix is not
+        # evidence of the failure it names: every archived truncation re-parsed
+        # as "Unterminated string" while the untruncated payloads failed at
+        # offsets past 160, so the excerpt reproduced the cut, not the judge
+        # (#3975). `_avg_scores` reads a fixed dimension list, so the extra key
+        # rides along without touching any average.
         scores = {
             "role_adherence": 0,
             "actionability": 0,
             "quality": 0,
             "appropriateness": 0,
             "reasoning": f"Failed to parse: {text[:200]}",
+            "judge_raw": text,
         }
 
     return scores

--- a/scripts/eval/eval-knowledge-integration.py
+++ b/scripts/eval/eval-knowledge-integration.py
@@ -238,7 +238,17 @@ Respond in JSON only, no other text:
         scores: dict[str, Any] = json.loads(text)
     except json.JSONDecodeError:
         print(f"WARNING: Failed to parse LLM response: {text[:100]}", file=sys.stderr)
-        scores = {"accuracy": 0, "depth": 0, "specificity": 0, "reasoning": f"Failed to parse: {text[:200]}"}
+        # `judge_raw` holds the payload whole. A 200-character prefix
+        # reproduces the truncation's parse error, not the judge's (#3975).
+        # `_avg_scores` reads a fixed dimension list, so the extra key does not
+        # reach any average.
+        scores = {
+            "accuracy": 0,
+            "depth": 0,
+            "specificity": 0,
+            "reasoning": f"Failed to parse: {text[:200]}",
+            "judge_raw": text,
+        }
 
     return scores
 

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -2033,7 +2033,7 @@ def _delta_exact(
     """
     if not _fully_graded(treatment) or not _fully_graded(control):
         return None
-    return treatment["avg_score_exact"] - control["avg_score_exact"]
+    return float(treatment["avg_score_exact"]) - float(control["avg_score_exact"])
 
 
 def _positive_verdict(desc_avg: float | None, baseline_avg: float | None) -> str:

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -555,7 +555,18 @@ Respond in JSON only, no other text:
         # The whole payload did not parse; the verdict came from its leading
         # object. Marking it is what makes the recovery auditable after the
         # run, which the searching version it replaced never was.
+        #
+        # The payload rides along for the same reason `_salvaged_or_failed_judge`
+        # keeps it (#3975). This is the third salvage path and it was the one
+        # storing nothing: the marker reached the `--max-salvaged-fraction`
+        # gate while the text the scores were inferred from was dropped, so an
+        # operator whose run tripped the bound found evidence for some salvaged
+        # samples and none for these. The round-9 residual lives here, an
+        # exemplar object at offset 0 followed by a prose refusal that still
+        # grades 5/5/5, and that text is the only record that the triple is
+        # wrong.
         result["judge_salvaged"] = True
+        result["judge_raw"] = text
     fingerprint = metadata.get("system_fingerprint")
     if isinstance(fingerprint, str):
         result["judge_system_fingerprint"] = fingerprint
@@ -1832,9 +1843,15 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
     # graded on one lucky scenario would otherwise take the headline from a
     # mechanism graded on all of them, and the table would refuse that same
     # comparison one line later as a delta.
+    # Ranked on the unrounded average for the same reason the gates read it:
+    # two mechanisms 0.004 apart round to one printed number, and `max` then
+    # keeps whichever `MECHANISMS` happens to list first. The headline named
+    # the wrong mechanism while the sibling `worst_negative_mechanism` a few
+    # lines below already ranked exactly. The published `best_avg_score` stays
+    # rounded, so archived runs still replay field for field.
     best_mech = max(
         (m for m in rule_enhanced if _fully_graded(summary["per_mechanism"][m])),
-        key=lambda m: summary["per_mechanism"][m]["avg_score"],
+        key=lambda m: summary["per_mechanism"][m]["avg_score_exact"],
         default=None,
     )
     best_avg = summary["per_mechanism"][best_mech]["avg_score"] if best_mech else None
@@ -1882,7 +1899,8 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
         pos_cells["description"], pos_cells["baseline"]
     )
     # The published deltas stay rounded, so the archived runs replay
-    # field-for-field. The delta gate reads this one.
+    # field-for-field. This unrounded twin exists for the rounding disclosure,
+    # not for the gate: the gate subtracts the two exact averages itself.
     summary["delta_description_vs_baseline_exact"] = _delta_exact(
         pos_cells["description"], pos_cells["baseline"]
     )
@@ -2005,7 +2023,14 @@ def _delta(treatment: dict[str, Any], control: dict[str, Any]) -> float | None:
 def _delta_exact(
     treatment: dict[str, Any], control: dict[str, Any]
 ) -> float | None:
-    """The same difference, off the unrounded averages, for the delta gate."""
+    """The same difference, off the unrounded averages, for disclosure.
+
+    Not what the delta gate reads. `_positive_verdict` subtracts the two exact
+    averages itself, so this value has one consumer: `_rounding_caveats`, which
+    compares it against the published rounded delta and discloses a pair that
+    straddles `MIN_DELTA_VS_BASELINE`. Naming the gate here asserted an outcome
+    this helper does not produce, which is the same defect #4031 named.
+    """
     if not _fully_graded(treatment) or not _fully_graded(control):
         return None
     return treatment["avg_score_exact"] - control["avg_score_exact"]
@@ -2120,6 +2145,29 @@ def _rounding_caveats(summary: dict[str, Any]) -> list[str]:
     return [line for line in candidates if line is not None]
 
 
+def _salvage_caveat(summary: dict[str, Any]) -> str | None:
+    """Disclose how much of the run rests on recovered payloads.
+
+    The `--max-salvaged-fraction` bound decides the exit code inside
+    `_salvage_gate_failed` and announces itself only on stderr, so the rendered
+    report printed a clean verdict beside a non-zero exit with nothing
+    explaining it. That is the publish-a-number-that-contradicts-the-verdict
+    shape the rounding caveats exist to remove, so the rate is disclosed
+    whenever recovery moved anything, whether or not the bound fired.
+    """
+    salvaged = summary.get("salvaged_sample_count") or 0
+    if not salvaged:
+        return None
+    fraction = summary.get("salvaged_sample_fraction")
+    rate = f" ({fraction:.1%})" if isinstance(fraction, float) else ""
+    return (
+        f"Salvaged judge samples: {salvaged} of "
+        f"{summary.get('graded_sample_count', 0)} graded{rate}; scores "
+        "recovered from payloads that did not parse, bounded by "
+        "--max-salvaged-fraction."
+    )
+
+
 def _render_caveats(summary: dict[str, Any]) -> list[str]:
     """Every line that qualifies the verdict above it.
 
@@ -2129,6 +2177,9 @@ def _render_caveats(summary: dict[str, Any]) -> list[str]:
     silent one.
     """
     lines: list[str] = _rounding_caveats(summary)
+    salvage_line = _salvage_caveat(summary)
+    if salvage_line is not None:
+        lines.append(salvage_line)
     for label, key in (
         ("Negative", "negative_gate_incomplete"),
         ("Positive", "positive_gate_incomplete"),

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -89,6 +89,10 @@ MAX_RUBRIC_SCORE = 5.0
 DEFAULT_SEED = 0
 DEFAULT_JUDGE_REPEATS = 3
 DEFAULT_JUDGE_REDUCER = "median"
+# Above the 8.3% (24 of 288) the 2026-07-29 reference run would salvage today,
+# so that run still reproduces, and low enough that a provider which starts
+# wrapping its verdict in prose fails the run instead of being absorbed.
+DEFAULT_MAX_SALVAGED_FRACTION = 0.15
 _SCORE_KEYS = ("activation_score", "citation_score", "behavior_score")
 _SCORE_REDUCERS: dict[str, Callable[[list[float]], float]] = {
     "mean": statistics.fmean,
@@ -504,7 +508,7 @@ Respond in JSON only, no other text:
     except ValueError:
         embedded = _recover_verdict(text)
         if embedded is None:
-            return _judge_parse_failure(text, f"judge parse error: {text[:200]}")
+            return _salvaged_or_failed_judge(text, "judge parse error", model)
         # _recover_verdict only returns text it already parsed with
         # _strict_json_loads, so this cannot raise.
         parsed = _strict_json_loads(embedded)
@@ -532,19 +536,20 @@ Respond in JSON only, no other text:
         # offers nothing exact to check.
         if _parsed_names_two_verdicts(parsed):
             return _failed_judge(
-                f"ambiguous judge output names two verdicts: {text[:200]}"
+                "ambiguous judge output names two verdicts", text, model
             )
     if not isinstance(parsed, dict):
-        return _failed_judge(f"judge returned non-object JSON: {text[:200]}")
+        return _failed_judge("judge returned non-object JSON", text, model)
     score_error = _judge_score_shape_error(parsed)
     if score_error is not None:
-        return _judge_parse_failure(text, score_error)
+        return _salvaged_or_failed_judge(text, score_error, model)
     result = {
         "activation_score": _clamp_score(parsed["activation_score"]),
         "citation_score": _clamp_score(parsed["citation_score"]),
         "behavior_score": _clamp_score(parsed["behavior_score"]),
         "reasoning": str(parsed.get("reasoning", ""))[:300],
         "judge_failed": False,
+        "judge_model": model,
     }
     if recovered_from_prefix:
         # The whole payload did not parse; the verdict came from its leading
@@ -580,6 +585,10 @@ def _reduce_score_samples(
     reducer = _SCORE_REDUCERS[reducer_name]
     graded = [s for s in samples if not s.get("judge_failed")]
     failed_count = len(samples) - len(graded)
+    # `judge_salvaged` used to die here: this function rebuilds the cell field
+    # by field, so the marker never reached a cell, a summary, or a gate, and
+    # the option to bound recovery on it did not exist (#3988).
+    salvaged_count = sum(1 for s in graded if s.get("judge_salvaged"))
     if not graded:
         return {
             "activation_score": None,
@@ -591,6 +600,7 @@ def _reduce_score_samples(
             "sample_count": len(samples),
             "graded_sample_count": 0,
             "failed_sample_count": failed_count,
+            "salvaged_sample_count": 0,
         }
     reduced: dict[str, Any] = {
         key: reducer([float(sample[key]) for sample in graded]) for key in _SCORE_KEYS
@@ -610,6 +620,7 @@ def _reduce_score_samples(
     reduced["sample_count"] = len(samples)
     reduced["graded_sample_count"] = len(graded)
     reduced["failed_sample_count"] = failed_count
+    reduced["salvaged_sample_count"] = salvaged_count
     return reduced
 
 
@@ -1431,8 +1442,22 @@ def _salvage_scores(text: str) -> dict[str, int] | None:
     return _complete_verdict(_scan_root_members(text, start))
 
 
-def _judge_parse_failure(text: str, reason: str) -> dict[str, Any]:
-    """Build a failed-judge record, salvaging scores when they are recoverable."""
+def _salvaged_or_failed_judge(text: str, reason: str, model: str) -> dict[str, Any]:
+    """Grade from an unparseable payload, or fail when nothing is recoverable.
+
+    Returns ``judge_failed: False`` plus ``judge_salvaged: True`` when
+    ``_salvage_scores`` recovers all three integers, so the sample counts as
+    graded. Returns ``_failed_judge(...)`` otherwise, and that is the only
+    branch reporting the sample as failed. The former name, ``
+    _judge_parse_failure``, asserted an outcome its primary path does not
+    produce (#4031).
+
+    Both branches keep the whole payload under ``judge_raw``. A 200-character
+    prefix used to stand in for it, and the parse error those prefixes
+    reproduce is the truncation's, not the judge's: 19 of the 24 archived
+    failures re-parse as "Unterminated string" while every full payload failed
+    on a missing comma, at offsets 162 to 421 (#3975).
+    """
     salvaged = _salvage_scores(text)
     if salvaged is not None:
         return {
@@ -1442,17 +1467,28 @@ def _judge_parse_failure(text: str, reason: str) -> dict[str, Any]:
             "reasoning": f"scores salvaged from unparseable judge output: {reason}",
             "judge_failed": False,
             "judge_salvaged": True,
+            "judge_raw": text,
+            "judge_model": model,
         }
-    return _failed_judge(reason)
+    return _failed_judge(reason, text, model)
 
 
-def _failed_judge(reason: str) -> dict[str, Any]:
+def _failed_judge(reason: str, raw: str, model: str) -> dict[str, Any]:
+    """Build a failed-judge record that keeps the evidence it failed on.
+
+    ``raw`` is stored whole. The judge runs at ``_anthropic_api.call_api``'s
+    default ``max_tokens``, so a payload is bounded at a few KB, and a cap
+    below that bound is what turned a diagnosable failure into a fabricated
+    one (#3975).
+    """
     return {
         "activation_score": 0,
         "citation_score": 0,
         "behavior_score": 0,
         "reasoning": reason,
         "judge_failed": True,
+        "judge_raw": raw,
+        "judge_model": model,
     }
 
 
@@ -1579,6 +1615,7 @@ def eval_one_scenario(
                     "judge_failed": True,
                     "reasoning": f"judge API failure: {e}",
                     "sample_index": sample_index,
+                    "judge_model": model,
                 }
             else:
                 sample["sample_index"] = sample_index
@@ -1671,6 +1708,35 @@ def _scenario_score_triple(
     return sum(triple) / len(_SCORE_KEYS), failed, True
 
 
+def _salvage_rate(scenarios: list[dict[str, Any]]) -> dict[str, Any]:
+    """The run-level salvage figures the `--max-salvaged-fraction` gate reads."""
+    salvaged, graded = _salvage_counts(scenarios)
+    return {
+        "salvaged_sample_count": salvaged,
+        "graded_sample_count": graded,
+        "salvaged_sample_fraction": salvaged / graded if graded else None,
+    }
+
+
+def _salvage_counts(scenarios: list[dict[str, Any]]) -> tuple[int, int]:
+    """Count (salvaged, graded) judge samples across every cell in a run.
+
+    A salvaged sample is one whose payload did not parse and whose three
+    scores were recovered from its readable prefix. Recovery is bounded and
+    marked, but it is still an inference about a malformed payload, so a run
+    that leans on it more than its reference does is a run whose provider
+    changed shape (#3988, ADR-091). Reads the reduced cell rather than the raw
+    samples so one definition of "graded" serves the gate and the table.
+    """
+    salvaged = graded = 0
+    for scenario in scenarios:
+        for cell in scenario.get("mechanisms", {}).values():
+            scores = cell.get("scores") or {}
+            salvaged += scores.get("salvaged_sample_count") or 0
+            graded += scores.get("graded_sample_count") or 0
+    return salvaged, graded
+
+
 def _incomplete_mechanisms(
     per_mech: dict[str, dict[str, Any]], mechs: list[str], pool_size: int
 ) -> list[str]:
@@ -1704,9 +1770,18 @@ def _mechanism_summary(
     # baseline, and a candidate for best_mechanism, none of which any
     # observation supports. An absent number has to be handled; a zero does
     # not, so it travels silently into the table.
-    avg = round(sum(scores) / len(scores), 2) if scores else None
+    # Two numbers, on purpose. `avg_score` is what the table prints, and
+    # rounding it keeps the published column readable. Every gate reads
+    # `avg_score_exact` instead, because a display rounding that crosses a
+    # floor turns a measured 3.4952 into a published 3.5 and lets a run that
+    # breached the restraint floor return PASS (#4070). `fmean` rather than a
+    # naive sum so a pool of k/3 terms does not accumulate drift near the
+    # floor.
+    exact = statistics.fmean(scores) if scores else None
+    avg = round(exact, 2) if exact is not None else None
     return {
         "avg_score": avg,
+        "avg_score_exact": exact,
         "scenario_count": len(pool),
         "graded_count": len(scores),
         "judge_failures": failures,
@@ -1745,7 +1820,9 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
         )
 
     baseline_avg = summary["per_mechanism"]["baseline"]["avg_score"]
-    desc_avg = summary["per_mechanism"]["description"]["avg_score"]
+    # The gates read the unrounded pair. See `_mechanism_summary`.
+    gate_baseline_avg = summary["per_mechanism"]["baseline"]["avg_score_exact"]
+    gate_desc_avg = summary["per_mechanism"]["description"]["avg_score_exact"]
 
     # `description` is the progressive-disclosure gate. The `full` mechanism is
     # retained only as a diagnostic ceiling and cannot rescue a failed front door.
@@ -1804,7 +1881,13 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
     summary["delta_description_vs_baseline"] = _delta(
         pos_cells["description"], pos_cells["baseline"]
     )
+    # The published deltas stay rounded, so the archived runs replay
+    # field-for-field. The delta gate reads this one.
+    summary["delta_description_vs_baseline_exact"] = _delta_exact(
+        pos_cells["description"], pos_cells["baseline"]
+    )
     summary["total_judge_failures"] = total_judge_failures
+    summary.update(_salvage_rate(scenarios))
     # Name the cells whose failures no gate reads. Deriving this in the
     # renderer instead would let the disclosure drift from the exclusion, which
     # is how the negative-baseline exclusion shipped silent in the first place.
@@ -1843,9 +1926,14 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
     # than failing every rule in it.
     gate_mechs = neg_gate_mechs
     gate_cells = {m: summary["negative_case_per_mechanism"][m] for m in gate_mechs}
-    graded_neg = [c["avg_score"] for c in gate_cells.values() if c["graded_count"] > 0]
+    graded_neg = [
+        c["avg_score_exact"] for c in gate_cells.values() if c["graded_count"] > 0
+    ]
     worst_neg_avg = min(graded_neg) if graded_neg else None
-    summary["worst_negative_avg"] = worst_neg_avg
+    summary["worst_negative_avg"] = (
+        round(worst_neg_avg, 2) if worst_neg_avg is not None else None
+    )
+    summary["worst_negative_avg_exact"] = worst_neg_avg
     # Name the population the number was read off. An average over a subset of
     # the negative scenarios, reported as if it covered them all, is the defect
     # this whole change exists to remove.
@@ -1859,7 +1947,7 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
     # covers, and a reader cannot recover it from the verdict.
     worst_neg_mech = min(
         (m for m in gate_mechs if gate_cells[m]["graded_count"] > 0),
-        key=lambda m: gate_cells[m]["avg_score"],
+        key=lambda m: gate_cells[m]["avg_score_exact"],
         default=None,
     )
     summary["worst_negative_mechanism"] = worst_neg_mech
@@ -1883,8 +1971,8 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
         gating_judge_failures=gating_judge_failures,
         worst_neg_avg=worst_neg_avg,
         has_positive_cases=bool(pos_scenarios),
-        desc_avg=desc_avg,
-        baseline_avg=baseline_avg,
+        desc_avg=gate_desc_avg,
+        baseline_avg=gate_baseline_avg,
     )
 
     return summary
@@ -1912,6 +2000,15 @@ def _delta(treatment: dict[str, Any], control: dict[str, Any]) -> float | None:
     treatment_avg: float = treatment["avg_score"]
     control_avg: float = control["avg_score"]
     return round(treatment_avg - control_avg, 2)
+
+
+def _delta_exact(
+    treatment: dict[str, Any], control: dict[str, Any]
+) -> float | None:
+    """The same difference, off the unrounded averages, for the delta gate."""
+    if not _fully_graded(treatment) or not _fully_graded(control):
+        return None
+    return treatment["avg_score_exact"] - control["avg_score_exact"]
 
 
 def _positive_verdict(desc_avg: float | None, baseline_avg: float | None) -> str:
@@ -1977,6 +2074,52 @@ def _decide_verdict(
 # ---------------------------------------------------------------------------
 
 
+def _floor_display_gap(
+    label: str, exact: float | None, published: float | None, floor: float
+) -> str | None:
+    """Disclose a published number that rounds across the floor its gate read.
+
+    Without this the table can print a clean 3.5 beside FAIL_OVER_ACTIVATION,
+    which is the same publish-a-number-that-contradicts-the-verdict defect
+    #4070 fixes, pointed the other way.
+    """
+    if exact is None or published is None or not math.isfinite(exact):
+        return None
+    if exact >= floor or published < floor:
+        return None
+    return (
+        f"{label} {exact:.4f} gated below the {floor} floor; "
+        f"the table rounds it to {published}."
+    )
+
+
+def _rounding_caveats(summary: dict[str, Any]) -> list[str]:
+    """Every gate whose published number and gated number straddle its floor."""
+    per_mech = summary.get("per_mechanism") or {}
+    description = per_mech.get("description") or {}
+    candidates = (
+        _floor_display_gap(
+            "Restraint",
+            summary.get("worst_negative_avg_exact"),
+            summary.get("worst_negative_avg"),
+            MIN_RESTRAINT_SCORE,
+        ),
+        _floor_display_gap(
+            "Description average",
+            description.get("avg_score_exact"),
+            description.get("avg_score"),
+            MIN_ACTIVATION_SCORE,
+        ),
+        _floor_display_gap(
+            "Description delta over baseline",
+            summary.get("delta_description_vs_baseline_exact"),
+            summary.get("delta_description_vs_baseline"),
+            MIN_DELTA_VS_BASELINE,
+        ),
+    )
+    return [line for line in candidates if line is not None]
+
+
 def _render_caveats(summary: dict[str, Any]) -> list[str]:
     """Every line that qualifies the verdict above it.
 
@@ -1985,7 +2128,7 @@ def _render_caveats(summary: dict[str, Any]) -> list[str]:
     exclusion without its disclosure is a visible omission rather than a
     silent one.
     """
-    lines: list[str] = []
+    lines: list[str] = _rounding_caveats(summary)
     for label, key in (
         ("Negative", "negative_gate_incomplete"),
         ("Positive", "positive_gate_incomplete"),
@@ -2126,6 +2269,19 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_JUDGE_REDUCER,
         choices=tuple(_SCORE_REDUCERS),
         help="Reducer used for repeated judge samples.",
+    )
+    parser.add_argument(
+        "--max-salvaged-fraction",
+        type=float,
+        default=DEFAULT_MAX_SALVAGED_FRACTION,
+        help=(
+            "Fail the run when more than this fraction of graded judge "
+            "samples had their scores recovered from an unparseable payload. "
+            "The 2026-07-29 reference run would salvage 24 of 288 samples "
+            f"(8.3%%), so the default of {DEFAULT_MAX_SALVAGED_FRACTION} sits "
+            "above it and a provider that starts emitting preambles is caught "
+            "rather than silently accommodated (#3988). Set to 1.0 to disable."
+        ),
     )
     return parser.parse_args()
 
@@ -2406,10 +2562,20 @@ def _process_one_rule(
     }, n_calls
 
 
+def _args_config_error(args: argparse.Namespace) -> str | None:
+    """Name the first out-of-range argument, or None when the run can start."""
+    if args.judge_repeats < 1:
+        return "--judge-repeats must be positive"
+    if not 0.0 <= args.max_salvaged_fraction <= 1.0:
+        return "--max-salvaged-fraction must be between 0 and 1"
+    return None
+
+
 def main() -> int:
     args = _parse_args()
-    if args.judge_repeats < 1:
-        print("ERROR: --judge-repeats must be positive", file=sys.stderr)
+    config_error = _args_config_error(args)
+    if config_error is not None:
+        print(f"ERROR: {config_error}", file=sys.stderr)
         return 2
 
     if args.dry_run:
@@ -2479,12 +2645,38 @@ def _process_scenario_file(
 
     if result is not None:
         all_results["rules"][rule_id] = result
-        ok, judge_failed = _classify_verdict(result["summary"]["verdict"])
+        summary = result["summary"]
+        if _salvage_gate_failed(rule_id, summary, args.max_salvaged_fraction):
+            state.overall_pass = False
+        ok, judge_failed = _classify_verdict(summary["verdict"])
         if not ok:
             state.overall_pass = False
         if judge_failed:
             state.external_failure = True
     return None
+
+
+def _salvage_gate_failed(
+    rule_id: str, summary: dict[str, Any], max_fraction: float
+) -> bool:
+    """Whether recovery carried more of this run than the bound allows.
+
+    Reported next to the verdict rather than folded into it: the scores are
+    real observations of the response, so the run measured what it says it
+    measured. What is in question is how much of that measurement rests on a
+    payload the judge did not serialize cleanly (#3988, ADR-091).
+    """
+    fraction = summary.get("salvaged_sample_fraction")
+    if fraction is None or fraction <= max_fraction:
+        return False
+    print(
+        f"ERROR: {rule_id}: {summary['salvaged_sample_count']} of "
+        f"{summary['graded_sample_count']} graded judge samples were salvaged "
+        f"from unparseable output ({fraction:.1%}), over the "
+        f"--max-salvaged-fraction bound of {max_fraction:.1%}",
+        file=sys.stderr,
+    )
+    return True
 
 
 def _classify_verdict(verdict: str) -> tuple[bool, bool]:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5444",
+  "version": "0.6.5445",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5445",
+  "version": "0.6.5482",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-measurement-discipline.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-measurement-discipline.md
@@ -107,8 +107,10 @@ correct. Both were about a different question than the one being asked.
 The entry point returns `judge_failed=False` and `judge_salvaged=True` for all
 24. `_recover_verdict` returning `None` means no *embedded complete object* was
 found, which is one route among several; the three top-level integers are still
-extractable, and the function named `_judge_parse_failure` extracts them. Its
-name asserts an outcome it does not produce, which is now issue #4031.
+extractable, and the entry point's record builder extracts them. At the time
+that builder was named `_judge_parse_failure`, a name asserting an outcome its
+primary path does not produce (issue #4031). It is now
+`_salvaged_or_failed_judge`, which names both branches.
 
 Two correct measurements pointed the opposite way from the real behaviour, and
 the reason was reading a name instead of a return value. Had the claim been

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-parser-forensics.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-parser-forensics.md
@@ -72,7 +72,9 @@ this function and each missed what the next found, so "it survived review" is
 weaker evidence here than the round count suggests. Sixteen defects of one
 class is evidence against hand-writing the parser at all (issue #3988, which
 tracks the argument; its round log stops at nine and is not the history of
-record. This document is).
+record. This document is). ADR-091 records what was decided: the bound salvage
+runs under, the residuals accepted, and provider-enforced structured output as
+the exit path.
 
 Round 12 found no defect of that class and was aimed at the two least-tested
 surfaces: the duplicate guard's paired-quote alternation, and the strict-parse

--- a/tests/eval/test_eval_agents_dry_run.py
+++ b/tests/eval/test_eval_agents_dry_run.py
@@ -35,6 +35,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVAL_DIR = REPO_ROOT / "scripts" / "eval"
 AGENTS_SCRIPT = EVAL_DIR / "eval-agents.py"
@@ -361,3 +363,73 @@ class TestEvalSuiteAgentsDryRun:
         assert result["passed"] is False
         assert result["skills"]["demo"]["passed"] is False
         assert result["skills"]["demo"]["exit_code"] == 3
+
+
+class TestJudgeFailureKeepsItsPayload:
+    """A judge payload that does not parse must survive whole (#3975).
+
+    The failure record kept a 200-character prefix of the payload and dropped
+    the rest. That prefix does not reproduce the error the eval saw: cutting a
+    JSON object mid-string re-parses as "Unterminated string" no matter what
+    actually broke it, so the archive named the truncation instead of the
+    judge.
+    """
+
+    @staticmethod
+    def _score(monkeypatch, judge_text):
+        monkeypatch.setattr(
+            eval_agents,
+            "_call_api_for_agents",
+            lambda *_args, **_kwargs: judge_text,
+        )
+        return eval_agents.score_agent_response(
+            "sk-test", "prompt", "response", "expected", "demo"
+        )
+
+    def test_an_unparseable_payload_is_stored_whole(self, monkeypatch):
+        payload = "I will not grade this. " + "x" * 4000
+
+        scores = self._score(monkeypatch, payload)
+
+        assert scores["judge_raw"] == payload
+        assert len(scores["judge_raw"]) > 200
+
+    def test_the_stored_payload_reproduces_the_live_parse_error(self, monkeypatch):
+        # The prefix re-parses as an unterminated string; the whole payload
+        # fails on the missing comma that actually broke it.
+        payload = (
+            '{"role_adherence": 5, "actionability": 4, "quality": 4, '
+            '"appropriateness": 3, "reasoning": "' + "a" * 300 + '" "trailing"}'
+        )
+
+        scores = self._score(monkeypatch, payload)
+
+        assert scores["judge_raw"] == payload
+        with pytest.raises(json.JSONDecodeError) as prefix_error:
+            json.loads(payload[:200])
+        with pytest.raises(json.JSONDecodeError) as whole_error:
+            json.loads(scores["judge_raw"])
+        assert "Unterminated string" in str(prefix_error.value)
+        assert "Unterminated string" not in str(whole_error.value)
+
+    def test_a_clean_payload_stores_no_raw(self, monkeypatch):
+        # Negative control: only a failure carries evidence.
+        payload = (
+            '{"role_adherence": 5, "actionability": 4, "quality": 4, '
+            '"appropriateness": 3, "reasoning": "ok"}'
+        )
+
+        scores = self._score(monkeypatch, payload)
+
+        assert "judge_raw" not in scores
+        assert scores["role_adherence"] == 5
+
+    def test_the_extra_key_does_not_reach_any_average(self, monkeypatch):
+        # Edge: `_avg_scores` reads a fixed dimension list, so a record with
+        # `judge_raw` must average exactly as one without it.
+        scores = self._score(monkeypatch, "not json")
+
+        averaged = eval_agents._avg_scores([scores])
+
+        assert "judge_raw" not in averaged
+        assert set(averaged) == set(eval_agents.DIMENSIONS)

--- a/tests/eval/test_eval_knowledge_integration.py
+++ b/tests/eval/test_eval_knowledge_integration.py
@@ -10,9 +10,12 @@ with an actionable message naming the unprompted skill.
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVAL_DIR = REPO_ROOT / "scripts" / "eval"
@@ -97,3 +100,63 @@ class TestCliZeroPromptGuard:
         assert "no prompts found" not in result.stderr
         assert "STOP" in result.stderr
         assert "NO_DATA" not in result.stderr
+
+
+class TestJudgeFailureKeepsItsPayload:
+    """A judge payload that does not parse must survive whole (#3975).
+
+    The failure record kept a 200-character prefix and dropped the rest. A
+    prefix cut mid-string re-parses as "Unterminated string" whatever actually
+    broke the object, so the archive recorded the truncation's error rather
+    than the judge's.
+    """
+
+    @staticmethod
+    def _score(monkeypatch, judge_text):
+        monkeypatch.setattr(eval_mod, "_call_api", lambda *_args, **_kwargs: judge_text)
+        return eval_mod.score_response("sk-test", "prompt", "response", "expected")
+
+    def test_an_unparseable_payload_is_stored_whole(self, monkeypatch):
+        payload = "I will not grade this. " + "x" * 4000
+
+        scores = self._score(monkeypatch, payload)
+
+        assert scores["judge_raw"] == payload
+        assert len(scores["judge_raw"]) > 200
+
+    def test_the_stored_payload_reproduces_the_live_parse_error(self, monkeypatch):
+        payload = (
+            '{"accuracy": 5, "depth": 4, "specificity": 4, "reasoning": "'
+            + "a" * 300
+            + '" "trailing"}'
+        )
+
+        scores = self._score(monkeypatch, payload)
+
+        assert scores["judge_raw"] == payload
+        with pytest.raises(json.JSONDecodeError) as prefix_error:
+            json.loads(payload[:200])
+        with pytest.raises(json.JSONDecodeError) as whole_error:
+            json.loads(scores["judge_raw"])
+        assert "Unterminated string" in str(prefix_error.value)
+        assert "Unterminated string" not in str(whole_error.value)
+
+    def test_a_clean_payload_stores_no_raw(self, monkeypatch):
+        # Negative control: only a failure carries evidence.
+        scores = self._score(
+            monkeypatch,
+            '{"accuracy": 5, "depth": 4, "specificity": 4, "reasoning": "ok"}',
+        )
+
+        assert "judge_raw" not in scores
+        assert scores["accuracy"] == 5
+
+    def test_the_extra_key_does_not_reach_any_average(self, monkeypatch):
+        # Edge: `_avg_scores` reads a fixed dimension list, so a record with
+        # `judge_raw` averages exactly as one without it.
+        scores = self._score(monkeypatch, "not json")
+
+        averaged = eval_mod._avg_scores([scores])
+
+        assert "judge_raw" not in averaged
+        assert set(averaged) == {"accuracy", "depth", "specificity"}

--- a/tests/eval/test_eval_rule_activation.py
+++ b/tests/eval/test_eval_rule_activation.py
@@ -904,11 +904,13 @@ class TestJudgeSampleReduction:
         assert full["scores"]["judge_failed"] is True
 
     def test_dry_run_counts_repeated_judge_calls(self, tmp_path, capsys):
-        rule_path = REPO_ROOT / ".claude" / "rules" / "working-with-legacy-code.md"
-        if not rule_path.is_file():
-            pytest.skip("working-with-legacy-code.md not present in this checkout")
+        # Was pinned to working-with-legacy-code.md, which left the repository
+        # and took this test with it: the skip fired on every run, and the call
+        # below still passed a bare Path where _process_one_rule now unpacks a
+        # (primary, reference) tuple. A live test caught neither.
+        rule_path = REPO_ROOT / ".claude" / "rules" / "testing.md"
         scenarios_data = {
-            "rule_id": "working-with-legacy-code",
+            "rule_id": "testing",
             "scenarios": [self._scenario()],
         }
         args = type(
@@ -923,7 +925,9 @@ class TestJudgeSampleReduction:
             },
         )()
 
-        _rule_id, result, calls = eval_mod._process_one_rule("key", scenarios_data, rule_path, args)
+        _rule_id, result, calls = eval_mod._process_one_rule(
+            "key", scenarios_data, (rule_path, None), args
+        )
 
         assert result is None
         assert calls == len(eval_mod.MECHANISMS) * 4
@@ -971,6 +975,9 @@ class TestJudgeSampleReduction:
 
 
 _JUDGE = '{"activation_score": 5, "citation_score": 4, "behavior_score": 5}'
+# Stamped on every judge sample so a per-model claim is checkable from the
+# record instead of from the artifact filename (#3975).
+_JUDGE_MODEL = "test-judge-model"
 
 
 def test_extract_json_object_returns_plain_object_unchanged():
@@ -1114,7 +1121,7 @@ def test_a_balanced_object_scan_does_not_reenter_nested_ones():
 
 
 # ---------------------------------------------------------------------------
-# _salvage_scores / _judge_parse_failure: an unparseable `reasoning` field must
+# _salvage_scores / _salvaged_or_failed_judge: an unparseable `reasoning` field must
 # not discard the three numbers the eval actually scores on.
 #
 # Observed in production: 24 of 144 Opus judge samples were thrown away, every
@@ -1264,7 +1271,7 @@ def test_the_ambiguity_refusal_names_itself_rather_than_a_parse_error(monkeypatc
 
     The guard sits before the parse so every path inherits it, including one
     nobody has written yet. Routing an ambiguous payload through
-    ``_judge_parse_failure`` would also refuse it today, but only because
+    ``_salvaged_or_failed_judge`` would also refuse it today, but only because
     ``_salvage_scores`` happens to carry its own copy of the guard. Depending
     on a downstream helper to do the refusing is the coupling that produced
     this defect; asserting on the reason string is what stops a later edit
@@ -2045,10 +2052,11 @@ def test_adjacent_string_literals_are_a_known_undetected_shape(monkeypatch):
     assert result["activation_score"] == 1
 
 
-def test_judge_parse_failure_does_not_combine_partial_objects():
-    result = eval_mod._judge_parse_failure(
+def test_salvaged_or_failed_judge_does_not_combine_partial_objects():
+    result = eval_mod._salvaged_or_failed_judge(
         '{"activation_score": 5}\n{"citation_score": 4, "behavior_score": 3}',
         "parse error",
+        _JUDGE_MODEL,
     )
 
     assert result["judge_failed"] is True
@@ -2104,47 +2112,59 @@ def test_salvage_refuses_a_score_field_spelled_with_a_unicode_escape():
 
 
 def test_salvage_scores_reject_duplicate_fields_before_reasoning():
-    result = eval_mod._judge_parse_failure(
+    result = eval_mod._salvaged_or_failed_judge(
         '{"activation_score": 4, "activation_score": 5, '
         '"citation_score": 3, "behavior_score": 5, "reasoning": "broken"}',
         "parse error",
+        _JUDGE_MODEL,
     )
 
     assert result["judge_failed"] is True
 
 
-def test_judge_parse_failure_salvages_scores_from_unescaped_quote_prose():
-    result = eval_mod._judge_parse_failure(_UNESCAPED_QUOTE_JUDGE, "judge parse error")
+def test_salvaged_or_failed_judge_salvages_scores_from_unescaped_quote_prose():
+    result = eval_mod._salvaged_or_failed_judge(
+        _UNESCAPED_QUOTE_JUDGE, "judge parse error", _JUDGE_MODEL
+    )
 
     assert result["judge_failed"] is False
     assert result["judge_salvaged"] is True
     assert result["activation_score"] == 5
     assert result["citation_score"] == 4
     assert result["behavior_score"] == 5
+    assert result["judge_raw"] == _UNESCAPED_QUOTE_JUDGE
+    assert result["judge_model"] == _JUDGE_MODEL
 
 
-def test_judge_parse_failure_still_fails_when_no_scores_are_present():
-    result = eval_mod._judge_parse_failure("I refuse to grade this.", "parse error")
+def test_salvaged_or_failed_judge_still_fails_when_no_scores_are_present():
+    result = eval_mod._salvaged_or_failed_judge(
+        "I refuse to grade this.", "parse error", _JUDGE_MODEL
+    )
 
     assert result["judge_failed"] is True
     assert result["activation_score"] == 0
     assert "judge_salvaged" not in result
+    assert result["judge_raw"] == "I refuse to grade this."
+    assert result["judge_model"] == _JUDGE_MODEL
 
 
-def test_judge_parse_failure_does_not_invent_a_missing_field():
+def test_salvaged_or_failed_judge_does_not_invent_a_missing_field():
     """Two of three is not a score. Salvage must be all-or-nothing."""
-    result = eval_mod._judge_parse_failure(
-        '{"activation_score": 5, "citation_score": 4}', "missing behavior_score"
+    result = eval_mod._salvaged_or_failed_judge(
+        '{"activation_score": 5, "citation_score": 4}',
+        "missing behavior_score",
+        _JUDGE_MODEL,
     )
 
     assert result["judge_failed"] is True
     assert result["behavior_score"] == 0
 
 
-def test_judge_parse_failure_rejects_a_non_numeric_score():
-    result = eval_mod._judge_parse_failure(
+def test_salvaged_or_failed_judge_rejects_a_non_numeric_score():
+    result = eval_mod._salvaged_or_failed_judge(
         '{"activation_score": "high", "citation_score": 4, "behavior_score": 5}',
         "non-numeric activation_score",
+        _JUDGE_MODEL,
     )
 
     assert result["judge_failed"] is True
@@ -2152,9 +2172,10 @@ def test_judge_parse_failure_rejects_a_non_numeric_score():
 
 @pytest.mark.parametrize("activation_score", ["0", "6", "-1", "05", "5.0", "5e0", "5junk"])
 def test_salvage_scores_rejects_an_invalid_value(activation_score):
-    salvaged = eval_mod._judge_parse_failure(
+    salvaged = eval_mod._salvaged_or_failed_judge(
         f'{{"activation_score": {activation_score}, "citation_score": 4, "behavior_score": 3}} "',
         "parse error",
+        _JUDGE_MODEL,
     )
 
     assert salvaged["judge_failed"] is True
@@ -2850,8 +2871,8 @@ def test_a_fenced_exemplar_after_the_verdict_does_not_win(
     assert result["judge_failed"] is True
     assert result["activation_score"] == 0
     # The recorded payload is the original, not the fence body, so the
-    # archived error prefix shows what the judge actually emitted.
-    assert "actual verdict" in result["reasoning"]
+    # archive shows what the judge actually emitted.
+    assert result["judge_raw"] == payload
 
 
 def test_a_lone_fenced_verdict_is_recovered_and_marked(
@@ -4977,3 +4998,501 @@ class TestTheHeadlineNeedsAWholePool:
         assert summary["best_mechanism"] is None
         assert summary["best_mechanism_partial"] is False
         assert "Best mechanism: none measured" in eval_mod.render_table("r", summary)
+
+
+# ---------------------------------------------------------------------------
+# Judge failures keep their evidence and name their model (issue #3975),
+# and the helper that grades them is named for what it returns (issue #4031)
+# ---------------------------------------------------------------------------
+
+
+def _parse_error_offset(payload: str) -> int:
+    try:
+        json.loads(payload)
+    except json.JSONDecodeError as exc:
+        return exc.pos
+    raise AssertionError("payload parses; it cannot exercise the failure path")
+
+
+def _parse_error_text(payload: str) -> str:
+    try:
+        json.loads(payload)
+    except json.JSONDecodeError as exc:
+        return str(exc)
+    raise AssertionError("payload parses; it cannot exercise the failure path")
+
+
+def _payload_failing_past(offset: int) -> str:
+    """An unparseable verdict whose JSON error sits past ``offset`` characters.
+
+    Shaped like the 24 archived failures: a well-formed score triple, then a
+    ``reasoning`` string long enough to push the damage out of any short
+    window, then an unescaped quote that breaks the object.
+    """
+    prose = "the response cited the rule and gated the behavior. " * 20
+    payload = (
+        '{"activation_score": 5, "citation_score": 4, "behavior_score": 3, '
+        f'"reasoning": "{prose}he said "no" loudly"}}'
+    )
+    assert _parse_error_offset(payload) > offset
+    return payload
+
+
+class TestJudgeFailureEvidence:
+    """A stored failure must reproduce the error the eval saw live.
+
+    The 200-character prefix that used to stand in for the payload did not:
+    19 of the 24 archived failures re-parse as "Unterminated string starting
+    at" while every real payload failed on a missing comma, at offsets 162 to
+    421.
+    """
+
+    def test_a_parse_failure_stores_the_whole_payload(self, monkeypatch):
+        payload = "I cannot grade this. " + _payload_failing_past(200)
+
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_failed"] is True
+        assert result["judge_raw"] == payload
+
+    def test_a_stored_failure_reparses_to_the_error_seen_live(self, monkeypatch):
+        payload = "I cannot grade this. " + _payload_failing_past(200)
+
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert _parse_error_text(result["judge_raw"]) == _parse_error_text(payload)
+
+    def test_the_stored_payload_no_longer_fabricates_a_parse_error(self, monkeypatch):
+        # The archived shape: the verdict leads the payload, so the record is
+        # salvaged rather than failed, and the evidence still has to survive.
+        payload = _payload_failing_past(200)
+
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_salvaged"] is True
+        assert result["judge_raw"] == payload
+        # The prefix the old cap kept re-parses as an unterminated string,
+        # which is the truncation's error, not the judge's.
+        assert "Unterminated string" in _parse_error_text(payload[:200])
+        assert "Unterminated string" not in _parse_error_text(result["judge_raw"])
+        assert "Expecting ',' delimiter" in _parse_error_text(result["judge_raw"])
+
+    def test_judge_raw_is_not_truncated_on_a_long_payload(self, monkeypatch):
+        payload = "x" * 5000
+
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_failed"] is True
+        assert len(result["judge_raw"]) == 5000
+
+    def test_a_clean_verdict_stores_no_raw_payload(self, monkeypatch):
+        result = _score_with_judge_text(monkeypatch, _JUDGE)
+
+        assert result["judge_failed"] is False
+        assert "judge_raw" not in result
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # Two verdicts named in one parseable payload: the refusal at the
+            # ambiguity guard.
+            '{"activation_score": 5, "citation_score": 4, "behavior_score": 3, '
+            '"reasoning": "see {\\"activation_score\\": 1}"}',
+            # Parseable JSON that is not an object.
+            "[1, 2, 3]",
+        ],
+    )
+    def test_the_sibling_refusals_also_store_the_payload(self, monkeypatch, payload):
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_failed"] is True
+        assert result["judge_raw"] == payload
+
+
+class TestJudgeSampleRecordsItsModel:
+    """Acceptance 3 of #3975: model identity readable from the sample record.
+
+    Before this, model was recoverable only from the artifact filename, so a
+    per-model claim could not be checked without parsing paths.
+    """
+
+    @staticmethod
+    def _score(monkeypatch, judge_text):
+        monkeypatch.setattr(eval_mod, "_call_api", lambda *_a, **_k: judge_text)
+        return eval_mod.score_response(
+            "sk-test",
+            {"input": "x", "expected_gate": "apply-rule"},
+            "response",
+            model=_JUDGE_MODEL,
+        )
+
+    def test_a_clean_verdict_records_the_model(self, monkeypatch):
+        assert self._score(monkeypatch, _JUDGE)["judge_model"] == _JUDGE_MODEL
+
+    def test_a_salvaged_verdict_records_the_model(self, monkeypatch):
+        result = self._score(monkeypatch, _UNESCAPED_QUOTE_JUDGE)
+
+        assert result["judge_salvaged"] is True
+        assert result["judge_model"] == _JUDGE_MODEL
+
+    def test_a_hard_failure_records_the_model(self, monkeypatch):
+        result = self._score(monkeypatch, "I refuse to grade this.")
+
+        assert result["judge_failed"] is True
+        assert result["judge_model"] == _JUDGE_MODEL
+
+    def test_a_judge_api_failure_records_the_model(self, monkeypatch):
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("judge is down")
+
+        monkeypatch.setattr(eval_mod, "_call_api", lambda *_a, **_k: "response text")
+        monkeypatch.setattr(eval_mod, "score_response", _boom)
+        monkeypatch.setattr(eval_mod.time, "sleep", lambda _s: None)
+
+        result = eval_mod.eval_one_scenario(
+            "sk-test",
+            {"description": "d", "body": "b", "name": "n"},
+            "rule-id",
+            {"id": "S1", "input": "x", "expected_gate": "apply-rule"},
+            _JUDGE_MODEL,
+            dry_run=False,
+            judge_repeats=1,
+        )
+
+        sample = result["mechanisms"]["baseline"]["score_samples"][0]
+        assert sample["judge_failed"] is True
+        assert sample["judge_model"] == _JUDGE_MODEL
+
+
+def test_the_inverted_helper_name_is_gone():
+    """#4031: the old name asserted an outcome its primary path never produces."""
+    assert not hasattr(eval_mod, "_judge_parse_failure")
+    assert hasattr(eval_mod, "_salvaged_or_failed_judge")
+
+
+# ---------------------------------------------------------------------------
+# Gates read the unrounded average (issue #4070)
+# ---------------------------------------------------------------------------
+
+
+def _straddling_scenario(
+    sample: dict[str, object],
+    negative: bool = False,
+    baseline_sample: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """One scenario whose non-baseline cells carry ``sample``."""
+    mech = _mech_from([sample])
+    mechanisms = {name: mech for name in eval_mod.MECHANISMS}
+    if baseline_sample is not None:
+        mechanisms["baseline"] = _mech_from([baseline_sample])
+    return {"negative_case": negative, "mechanisms": mechanisms}
+
+
+def _straddling_pool(
+    low_count: int,
+    high_count: int,
+    negative: bool = False,
+    baseline_sample: dict[str, object] | None = None,
+) -> list[dict[str, object]]:
+    """A pool whose exact mean lands inside the 0.005 rounding window at 3.5.
+
+    ``_mixed(4, 3, 3)`` reduces to 10/3 and ``_mixed(4, 4, 3)`` to 11/3. 18 of
+    the first and 17 of the second average 367/105 = 3.49524, which the table
+    rounds to 3.5. Swap the counts for 368/105 = 3.50476, which also rounds to
+    3.5 but sits above the floor.
+    """
+    low = [
+        _straddling_scenario(_mixed(4, 3, 3), negative, baseline_sample)
+        for _ in range(low_count)
+    ]
+    high = [
+        _straddling_scenario(_mixed(4, 4, 3), negative, baseline_sample)
+        for _ in range(high_count)
+    ]
+    return low + high
+
+
+class TestGatesReadTheUnroundedAverage:
+    def test_a_restraint_average_inside_the_rounding_window_fails(self):
+        scenarios = [_make_scenario(baseline=1, description=5, full=5)]
+        scenarios += _straddling_pool(18, 17, negative=True)
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["verdict"] == "FAIL_OVER_ACTIVATION"
+        # The table still prints the rounded number; only the gate changed.
+        assert summary["worst_negative_avg"] == 3.5
+        assert summary["worst_negative_avg_exact"] < eval_mod.MIN_RESTRAINT_SCORE
+
+    def test_a_restraint_average_that_rounds_down_to_the_floor_still_passes(self):
+        scenarios = [_make_scenario(baseline=1, description=5, full=5)]
+        scenarios += _straddling_pool(17, 18, negative=True)
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["worst_negative_avg"] == 3.5
+        assert summary["worst_negative_avg_exact"] > eval_mod.MIN_RESTRAINT_SCORE
+        assert summary["verdict"] == "PASS"
+
+    def test_a_description_average_inside_the_rounding_window_fails(self):
+        scenarios = _straddling_pool(18, 17, baseline_sample=_mixed(1, 1, 1))
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["per_mechanism"]["description"]["avg_score"] == 3.5
+        assert summary["verdict"] == "FAIL_THRESHOLD"
+
+    def test_a_delta_inside_the_rounding_window_fails(self):
+        # Baseline exact 3.50476 rounds to 3.5, description is exactly 4.0.
+        # The rounded delta is 0.5 and clears the gate; the true delta is
+        # 0.49524 and does not.
+        baseline_samples = [_mixed(4, 3, 3)] * 17 + [_mixed(4, 4, 3)] * 18
+        scenarios = [
+            _straddling_scenario(_mixed(4, 4, 4), baseline_sample=sample)
+            for sample in baseline_samples
+        ]
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["baseline_avg"] == 3.5
+        assert summary["delta_description_vs_baseline"] == 0.5
+        assert summary["delta_description_vs_baseline_exact"] < 0.5
+        assert summary["verdict"] == "FAIL_NO_DELTA"
+
+    def test_a_clean_pool_is_unaffected(self):
+        scenarios = [
+            _make_scenario(baseline=1, description=5, full=5),
+            _make_scenario(baseline=1, description=5, full=5, negative=True),
+        ]
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["verdict"] == "PASS"
+        assert summary["worst_negative_avg"] == 5.0
+        assert summary["worst_negative_avg_exact"] == 5.0
+
+    def test_an_ungraded_negative_pool_reports_no_exact_average(self):
+        summary = eval_mod.aggregate([_make_scenario(baseline=1, description=5, full=5)])
+
+        assert summary["worst_negative_avg"] is None
+        assert summary["worst_negative_avg_exact"] is None
+        assert summary["verdict"] == "PASS"
+
+    def test_the_worst_mechanism_is_named_off_the_unrounded_average(self):
+        scenarios = [
+            _make_scenario(baseline=1, description=5, full=5),
+            {
+                "negative_case": True,
+                "mechanisms": {
+                    "baseline": _mech_from([_mixed(5, 5, 5)]),
+                    "description": _mech_from([_mixed(4, 3, 3)]),
+                    "full": _mech_from([_mixed(4, 4, 3)]),
+                },
+            },
+        ]
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["worst_negative_mechanism"] == "description"
+
+
+class TestRoundingDisclosure:
+    def test_the_table_discloses_a_restraint_number_that_rounds_over_the_floor(self):
+        scenarios = [_make_scenario(baseline=1, description=5, full=5)]
+        scenarios += _straddling_pool(18, 17, negative=True)
+
+        table = eval_mod.render_table("some-rule", eval_mod.aggregate(scenarios))
+
+        assert "Restraint 3.4952 gated below the 3.5 floor" in table
+
+    def test_no_disclosure_when_display_and_gate_agree(self):
+        scenarios = [
+            _make_scenario(baseline=1, description=5, full=5),
+            _make_scenario(baseline=1, description=5, full=5, negative=True),
+        ]
+
+        table = eval_mod.render_table("some-rule", eval_mod.aggregate(scenarios))
+
+        assert "gated below" not in table
+
+    def test_an_unusable_pair_produces_no_disclosure(self):
+        assert eval_mod._floor_display_gap("Restraint", float("nan"), 3.5, 3.5) is None
+        assert eval_mod._floor_display_gap("Restraint", None, 3.5, 3.5) is None
+        assert eval_mod._floor_display_gap("Restraint", 3.4, None, 3.5) is None
+
+
+# ---------------------------------------------------------------------------
+# The salvage marker survives reduction and bounds the run (issue #3988)
+# ---------------------------------------------------------------------------
+
+
+def _salvaged_sample(score: int = 5) -> dict[str, object]:
+    sample = _mixed(score, score, score)
+    sample["judge_salvaged"] = True
+    return sample
+
+
+class TestSalvagedSampleCount:
+    def test_a_salvaged_sample_is_counted_on_the_reduced_cell(self):
+        reduced = eval_mod._reduce_score_samples(
+            [_mixed(5, 5, 5), _salvaged_sample(), _mixed(4, 4, 4)], "median"
+        )
+
+        assert reduced["graded"] is True
+        assert reduced["salvaged_sample_count"] == 1
+
+    def test_clean_samples_count_zero(self):
+        reduced = eval_mod._reduce_score_samples([_mixed(5, 5, 5)] * 3, "median")
+
+        assert reduced["salvaged_sample_count"] == 0
+
+    def test_an_all_failed_cell_reports_zero_and_ungraded(self):
+        failed = [{"judge_failed": True, "reasoning": "boom"}] * 3
+
+        reduced = eval_mod._reduce_score_samples(failed, "median")
+
+        assert reduced["graded"] is False
+        assert reduced["salvaged_sample_count"] == 0
+
+    def test_the_counts_add_up_across_mechanisms_and_scenarios(self):
+        scenarios = [
+            _scenario_from(_mech_from([_salvaged_sample(), _mixed(5, 5, 5)])),
+            _scenario_from(_mech_from([_mixed(5, 5, 5), _mixed(4, 4, 4)])),
+        ]
+
+        salvaged, graded = eval_mod._salvage_counts(scenarios)
+
+        # Three mechanisms per scenario, two samples each.
+        assert (salvaged, graded) == (3, 12)
+
+    def test_an_archived_cell_without_the_key_contributes_nothing(self):
+        salvaged, graded = eval_mod._salvage_counts(
+            [_make_scenario(baseline=5, description=5, full=5)]
+        )
+
+        assert (salvaged, graded) == (0, 0)
+
+    def test_the_run_summary_publishes_the_fraction(self):
+        scenarios = [_scenario_from(_mech_from([_salvaged_sample(), _mixed(5, 5, 5)]))]
+
+        summary = eval_mod.aggregate(scenarios)
+
+        assert summary["salvaged_sample_count"] == 3
+        assert summary["graded_sample_count"] == 6
+        assert summary["salvaged_sample_fraction"] == pytest.approx(0.5)
+
+    def test_a_run_with_no_graded_samples_reports_no_fraction(self):
+        summary = eval_mod.aggregate([_make_scenario(baseline=5, description=5, full=5)])
+
+        assert summary["salvaged_sample_fraction"] is None
+
+
+class TestSalvageGate:
+    def test_a_run_at_the_bound_passes(self, capsys):
+        summary = {
+            "salvaged_sample_fraction": 0.15,
+            "salvaged_sample_count": 3,
+            "graded_sample_count": 20,
+        }
+
+        assert eval_mod._salvage_gate_failed("r", summary, 0.15) is False
+        assert capsys.readouterr().err == ""
+
+    def test_a_run_one_notch_over_the_bound_fails(self, capsys):
+        summary = {
+            "salvaged_sample_fraction": 0.16,
+            "salvaged_sample_count": 4,
+            "graded_sample_count": 25,
+        }
+
+        assert eval_mod._salvage_gate_failed("r", summary, 0.15) is True
+        assert "16.0%" in capsys.readouterr().err
+
+    def test_a_run_that_measured_nothing_does_not_fire(self):
+        assert (
+            eval_mod._salvage_gate_failed("r", {"salvaged_sample_fraction": None}, 0.0)
+            is False
+        )
+
+    def test_the_archive_baseline_fraction_is_under_the_default(self):
+        # 24 of 288 samples, the measured rate the default was chosen above.
+        assert 24 / 288 < eval_mod.DEFAULT_MAX_SALVAGED_FRACTION
+
+
+class TestSalvageGateExitCodes:
+    """The bound has to reach the process boundary, not just a helper."""
+
+    @staticmethod
+    def _scenario_file(tmp_path):
+        path = tmp_path / "scenarios.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "rule_id": "testing",
+                    "rule_path": ".claude/rules/testing.md",
+                    "scenarios": [
+                        {
+                            "id": "S1",
+                            "input": "do the thing",
+                            "expected_gate": "apply-rule",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def _run(self, monkeypatch, tmp_path, extra_argv):
+        monkeypatch.setattr(eval_mod, "_load_api_key", lambda: "sk-test")
+        monkeypatch.setattr(eval_mod, "verify_model_available", lambda *_a: None)
+        # One salvaged sample of three per rule-enhanced cell, so the run
+        # exceeds the default bound while its verdict is a clean PASS. The
+        # gate has to be what fails it, not the scores.
+        rule_cell = _mech_from([_salvaged_sample(), _mixed(5, 5, 5)])
+        scenario_result = {
+            "id": "S1",
+            "desc": "",
+            "negative_case": False,
+            "mechanisms": {
+                "baseline": _mech_from([_mixed(1, 1, 1), _mixed(1, 1, 1)]),
+                "description": rule_cell,
+                "full": rule_cell,
+            },
+        }
+        monkeypatch.setattr(
+            eval_mod, "eval_one_scenario", lambda *_a, **_k: scenario_result
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "eval-rule-activation.py",
+                "--scenarios",
+                str(self._scenario_file(tmp_path)),
+                *extra_argv,
+            ],
+        )
+        return eval_mod.main()
+
+    def test_a_run_over_the_bound_exits_one(self, monkeypatch, tmp_path, capsys):
+        code = self._run(monkeypatch, tmp_path, [])
+
+        assert code == 1
+        assert "--max-salvaged-fraction" in capsys.readouterr().err
+
+    def test_raising_the_bound_lets_the_same_run_pass(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        code = self._run(monkeypatch, tmp_path, ["--max-salvaged-fraction", "1.0"])
+
+        assert code == 0
+        assert "--max-salvaged-fraction" not in capsys.readouterr().err
+
+    def test_a_bound_outside_zero_to_one_is_a_config_error(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        code = self._run(monkeypatch, tmp_path, ["--max-salvaged-fraction", "1.5"])
+
+        assert code == 2
+        assert "must be between 0 and 1" in capsys.readouterr().err

--- a/tests/eval/test_eval_rule_activation.py
+++ b/tests/eval/test_eval_rule_activation.py
@@ -5109,6 +5109,86 @@ class TestJudgeFailureEvidence:
         assert result["judge_raw"] == payload
 
 
+# The round-9 residual, verbatim: a well-formed verdict object at offset 0
+# followed by an explicit English refusal. The prefix recovery reads the object
+# and publishes 5/5/5; the refusal is the only text saying the triple is wrong.
+_PREFIX_RECOVERY_REFUSAL = (
+    '{"activation_score": 5, "citation_score": 5, "behavior_score": 5, '
+    '"reasoning": "example"}\n\n'
+    "Actually, I cannot score this response: the rule text was not provided."
+)
+
+
+class TestPrefixRecoveryKeepsItsPayload:
+    """The third salvage path stored no evidence, and the gate counted it.
+
+    `_salvaged_or_failed_judge` keeps `judge_raw` on both of its branches, but
+    `score_response` has its own salvage path: whole-payload parse fails,
+    `_recover_verdict` returns the leading object, and the record used to carry
+    `judge_salvaged: True` with no payload at all. `_reduce_score_samples`
+    counts those toward `salvaged_sample_count`, so they feed the
+    `--max-salvaged-fraction` bound, and an operator whose run tripped the
+    bound found evidence for some salvaged samples and nothing for these.
+    """
+
+    def test_a_prefix_recovery_stores_the_whole_payload(self, monkeypatch):
+        result = _score_with_judge_text(monkeypatch, _PREFIX_RECOVERY_REFUSAL)
+
+        assert result["judge_salvaged"] is True
+        assert result["judge_failed"] is False
+        assert result["judge_raw"] == _PREFIX_RECOVERY_REFUSAL
+
+    def test_the_stored_payload_keeps_the_refusal_the_scores_contradict(
+        self, monkeypatch
+    ):
+        # The published triple is 5/5/5 and the payload says the judge refused.
+        # Recording the refusal is the whole point: the residual is accepted by
+        # design, so the artifact has to let a reader find it.
+        result = _score_with_judge_text(monkeypatch, _PREFIX_RECOVERY_REFUSAL)
+
+        assert result["activation_score"] == 5
+        assert "I cannot score this response" in result["judge_raw"]
+
+    def test_a_prefix_recovery_is_not_truncated(self, monkeypatch):
+        # `score_response` strips the payload before parsing, so build one with
+        # no trailing whitespace and assert the body survives whole.
+        payload = _JUDGE + "\n" + ".".join(["trailing prose"] * 500)
+
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_salvaged"] is True
+        assert result["judge_raw"] == payload
+        assert len(result["judge_raw"]) > 5000
+
+    def test_a_clean_payload_still_stores_no_raw(self, monkeypatch):
+        # Negative control. Only salvaged and failed records carry evidence;
+        # a clean parse has nothing to explain.
+        result = _score_with_judge_text(monkeypatch, _JUDGE)
+
+        assert "judge_salvaged" not in result
+        assert "judge_raw" not in result
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # Prefix recovery: the object leads, prose follows.
+            _PREFIX_RECOVERY_REFUSAL,
+            # Root scan through `_salvaged_or_failed_judge`: the leading object
+            # is itself malformed, so the scores come off its readable members.
+            _UNESCAPED_QUOTE_JUDGE,
+        ],
+    )
+    def test_every_salvaged_sample_the_gate_counts_carries_its_payload(
+        self, monkeypatch, payload
+    ):
+        # One invariant over both salvage paths. The `--max-salvaged-fraction`
+        # bound does not distinguish them, so neither may the evidence.
+        result = _score_with_judge_text(monkeypatch, payload)
+
+        assert result["judge_salvaged"] is True
+        assert result["judge_raw"] == payload
+
+
 class TestJudgeSampleRecordsItsModel:
     """Acceptance 3 of #3975: model identity readable from the sample record.
 
@@ -5210,6 +5290,73 @@ def _straddling_pool(
         for _ in range(high_count)
     ]
     return low + high
+
+
+def _split_pool(
+    description_low: int, full_low: int, pool_size: int = 35
+) -> list[dict[str, object]]:
+    """A pool where `description` and `full` round alike but differ exactly.
+
+    `_mixed(4, 3, 3)` reduces to 10/3 and `_mixed(4, 4, 3)` to 11/3. Over 35
+    scenarios, 18 low and 17 high average 3.49524 while 17 low and 18 high
+    average 3.50476. Both print as 3.5, so a ranking that reads the rounded
+    column cannot tell them apart and falls back to `MECHANISMS` order.
+    """
+    scenarios: list[dict[str, object]] = []
+    for index in range(pool_size):
+        scenarios.append(
+            {
+                "negative_case": False,
+                "mechanisms": {
+                    "baseline": _mech_from([_mixed(1, 1, 1)]),
+                    "description": _mech_from(
+                        [_mixed(4, 3, 3) if index < description_low else _mixed(4, 4, 3)]
+                    ),
+                    "full": _mech_from(
+                        [_mixed(4, 3, 3) if index < full_low else _mixed(4, 4, 3)]
+                    ),
+                },
+            }
+        )
+    return scenarios
+
+
+class TestBestMechanismRanksOnTheUnroundedAverage:
+    """The headline named the wrong mechanism inside the rounding window.
+
+    `worst_negative_mechanism` already ranked on `avg_score_exact`; its
+    positive sibling still ranked on the rounded column, where two mechanisms
+    0.01 apart tie and `max` keeps whichever `MECHANISMS` lists first.
+    """
+
+    def test_the_higher_exact_average_wins_a_rounded_tie(self):
+        # `full` is exactly higher; both print 3.5. `description` is listed
+        # first, so a rounded ranking would hand it the headline.
+        summary = eval_mod.aggregate(_split_pool(description_low=18, full_low=17))
+
+        assert summary["per_mechanism"]["description"]["avg_score"] == 3.5
+        assert summary["per_mechanism"]["full"]["avg_score"] == 3.5
+        assert (
+            summary["per_mechanism"]["full"]["avg_score_exact"]
+            > summary["per_mechanism"]["description"]["avg_score_exact"]
+        )
+        assert summary["best_mechanism"] == "full"
+
+    def test_the_ranking_still_follows_the_other_direction(self):
+        # Negative control: swap which mechanism is exactly higher and the
+        # headline follows, so the assertion above is not passing on list order.
+        summary = eval_mod.aggregate(_split_pool(description_low=17, full_low=18))
+
+        assert summary["per_mechanism"]["description"]["avg_score"] == 3.5
+        assert summary["per_mechanism"]["full"]["avg_score"] == 3.5
+        assert summary["best_mechanism"] == "description"
+
+    def test_the_published_headline_average_stays_rounded(self):
+        # Edge: only the ranking key changed. `best_avg_score` is still the
+        # rounded number, so archived runs replay field for field.
+        summary = eval_mod.aggregate(_split_pool(description_low=18, full_low=17))
+
+        assert summary["best_avg_score"] == 3.5
 
 
 class TestGatesReadTheUnroundedAverage:
@@ -5385,6 +5532,46 @@ class TestSalvagedSampleCount:
         summary = eval_mod.aggregate([_make_scenario(baseline=5, description=5, full=5)])
 
         assert summary["salvaged_sample_fraction"] is None
+
+
+class TestSalvageDisclosureInTheReport:
+    """The bound moved the exit code and the report said nothing.
+
+    `_salvage_gate_failed` prints to stderr and flips the exit code. The
+    rendered table, which is what a reader keeps, showed a clean verdict beside
+    a non-zero exit with nothing explaining it: the same
+    publish-a-number-that-contradicts-the-verdict shape the rounding caveats
+    exist to remove.
+    """
+
+    def test_the_table_names_the_salvage_rate(self):
+        scenarios = [_scenario_from(_mech_from([_salvaged_sample(), _mixed(5, 5, 5)]))]
+
+        table = eval_mod.render_table("r", eval_mod.aggregate(scenarios))
+
+        assert "Salvaged judge samples: 3 of 6 graded (50.0%)" in table
+        assert "--max-salvaged-fraction" in table
+
+    def test_a_run_with_no_salvage_prints_no_disclosure(self):
+        # Negative control: the line must distinguish, not decorate.
+        scenarios = [_scenario_from(_mech_from([_mixed(5, 5, 5)] * 2))]
+
+        table = eval_mod.render_table("r", eval_mod.aggregate(scenarios))
+
+        assert "Salvaged judge samples" not in table
+
+    def test_an_archived_summary_without_the_keys_prints_no_disclosure(self):
+        # Edge: artifacts predating the counters carry neither key.
+        assert eval_mod._salvage_caveat({}) is None
+
+    def test_a_count_without_a_fraction_still_discloses(self):
+        # Edge: a hand-built or partial summary must not crash the renderer.
+        line = eval_mod._salvage_caveat(
+            {"salvaged_sample_count": 2, "graded_sample_count": 0}
+        )
+
+        assert line is not None
+        assert "2 of 0 graded" in line
 
 
 class TestSalvageGate:


### PR DESCRIPTION
## Summary

The rule-activation eval stored a 200-character prefix of every judge payload that failed to parse. Measured failure offsets across the 24 archived failures run 162 to 421, so the window cut the damage out: re-parsing the stored prefixes yields "Unterminated string starting at" 19 times while the real payloads yield "Expecting ',' delimiter" 24 times. The archive recorded the truncation, not the judge. Operators reading a failed run got a fabricated cause.

That one storage decision hid three more defects in the same file, each filed separately. The gates compared display-rounded averages against their floors, so a negative pool measuring 3.49524 published 3.5 and returned PASS instead of FAIL_OVER_ACTIVATION. The `judge_salvaged` marker was written twice and read nowhere, so no gate could bound how much of a verdict came from recovery. And `_judge_parse_failure` returned `judge_failed: False` on its primary path, which is the opposite of what the name says.

All four are now fixed. Every failed and salvaged judge record carries the whole payload under `judge_raw`, on all three salvage paths and in both sibling scorers. Every judge sample carries `judge_model`, including the RuntimeError path, so a per-model claim is checkable from the record instead of the artifact filename. Every gate reads an exact average while the table keeps publishing the rounded one, so archived runs replay field for field. The salvage marker survives reduction, reaches the run summary, and `--max-salvaged-fraction` fails the run when recovery carried more of the verdict than the bound allows. ADR-091 records the decision to keep the hand-written recovery path rather than delete it, the round-9 residual it accepts, and provider-enforced structured output as the exit path.

Fixes #3975
Fixes #4070
Fixes #4031
Fixes #3988

## What changed

| File | Why |
|---|---|
| `scripts/eval/eval-rule-activation.py` | All four defects live here. Stores the whole payload under `judge_raw` on every failure and salvage path, stamps `judge_model` on every sample, emits `avg_score_exact` beside the rounded `avg_score` and points every gate at it, propagates `judge_salvaged` through reduction as `salvaged_sample_count` and `salvaged_sample_fraction`, adds the `--max-salvaged-fraction` bound, and renames `_judge_parse_failure` to `_salvaged_or_failed_judge` with the return contract stated in the docstring. |
| `scripts/eval/eval-agents.py` | Same truncation shape at the zero-score failure record. Now stores `judge_raw` alongside the truncated reasoning line. `_avg_scores` reads a fixed dimension list, so the extra key reaches no average. |
| `scripts/eval/eval-knowledge-integration.py` | Same truncation shape, same fix, same reason the extra key is inert. |
| `tests/eval/test_eval_rule_activation.py` | Payload retention on all three paths, the cross-path invariant that every salvaged sample the gate counts carries its payload, model stamping on four sample kinds, rounding-window boundary tests for all three gates, rounded-tie ranking, and the salvage disclosure with its negative controls. Also revives `test_dry_run_counts_repeated_judge_calls`, which skipped on every run since its pinned rule file left the repository. |
| `tests/eval/test_eval_agents_dry_run.py` | New. Whole payload stored, the stored payload reproduces the live parse error while the 200-character prefix does not, a clean payload stores no raw, and the extra key reaches no average. |
| `tests/eval/test_eval_knowledge_integration.py` | New, same four cases for the second sibling scorer. |
| `.agents/architecture/ADR-091-judge-verdict-recovery-bounds.md` | New. Four files on this branch cited ADR-091 while the file itself was untracked. Records the decision, the accepted residual, and the exit path. |
| `.agents/analysis/ADR-091-debate-log.md` | New. Records the review that actually happened and states plainly that the adr-review six-agent debate did not run, because this harness exposes no Task tool. |
| `.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/README.md` | Told readers only 200 characters of each payload survive. `recovered-judge-payloads.json` sits in the same directory with the full raw for all 288 samples and the README never mentioned it. |
| `.claude/skills/context-optimizer/references/rule-audit-measurement-discipline.md` | Named `_judge_parse_failure` in prose and called the name an outcome it does not produce. Now records the old name as history and points at the new one. |
| `.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md` | Pointed readers at the issue for the argument. Now also names ADR-091, which records what was decided. |
| `src/copilot-cli/skills/context-optimizer/references/*.md` | Copilot mirrors, regenerated with `build/scripts/generate_skills.py`. |
| `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json` | Both plugin roots ship the changed reference files, so the parity pair moves together to 0.6.5482. |
| `.agents/sessions/2026-07-31-session-3975-eval-recovery-evidence-and-gating.json` | Session log for this work. |
| `.agents/memory/episodes/episode-2026-07-31-session-3975-*.json` | Episode extracted from the session log by the commit hook. |
| `.agents/retrospective/2026-08-01-eval-judge-recovery-evidence.md` | Records the shared root across the four issues, the two tests that passed for the wrong reason on the first pass, and two tooling defects found on the path. |

## Evidence

```
uv run pytest tests/eval/test_eval_rule_activation.py tests/eval/test_eval_agents_dry_run.py tests/eval/test_eval_knowledge_integration.py -q
```

```
396 passed in 4.35s
```

Full suite, run by the pre-push hook against the pushed head:

```
uv run pytest tests/ -q
```

```
19717 passed, 28 skipped, 50 deselected, 2 warnings in 467.07s (0:07:47)
```

Also green: `uv run --extra dev ruff check` on all six changed Python files ("All checks passed!"), `uv run mypy` on the three changed eval scripts ("Success: no issues found in 1 source file" for `eval-rule-activation.py`; the one remaining `eval-agents.py:732` operator error is pre-existing on `main` at line 725 and untouched by this branch), and `uv run python scripts/validation/pre_pr.py` ("RESULT: All validations passed").

Every new regression test was run against pre-fix code and required to fail there.

## Sub-claims covered

### #3975

- 200-character prefix is too short to diagnose a judge parse failure: covered, `scripts/eval/eval-rule-activation.py:1466` states the contract and `:1481`, `:1501`, `:569` store the whole payload.
- The truncation fabricates a cause: covered, `tests/eval/test_eval_rule_activation.py:5065` asserts the stored payload no longer re-parses to a different error than the live one.
- Acceptance 1, a parse failure retains enough of the response to identify the original parse error: covered, `scripts/eval/eval-rule-activation.py:1481` and `:1501`, tested at `tests/eval/test_eval_rule_activation.py:5050`.
- Acceptance 2, re-parsing a stored failure reproduces the error the eval saw live: covered, `tests/eval/test_eval_rule_activation.py:5065` for the primary scorer, `tests/eval/test_eval_agents_dry_run.py:397` and `tests/eval/test_eval_knowledge_integration.py:127` for the siblings.
- Acceptance 3, model identity readable from the sample record: covered, `scripts/eval/eval-rule-activation.py:552`, `:1482`, `:1502`, `:1629`.
- Sibling truncation sites in the same function (the ambiguous two-verdict refusal and the non-object JSON refusal): covered, both route through `_salvaged_or_failed_judge` at `scripts/eval/eval-rule-activation.py:511` and `:545`, tested at `tests/eval/test_eval_rule_activation.py:5105`.
- The RuntimeError judge sample carries no model: covered, `scripts/eval/eval-rule-activation.py:1629`, tested at `tests/eval/test_eval_rule_activation.py:5224`.
- Discovered during triage, the archive README says the evidence is gone while it sits next to the reader: covered, `.agents/analysis/eval-artifacts/2026-07-29-unified-software-engineering/README.md:78` now names `recovered-judge-payloads.json`.

### #4070

- Restraint gate compares a display-rounded average against `MIN_RESTRAINT_SCORE`: covered, the worst negative average is selected off `avg_score_exact` at `scripts/eval/eval-rule-activation.py:1968` and compared at `:2076`. Test at `tests/eval/test_eval_rule_activation.py:5363`.
- Positive activation gate compares the same rounded average: covered, `scripts/eval/eval-rule-activation.py:1836` feeds `_positive_verdict` at `:2050`. Test at `tests/eval/test_eval_rule_activation.py:5384`.
- `round(..., 2)` in `_mechanism_summary` conflates the published value with the gated value: covered, `scripts/eval/eval-rule-activation.py:1795` emits `avg_score_exact` beside the rounded `avg_score`, and the published headline stays rounded (test at `tests/eval/test_eval_rule_activation.py:5354`).
- The fix must preserve the negated `>=` form in `_positive_verdict` so a NaN average fails closed: covered as a non-regression, `scripts/eval/eval-rule-activation.py:2050-2055` keeps the negated form with the reason in the docstring; `tests/eval/test_eval_rule_activation.py:658` still pins NaN failing closed.
- Regression test pinning an average inside the rounding window just below each floor: covered, `tests/eval/test_eval_rule_activation.py:5363`, `:5384`, `:5392`, one per gate.
- Check that the 8 archived artifacts replay unaffected: covered, `tests/eval/test_eval_rule_activation.py:5354` pins the published headline as rounded so archived summaries replay field for field.
- Adjacent, not claimed in the issue: `beats_baseline` subtracts two rounded averages: covered, `scripts/eval/eval-rule-activation.py:2051` now subtracts the exact averages. Test at `tests/eval/test_eval_rule_activation.py:5392`.

### #4031

- `_judge_parse_failure` returns `judge_failed: False` on the salvage path, inverting what the name states: covered, renamed to `_salvaged_or_failed_judge` at `scripts/eval/eval-rule-activation.py:1456`.
- The call site reads as if the sample failed when it did not: covered, `scripts/eval/eval-rule-activation.py:511` and `:545`.
- The docstring does not state the return contract: covered, `scripts/eval/eval-rule-activation.py:1457-1470` states both branches and what each returns.
- The remedy is a rename that states the action rather than the trigger, without colliding with `_salvage_scores`: covered, the new name is `_salvaged_or_failed_judge`; `_salvage_scores` is untouched.
- Consequential, not claimed in the issue: the skill reference naming `_judge_parse_failure` goes stale on rename: covered, `.claude/skills/context-optimizer/references/rule-audit-measurement-discipline.md:111-113` and its Copilot mirror.

### #3988

- The hand-written recovery path still exists, Option 1 (delete) not taken: covered as a decision rather than a code change. ADR-091 records why deleting is wrong: the measurement that motivated deletion was retracted in-repo at `.claude/skills/context-optimizer/references/rule-audit-parser-forensics.md:59-66`.
- Round 9 finding 1, an exemplar object at offset 0 followed by an explicit English refusal still grades 5/5/5: covered as accepted-by-design and now written down. ADR-091 records the residual, and the refusal text is no longer discarded: `tests/eval/test_eval_rule_activation.py:5134` asserts the salvaged record keeps the refusal its scores contradict.
- Option 3, gate the run on the salvage marker: covered, `scripts/eval/eval-rule-activation.py:634` (reduction), `:1726-1728` (run summary), `:2325` (flag), `:2700` (gate). Tests at `tests/eval/test_eval_rule_activation.py:5522` and the exit-code cases at `:5669-5682`.
- Option 2, provider-enforced structured output or tool-call schema: NOT covered by code. ADR-091 names it as the durable exit path and the condition under which it gets built. Implementing it means changing how every provider adapter in `scripts/eval/` requests a verdict, which is a separate change with its own blast radius.
- No ADR records the decision, so it keeps being re-litigated: covered, `.agents/architecture/ADR-091-judge-verdict-recovery-bounds.md`, status proposed.
- Verification is not blind, the same author wrote every parser and every test: NOT covered. This branch does not fix it and cannot: the same constraint applies to this change. `.agents/analysis/ADR-091-debate-log.md` states plainly that the adr-review six-agent debate did not run because this harness exposes no Task tool, and records the three-reviewer review that did happen instead. An independent reviewer on this PR is the mitigation available today.

## Notes for the reviewer

Two defects found on the path, neither fixed here:

- `.claude/skills/session-end/scripts/complete_session_log.py:76` resolves the repository root with `git rev-parse --git-common-dir`, which in a linked worktree points at the main checkout. It auto-detected and wrote to an unrelated session log belonging to another branch; the stray write had to be reverted by hand. Passing `--session-path` with a path inside the worktree then failed with "Session path must be inside '<main checkout>/.agents/sessions'". This is the issue #3402 class, and `.claude/rules/ci-scripts.md` MUST 7 already requires the check this script skips.
- `tests/ci/test_validation_scripts_are_reachable.py:110` skips any path containing a part named `worktrees`. A worktree created under `.claude/worktrees/` therefore has every source skipped, the reference graph comes back empty, and 109 of that file's tests fail with "the probe is not walking the tree". `tests/test_skill_bundle_suites_run.py` fails from the same location for a related reason. Both pass from a worktree outside that path, which is where this branch was pushed from.
