### PR TITLE
fix(governance): ADR-091 is not implemented, its artifacts were deleted

### DIFF
--- a/.agents/architecture/ADR-091-post-merge-version-bot.md
+++ b/.agents/architecture/ADR-091-post-merge-version-bot.md
@@ -6,7 +6,7 @@ decision-makers: [rjmurillo]
 supersedes: [ADR-079]
 superseded-by: ADR-092
 explainer: null
-implemented: true
+implemented: false
 ---
 
 # ADR-091: Post-Merge Bot Owns Plugin Version and Count Baselines

--- a/.agents/memory/episodes/episode-2026-08-01-session-4179-adr-091-implemented-flag.json
+++ b/.agents/memory/episodes/episode-2026-08-01-session-4179-adr-091-implemented-flag.json
@@ -1,0 +1,78 @@
+{
+  "id": "episode-2026-08-01-session-4179-adr-091-implemented-flag",
+  "session": "2026-08-01-session-4179-adr-091-implemented-flag",
+  "timestamp": "2026-08-01T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Correct the ADR-091 implemented flag on main. PR #4179 merged carrying implemented: true while deleting both artifacts that implemented the decision.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked ADR-091 frontmatter on main after #4179 merged",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Traced why the fix did not land with the PR",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced the underlying merge behaviour",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed ADR-092 itself landed correctly",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-01T18:25:34+00:00",
+      "type": "commit",
+      "content": "Commit: 1a2bd3fe8f6a",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-08-01-session-4179-adr-091-implemented-flag.json
+++ b/.agents/memory/episodes/episode-2026-08-01-session-4179-adr-091-implemented-flag.json
@@ -13,9 +13,7 @@
       "type": "milestone",
       "content": "Checked ADR-091 frontmatter on main after #4179 merged",
       "caused_by": [],
-      "leads_to": [
-        "e005"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
     },
     {
@@ -24,9 +22,7 @@
       "type": "milestone",
       "content": "Traced why the fix did not land with the PR",
       "caused_by": [],
-      "leads_to": [
-        "e005"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
     },
     {
@@ -35,9 +31,7 @@
       "type": "milestone",
       "content": "Reproduced the underlying merge behaviour",
       "caused_by": [],
-      "leads_to": [
-        "e005"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
     },
     {
@@ -46,22 +40,24 @@
       "type": "milestone",
       "content": "Confirmed ADR-092 itself landed correctly",
       "caused_by": [],
-      "leads_to": [
-        "e005"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
     },
     {
       "id": "e005",
-      "timestamp": "2026-08-01T18:25:34+00:00",
+      "timestamp": "2026-08-01T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: 1a2bd3fe8f6a",
-      "caused_by": [
-        "e001",
-        "e002",
-        "e003",
-        "e004"
-      ],
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-01T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a5017d74df4daa5a733e750f2813ac70ad176fe6",
+      "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-08-01-session-4179-adr-091-implemented-flag"
     }
@@ -71,7 +67,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
+++ b/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
@@ -113,7 +113,7 @@
   "endingCommit": "a5017d74df4daa5a733e750f2813ac70ad176fe6",
   "nextSteps": [
     "Close #4202 once this lands: the workflow it describes is deleted from main by ADR-092, so the direct-push failure cannot recur",
-    "Correct the public causal account in #4195: adversarial review showed the two count decreases came from prose and table edits, not from fenced-block stripping",
+    "Correct the public causal account in #4195: both the original account (fenced-block stripping) and the adversarial replacement (prose and table edits) located the movement in the files map, which PR #4197 never touched. Regenerating files from PR #4182's own tree gives 0 disagreements; the three moved entries are in marker_files. Both accounts partitioned the JSON diff with a text filter, which cannot separate two maps whose keys share the same shape",
     "Consider a validator that rejects implemented: true when a decision record is superseded and its named artifacts are absent"
   ]
 }

--- a/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
+++ b/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
@@ -110,7 +110,7 @@
       "result": "The version key is absent from both parity manifests on main, which is what ADR-092 requires."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "a5017d74df4daa5a733e750f2813ac70ad176fe6",
   "nextSteps": [
     "Close #4202 once this lands: the workflow it describes is deleted from main by ADR-092, so the direct-push failure cannot recur",
     "Correct the public causal account in #4195: adversarial review showed the two count decreases came from prose and table edits, not from fenced-block stripping",

--- a/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
+++ b/.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4179,
+    "date": "2026-08-01",
+    "branch": "rjmurillo/fix-adr-091-implemented-flag",
+    "startingCommit": "25ee6eb7b",
+    "objective": "Correct the ADR-091 implemented flag on main. PR #4179 merged carrying implemented: true while deleting both artifacts that implemented the decision."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Copilot CLI harness; Serena MCP tools are not exposed in this session"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not reachable without Serena activation"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md read-only; git status shows it unmodified per ADR-014"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file, staged with the commit it documents"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned rjmurillo/fix-adr-091-implemented-flag"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commit made from the linked worktree wt-adr091, not from the shared main checkout"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Frontmatter claim tested against the tree before and after the change"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status shows no modification to .agents/HANDOFF.md"
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena not available in this harness"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdown-autofix and markdown-check run in the pre-commit hook group"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-091 frontmatter fix committed with this log"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Verified both implementing artifacts absent on main with git cat-file -e before changing the flag"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #4202 records the operational half of this finding"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-line governance correction; no separate retrospective"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Third occurrence of this same incoherent state. It reached main because the fix was prepared on a branch that merged before the fix landed on it."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Checked ADR-091 frontmatter on main after #4179 merged",
+      "result": "implemented: true alongside status: superseded and superseded-by: ADR-092. Both implementing artifacts, .github/workflows/post-merge-version-bump.yml and scripts/ci/auto_bump_plugin_version.py, are absent from main, so the flag is false."
+    },
+    {
+      "step": 2,
+      "action": "Traced why the fix did not land with the PR",
+      "result": "I prepared the correction on the PR branch, but the PR merged at its previous tip while the pre-push suite was still running. The push then recreated an already-deleted branch instead of updating an open PR. Verified by PR state MERGED at headOid 1a2bd3fe8f6a while my push reported a new branch."
+    },
+    {
+      "step": 3,
+      "action": "Reproduced the underlying merge behaviour",
+      "result": "The incoherent state arrives through clean auto-merges. Two sides edit different lines of the same frontmatter block, so git has nothing to flag and neither reviewer sees a conflict."
+    },
+    {
+      "step": 4,
+      "action": "Confirmed ADR-092 itself landed correctly",
+      "result": "The version key is absent from both parity manifests on main, which is what ADR-092 requires."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Close #4202 once this lands: the workflow it describes is deleted from main by ADR-092, so the direct-push failure cannot recur",
+    "Correct the public causal account in #4195: adversarial review showed the two count decreases came from prose and table edits, not from fenced-block stripping",
+    "Consider a validator that rejects implemented: true when a decision record is superseded and its named artifacts are absent"
+  ]
+}


### PR DESCRIPTION
## Summary

ADR-091 is marked `implemented: true` on main while both artifacts that implemented it are absent from the tree. ADR-092 superseded it and deleted them. This flips the flag to `false` so the record matches the repository.

Refs #4080, refs #4202.

## Why this matters

`implemented` is the field a reader trusts to answer "is this decision live in the code". A superseded record that still claims implementation is worse than no record: it sends the next reader looking for a workflow that is not there, and it makes the governance set unusable as an index of what is actually running.

This is the third time the same record has auto merged into an incoherent state. Git merged cleanly each time because the two sides edited different lines of the same fact. A clean merge is not a coherent one.

## Evidence

Verified on main at `25ee6eb7be40`, see `.github/workflows/post-merge-version-bump.yml` and `scripts/ci/auto_bump_plugin_version.py`:

```
$ git cat-file -e origin/main:.github/workflows/post-merge-version-bump.yml && echo present || echo absent
absent
$ git cat-file -e origin/main:scripts/ci/auto_bump_plugin_version.py && echo present || echo absent
absent
```

Both are gone, while the record read:

```
status: superseded
superseded-by: ADR-092
implemented: true
```

## Changes

- `.agents/architecture/ADR-091-post-merge-version-bot.md`: `implemented: true` becomes `false`.
- `.agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json`: session log, required by the hook policy for any change under the governance tree.

## Verification

Session log passes the validator:

```
$ uv run python scripts/validate_session_json.py .agents/sessions/2026-08-01-session-4179-adr-091-implemented-flag.json --pre-commit
```

No behavior changes, no code paths touched.

## Follow up worth considering

A validator could reject `implemented: true` on a record whose status is `superseded` and whose named artifacts are absent. Three occurrences of the same incoherence argue for mechanizing the check rather than catching it by eye a fourth time. Not in this PR.
