### PR TITLE
fix(agents): scope the bash prohibition to authoring and correct the plugin-bump rule

### DIFF
--- a/.agents/architecture/ADR-091-post-merge-version-bot.md
+++ b/.agents/architecture/ADR-091-post-merge-version-bot.md
@@ -6,7 +6,7 @@ decision-makers: [rjmurillo]
 supersedes: [ADR-079]
 superseded-by: null
 explainer: null
-implemented: false
+implemented: true
 ---
 
 # ADR-091: Post-Merge Bot Owns Plugin Version and Count Baselines

--- a/.agents/memory/episodes/episode-2026-08-01-session-4169-agents-md-compression-defects.json
+++ b/.agents/memory/episodes/episode-2026-08-01-session-4169-agents-md-compression-defects.json
@@ -1,0 +1,163 @@
+{
+  "id": "episode-2026-08-01-session-4169-agents-md-compression-defects",
+  "session": "2026-08-01-session-4169-agents-md-compression-defects",
+  "timestamp": "2026-08-01T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix two AGENTS.md directives that contradict the gates they summarize (issue #4169), and correct unverifiable figures in the context-optimizer rule-audit reference (issue #4175)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Audited the always-on rule corpus for directives that contradict an enforced gate",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Tested whether shared-vocabulary ranking could find such contradictions automatically",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked the plugin bump directive against ADR-091",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified before correcting ADR-091 frontmatter, rather than assuming it was stale",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-verified my own vendor-portability declaration in the rule-audit reference",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a review gate with two independent reviewers before publishing anything",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bisected main after discovering it was red on a clean checkout",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Investigated why a regression reached main without any check failing",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a positive control before filing a stronger claim about missing CI",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Searched for an existing issue before filing about the ratchet being undiagnosable",
+      "caused_by": [],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-01T15:27:33+00:00",
+      "type": "commit",
+      "content": "Commit: 1a4f2ba07",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010"
+      ],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-01T15:28:04+00:00",
+      "type": "commit",
+      "content": "Commit: 83150f835",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-08-01-session-4169-agents-md-compression-defects.json
+++ b/.agents/memory/episodes/episode-2026-08-01-session-4169-agents-md-compression-defects.json
@@ -13,9 +13,7 @@
       "type": "milestone",
       "content": "Audited the always-on rule corpus for directives that contradict an enforced gate",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -24,9 +22,7 @@
       "type": "milestone",
       "content": "Tested whether shared-vocabulary ranking could find such contradictions automatically",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -35,9 +31,7 @@
       "type": "milestone",
       "content": "Checked the plugin bump directive against ADR-091",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -46,9 +40,7 @@
       "type": "milestone",
       "content": "Verified before correcting ADR-091 frontmatter, rather than assuming it was stale",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -57,9 +49,7 @@
       "type": "milestone",
       "content": "Re-verified my own vendor-portability declaration in the rule-audit reference",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -68,9 +58,7 @@
       "type": "milestone",
       "content": "Ran a review gate with two independent reviewers before publishing anything",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -79,9 +67,7 @@
       "type": "milestone",
       "content": "Bisected main after discovering it was red on a clean checkout",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -90,9 +76,7 @@
       "type": "milestone",
       "content": "Investigated why a regression reached main without any check failing",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -101,9 +85,7 @@
       "type": "milestone",
       "content": "Ran a positive control before filing a stronger claim about missing CI",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
@@ -112,41 +94,33 @@
       "type": "milestone",
       "content": "Searched for an existing issue before filing about the ratchet being undiagnosable",
       "caused_by": [],
-      "leads_to": [
-        "e011"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
       "id": "e011",
-      "timestamp": "2026-08-01T15:27:33+00:00",
+      "timestamp": "2026-08-01T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: 1a4f2ba07",
-      "caused_by": [
-        "e001",
-        "e002",
-        "e003",
-        "e004",
-        "e005",
-        "e006",
-        "e007",
-        "e008",
-        "e009",
-        "e010"
-      ],
-      "leads_to": [
-        "e012"
-      ],
+      "caused_by": [],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     },
     {
       "id": "e012",
-      "timestamp": "2026-08-01T15:28:04+00:00",
+      "timestamp": "2026-08-01T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: 83150f835",
-      "caused_by": [
-        "e011"
-      ],
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 0e02b65dc",
+      "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-08-01-session-4169-agents-md-compression-defects"
     }
