### PR TITLE
fix(eval): harden adapter edge cases

### DIFF
--- a/scripts/eval/_copilot_cli.py
+++ b/scripts/eval/_copilot_cli.py
@@ -13,11 +13,21 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import tempfile
 import time
 from pathlib import Path
+
+from _copilot_cli_constants import (
+    FOOTER_COLUMN,
+    FOOTER_LABEL_RE,
+    FOOTER_PROSE_ENDINGS,
+    FOOTER_VALUE_MAX_WORDS,
+    PROVIDER_LABEL,
+    SESSION_STATE_ENV,
+    TRACE_LINE_PREFIXES,
+    UNVERIFIED_MODEL_ENV,
+)
 
 __all__ = ["_CopilotCLIProvider"]
 
@@ -60,47 +70,14 @@ class _CopilotCLIProvider:
     HTTP-provider score.
     """
 
-    # The CLI prints a stats block after the answer, formatted as a fixed-width
-    # label column. Matching on "2+ spaces" is wrong: the widest label
-    # ("AI Credits") fills the column and leaves a single space before its
-    # value. Match the label, then require the padded prefix to reach the
-    # column width, which is what separates a stats line from prose that
-    # happens to open with the same word ("Tokens are the unit of billing").
-    _FOOTER_LABEL_RE = re.compile(
-        r"^(?:Changes|AI Credits|Tokens|Resume|Total duration|Wall time)( +)",
-    )
-    _FOOTER_COLUMN = 11
-
-    #: A stats value is a short token ("1m2s", "12,345", "$0.04"). Prose that
-    #: opens with a label longer than the column ("Total duration and latency
-    #: are ...") satisfies the column test vacuously, so the remainder is
-    #: checked too: real values are short and do not close a sentence.
-    _FOOTER_VALUE_MAX_WORDS = 5
-    _FOOTER_PROSE_ENDINGS = (".", "!", "?", ":", ",")
-
-    #: Where the CLI records structured per-session events. Overridable so the
-    #: tests can point at a fixture tree instead of the operator's real one.
-    _SESSION_STATE_ENV = "COPILOT_SESSION_STATE_DIR"
-
-    #: Opt-in to grade a reply whose model was never confirmed. Off by default:
-    #: every consumer of this transport publishes model-attributed results
-    #: ("4 of 4 on Opus"), and the CLI accepts `--model` without confirming it,
-    #: so an unverified reply is a number attached to an unknown population.
-    #: An operator whose CLI writes no session log can set this and accept that
-    #: loss knowingly, which is the difference between a disclosed limit and a
-    #: silent one.
-    _UNVERIFIED_MODEL_ENV = "EVAL_COPILOT_ALLOW_UNVERIFIED_MODEL"
-
-    #: The CLI opens a tool-call trace with a bullet and indents its body with
-    #: box-drawing bars. `_strip_footer` cannot remove them: it anchors at the
-    #: end of the output, and traces precede the answer. Matching is anchored at
-    #: the start of a line because a model answer may legitimately mention these
-    #: characters mid-sentence, while the CLI only ever emits them as a prefix.
-    _TRACE_LINE_PREFIXES = ("\u25cf", "\u2502", "\u251c", "\u2514")
-
-    #: Used by both instance messages and the classmethod that reads the
-    #: transcript, so it lives on the class rather than in ``__init__`` alone.
-    _PROVIDER_LABEL = "Copilot CLI"
+    _FOOTER_LABEL_RE = FOOTER_LABEL_RE
+    _FOOTER_COLUMN: int = FOOTER_COLUMN
+    _FOOTER_VALUE_MAX_WORDS: int = FOOTER_VALUE_MAX_WORDS
+    _FOOTER_PROSE_ENDINGS: tuple[str, ...] = FOOTER_PROSE_ENDINGS
+    _SESSION_STATE_ENV: str = SESSION_STATE_ENV
+    _UNVERIFIED_MODEL_ENV: str = UNVERIFIED_MODEL_ENV
+    _TRACE_LINE_PREFIXES: tuple[str, ...] = TRACE_LINE_PREFIXES
+    _PROVIDER_LABEL: str = PROVIDER_LABEL
 
     def __init__(self, *, executable: str = "copilot", timeout: float = 900.0) -> None:
         self.name = "copilot-cli"
@@ -303,21 +280,31 @@ class _CopilotCLIProvider:
     def _strip_footer(cls, text: str) -> str:
         """Remove the CLI's trailing stats block.
 
