### PR TITLE
fix(eval): version artifacts and skip empty full

### DIFF
--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -90,6 +90,7 @@ MAX_RUBRIC_SCORE = 5.0
 DEFAULT_SEED = 0
 DEFAULT_JUDGE_REPEATS = 3
 DEFAULT_JUDGE_REDUCER = "median"
+RESULTS_SCHEMA_VERSION = 1
 _SCORE_KEYS = ("activation_score", "citation_score", "behavior_score")
 _SCORE_REDUCERS: dict[str, Callable[[list[float]], float]] = {
     "mean": statistics.fmean,
@@ -176,6 +177,8 @@ def build_system_prompt(mechanism: str, rule: dict[str, str], rule_id: str) -> s
             "and apply them when relevant."
         )
     if mechanism == "full":
+        if not rule["body"].strip() and not rule.get("skill_name"):
+            return ""
         return (
             "The following project rule applies to your work. "
             "Apply it when relevant.\n\n"
@@ -208,6 +211,35 @@ def _is_negative_gate(value: object) -> bool:
     wrong and the population it joins is wrong.
     """
     return _normalize_gate(value) == NEGATIVE_GATE
+
+
+def _validate_results_artifact_schema(data: dict[str, Any]) -> None:
+    """Refuse stored result artifacts written by an unknown schema."""
+    schema_version = data.get("schema_version")
+    if schema_version is None:
+        return
+    if schema_version != RESULTS_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported eval results schema_version "
+            f"{schema_version!r}; expected {RESULTS_SCHEMA_VERSION}"
+        )
+
+
+def _results_artifact_rules(data: dict[str, Any]) -> dict[str, Any]:
+    """Return stored result rules after checking the artifact schema."""
+    _validate_results_artifact_schema(data)
+    rules = data.get("rules")
+    if isinstance(rules, dict):
+        return rules
+    raise ValueError("eval results artifact must contain a rules object")
+
+
+def _graded_count(cell: dict[str, Any]) -> int:
+    """Read coverage from current and pre-coverage stored result cells."""
+    graded_count = cell.get("graded_count")
+    if graded_count is not None:
+        return int(graded_count)
+    return int(cell["scenario_count"])
 
 
 # Calibrated against the shipped corpus: the 32 distinct real positive gate
@@ -1546,13 +1578,10 @@ def _prompt_collapses_to_baseline(
     Written as a comparison against the baseline prompt rather than a test for
     emptiness so it keeps holding if baseline ever carries text.
 
-    This sees only what `build_system_prompt` produced. A rule with an empty
-    body still yields a `full` prompt carrying the preamble and nothing else,
-    which is a different string from baseline and so passes here, and for a
-    routed target the `full` prompt is replaced after routing resolves a
-    reference. Declining `full` on an empty body would therefore discard a
-    measurement the routed path did make. That case is filed separately
-    rather than guessed at here. See issue 4103.
+    This sees only what `build_system_prompt` produced. A non-routed rule with
+    an empty body produces an empty `full` prompt, so it declines here. A routed
+    target has `skill_name` and can still resolve real reference content, so the
+    prompt builder preserves that path.
     """
     if mechanism == "baseline":
         return False
@@ -1849,7 +1878,7 @@ def _incomplete_mechanisms(
     over. That is the defect this instrument keeps re-growing, so the check
     lives in one place and both pools call it.
     """
-    return sorted(m for m in mechs if per_mech[m]["graded_count"] < pool_size)
+    return sorted(m for m in mechs if _graded_count(per_mech[m]) < pool_size)
 
 
 def _mechanism_summary(
@@ -2136,10 +2165,10 @@ def aggregate(scenarios: list[dict[str, Any]], routed: bool = False) -> dict[str
     ]
     summary["negative_floor_partial"] = not summary[
         "negative_floor_mechanisms"
-    ] and any(gate_cells[m]["graded_count"] > 0 for m in gate_mechs)
+    ] and any(_graded_count(gate_cells[m]) > 0 for m in gate_mechs)
     summary["worst_negative_mechanism"] = worst_neg_mech
     summary["worst_negative_graded"] = (
-        gate_cells[worst_neg_mech]["graded_count"] if worst_neg_mech else 0
+        _graded_count(gate_cells[worst_neg_mech]) if worst_neg_mech else 0
     )
 
     # The positive verdict is read off `description` and `baseline`, so those
@@ -2231,7 +2260,7 @@ def _fully_graded(cell: dict[str, Any]) -> bool:
     """Whether a cell's average covers every scenario in its pool."""
     return (
         cell.get("avg_score") is not None
-        and cell.get("graded_count") == cell.get("scenario_count")
+        and _graded_count(cell) == cell.get("scenario_count")
     )
 
 
@@ -2493,10 +2522,12 @@ def render_table(rule_id: str, summary: dict[str, Any]) -> str:
         # score: low on the positive side it looks like the mechanism failed,
         # and low on the negative side it looks like total over-activation.
         # Both columns report the absence instead.
-        pos = pos_stats["avg_score"] if pos_stats["graded_count"] else "-"
-        neg = neg_stats["avg_score"] if neg_stats["graded_count"] else "-"
-        pos_graded = f"{pos_stats['graded_count']}/{pos_stats['scenario_count']}"
-        neg_graded = f"{neg_stats['graded_count']}/{neg_stats['scenario_count']}"
+        pos_count = _graded_count(pos_stats)
+        neg_count = _graded_count(neg_stats)
+        pos = pos_stats["avg_score"] if pos_count else "-"
+        neg = neg_stats["avg_score"] if neg_count else "-"
+        pos_graded = f"{pos_count}/{pos_stats['scenario_count']}"
+        neg_graded = f"{neg_count}/{neg_stats['scenario_count']}"
         # Read the published value rather than deriving a third one here: the
         # number on the screen and the number in the record must not drift. A
         # record written before the measured gap existed carries only the
@@ -2973,7 +3004,10 @@ def main() -> int:
             print(f"ERROR: {e}", file=sys.stderr)
             return 2
 
-    all_results: dict[str, Any] = {"rules": {}}
+    all_results: dict[str, Any] = {
+        "schema_version": RESULTS_SCHEMA_VERSION,
+        "rules": {},
+    }
     state = _RunState()
 
     for scenario_file in args.scenarios:

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -155,10 +155,15 @@ def parse_skill_reference(skill_path: Path, reference_path: Path) -> dict[str, s
     }
 
 
+def _baseline_system_prompt(_rule: dict[str, str], _rule_id: str) -> str:
+    """Construct the baseline prompt shared by collapsed mechanisms."""
+    return ""
+
+
 def build_system_prompt(mechanism: str, rule: dict[str, str], rule_id: str) -> str:
     """Construct the system prompt for a given activation mechanism."""
     if mechanism == "baseline":
-        return ""
+        return _baseline_system_prompt(rule, rule_id)
     if mechanism == "description":
         if not rule["description"]:
             return ""
@@ -178,7 +183,7 @@ def build_system_prompt(mechanism: str, rule: dict[str, str], rule_id: str) -> s
         )
     if mechanism == "full":
         if not rule["body"].strip() and not rule.get("skill_name"):
-            return ""
+            return _baseline_system_prompt(rule, rule_id)
         return (
             "The following project rule applies to your work. "
             "Apply it when relevant.\n\n"

--- a/tests/eval/test_eval_rule_activation.py
+++ b/tests/eval/test_eval_rule_activation.py
@@ -7720,6 +7720,14 @@ class TestAMechanismTheTargetCannotReachIsNotMeasured:
         system = eval_mod.build_system_prompt("full", rule, "t")
         assert eval_mod._prompt_collapses_to_baseline("full", system, rule, "t") is True
 
+    def test_an_empty_body_reuses_the_baseline_prompt(self, monkeypatch):
+        monkeypatch.setattr(
+            eval_mod, "_baseline_system_prompt", lambda _rule, _rule_id: "BASE"
+        )
+        rule = self._rule(description="d", body="")
+        assert eval_mod.build_system_prompt("baseline", rule, "t") == "BASE"
+        assert eval_mod.build_system_prompt("full", rule, "t") == "BASE"
+
     def test_a_routed_empty_body_does_not_collapse_before_resolution(self):
         rule = {**self._rule(description="d", body=""), "skill_name": "s"}
         system = eval_mod.build_system_prompt("full", rule, "t")

--- a/tests/eval/test_eval_rule_activation.py
+++ b/tests/eval/test_eval_rule_activation.py
@@ -6571,6 +6571,15 @@ class TestALiveRunReportsWhatItAccumulated:
         assert code == 1
         assert out.is_file()
 
+    def test_writing_the_artifact_records_the_schema_version(
+        self, monkeypatch, tmp_path
+    ):
+        out = tmp_path / "results.json"
+        code = self._main_live(monkeypatch, tmp_path, "PASS", output=out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert code == 0
+        assert data["schema_version"] == eval_mod.RESULTS_SCHEMA_VERSION
+
     def test_the_dry_run_and_live_run_agree_on_a_clean_result(
         self, monkeypatch, tmp_path
     ):
@@ -7336,17 +7345,15 @@ class TestAStoredRunStillRenders:
         assert summary["delta_description_vs_baseline_measured"] == 1.01
         assert "+1.01" in eval_mod.render_table("some-rule", summary)
 
-    def test_every_stored_run_that_records_its_coverage_renders(self):
+    def test_every_stored_run_renders(self):
         """The real records, not a fixture shaped like one."""
         rendered = 0
         for path in sorted(_ARCHIVE_DIR.glob("*.json")):
             if path.name == _RECOVERED_PAYLOADS.name:
                 continue
             data = json.loads(path.read_text(encoding="utf-8"))
-            for rule_id, rule in (data.get("rules") or {}).items():
+            for rule_id, rule in eval_mod._results_artifact_rules(data).items():
                 summary = rule["summary"]
-                if "graded_count" not in summary["per_mechanism"]["description"]:
-                    continue
                 assert "delta_full_vs_baseline_measured" not in summary
                 table = eval_mod.render_table(rule_id, summary)
                 for mech in ("description", "full"):
@@ -7354,7 +7361,7 @@ class TestAStoredRunStillRenders:
                     if recorded is not None:
                         assert f"{recorded:+}" in table
                 rendered += 1
-        assert rendered == 7
+        assert rendered == 8
 
 
 class TestAPoolMarkerMustSayWhichPoolItMeans:
@@ -7433,19 +7440,13 @@ class TestEveryReaderOfAStoredRunIsExercisedAgainstOne:
     #: Readers that can be handed a stored summary and nothing else.
     READERS = ("_render_caveats", "render_table")
 
-    #: The one stored record no reader can fully read, and why. It was written
-    #: before per mechanism coverage counts existed, so the table cannot say
-    #: how many scenarios each average rests on. Printing an average without
-    #: that count would assert a coverage the record does not record.
-    PREDATES_COVERAGE_COUNTS = "t-sol56.json"
-
     @staticmethod
     def _stored_summaries():
         for path in sorted(_ARCHIVE_DIR.glob("*.json")):
             if path.name == _RECOVERED_PAYLOADS.name:
                 continue
             data = json.loads(path.read_text(encoding="utf-8"))
-            for rule_id, rule in (data.get("rules") or {}).items():
+            for rule_id, rule in eval_mod._results_artifact_rules(data).items():
                 yield path.name, rule_id, rule["summary"]
 
     @staticmethod
@@ -7454,7 +7455,7 @@ class TestEveryReaderOfAStoredRunIsExercisedAgainstOne:
             if path.name == _RECOVERED_PAYLOADS.name:
                 continue
             data = json.loads(path.read_text(encoding="utf-8"))
-            for rule_id, rule in (data.get("rules") or {}).items():
+            for rule_id, rule in eval_mod._results_artifact_rules(data).items():
                 yield path.name, rule_id, rule
 
     def test_a_summary_reader_is_either_replayed_or_exercised_here(self, monkeypatch):
@@ -7513,24 +7514,42 @@ class TestEveryReaderOfAStoredRunIsExercisedAgainstOne:
         for _name, _rule_id, summary in self._stored_summaries():
             eval_mod._render_caveats(summary)
 
-    def test_the_table_reads_every_record_that_states_its_coverage(self):
+    def test_the_table_reads_every_stored_record(self):
         read = []
         for name, rule_id, summary in self._stored_summaries():
-            if name == self.PREDATES_COVERAGE_COUNTS:
-                continue
             eval_mod.render_table(rule_id, summary)
             read.append(name)
-        assert len(read) == 7
+        assert len(read) == 8
 
-    def test_the_one_unreadable_record_fails_for_the_pinned_reason(self):
-        """If this stops raising, the exclusion above is stale and must go."""
+    def test_the_pre_coverage_count_record_renders_with_full_coverage(self):
         name, rule_id, summary = next(
             r for r in self._stored_summaries()
-            if r[0] == self.PREDATES_COVERAGE_COUNTS
+            if r[0] == "t-sol56.json"
         )
         assert "graded_count" not in summary["per_mechanism"]["description"]
-        with pytest.raises(KeyError, match="graded_count"):
-            eval_mod.render_table(rule_id, summary)
+        table = eval_mod.render_table(rule_id, summary)
+        assert name == "t-sol56.json"
+        assert rule_id in table
+        assert "3/3" in table
+
+    def test_a_current_results_artifact_records_its_schema_version(self):
+        assert eval_mod.RESULTS_SCHEMA_VERSION == 1
+        data = {"schema_version": eval_mod.RESULTS_SCHEMA_VERSION, "rules": {}}
+        assert eval_mod._results_artifact_rules(data) == {}
+
+    def test_a_legacy_results_artifact_without_schema_version_still_reads(self):
+        data = {"rules": {"r": {"summary": {}}}}
+        assert set(eval_mod._results_artifact_rules(data)) == {"r"}
+
+    def test_an_unknown_results_artifact_schema_fails_loudly(self):
+        data = {"schema_version": eval_mod.RESULTS_SCHEMA_VERSION + 1, "rules": {}}
+        with pytest.raises(ValueError, match="unsupported eval results schema_version"):
+            eval_mod._results_artifact_rules(data)
+
+    def test_a_schema_checked_artifact_must_still_have_rules(self):
+        data = {"schema_version": eval_mod.RESULTS_SCHEMA_VERSION}
+        with pytest.raises(ValueError, match="must contain a rules object"):
+            eval_mod._results_artifact_rules(data)
 
 
 class TestARouteResultMustSayWhetherItMatched:
@@ -7689,19 +7708,21 @@ class TestAMechanismTheTargetCannotReachIsNotMeasured:
         system = eval_mod.build_system_prompt("full", rule, "t")
         assert eval_mod._prompt_collapses_to_baseline("full", system, rule, "t") is False
 
-    def test_an_empty_body_does_not_collapse_full(self):
-        """The known limit of this check, measured rather than assumed.
-
-        An empty body still yields a `full` prompt carrying the preamble, so
-        it is a different string from baseline and passes here even though it
-        puts no rule in front of the model. Declining it is not safe from this
-        position: for a routed target the `full` prompt is replaced after
-        routing resolves a reference, so a decline would discard a
-        measurement the run did make. Filed as issue 4103.
-        """
+    def test_an_empty_body_collapses_full(self):
+        """No body means the full mechanism carries no rule content."""
         rule = self._rule(description="d", body="")
         system = eval_mod.build_system_prompt("full", rule, "t")
-        assert system != eval_mod.build_system_prompt("baseline", rule, "t")
+        assert system == eval_mod.build_system_prompt("baseline", rule, "t")
+        assert eval_mod._prompt_collapses_to_baseline("full", system, rule, "t") is True
+
+    def test_a_whitespace_body_collapses_full(self):
+        rule = self._rule(description="d", body="\n  \t")
+        system = eval_mod.build_system_prompt("full", rule, "t")
+        assert eval_mod._prompt_collapses_to_baseline("full", system, rule, "t") is True
+
+    def test_a_routed_empty_body_does_not_collapse_before_resolution(self):
+        rule = {**self._rule(description="d", body=""), "skill_name": "s"}
+        system = eval_mod.build_system_prompt("full", rule, "t")
         assert eval_mod._prompt_collapses_to_baseline("full", system, rule, "t") is False
 
     def test_a_declined_cell_carries_no_measurement(self):
@@ -7769,7 +7790,7 @@ class TestAMechanismTheTargetCannotReachIsNotMeasured:
             )
         assert eval_mod.aggregate(scenarios)["verdict"] == "PASS"
 
-    def test_the_runner_declines_the_cell_without_calling_the_model(self, monkeypatch):
+    def test_the_runner_declines_the_description_cell_without_calling_the_model(self, monkeypatch):
         called: list[str] = []
         monkeypatch.setattr(eval_mod, "RATE_LIMIT_SLEEP_SEC", 0)
         monkeypatch.setattr(
@@ -7796,6 +7817,35 @@ class TestAMechanismTheTargetCannotReachIsNotMeasured:
         assert result["mechanisms"]["description"]["declined"]
         assert "scores" in result["mechanisms"]["full"]
         assert len(called) == 2, "one call each for baseline and full, none for description"
+
+    def test_the_runner_declines_empty_full_without_calling_the_model(self, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(eval_mod, "RATE_LIMIT_SLEEP_SEC", 0)
+        monkeypatch.setattr(
+            eval_mod, "_call_api", lambda *a, **k: called.append("api") or "response"
+        )
+        monkeypatch.setattr(
+            eval_mod,
+            "score_response",
+            lambda *a, **k: {
+                "activation_score": 5,
+                "citation_score": 5,
+                "behavior_score": 5,
+                "judge_failed": False,
+            },
+        )
+        result = eval_mod.eval_one_scenario(
+            "key",
+            self._rule(description="d", body=""),
+            "rule",
+            {"id": "S1", "desc": "d", "input": "x", "expected_gate": "apply-rule"},
+            "model",
+            dry_run=False,
+        )
+        assert "scores" in result["mechanisms"]["baseline"]
+        assert "scores" in result["mechanisms"]["description"]
+        assert result["mechanisms"]["full"]["declined"]
+        assert len(called) == 2, "one call each for baseline and description, none for full"
 
     def test_the_motivating_case_is_still_reachable_in_this_repository(self):
         """If this fails, every rule gained a description and the check idles."""


### PR DESCRIPTION
## Summary

Fixes #4100.
Fixes #4103.

This change adds result artifact schema versioning and keeps legacy artifacts readable. It also declines the non-routed full mechanism when the rule body is empty, so the eval no longer scores a prompt that carries no rule content.

## Verification

```text
uv run pytest tests/eval/test_eval_rule_activation.py -x
607 passed, 1 skipped in 100.90s

uv run ruff check scripts/eval/eval-rule-activation.py tests/eval/test_eval_rule_activation.py
All checks passed!
```

Live detector check:

```text
Reverted code only: 4 detector tests failed.
Restored code: 4 detector tests passed.
```

Archive check:

```text
artifact_count= 8
archive_empty_body_records= []
positive_control_empty_body_records= ['positive-control.json:empty-rule:body']
```

## Notes

Missing `schema_version` is treated as legacy and still reads. Unknown non-null versions fail loudly.
