### PR TITLE
fix(plugin): restore Copilot manifest description

### DIFF
--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
-  "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
+  "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
   "version": "0.6.5494",
   "author": {
     "name": "rjmurillo"

--- a/tests/test_marketplace_two_plugin.py
+++ b/tests/test_marketplace_two_plugin.py
@@ -18,6 +18,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CLAUDE_MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 COPILOT_MARKETPLACE = REPO_ROOT / ".github" / "plugin" / "marketplace.json"
 CLAUDE_AGENTS_PLUGIN = REPO_ROOT / "src" / "claude" / ".claude-plugin" / "plugin.json"
+CLAUDE_TOOLKIT_PLUGIN = REPO_ROOT / ".claude" / ".claude-plugin" / "plugin.json"
+COPILOT_TOOLKIT_PLUGIN = (
+    REPO_ROOT / "src" / "copilot-cli" / ".claude-plugin" / "plugin.json"
+)
 
 CLAUDE_PLUGIN_NAMES = {"claude-agents", "project-toolkit"}
 COPILOT_PLUGIN_NAMES = {"project-toolkit"}
@@ -92,16 +96,31 @@ class TestMarketplaceShape:
 
 
 class TestMarketplaceSourceManifestParity:
-    """Marketplace entries must match the plugin manifests they publish."""
+    """Descriptions stay aligned for the three published plugin roots.
 
-    def test_claude_agents_description_matches_source_manifest(self) -> None:
-        marketplace = _load_marketplace(CLAUDE_MARKETPLACE)
-        plugin_manifest = _load_marketplace(CLAUDE_AGENTS_PLUGIN)
-        claude_agents_entry = next(
-            plugin for plugin in marketplace["plugins"] if plugin["name"] == "claude-agents"
+    This guards the #4158 regression where the Copilot CLI manifest copied the
+    Claude Code description while its marketplace entry stayed correct. It is
+    not a general name or manifest parity policy.
+    """
+
+    @pytest.mark.parametrize(
+        ("marketplace_path", "plugin_name", "manifest_path"),
+        [
+            (CLAUDE_MARKETPLACE, "claude-agents", CLAUDE_AGENTS_PLUGIN),
+            (CLAUDE_MARKETPLACE, "project-toolkit", CLAUDE_TOOLKIT_PLUGIN),
+            (COPILOT_MARKETPLACE, "project-toolkit", COPILOT_TOOLKIT_PLUGIN),
+        ],
+    )
+    def test_description_matches_source_manifest(
+        self, marketplace_path: Path, plugin_name: str, manifest_path: Path
+    ) -> None:
+        marketplace = _load_marketplace(marketplace_path)
+        plugin_manifest = _load_marketplace(manifest_path)
+        entry = next(
+            plugin for plugin in marketplace["plugins"] if plugin["name"] == plugin_name
         )
 
-        assert claude_agents_entry["description"] == plugin_manifest["description"]
+        assert entry["description"] == plugin_manifest["description"]
 
 
 class TestSourceDirsExist:


### PR DESCRIPTION
Fixes #4158

## Summary

Corrects the Copilot CLI plugin manifest description so it matches the Copilot marketplace entry instead of the Claude Code text.

I corrected the text rather than expanding the manifest parity gate. The gate source says description parity was deliberately rejected because upstream allows marketplace metadata to differ from plugin manifest fields.

## Validation

```text
Revert detector: 1 failed, 2 passed, exit 1
Restore detector: 3 passed, exit 0
Post-rebase targeted tests: 132 passed
Plugin manifest parity: Plugin manifest versions match: 0.6.5493
Manifest validator: exit 0
Plugin version bump validator: plugin-version-bump: OK
Changed-file ruff: All checks passed
Pre-push: PUSH_EXIT=0
```

## Scope check

All three plugin roots were checked against their marketplace-facing descriptions. Only the Copilot CLI root was wrong.