-        Walks backwards from the end, dropping blank lines and footer-shaped
-        lines, and stops at the first line that is neither. Anchoring at the
-        end keeps a stats-shaped line intact anywhere except the end. An
-        answer whose last line is stats-shaped is truncated, because nothing
-        on this path separates it from the chrome it imitates. See #4125.
+        Footer chrome must be separated from the answer by a blank line. When
+        stdout ends in footer-shaped lines without that separator, the fallback
+        path cannot tell chrome from model text, so it refuses the run instead
+        of silently truncating the answer. See #4125.
         """
         lines = text.splitlines()
         end = len(lines)
-        while end > 0:
-            candidate = lines[end - 1]
-            if not candidate.strip() or cls._is_footer_line(candidate):
-                end -= 1
-                continue
-            break
-        return "\n".join(lines[:end]).strip()
+        while end > 0 and not lines[end - 1].strip():
+            end -= 1
+        footer_start = end
+        while footer_start > 0 and cls._is_footer_line(lines[footer_start - 1]):
+            footer_start -= 1
+        if footer_start == end:
+            return "\n".join(lines[:end]).strip()
+        if footer_start > 0 and lines[footer_start - 1].strip():
+            raise RuntimeError(
+                f"{cls._PROVIDER_LABEL} stdout ends with a stats-shaped line, "
+                "but no blank line separates it from the answer. Nothing on "
+                "this fallback path can tell CLI stats from model text, so the "
+                "run is refused rather than truncated."
+            )
+        answer_end = footer_start
+        while answer_end > 0 and not lines[answer_end - 1].strip():
+            answer_end -= 1
+        return "\n".join(lines[:answer_end]).strip()
 
     @classmethod
     def _unverified_model_allowed(cls) -> bool:

--- a/scripts/eval/_copilot_cli_constants.py
+++ b/scripts/eval/_copilot_cli_constants.py
@@ -1,0 +1,16 @@
+"""Constants shared by the Copilot CLI eval transport."""
+
+from __future__ import annotations
+
+import re
+
+FOOTER_LABEL_RE = re.compile(
+    r"^(?:Changes|AI Credits|Tokens|Resume|Total duration|Wall time)( +)",
+)
+FOOTER_COLUMN: int = 11
+FOOTER_VALUE_MAX_WORDS: int = 5
+FOOTER_PROSE_ENDINGS: tuple[str, ...] = (".", "!", "?", ":", ",")
+SESSION_STATE_ENV: str = "COPILOT_SESSION_STATE_DIR"
+UNVERIFIED_MODEL_ENV: str = "EVAL_COPILOT_ALLOW_UNVERIFIED_MODEL"
+TRACE_LINE_PREFIXES: tuple[str, ...] = ("\u25cf", "\u2502", "\u251c", "\u2514")
+PROVIDER_LABEL: str = "Copilot CLI"

--- a/scripts/eval/_eval_api_adapter.py
+++ b/scripts/eval/_eval_api_adapter.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import json
 import os
 import random
-import re
 import sys
 import time
 from collections.abc import Callable
@@ -39,29 +38,28 @@ from dataclasses import dataclass
 from typing import Literal, Protocol, cast
 
 # Sibling import; loaded under the same EVAL_DIR sys.path entry that the CLI uses.
+import _eval_api_adapter_constants as _constants
 from _anthropic_api import call_api, load_api_key
 
 OutcomeLiteral = Literal["success", "error"]
 
-# Error category taxonomy. Stable strings written into RunRecord.error_category.
-ERR_RATE_LIMIT = "rate_limit"
-ERR_SERVER_ERROR = "server_error"
-ERR_TIMEOUT = "timeout"
-ERR_CLIENT_ERROR = "client_error"
-ERR_AUTH = "auth"
-ERR_UNKNOWN = "unknown"
-
-# Bounded retry policy.
-DEFAULT_MAX_RETRIES = 3
-_BACKOFF_BASE_SEC = 1.0
-_BACKOFF_MAX_SEC = 30.0
-
-# Total wall-time budget across all attempts for one logical call.
-# `_anthropic_api.call_api` uses a 120s per-attempt timeout; with 3 retries
-# the worst case before this guard was 6 minutes per call. 180s caps the
-# guarantee at one slow attempt without forfeiting fast retries.
-DEFAULT_TOTAL_TIMEOUT_SEC = 180.0
-ERR_TOTAL_TIMEOUT = "timeout_total"
+ERR_RATE_LIMIT: str = _constants.ERR_RATE_LIMIT
+ERR_SERVER_ERROR: str = _constants.ERR_SERVER_ERROR
+ERR_TIMEOUT: str = _constants.ERR_TIMEOUT
+ERR_CLIENT_ERROR: str = _constants.ERR_CLIENT_ERROR
+ERR_AUTH: str = _constants.ERR_AUTH
+ERR_UNKNOWN: str = _constants.ERR_UNKNOWN
+ERR_TOTAL_TIMEOUT: str = _constants.ERR_TOTAL_TIMEOUT
+DEFAULT_MAX_RETRIES: int = _constants.DEFAULT_MAX_RETRIES
+DEFAULT_TOTAL_TIMEOUT_SEC: float = _constants.DEFAULT_TOTAL_TIMEOUT_SEC
+_BACKOFF_BASE_SEC: float = _constants.BACKOFF_BASE_SEC
+_BACKOFF_MAX_SEC: float = _constants.BACKOFF_MAX_SEC
+_HTTP_STATUS_RE = _constants.HTTP_STATUS_RE
+_TIMEOUT_HINT: str = _constants.TIMEOUT_HINT
+_RATE_LIMIT_HINT: str = _constants.RATE_LIMIT_HINT
+_AUTH_HINT_RE = _constants.AUTH_HINT_RE
+_ALLOWED_LOG_FIELDS: frozenset[str] = _constants.ALLOWED_LOG_FIELDS
+_BANNED_LOG_FIELDS: frozenset[str] = _constants.BANNED_LOG_FIELDS
 
 
 @dataclass(frozen=True)
@@ -83,17 +81,6 @@ class APICallResult:
     attempts: int
     tokens_estimated: bool = True
     system_fingerprint: str | None = None
-
-
-# Match the HTTP-status hint that `_anthropic_api.call_api` puts into its
-# RuntimeError message: "Anthropic API returned HTTP <code>: ...". Capture
-# the numeric code so the adapter can categorize without re-implementing the
-# request loop.
-_HTTP_STATUS_RE = re.compile(r"HTTP (\d{3})")
-_TIMEOUT_HINT = "timed out"
-# Subprocess-backed providers have no HTTP status to report. They surface a
-# rate limit as text on stderr, which the provider copies into the message.
-_RATE_LIMIT_HINT = "rate limit"
 
 
 def _categorize_error(exc: Exception) -> str:
@@ -122,6 +109,8 @@ def _categorize_error(exc: Exception) -> str:
             return ERR_TIMEOUT
         if _RATE_LIMIT_HINT in message.lower():
             return ERR_RATE_LIMIT
+        if _AUTH_HINT_RE.search(message):
+            return ERR_AUTH
         return ERR_SERVER_ERROR
     code = int(match.group(1))
     if code in (401, 403):
@@ -134,11 +123,11 @@ def _categorize_error(exc: Exception) -> str:
         return ERR_SERVER_ERROR
     if 400 <= code < 500:
         return ERR_CLIENT_ERROR
-    return ERR_UNKNOWN
+    return cast(str, ERR_UNKNOWN)
 
 
 # Retried = transient. Anything else is recorded once and not retried.
-_TRANSIENT = frozenset({ERR_RATE_LIMIT, ERR_SERVER_ERROR, ERR_TIMEOUT})
+_TRANSIENT: frozenset[str] = frozenset({ERR_RATE_LIMIT, ERR_SERVER_ERROR, ERR_TIMEOUT})
 
 
 def _is_transient(category: str) -> bool:
@@ -157,9 +146,17 @@ def _backoff_delay_seconds(attempt: int) -> float:
 def _emit_log(record: dict[str, object]) -> None:
     """Write a structured JSON log line to stderr.
 
