### PR TITLE
fix(ci-scripts): fail loudly on gh and resolver JSON failures (silent-pass audit of PR #4021)

### DIFF
--- a/scripts/ci/find_copilot_ready_issues.py
+++ b/scripts/ci/find_copilot_ready_issues.py
@@ -5,14 +5,9 @@ Replaces the inline bash block in copilot-context-synthesis.yml
 copilot-ready label, then writes space-separated issue numbers and a
 count to GITHUB_OUTPUT.
 
-When gh CLI fails (e.g., no auth in a local test run), the script writes
-count=0 to GITHUB_OUTPUT and exits 0, matching the original pipeline
-behavior where `gh issue list | tr` would absorb a gh failure silently
-(tr exits 0 on empty input). A WARNING is emitted to stderr so the
-degradation is visible in CI logs.
-
 EXIT CODES (ADR-035):
-  0  - Success (includes zero-issues case and graceful gh degradation)
+  0  - Success (includes zero-issues case)
+  1  - gh CLI failure
   2  - Configuration error (GITHUB_OUTPUT not set)
 """
 
@@ -23,11 +18,12 @@ import subprocess
 import sys
 
 EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
 EXIT_CONFIG = 2
 
 
-def find_issues() -> tuple[list[str], int]:
-    """Return (issue_number_list, returncode) from gh CLI."""
+def find_issues() -> tuple[list[str], int, str]:
+    """Return (issue_number_list, returncode, stderr) from gh CLI."""
     result = subprocess.run(
         [
             "gh",
@@ -47,10 +43,10 @@ def find_issues() -> tuple[list[str], int]:
         encoding="utf-8",
     )
     if result.returncode != 0:
-        return [], result.returncode
+        return [], result.returncode, result.stderr
 
     numbers = result.stdout.strip().split() if result.stdout.strip() else []
-    return numbers, 0
+    return numbers, 0, ""
 
 
 def main() -> int:
@@ -60,14 +56,14 @@ def main() -> int:
         return EXIT_CONFIG
 
     print("Searching for issues with copilot-ready label...")
-    numbers, rc = find_issues()
+    numbers, rc, stderr = find_issues()
 
     if rc != 0:
         print(
-            f"WARNING: gh issue list failed (exit {rc}); treating as zero issues",
+            f"::error::gh issue list failed (exit {rc}): {stderr}",
             file=sys.stderr,
         )
-        numbers = []
+        return EXIT_FAILURE
 
     issues = " ".join(numbers)
     count = len(numbers)

--- a/scripts/ci/find_copilot_ready_issues.py
+++ b/scripts/ci/find_copilot_ready_issues.py
@@ -43,7 +43,7 @@ def find_issues() -> tuple[list[str], int, str]:
         encoding="utf-8",
     )
     if result.returncode != 0:
-        return [], result.returncode, result.stderr
+        return [], result.returncode, result.stderr or ""
 
     numbers = result.stdout.strip().split() if result.stdout.strip() else []
     return numbers, 0, ""
@@ -59,8 +59,9 @@ def main() -> int:
     numbers, rc, stderr = find_issues()
 
     if rc != 0:
+        safe = stderr.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
         print(
-            f"::error::gh issue list failed (exit {rc}): {stderr}",
+            f"::error::gh issue list failed (exit {rc}): {safe}",
             file=sys.stderr,
         )
         return EXIT_FAILURE

--- a/scripts/ci/run_pr_conflict_resolver.py
+++ b/scripts/ci/run_pr_conflict_resolver.py
@@ -71,8 +71,12 @@ def main() -> int:
 
     try:
         parsed = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        parsed = {}
+    except json.JSONDecodeError as exc:
+        print(
+            f"::error::PR #{pr_number}: resolver output is not valid JSON: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_FAILURE
 
     with open(output_path, "a", encoding="utf-8") as f:
         if parsed.get("success"):

--- a/tests/ci/test_find_copilot_ready_issues.py
+++ b/tests/ci/test_find_copilot_ready_issues.py
@@ -175,7 +175,7 @@ def test_gh_failure_exit_code_propagated(monkeypatch: pytest.MonkeyPatch, tmp_pa
     output_file = tmp_path / "output"
     output_file.write_text("")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    # gh exits 2 (auth failure) — must propagate as EXIT_FAILURE
+    # gh exits 2 (auth failure); must propagate as EXIT_FAILURE
     rec = _GhRecorder(returncode=2)
     _install(monkeypatch, rec)
     rc = main()

--- a/tests/ci/test_find_copilot_ready_issues.py
+++ b/tests/ci/test_find_copilot_ready_issues.py
@@ -107,20 +107,16 @@ def test_single_issue_writes_one_number(monkeypatch: pytest.MonkeyPatch, tmp_pat
 # ---------------------------------------------------------------------------
 
 
-def test_gh_failure_degrades_to_zero_issues(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """When gh fails, script exits 0 and writes count=0 (matches original pipeline behavior)."""
+def test_gh_failure_returns_exit_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When gh fails the step must fail (match bash set -eo pipefail original)."""
     output_file = tmp_path / "output"
     output_file.write_text("")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
     rec = _GhRecorder(returncode=1)
     _install(monkeypatch, rec)
-    assert main() == 0
-    # count=0 and issues= written on gh failure
-    content = output_file.read_text()
-    assert "count=0" in content
-    assert "issues=" in content
+    assert main() == find_copilot_ready_issues.EXIT_FAILURE
+    # No output should be written on failure
+    assert output_file.read_text() == ""
 
 
 # ---------------------------------------------------------------------------
@@ -172,3 +168,16 @@ def test_count_matches_number_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     issues_val = issues_line[len("issues=") :]
     count_val = int(count_line[len("count=") :])
     assert count_val == len(issues_val.split())
+
+
+def test_gh_failure_exit_code_propagated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mutant guard: swallowing the gh error (returning EXIT_SUCCESS) must die."""
+    output_file = tmp_path / "output"
+    output_file.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    # gh exits 2 (auth failure) — must propagate as EXIT_FAILURE
+    rec = _GhRecorder(returncode=2)
+    _install(monkeypatch, rec)
+    rc = main()
+    assert rc == find_copilot_ready_issues.EXIT_FAILURE
+    assert rc != find_copilot_ready_issues.EXIT_SUCCESS

--- a/tests/ci/test_run_pr_conflict_resolver.py
+++ b/tests/ci/test_run_pr_conflict_resolver.py
@@ -83,12 +83,14 @@ def test_main_needs_ai(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# main - invalid JSON from resolver falls back to empty
+# main - invalid JSON from resolver must fail the step
 # ---------------------------------------------------------------------------
 
 
 def test_main_invalid_json_from_resolver(tmp_path, monkeypatch):
+    """Resolver exits 0 but writes garbage stdout: step must FAIL (match PowerShell original)."""
     out = tmp_path / "output.txt"
+    out.write_text("", encoding="utf-8")
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
     monkeypatch.setenv("PR_NUMBER", "11")
     monkeypatch.setenv("HEAD_REF", "feat/x")
@@ -98,7 +100,25 @@ def test_main_invalid_json_from_resolver(tmp_path, monkeypatch):
     mock = MagicMock(returncode=0, stdout="not json", stderr="")
     with patch("scripts.ci.run_pr_conflict_resolver.subprocess.run", return_value=mock):
         rc = rpcr.main()
-    assert rc == rpcr.EXIT_SUCCESS
+    assert rc == rpcr.EXIT_FAILURE
+    # No needs_ai written to GITHUB_OUTPUT on failure
     content = out.read_text(encoding="utf-8")
-    # Empty parsed dict -> success=False path -> needs_ai=true
-    assert "needs_ai=true" in content
+    assert "needs_ai" not in content
+
+
+def test_json_parse_failure_does_not_write_needs_ai(tmp_path, monkeypatch):
+    """Mutant guard: restoring 'parsed = {}' must kill this test."""
+    out = tmp_path / "output.txt"
+    out.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("PR_NUMBER", "99")
+    monkeypatch.setenv("HEAD_REF", "fix/y")
+    monkeypatch.setenv("BASE_REF", "main")
+    monkeypatch.setenv("REPO_OWNER", "o")
+    monkeypatch.setenv("REPO_NAME", "r")
+    mock = MagicMock(returncode=1, stdout="{broken json", stderr="")
+    with patch("scripts.ci.run_pr_conflict_resolver.subprocess.run", return_value=mock):
+        rc = rpcr.main()
+    assert rc == rpcr.EXIT_FAILURE
+    assert rc != rpcr.EXIT_SUCCESS
+    assert "needs_ai" not in out.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

### What

Fix two silent-pass defects in scripts extracted by PR #4021: `scripts/ci/find_copilot_ready_issues.py` and `scripts/ci/run_pr_conflict_resolver.py`. Both scripts returned EXIT_SUCCESS on failure paths where the original shell would have failed the step.

### Why

Post-merge adversarial audit of PR #4021 (ADR-006 batch 7) per the silent-pass defect class described in issue #4021's review thread. The audit compared each extracted script's failure behavior against its shell original. Two scripts deviated; three existing tests asserted the broken behavior.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #3515 | ADR-006 extraction: copilot-context-synthesis.yml |
| **Issue** | Refs #3524 | ADR-006 extraction: velocity-accelerator.yml |
| **Issue** | Refs #3525 | ADR-006 extraction: pr-maintenance.yml |

## Changes

- `scripts/ci/find_copilot_ready_issues.py`: return EXIT_FAILURE (1) when `gh issue list` exits nonzero. Original bash ran under `set -eo pipefail`; a failed `gh issue list` propagated as a nonzero pipeline exit and failed the step. Python was returning EXIT_SUCCESS with count=0 ("graceful degradation") which made auth and API failures appear green.
- `scripts/ci/run_pr_conflict_resolver.py`: return EXIT_FAILURE on `json.JSONDecodeError` instead of defaulting to `parsed = {}`. Original PowerShell had no `try/catch` around `ConvertFrom-Json`; a resolver that exited 0 or 1 with invalid stdout would throw a terminating error and fail the step. Python was silently writing `needs_ai=true` and returning EXIT_SUCCESS.
- `tests/ci/test_find_copilot_ready_issues.py`: renamed `test_gh_failure_degrades_to_zero_issues` to `test_gh_failure_returns_exit_failure`; updated assertion to EXIT_FAILURE. Added `test_gh_failure_exit_code_propagated` as a mutant guard.
- `tests/ci/test_run_pr_conflict_resolver.py`: updated `test_main_invalid_json_from_resolver` to assert EXIT_FAILURE and no `needs_ai` output. Added `test_json_parse_failure_does_not_write_needs_ai` as a mutant guard.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, no rush

**Focus areas**: Exit code on failure paths and the mutation guard tests in the test files.

## Testing

- 1660 tests pass (same count as before these changes; 2 test assertions corrected from wrong to right)
- 2/2 mutants killed: restoring `parsed = {}` in the JSONDecodeError handler causes `test_main_invalid_json_from_resolver` to fail; restoring EXIT_SUCCESS in the gh failure handler causes `test_gh_failure_returns_exit_failure` to fail.

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py`; pass `--quick` to skip slow validations or `--skip-tests` for very fast iterations)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

### Silent-Pass Audit (all 11 scripts from PR #4021)

| Script | Original shell type | Python failure behavior | Status |
|--------|--------------------|-----------------------|--------|
| `run_copilot_synthesis.py` | bash set-e | EXIT_FAILURE on subprocess fail | CLEAN |
| `find_copilot_ready_issues.py` | bash set-eo pipefail | was EXIT_SUCCESS, now EXIT_FAILURE | FIXED |
| `sweep_copilot_synthesis.py` | PowerShell try/catch | EXIT_SUCCESS (intentional sweep behavior) | CLEAN |
| `write_synthesis_sweep_summary.py` | bash | EXIT_CONFIG on OSError | CLEAN |
| `detect_velocity_opportunities.py` | PowerShell try/catch | EXIT_SUCCESS matches original | CLEAN |
| `post_velocity_summary.py` | PowerShell via Python subprocess | EXIT_SUCCESS matches original | CLEAN |
| `run_pr_conflict_resolver.py` | PowerShell no try/catch | was EXIT_SUCCESS, now EXIT_FAILURE | FIXED |
| `prepare_conflict_context.py` | PowerShell no exit-code checks | unchecked (preserved original) | CLEAN |
| `apply_ai_conflict_resolution.py` | PowerShell, remaining-conflict check | unchecked + remaining check (preserved) | CLEAN |
| `detect_human_changes_requested.py` | PowerShell explicit LASTEXITCODE | EXIT_SUCCESS matches original | CLEAN |
| `write_pr_maintenance_summary.py` | PowerShell no try/catch (unreachable) | EXIT_SUCCESS (unreachable path) | NOTED |

## Related Issues

Refs #3515
Refs #3524
Refs #3525