@@ -156,7 +130,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/sessions/2026-08-01-session-4169-agents-md-compression-defects.json
+++ b/.agents/sessions/2026-08-01-session-4169-agents-md-compression-defects.json
@@ -64,7 +64,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "1a4f2ba07 on this branch; 83150f835 on rjmurillo/doc-conflict-audit-method"
+        "Evidence": "0e02b65dc on this branch; 3 commits on rjmurillo/doc-conflict-audit-method"
       },
       "validationPassed": {
         "level": "MUST",
@@ -140,7 +140,7 @@
       "result": "#3902 already covered it, so measured cost evidence was added to that thread instead of opening a duplicate. A duplicate filed earlier in the session, #4173, had already shown the cost of skipping this step."
     }
   ],
-  "endingCommit": "1a4f2ba07",
+  "endingCommit": "0e02b65dc",
   "nextSteps": [
     "Merge PR #4174 once CI completes; it fixes all three main-red failures by extracting constants rather than suppressing the file-size rule",
     "Push rjmurillo/fix-agents-bash-contradiction and rjmurillo/doc-conflict-audit-method once main is green, then release the remaining fleet branches in sequence",

--- a/.agents/sessions/2026-08-01-session-4169-agents-md-compression-defects.json
+++ b/.agents/sessions/2026-08-01-session-4169-agents-md-compression-defects.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4169,
+    "date": "2026-08-01",
+    "branch": "rjmurillo/fix-agents-bash-contradiction",
+    "startingCommit": "4d749bccb",
+    "objective": "Fix two AGENTS.md directives that contradict the gates they summarize (issue #4169), and correct unverifiable figures in the context-optimizer rule-audit reference (issue #4175)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Copilot CLI harness; Serena MCP tools not exposed in this session"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not reachable without Serena activation"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md read-only; not modified per ADR-014"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file, created before the final commit of the session"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned rjmurillo/fix-agents-bash-contradiction in the linked worktree wt-agents-bash"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All commits made from linked worktrees; the shared checkout at ai-agents5 stayed clean on main"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Both review gate agents returned and every finding was addressed before the gate token was emitted"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status shows no modification to .agents/HANDOFF.md"
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena unavailable in this harness; durable findings were filed as GitHub issues instead"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "lefthook markdown-check and markdown-autofix passed on every commit in this session"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "1a4f2ba07 on this branch; 83150f835 on rjmurillo/doc-conflict-audit-method"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "run_plugin_version_bump_ci.py reports plugin-version-bump OK on both branches; check_plugin_manifest_parity.py passes both checks"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Scope correction posted to #4175; measured cost evidence added to #3902; #4176 filed"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Two review agents run as a gate: code-review on both branch diffs, and a GPT-5.6 Sol rubber-duck on the PR body"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Rework was needed twice and is recorded in the work log rather than hidden: the PR body misquoted command output, and the reference document shipped two wrong figures"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Audited the always-on rule corpus for directives that contradict an enforced gate",
+      "result": "One genuine contradiction found and filed as #4169. AGENTS.md listed 'Use bash' under Never, while the detailed rules prohibit only creating new bash scripts. Two hypotheses were disproved rather than shipped."
+    },
+    {
+      "step": 2,
+      "action": "Tested whether shared-vocabulary ranking could find such contradictions automatically",
+      "result": "Disproved. The contradicting pair shares exactly one content word, while pairs that merely agree share up to seven, so any vocabulary ranking sorts a true conflict below noise. The contradiction lives in the verb."
+    },
+    {
+      "step": 3,
+      "action": "Checked the plugin bump directive against ADR-091",
+      "result": "AGENTS.md said 'Bump plugin manifest' unqualified, but ADR-091 made the two parity manifests bot-owned, so a manual bump is now a violation with reason manually-bumped. Corrected the line and kept its trigger condition."
+    },
+    {
+      "step": 4,
+      "action": "Verified before correcting ADR-091 frontmatter, rather than assuming it was stale",
+      "result": "ADR-091 is named for a post-merge bot, so implemented false would have been correct for a validator-only rollout. Confirmed .github/workflows/post-merge-version-bump.yml exists, so both halves are live and the frontmatter is genuinely wrong."
+    },
+    {
+      "step": 5,
+      "action": "Re-verified my own vendor-portability declaration in the rule-audit reference",
+      "result": "Two of its four figures were wrong. It claimed 23k lines across 80 files; the tree is 24,656 lines across 44 files. It attributed a phrase to SKILL.md that does not appear there. Both corrected to measured values and verbatim quotes."
+    },
+    {
+      "step": 6,
+      "action": "Ran a review gate with two independent reviewers before publishing anything",
+      "result": "No Critical or High findings. Six real defects across the two reviewers were fixed, including a table that quoted a string my other branch deletes, a citation described as an executable dependency, and a verification transcript that omitted 39 lines while presented as verbatim."
+    },
+    {
+      "step": 7,
+      "action": "Bisected main after discovering it was red on a clean checkout",
+      "result": "Traced to 08749a142 from PR #4144, which pushed scripts/eval/_copilot_cli.py over the 500 line taste threshold and changed a provider contract two tests still encoded."
+    },
+    {
+      "step": 8,
+      "action": "Investigated why a regression reached main without any check failing",
+      "result": "Filed #4176. Six workflows trigger on push to main with cancel-in-progress true and a concurrency group keyed on github.ref, which is constant for every merge, so each merge cancels the previous merge's verification. On 08749a142 the Python Tests push run was cancelled."
+    },
+    {
+      "step": 9,
+      "action": "Ran a positive control before filing a stronger claim about missing CI",
+      "result": "The control caught my own detector as broken. gh run list --commit silently returns zero runs for an abbreviated SHA, which would have supported a false claim that no CI ran at all. Re-measured everything with full 40 character SHAs."
+    },
+    {
+      "step": 10,
+      "action": "Searched for an existing issue before filing about the ratchet being undiagnosable",
+      "result": "#3902 already covered it, so measured cost evidence was added to that thread instead of opening a duplicate. A duplicate filed earlier in the session, #4173, had already shown the cost of skipping this step."
+    }
+  ],
+  "endingCommit": "1a4f2ba07",
+  "nextSteps": [
+    "Merge PR #4174 once CI completes; it fixes all three main-red failures by extracting constants rather than suppressing the file-size rule",
+    "Push rjmurillo/fix-agents-bash-contradiction and rjmurillo/doc-conflict-audit-method once main is green, then release the remaining fleet branches in sequence",
+    "Decide on #4176 whether a cancelled post-merge run on main should raise an alert, since a cancelled conclusion is currently neither success nor failure and nothing notices"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 ## Boundaries
 
 **BLOCKING verify**: unrun gen'd artifact -> runtime test|security thread -> code fix or owner|skip validation -> `pre_pr.py`
-**Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|Bump src/claude manifest (ADR-091)
+**Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|src/claude edit -> bump manifest (ADR-091)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
 **Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact
@@ -36,7 +36,7 @@ Knowledge -> context. Actions -> skills.
 |Security: security-detection|Quality: analyze|Learn: reflect|Lifecycle: /spec /plan /build /test /review /ship
 |CI-feedback sub-loop: cluster, ladder build->test->review->ship. See `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
 |ADR-078: no skill -> autoplan; multi-step/cross-cutting -> orchestrator; no return loop
-|New capability: buy-vs-build Quick BEFORE /spec+baseline; >13wk no baseline = prune. Skip: bug/doc/refactor/approved-capability-extension
+|New capability: buy-vs-build Quick BEFORE /spec+baseline; >13wk no baseline = prune. Skip: bug/doc/refactor/approved-cap-extension
 |Harness work: read agent-harness-reference; mutate via ai-agents-portability-campaign
 
 ### ADR Review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@
 ## Boundaries
 
 **BLOCKING verify**: unrun gen'd artifact -> runtime test|security thread -> code fix or owner|skip validation -> `pre_pr.py`
-**Always**: Python (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|Bump plugin manifest
+**Always**: Python (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|Bump src/claude manifest when touching src/claude/** (ADR-091: parity pair is bot-owned)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Edit HANDOFF.md|Use bash|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact
+**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact
 
 ## Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 ## Boundaries
 
 **BLOCKING verify**: unrun gen'd artifact -> runtime test|security thread -> code fix or owner|skip validation -> `pre_pr.py`
-**Always**: Python (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|Bump src/claude manifest when touching src/claude/** (ADR-091: parity pair is bot-owned)
+**Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|Bump src/claude manifest (ADR-091)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
 **Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact


### PR DESCRIPTION
## What this changes

`AGENTS.md` is injected into every session on every harness, so a line that reads wrong is read wrong thousands of times. Two lines in it were wrong in different ways, and review caught a third problem in how I described the change.

### 1. The bash prohibition was unscoped

The `**Never**` list said `Use bash`. Taken literally that forbids the shell, which is false: this repo runs `git`, `gh`, `uv`, and `lefthook` from bash constantly, and several always-on gates shell out. The rule it was compressing is ADR-042, which is about **authoring** new automation in bash rather than Python. The line now reads `New bash scripts`, which is the rule that actually exists.

This mattered beyond style. An agent reading `Use bash` under `**Never**` has to either ignore a stated prohibition or refuse work the repo requires. Both are bad, and the first teaches it that the rules in this file are approximate.

### 2. The manifest bump read as unconditional

The `**Always**` list ended with `Bump plugin manifest`. Two defects there. It named no plugin, and there are three. And the requirement is conditional, not always: a bump is required only when a non-manifest file inside a plugin source directory appears in the diff, and a metadata-only edit to the manifest itself needs none.

Under ADR-091 two of the three plugin roots are bot managed and PRs must **not** bump them, which leaves `src/claude` as the one a contributor is responsible for. So the line now names it, and carries the condition in the arrow idiom the file already uses one line above:

    src/claude edit -> bump manifest (ADR-091)

### 3. Scope, which the first draft of this description got wrong

Review pointed out that I described this as one file and two lines with no behavior change, and that was not accurate. The real scope is four files:

- `AGENTS.md`, the change above
- `.agents/architecture/ADR-091-post-merge-version-bot.md`, frontmatter flipped to `implemented: true`
- `.agents/sessions/2026-08-01-session-4169-agents-md-compression-defects.json`, the session record
- `.agents/memory/episodes/episode-2026-08-01-session-4169-agents-md-compression-defects.json`, the episode

The ADR flip is the substantive one and it deserved to be called out rather than buried. Calling a four file change "one file" is how an ADR state change gets merged without anyone looking at it.

There is also a fourth edit inside line 24 that the earlier description did not mention: `Update Serena` was removed from the `**Always**` list. That was not a deletion of the rule. It already appears in the `**End**` gate on line 19, so the `**Always**` copy was redundant, and removing it bought the bytes the conditional phrasing needed. Line 19 still carries it.

## Byte budget

This file is capped at 3000 bytes and the cap is enforced on every commit. It sat at 2997, so the conditional phrasing had to pay for itself. It does, by shortening `approved-capability-extension` to `approved-cap-extension` on the capability line, where the words `New capability:` already open the sentence.

    before   2997 bytes
    after    2998 bytes   (budget check passes)

## Verification

- workspace budget check passes, `AGENTS.md: 2,998 bytes [OK]`
- zero em dashes and zero en dashes, verified at byte level
- markdownlint clean on the changed file
- `taste-lints` clean, no new violations
- the conditional claim was checked against the validator itself, which requires a strictly greater version only when a non-manifest file under a plugin source dir is in the diff

## References

The bump condition described above is implemented in `build/scripts/validate_plugin_version_bump.py`, and the bot managed flags come from ADR-091.

Refs #4169