-    Caller MUST NOT include API keys, request bodies, or raw error payloads.
-    Only the fields listed in DESIGN-004 §5.4 belong here.
+    The closed field schema enforces DESIGN-004 §5.4. Unknown keys are refused
+    before serialization so payload-shaped fields cannot enter stderr by
+    caller convention drift.
     """
+    unknown = record.keys() - _ALLOWED_LOG_FIELDS
+    if unknown:
+        banned = unknown & _BANNED_LOG_FIELDS
+        detail = f"_emit_log rejected unknown keys: {sorted(unknown)}"
+        if banned:
+            detail += f" including banned fields: {sorted(banned)}"
+        raise ValueError(detail)
     sys.stderr.write(json.dumps(record, sort_keys=True) + "\n")
     sys.stderr.flush()
 

--- a/scripts/eval/_eval_api_adapter_constants.py
+++ b/scripts/eval/_eval_api_adapter_constants.py
@@ -1,0 +1,58 @@
+"""Constants for the eval API adapter."""
+
+from __future__ import annotations
+
+import re
+
+ERR_RATE_LIMIT: str = "rate_limit"
+ERR_SERVER_ERROR: str = "server_error"
+ERR_TIMEOUT: str = "timeout"
+ERR_CLIENT_ERROR: str = "client_error"
+ERR_AUTH: str = "auth"
+ERR_UNKNOWN: str = "unknown"
+ERR_TOTAL_TIMEOUT: str = "timeout_total"
+
+DEFAULT_MAX_RETRIES: int = 3
+BACKOFF_BASE_SEC: float = 1.0
+BACKOFF_MAX_SEC: float = 30.0
+DEFAULT_TOTAL_TIMEOUT_SEC: float = 180.0
+
+HTTP_STATUS_RE = re.compile(r"HTTP (\d{3})")
+TIMEOUT_HINT: str = "timed out"
+RATE_LIMIT_HINT: str = "rate limit"
+AUTH_HINT_RE = re.compile(
+    r"(authentication failed|not logged in|not signed in|please (?:log|sign) in|login required)",
+    re.IGNORECASE,
+)
+
+ALLOWED_LOG_FIELDS: frozenset[str] = frozenset(
+    {
+        "fixture_id",
+        "variant",
+        "run_index",
+        "model_id",
+        "attempt",
+        "outcome",
+        "latency_ms",
+        "tokens_in",
+        "tokens_out",
+        "error_category",
+    }
+)
+BANNED_LOG_FIELDS: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "headers",
+        "messages",
+        "payload",
+        "prompt",
+        "raw_error",
+        "raw_response",
+        "request_body",
+        "response_body",
+        "secret",
+        "system",
+        "token",
+    }
+)

--- a/tests/eval/test_providers.py
+++ b/tests/eval/test_providers.py
@@ -355,6 +355,96 @@ class TestAStatusOutranksATextHint:
 
         assert _eval_api_adapter._categorize_error(exc) == "rate_limit"
 
+    def test_subprocess_auth_hint_is_narrow_and_status_still_wins(self) -> None:
+        exc = RuntimeError(
+            "Copilot CLI exited with code 1: authentication failed: token expired"
+        )
+
+        category = _eval_api_adapter._categorize_error(exc)
+
+        assert category == "auth"
+        assert not _eval_api_adapter._is_transient(category)
+        status_exc = RuntimeError("Anthropic API returned HTTP 500: authentication failed")
+        unrelated_exc = RuntimeError(
+            "Copilot CLI exited with code 1: authorization cache failed"
+        )
+        assert _eval_api_adapter._categorize_error(status_exc) == "server_error"
+        assert _eval_api_adapter._categorize_error(unrelated_exc) == "server_error"
+
+
+class TestSubprocessAuthFailureIsPermanent:
+    def test_call_model_does_not_retry_a_subprocess_auth_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+        sleeps: list[float] = []
+
+        def _raise_auth(_prompt: str, _model_id: str, _system: str) -> str:
+            nonlocal attempts
+            attempts += 1
+            raise RuntimeError("Copilot CLI exited with code 1: authentication failed")
+
+        monkeypatch.setattr(
+            _eval_api_adapter, "_backoff_delay_seconds", lambda attempt: 0.0
+        )
+        adapter = _eval_api_adapter.AnthropicAPIAdapter(
+            transport=_raise_auth,
+            sleep=sleeps.append,
+        )
+
+        result = adapter.call_model("prompt", "model", "fixture", "variant", 0)
+
+        assert result.error_category == "auth"
+        assert result.attempts == 1
+        assert attempts == 1
+        assert sleeps == []
+
+
+class TestEvalLogSchema:
+    def test_emit_log_accepts_the_closed_schema_and_rejects_payload_fields(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _eval_api_adapter._emit_log(
+            {
+                "fixture_id": "fx",
+                "variant": "baseline",
+                "run_index": 0,
+                "model_id": "model",
+                "attempt": 1,
+                "outcome": "success",
+                "latency_ms": 12.3,
+                "tokens_in": 4,
+                "tokens_out": 5,
+                "error_category": None,
+            }
+        )
+
+        logged = json.loads(capsys.readouterr().err)
+
+        assert logged["fixture_id"] == "fx"
+        assert set(logged) == _eval_api_adapter._ALLOWED_LOG_FIELDS
+        record = {
+            "fixture_id": "fx",
+            "variant": "baseline",
+            "run_index": 0,
+            "model_id": "model",
+            "attempt": 1,
+            "outcome": "error",
+            "latency_ms": 0.0,
+            "tokens_in": 0,
+            "tokens_out": 0,
+            "error_category": "server_error",
+            "payload": {"prompt": "secret"},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _eval_api_adapter._emit_log(record)
+
+        message = str(exc_info.value)
+        assert "payload" in message
+        assert "banned fields" in message
+        assert capsys.readouterr().err == ""
+
 
 def test_call_api_routes_to_resolve_provider_for_openai(
     monkeypatch: pytest.MonkeyPatch,
@@ -696,28 +786,39 @@ def test_strip_footer_returns_empty_when_output_is_only_a_footer() -> None:
     assert _providers._CopilotCLIProvider._strip_footer(raw) == ""
 
 
-@pytest.mark.parametrize(
-    ("raw", "kept"),
-    [
-        ("Model answer:\nTokens     42\n\nTokens     1.2k\n", "Model answer:"),
-        ("The count is:\nTokens     42\n", "The count is:"),
-    ],
-    ids=["footer-follows-the-lost-line", "no-footer-present-at-all"],
-)
-def test_strip_footer_truncates_an_answer_that_ends_in_a_stats_shaped_line(
-    raw: str, kept: str
-) -> None:
-    """Record the truncation this stripper cannot avoid. Refs #4125.
+class TestAmbiguousFooterIsRefused:
+    @pytest.mark.parametrize(
+        ("raw", "kept"),
+        [
+            (
+                "Model answer:\nTokens     42\n\nTokens     1.2k\n",
+                "Model answer:\nTokens     42",
+            ),
+            (
+                "The count is:\nTokens     42\n\nChanges    +0 -0\n",
+                "The count is:\nTokens     42",
+            ),
+        ],
+        ids=["footer-follows-the-stats-shaped-answer-line", "footer-follows-answer"],
+    )
+    def test_strip_footer_keeps_a_stats_shaped_answer_line_when_footer_is_separated(
+        self, raw: str, kept: str
+    ) -> None:
+        assert _providers._CopilotCLIProvider._strip_footer(raw) == kept
 
