### PR TITLE
fix(hooks): resolve pinned semgrep

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -3192,6 +3192,64 @@ def _filesystem_collision_key(path: str) -> str | None:
     return "/".join(normalized_parts)
 
 
+class _SemgrepExecutableError(RuntimeError):
+    """Semgrep executable resolution failed before the scan ran."""
+
+
+@lru_cache(maxsize=1)
+def _semgrep_pinned_version(repo_root: Path = REPO_ROOT) -> str:
+    pyproject = repo_root / "pyproject.toml"
+    matches: list[str] = re.findall(
+        r'^\s*"semgrep==([^"]+)",\s*$',
+        pyproject.read_text(),
+        re.MULTILINE,
+    )
+    versions = set(matches)
+    if len(versions) != 1:
+        raise _SemgrepExecutableError(
+            f"pyproject.toml must declare one semgrep pin, found: {sorted(versions)!r}\n"
+        )
+    return versions.pop()
+
+
+@lru_cache(maxsize=1)
+def _resolve_semgrep_executable(repo_root: Path = REPO_ROOT) -> str:
+    sibling_name = "semgrep.exe" if os.name == "nt" else "semgrep"
+    sibling = Path(sys.executable).parent / sibling_name
+    if sibling.is_file() and os.access(sibling, os.X_OK):
+        return str(sibling)
+
+    resolved = shutil.which("semgrep")
+    if resolved is None:
+        raise FileNotFoundError("semgrep")
+
+    version = _probe_semgrep_version(resolved, repo_root)
+    pinned = _semgrep_pinned_version(repo_root)
+    if version != pinned:
+        raise _SemgrepExecutableError(
+            f"semgrep version mismatch: pyproject.toml pins {pinned}, "
+            f"but {resolved} reports {version}\n"
+        )
+    return resolved
+
+
+def _probe_semgrep_version(executable: str, repo_root: Path) -> str:
+    result = _run_command(
+        [executable, "--version"],
+        repo_root,
+        timeout_seconds=SEMGREP_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        raise _SemgrepExecutableError(
+            f"semgrep version probe failed for {executable}: {result.stderr.strip()}\n"
+        )
+    version = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+    if not version:
+        raise _SemgrepExecutableError(
+            f"semgrep version probe returned no version for {executable}\n"
+        )
+    return version
+
 def _run_semgrep_tree(
     tree: Path,
     paths: Sequence[str],
@@ -3201,9 +3259,9 @@ def _run_semgrep_tree(
     finding: subprocess.CompletedProcess[str] | None = None
     last_result: subprocess.CompletedProcess[str] | None = None
     try:
-        for batch in _semgrep_target_batches(targets):
+        for batch in _semgrep_target_batches(targets, repo_root):
             result = _run_command(
-                _semgrep_command("auto", batch),
+                _semgrep_command("auto", batch, repo_root),
                 repo_root,
                 timeout_seconds=SEMGREP_TIMEOUT_SECONDS,
             )
@@ -3217,14 +3275,20 @@ def _run_semgrep_tree(
                 finding = verified
     except FileNotFoundError:
         return subprocess.CompletedProcess([], 2, "", "semgrep executable not found\n")
+    except _SemgrepExecutableError as error:
+        return subprocess.CompletedProcess([], 2, "", str(error))
     except OSError as error:
         return subprocess.CompletedProcess([], 2, "", f"cannot execute semgrep: {error}\n")
     return finding or last_result or subprocess.CompletedProcess([], 0, "", "")
 
 
-def _semgrep_command(config: str, targets: Sequence[str]) -> list[str]:
+def _semgrep_command(
+    config: str,
+    targets: Sequence[str],
+    repo_root: Path = REPO_ROOT,
+) -> list[str]:
     return [
-        "semgrep",
+        _resolve_semgrep_executable(repo_root),
         "scan",
         "--config",
         config,
@@ -3242,8 +3306,11 @@ def _semgrep_command(config: str, targets: Sequence[str]) -> list[str]:
     ]
 
 
-def _semgrep_target_batches(targets: Sequence[str]) -> list[list[str]]:
-    base_length = sum(len(argument) + 1 for argument in _semgrep_command("auto", []))
+def _semgrep_target_batches(
+    targets: Sequence[str],
+    repo_root: Path = REPO_ROOT,
+) -> list[list[str]]:
+    base_length = sum(len(argument) + 1 for argument in _semgrep_command("auto", [], repo_root))
     batches: list[list[str]] = []
     batch: list[str] = []
     batch_length = base_length

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -3199,9 +3199,15 @@ class _SemgrepExecutableError(RuntimeError):
 @lru_cache(maxsize=1)
 def _semgrep_pinned_version(repo_root: Path = REPO_ROOT) -> str:
     pyproject = repo_root / "pyproject.toml"
+    try:
+        pyproject_text = pyproject.read_text(encoding="utf-8")
+    except OSError as error:
+        raise _SemgrepExecutableError(
+            f"cannot read semgrep pin from {pyproject}: {error}\n"
+        ) from error
     matches: list[str] = re.findall(
         r'^\s*"semgrep==([^"]+)",\s*$',
-        pyproject.read_text(),
+        pyproject_text,
         re.MULTILINE,
     )
     versions = set(matches)

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -2988,6 +2988,38 @@ def test_semgrep_fallback_version_mismatch_blocks(
     policy._resolve_semgrep_executable.cache_clear()
 
 
+def test_semgrep_missing_pyproject_reports_pin_read_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    fallback = tmp_path / "path-semgrep"
+    monkeypatch.setattr(policy.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(policy.shutil, "which", lambda command: str(fallback))
+    monkeypatch.setattr(
+        policy,
+        "_run_command",
+        lambda args, *_args, **_kwargs: subprocess.CompletedProcess(
+            args,
+            0,
+            "1.171.0\n",
+            "",
+        ),
+    )
+
+    result = policy._run_semgrep_tree(tmp_path, ["source.py"], tmp_path)
+
+    assert result.returncode == 2
+    assert "cannot read semgrep pin from" in result.stderr
+    assert "pyproject.toml" in result.stderr
+    assert "semgrep executable not found" not in result.stderr
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+
+
 def test_semgrep_pin_is_read_from_pyproject() -> None:
     policy._semgrep_pinned_version.cache_clear()
     pyproject = PROJECT_ROOT / "pyproject.toml"

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -2887,6 +2887,116 @@ def test_pushed_semgrep_detects_collision_with_unchanged_head_path(
     assert policy.scan_pushed_heads(io.StringIO(), tmp_path) == 2
 
 
+def test_semgrep_uses_sibling_binary_without_version_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    sibling = bin_dir / ("semgrep.exe" if os.name == "nt" else "semgrep")
+    sibling.write_text("", encoding="utf-8")
+    sibling.chmod(0o755)
+    monkeypatch.setattr(policy.sys, "executable", str(bin_dir / "python"))
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: Sequence[str],
+        *_args: object,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        assert args[1] != "--version"
+        return _semgrep_completed(0, [tmp_path / "source.py"])
+
+    monkeypatch.setattr(policy, "_run_command", fake_run)
+
+    result = policy._run_semgrep_tree(tmp_path, ["source.py"], tmp_path)
+
+    assert result.returncode == 0
+    assert calls[0][0] == str(sibling)
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+
+
+def test_semgrep_falls_back_to_matching_path_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    fallback = tmp_path / "path-semgrep"
+    monkeypatch.setattr(policy.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(policy.shutil, "which", lambda command: str(fallback))
+    monkeypatch.setattr(policy, "_semgrep_pinned_version", lambda _repo_root=tmp_path: "1.171.0")
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: Sequence[str],
+        *_args: object,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        if args == [str(fallback), "--version"]:
+            return subprocess.CompletedProcess(args, 0, "1.171.0\n", "")
+        return _semgrep_completed(0, [tmp_path / "source.py"])
+
+    monkeypatch.setattr(policy, "_run_command", fake_run)
+
+    result = policy._run_semgrep_tree(tmp_path, ["source.py"], tmp_path)
+
+    assert result.returncode == 0
+    assert calls[0] == [str(fallback), "--version"]
+    assert calls[1][0] == str(fallback)
+    policy._resolve_semgrep_executable.cache_clear()
+
+
+def test_semgrep_fallback_version_mismatch_blocks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy._resolve_semgrep_executable.cache_clear()
+    policy._semgrep_pinned_version.cache_clear()
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    fallback = tmp_path / "path-semgrep"
+    monkeypatch.setattr(policy.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(policy.shutil, "which", lambda command: str(fallback))
+    monkeypatch.setattr(policy, "_semgrep_pinned_version", lambda _repo_root=tmp_path: "1.171.0")
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: Sequence[str],
+        *_args: object,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, "1.153.1\n", "")
+
+    monkeypatch.setattr(policy, "_run_command", fake_run)
+
+    result = policy._run_semgrep_tree(tmp_path, ["source.py"], tmp_path)
+
+    assert result.returncode == 2
+    assert "pyproject.toml pins 1.171.0" in result.stderr
+    assert str(fallback) in result.stderr
+    assert "1.153.1" in result.stderr
+    assert calls == [[str(fallback), "--version"]]
+    policy._resolve_semgrep_executable.cache_clear()
+
+
+def test_semgrep_pin_is_read_from_pyproject() -> None:
+    policy._semgrep_pinned_version.cache_clear()
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    matches = re.findall(r'^\s*"semgrep==([^"]+)",\s*$', pyproject.read_text(), re.MULTILINE)
+
+    assert matches == [policy._semgrep_pinned_version(PROJECT_ROOT)] * 2
+    policy._semgrep_pinned_version.cache_clear()
+
+
 def test_semgrep_missing_executable_blocks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Resolves the pre-push Semgrep executable from the active Python environment before PATH.
- Probes PATH fallback versions against the pyproject Semgrep pin and fails closed on mismatch.
- Adds regression tests for sibling resolution, fallback resolution, version mismatch, and pin drift.

## Validation
- `uv run ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py`
- `uv run mypy scripts/validation/git_hook_policy.py`
- `uv run pytest tests/test_lefthook_integration.py -q -x`
- `uv run python scripts/validation/pre_pr.py`
- Mutation proof: four new detector tests failed after inverting resolution and pin behavior, then passed after restore.
- Push hook: `PUSH_EXIT=0`

## Security Review
Security agent reviewed the diff. Verdict: approved. One medium accepted-risk note: the sibling environment fast path trusts the pinned project environment and avoids a per-push version probe.

## Follow-up
Filed #4190 for the older `scripts/security/run_semgrep.py` scanner, which still uses bare PATH resolution but is not the active pre-push gate.

Fixes #4178
