### PR TITLE
fix(validation): detect duplicate test helpers

### DIFF
--- a/scripts/validation/check_duplicate_test_helpers.py
+++ b/scripts/validation/check_duplicate_test_helpers.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Gate: no duplicate module-level test helper definitions.
+
+Ruff F811 ignores names that match ``lint.dummy-variable-rgx``. Ruff documents
+that F811 ignores dummy variables, and the default regex matches `_helper`.
+This gate covers the repository-specific gap for tests, where helpers are often
+private by naming convention and a later definition silently replaces the
+earlier one.
+
+Exit codes (ADR-035):
+    0 - Success (no duplicate module-level test helpers found)
+    1 - Logic error (one or more duplicate helpers found)
+    2 - Config error (invalid repository root)
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_SKIP_DIRS = frozenset(
+    {
+        ".venv",
+        "venv",
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        "site-packages",
+    }
+)
+
+
+def _is_git_root(repo_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return Path(result.stdout.strip()).resolve() == repo_root.resolve()
+
+
+def _tracked_test_files(repo_root: Path) -> list[Path]:
+    """Return tracked and untracked ``tests/**/*.py`` files when possible."""
+    if not _is_git_root(repo_root):
+        return _walk_test_files(repo_root)
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "--",
+                "tests",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return _walk_test_files(repo_root)
+
+    paths = []
+    for line in result.stdout.splitlines():
+        path = repo_root / line
+        if path.suffix == ".py" and path.is_file():
+            paths.append(path)
+    return paths
+
+
+def _walk_test_files(repo_root: Path) -> list[Path]:
+    tests_root = repo_root / "tests"
+    if not tests_root.is_dir():
+        return []
+
+    files: list[Path] = []
+    for path in tests_root.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in path.relative_to(repo_root).parts):
+            continue
+        files.append(path)
+    return files
+
+
+def find_duplicate_module_level_helpers(repo_root: Path) -> list[tuple[Path, str, int, int]]:
+    """Return duplicate module-level test helper definitions.
+
+    Each tuple is ``(path, name, first_line, duplicate_line)``. Only top-level
+    ``def`` and ``async def`` statements are considered. Nested helpers and class
+    methods have their own scopes, so they are not reported.
+    """
+    findings: list[tuple[Path, str, int, int]] = []
+    for path in _tracked_test_files(repo_root):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, UnicodeError, SyntaxError):
+            continue
+
+        seen: dict[str, int] = {}
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            previous = seen.get(node.name)
+            if previous is not None:
+                findings.append((path, node.name, previous, node.lineno))
+            else:
+                seen[node.name] = node.lineno
+    return findings
+
+
+def validate_duplicate_test_helpers(repo_root: Path) -> bool:
+    """Return True when no duplicate module-level test helpers are found."""
+    findings = find_duplicate_module_level_helpers(repo_root)
+    if not findings:
+        return True
+
+    print(
+        f"[FAIL] {len(findings)} duplicate module-level test helper definition(s) found:",
+        file=sys.stderr,
+    )
+    for path, name, first_line, duplicate_line in findings:
+        rel = path.relative_to(repo_root) if path.is_relative_to(repo_root) else path
+        print(f"  {rel}:{first_line} and {duplicate_line} duplicate {name}()", file=sys.stderr)
+    print("\nFix: rename or merge the duplicate helper definitions.", file=sys.stderr)
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns an ADR-035 exit code."""
+    args = argv if argv is not None else sys.argv[1:]
+    repo_root = Path(args[0]).resolve() if args else Path(__file__).resolve().parents[2]
+    if not repo_root.is_dir():
+        print(f"[FAIL] Invalid repository root: {repo_root}", file=sys.stderr)
+        return 2
+    return 0 if validate_duplicate_test_helpers(repo_root) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -24,6 +24,7 @@ if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
 
 from active_plan_closeout import validate_active_plan_closeout
+from check_duplicate_test_helpers import validate_duplicate_test_helpers
 from check_nested_tests import validate_no_nested_tests
 from check_test_tree_writes import validate_test_tree_writes
 from check_unreachable_code import validate_unreachable_code
@@ -124,6 +125,12 @@ def run_all_validations(
         "Nested Test Detection",
         state,
         lambda: validate_no_nested_tests(repo_root),
+    )
+
+    run_validation(
+        "Duplicate Test Helper Detection",
+        state,
+        lambda: validate_duplicate_test_helpers(repo_root),
     )
 
     run_validation(

--- a/tests/validation/test_check_duplicate_test_helpers.py
+++ b/tests/validation/test_check_duplicate_test_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
-from collections.abc import Generator
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,7 +19,7 @@ import pre_pr_sequence  # noqa: E402
 
 
 @pytest.fixture
-def repo_workspace() -> Generator[Path]:
+def repo_workspace() -> Iterator[Path]:
     scratch_root = REPO_ROOT / ".pytest_tmp"
     scratch_root.mkdir(exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="duplicate-test-helpers-", dir=scratch_root) as raw:

--- a/tests/validation/test_check_duplicate_test_helpers.py
+++ b/tests/validation/test_check_duplicate_test_helpers.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(VALIDATION_DIR))
+
+import check_duplicate_test_helpers as checker  # noqa: E402
+import pre_pr_sequence  # noqa: E402
+
+
+@pytest.fixture
+def repo_workspace() -> Generator[Path]:
+    scratch_root = REPO_ROOT / ".pytest_tmp"
+    scratch_root.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="duplicate-test-helpers-", dir=scratch_root) as raw:
+        repo = Path(raw)
+        (repo / "tests").mkdir()
+        yield repo
+
+
+def _write(repo: Path, relative_path: str, content: str) -> Path:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestDuplicateTestHelpers:
+    def test_repository_tests_have_no_duplicate_module_level_helpers(self) -> None:
+        assert checker.find_duplicate_module_level_helpers(REPO_ROOT) == []
+
+    def test_accepts_unique_module_level_helpers(self, repo_workspace: Path) -> None:
+        _write(
+            repo_workspace,
+            "tests/test_ok.py",
+            "def _first():\n"
+            "    return 1\n\n"
+            "def _second():\n"
+            "    return 2\n",
+        )
+
+        assert checker.find_duplicate_module_level_helpers(repo_workspace) == []
+        assert checker.validate_duplicate_test_helpers(repo_workspace)
+
+    def test_reports_duplicate_private_helper_with_both_lines(
+        self, repo_workspace: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(
+            repo_workspace,
+            "tests/test_duplicate.py",
+            "def _helper():\n"
+            "    return 1\n\n"
+            "def _helper(value):\n"
+            "    return value\n",
+        )
+
+        findings = checker.find_duplicate_module_level_helpers(repo_workspace)
+        valid = checker.validate_duplicate_test_helpers(repo_workspace)
+        captured = capsys.readouterr()
+
+        assert not valid
+        assert findings == [(repo_workspace / "tests/test_duplicate.py", "_helper", 1, 4)]
+        assert "tests/test_duplicate.py:1 and 4 duplicate _helper()" in captured.err
+
+    def test_reports_duplicate_async_helpers(self, repo_workspace: Path) -> None:
+        _write(
+            repo_workspace,
+            "tests/test_async_duplicate.py",
+            "async def _load():\n"
+            "    return 1\n\n"
+            "async def _load(value):\n"
+            "    return value\n",
+        )
+
+        assert checker.find_duplicate_module_level_helpers(repo_workspace) == [
+            (repo_workspace / "tests/test_async_duplicate.py", "_load", 1, 4)
+        ]
+
+    def test_ignores_nested_functions_and_class_methods(self, repo_workspace: Path) -> None:
+        _write(
+            repo_workspace,
+            "tests/test_scopes.py",
+            "def _outer():\n"
+            "    def _helper():\n"
+            "        return 1\n"
+            "    def _helper(value):\n"
+            "        return value\n"
+            "    return _helper(2)\n\n"
+            "class TestThing:\n"
+            "    def _helper(self):\n"
+            "        return 1\n"
+            "    def _helper(self, value):\n"
+            "        return value\n",
+        )
+
+        assert checker.find_duplicate_module_level_helpers(repo_workspace) == []
+
+    def test_cli_exit_codes(self, repo_workspace: Path) -> None:
+        script = REPO_ROOT / "scripts/validation/check_duplicate_test_helpers.py"
+        clean_repo = repo_workspace / "clean"
+        dirty_repo = repo_workspace / "dirty"
+        clean_repo.mkdir()
+        dirty_repo.mkdir()
+        (clean_repo / "tests").mkdir()
+        (dirty_repo / "tests").mkdir()
+        _write(clean_repo, "tests/test_clean.py", "def _one():\n    return 1\n")
+        _write(
+            dirty_repo,
+            "tests/test_dirty.py",
+            "def _same():\n    return 1\n\ndef _same():\n    return 2\n",
+        )
+
+        clean = subprocess.run(
+            [sys.executable, str(script), str(clean_repo)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        dirty = subprocess.run(
+            [sys.executable, str(script), str(dirty_repo)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        config = subprocess.run(
+            [sys.executable, str(script), str(repo_workspace / "missing")],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+        assert clean.returncode == 0
+        assert dirty.returncode == 1
+        assert config.returncode == 2
+        assert "duplicate _same()" in dirty.stderr
+        assert "Invalid repository root" in config.stderr
+
+    def test_pre_pr_sequence_runs_duplicate_helper_detection_after_nested_tests(self) -> None:
+        recorded: list[str] = []
+
+        def fake_run_validation(
+            name: str, _state: object, _callback: object, skip: bool = False
+        ) -> bool:
+            recorded.append(name)
+            return True
+
+        state = SimpleNamespace(total=0, passed=0, failed=0, skipped=0)
+        args = SimpleNamespace(quick=True, skip_tests=False, verbose=False)
+        pre_pr_sequence.run_all_validations(REPO_ROOT, args, state, fake_run_validation)
+
+        idx = recorded.index("Nested Test Detection")
+        assert recorded[idx + 1] == "Duplicate Test Helper Detection"


### PR DESCRIPTION
Fixes #4060

## Summary

Adds a validation script that scans tests for duplicate module-level helper definitions. Wires it into the pre-PR sequence and adds pytest coverage for detection, clean cases, async helpers, scoped helpers, CLI exit codes, and the pre-PR hook point.

## Triage

Ruff 0.15.16 still misses two same-named private helpers. The scratch fixture returned exit 0 from `uv run ruff check` with `All checks passed!`.

Current repository scan found 0 duplicate module-level function definitions across 658 test files.

Priority remains P2. Fix is merited because the failure mode is silent shadowing in large test modules, and existing CI does not run mypy over the full test tree.

## Cheaper mechanisms checked

Ruff docs say F811 ignores names matching `lint.dummy-variable-rgx`; the default matches private helper names. Ruff issue 10522 tracks a broader duplicate-function rule and is still open.

Mypy catches the fixture with `no-redef`, but this repo only ratchets changed lines and has test overrides. Pylint is not a dependency. Narrowing `dummy-variable-rgx` would alter unused-variable and unused-argument semantics across the repo.

## Validation

```text
uv run ruff check scripts/validation/check_duplicate_test_helpers.py scripts/validation/pre_pr_sequence.py tests/validation/test_check_duplicate_test_helpers.py
uv run mypy tests/validation/test_check_duplicate_test_helpers.py
uv run pytest tests/validation/test_check_duplicate_test_helpers.py::TestDuplicateTestHelpers
uv run python scripts/validation/check_duplicate_test_helpers.py
uv run python scripts/validation/pre_pr.py --quick --skip-tests
```

Negative control: disabling the detector append made 3 tests fail. Restoring it made all 7 selected tests pass.

Push hook: full pre-push passed and branch pushed with `PUSH_EXIT=0`.

## References

- Ruff F811 docs: https://docs.astral.sh/ruff/rules/redefined-while-unused/
- Ruff setting docs: https://docs.astral.sh/ruff/settings/#lint_dummy-variable-rgx
- Ruff duplicate function request: https://github.com/astral-sh/ruff/issues/10522