-    Both inputs end in a line the model wrote. The second carries no CLI
-    chrome at all, so nothing was there to strip. The stripper removes the
-    line anyway, because a short stats-shaped value is indistinguishable
-    from the chrome it imitates once it sits at the end of the output.
-
-    This pins the loss so a change in it is visible, not because the loss is
-    wanted. The issue holds the options for removing it.
-    """
-    assert _providers._CopilotCLIProvider._strip_footer(raw) == kept
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "The count is:\nTokens     42\n",
+            "Model answer:\nChanges    +0 -0\n",
+        ],
+        ids=["single-stats-shaped-line", "changes-shaped-line"],
+    )
+    def test_strip_footer_refuses_a_stats_shaped_answer_line_without_separator(
+        self, raw: str
+    ) -> None:
+        with pytest.raises(RuntimeError, match="stats-shaped line"):
+            _providers._CopilotCLIProvider._strip_footer(raw)
 
 
 class _FakeCompleted:
@@ -779,18 +880,20 @@ def test_copilot_complete_returns_stripped_answer(
     assert prompt == "be terse\n\nthe question"
 
 
-def test_copilot_complete_drops_roles_when_folding_a_conversation(
+def test_copilot_complete_refuses_ambiguous_footer_shaped_stdout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Characterization, not endorsement. See #4128.
+    _allow_unverified_model(monkeypatch)
+    _capture_run(monkeypatch, _FakeCompleted(stdout="The count is:\nTokens     42\n"))
+    provider = _providers._CopilotCLIProvider()
 
-    The CLI has one prompt channel, so a conversation can only be folded flat.
-    Nothing in the fold records who spoke, so an assistant turn reaches the
-    model as user-authored instruction text. No caller sends one today: the
-    eval adapter builds a single user message, which is what the test above
-    covers. This pins the loss so whoever adds a role guard is told the
-    behaviour moved, instead of finding out from a changed eval score.
-    """
+    with pytest.raises(RuntimeError, match="stats-shaped line"):
+        provider.complete(messages=[{"role": "user", "content": "q"}], model="m")
+
+
+def test_copilot_complete_folds_supported_roles_into_one_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _allow_unverified_model(monkeypatch)
     seen = _capture_run(monkeypatch, _FakeCompleted(stdout="ok\n"))
     provider = _providers._CopilotCLIProvider()
@@ -798,14 +901,14 @@ def test_copilot_complete_drops_roles_when_folding_a_conversation(
     provider.complete(
         messages=[
             {"role": "user", "content": "Question"},
-            {"role": "assistant", "content": "Prior assistant answer"},
+            {"role": "system", "content": "Extra constraints"},
             {"role": "user", "content": "Follow-up"},
         ],
         model="m",
     )
 
     prompt = seen["argv"][seen["argv"].index("--prompt") + 1]
-    assert prompt == "Question\n\nPrior assistant answer\n\nFollow-up"
+    assert prompt == "Question\n\nExtra constraints\n\nFollow-up"
 
 
 def test_copilot_complete_isolates_cwd_and_disables_builtin_mcps(
@@ -853,6 +956,7 @@ def test_copilot_complete_raises_on_empty_prompt() -> None:
 def test_copilot_complete_allows_system_role_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _allow_unverified_model(monkeypatch)
     seen = _capture_run(monkeypatch, _FakeCompleted(stdout="ok\n"))
     provider = _providers._CopilotCLIProvider()
 


### PR DESCRIPTION
## Summary
- Adds a closed schema to eval adapter stderr logs so payload-shaped fields fail before serialization.
- Refuses ambiguous Copilot CLI stdout footer stripping instead of truncating model text.
- Categorizes explicit subprocess authentication failures as auth, so they do not retry as server errors.
- Extracts eval constants so provider files stay below the taste-lint error threshold without changing the baseline.

## Validation
- `uv run pytest tests/eval/test_providers.py -x`: 159 passed.
- Focused detector revert cycle: source reverted to origin main, 8 selected detector nodes failed. Source restored, 11 selected nodes passed.
- Taste count ratchet: OK (count == baseline 608).
- Scoped ruff and scoped mypy passed on the five changed files.
- `uv run ruff check .`: fails on pre-existing out-of-scope files. This PR did not change those files.
- Push hook: PUSH_EXIT=0. Pre-PR validation, taste ratchet, type check, and full python tests passed.

Fixes #4119
Fixes #4125
Fixes #4129
Refs #4120
Refs #4121
Refs #4123

## References
- see tests/evals/test_eval_agent_vs_baseline.py still pins #4121 old behavior and is outside this worktree scope.
- see scripts/eval/_providers.py still has a #4123 malformed fingerprint coercion site and is outside this worktree scope.
