### PR TITLE
feat(eval): add the report command that reveals the held-out test group

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -660,19 +660,28 @@ reads the third group:
 uv run --frozen python "$OA" report --results cand.json --split split.json
 ```
 
-It prints `score`, `group`, `n`, and `fingerprint`, and no `decision` field,
-because it reports rather than decides. Exit 0 on a number, 1 on a refusal,
-2 on a split it cannot use.
+It prints `score`, `group`, `n`, `corpus_verified`, and `fingerprint`, and no
+`decision` field, because it reports rather than decides. Exit 0 on a number,
+1 on a refusal, 2 on a split it cannot use.
 
-Four things bound it. It has no `--group`, so it reads `test` and nothing
+Five things bound it. It has no `--group`, so it reads `test` and nothing
 else. It answers once per test group: the second call refuses, and the record
 is keyed on the group's membership, so copying or renaming the split does not
 buy another. Its budget is separate from the gate's, so an exhausted
 consultation budget does not block the report and a spent report does not
-block the gate. And a results file that does not cover the test group is
-refused **after** the read is charged, for the same reason the gate charges
-first: a free coverage probe against a withheld group is an oracle over its
-membership.
+block the gate. It honours the corpus pin the gate honours, refusing results
+that name a corpus the split does not, which the gate refuses because a
+comparison across a corpus change measures the change too, and this command
+refuses because nothing downstream compares the number at all. And a results
+file that does not cover the test group is refused **after** the read is
+charged, for the same reason the gate charges first: a free coverage probe
+against a withheld group is an oracle over its membership.
+
+The corpus refusal is free, unlike the coverage one. A corpus identity is a
+header on the file the caller supplied, decidable without touching the group,
+so it is read before the lock and charges nothing. `corpus_verified` reports
+whether the check ran at all: the rule and hook paths publish no corpus
+identity, so `false` there means unchecked rather than failed.
 
 Score the artifact over the whole task set before calling this. There is one
 attempt, and spending it on a short results file means re-splitting and

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -418,7 +418,7 @@ This tool splits the task ids into three groups and keeps them apart:
 |-------|-------------|---------|---------------|
 | `opt` | The optimizing agent | Read failures here, propose edits from them. | The remainder, 0.6 |
 | `sel` | The gate | Decides accept or reject. Each decision spends one consultation from a fixed budget. | 0.4 |
-| `test` | Nothing yet | Reserved for a final report. **No command scores it**, so today it only shrinks `opt` and `sel`. See ADR-087 Open Requirement 7. | 0.0, opt in with `--test-ratio` |
+| `test` | `report`, once | The final number, read after the loop converges. `report` scores it once and refuses every read after that. It never gates. | 0.0, opt in with `--test-ratio` |
 
 `--test-ratio` defaults to zero, so out of the box you get two groups and an
 empty `test`. That is a concession to this repo's real fixture counts: most
@@ -448,6 +448,7 @@ one-fixture gate, which measures nothing.
 | `score` | Fraction of one group passing. |
 | `apply` | Apply bounded patches to an artifact file. |
 | `gate` | Decide whether the candidate replaces the incumbent. |
+| `report` | Score the `test` group once, after the loop is done. |
 | `buffer-check` | Has this edit already been rejected? |
 | `buffer-add` | Record a rejected edit so it is not re-proposed. |
 
@@ -649,6 +650,37 @@ was rejected so a later step, or a reader auditing the buffer, can tell a gate
 reject apart from a refused patch or an operator veto. Name the deciding
 signal, not the intent: `gate: sel score dropped 0.62 -> 0.55` tells the next
 reader something, `bad edit` does not.
+
+### Reporting the test group, once
+
+When the loop has converged and the consultation budget is spent, one command
+reads the third group:
+
+```bash
+uv run --frozen python "$OA" report --results cand.json --split split.json
+```
+
+It prints `score`, `group`, `n`, and `fingerprint`, and no `decision` field,
+because it reports rather than decides. Exit 0 on a number, 1 on a refusal,
+2 on a split it cannot use.
+
+Four things bound it. It has no `--group`, so it reads `test` and nothing
+else. It answers once per test group: the second call refuses, and the record
+is keyed on the group's membership, so copying or renaming the split does not
+buy another. Its budget is separate from the gate's, so an exhausted
+consultation budget does not block the report and a spent report does not
+block the gate. And a results file that does not cover the test group is
+refused **after** the read is charged, for the same reason the gate charges
+first: a free coverage probe against a withheld group is an oracle over its
+membership.
+
+Score the artifact over the whole task set before calling this. There is one
+attempt, and spending it on a short results file means re-splitting and
+re-running the loop.
+
+`--test-ratio` defaults to 0, so this command has nothing to read unless the
+split was drawn with a test group. It says so rather than reporting a score
+over an empty set.
 
 ### What the gate refuses
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -2493,10 +2493,41 @@ def cmd_report(args: argparse.Namespace) -> int:
             "run the loop against that split, and report at the end."
         )
     holdout_key = _holdout_key(split, _REPORT_GROUP)
+
+    # Header only, and before the lock, so the corpus refusal costs nothing.
+    # `cmd_gate` orders it the same way and for the same reason, and the stake
+    # is higher here: its budget is whatever cap the run opened with, this one
+    # is one, so charging a file scored against the wrong task set would cost a
+    # re-split and a re-run of the loop. Reading the header is not a reveal
+    # either, since the caller supplied the file and the refusal below prints
+    # no task id.
+    pin = split.get("corpus", _UNPINNED)
+    with _digest_scrubbed(holdout_key):
+        corpus = _corpus_header(args.results)
+        _refuse_unparseable_input(args.results)
+    # `_corpus_conflict` counts the distinct identities declared across the
+    # inputs, so the gate's two files and this command's one reach it through
+    # the same predicate; passing the single header on both sides lets the set
+    # collapse it rather than restating the rule with one fewer term.
+    if _corpus_refused(pin, corpus, corpus):
+        _emit({
+            "decision": "REFUSE",
+            "reason": (
+                "the split and the results do not agree on one corpus, so the "
+                "number would describe a different task set than the split "
+                "names. Re-score the artifact so that one corpus is named "
+                "across both, and report again. This attempt spent nothing."
+            ),
+            "reported": False,
+            "group": _REPORT_GROUP,
+            "fingerprint": split["fingerprint"],
+        })
+        return EXIT_LOGIC
+
     # The lock spans the read, the compare, and the write, so two reports
     # started together cannot both find an unspent budget and both reveal.
     with _ledger_held(holdout_key):
-        return _report_reveal(args, split, holdout_key, test_ids)
+        return _report_reveal(args, split, holdout_key, test_ids, pin)
 
 
 def _report_reveal(
@@ -2504,6 +2535,7 @@ def _report_reveal(
     split: dict[str, Any],
     holdout_key: str,
     test_ids: list[str],
+    pin: object,
 ) -> int:
     """Spend the one reveal and report what it bought."""
     ledger = _ledger_path(holdout_key, _REPORT_LEDGER_SUFFIX)
@@ -2539,7 +2571,8 @@ def _report_reveal(
 
     # Read before the charge, so a file that never parsed is a config error
     # rather than a spent budget. `cmd_gate` orders its own read the same way.
-    results = _read_results(args.results).results
+    results_file = _read_results(args.results)
+    results = results_file.results
 
     # Charge before reading the group, not after emitting a number. A crash
     # between the two would otherwise leave the group read and the reveal
@@ -2567,6 +2600,11 @@ def _report_reveal(
         "score": _score_group(results, split, _REPORT_GROUP),
         "group": _REPORT_GROUP,
         "n": len(test_ids),
+        # False means the check never ran, not that it failed: a disagreement
+        # refused above without charging. One field rather than the gate's two,
+        # because `corpus_pinned` and `corpus_verified` differ there only in the
+        # unpinned pair that agrees with itself, and one file has no such pair.
+        "corpus_verified": results_file.corpus is not None and results_file.corpus == pin,
         "fingerprint": split["fingerprint"],
     })
     return EXIT_OK

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -20,9 +20,18 @@ so the loop is drivable from a shell or from an agent's tool calls.
     optimize-artifact.py gate --incumbent base.json --candidate cand.json \\
         --split split.json --incumbent-fingerprint "$FP"
 
+Once the loop converges, and only once, the third group answers:
+
+    optimize-artifact.py report --results cand.json --split split.json
+
 `gate` scores both sides itself from the split's held-out `sel` group rather
 than accepting two numbers. Taking bare numbers would make the loop's most
 damaging mistake, gating on optimize-set scores, a typo away at every step.
+
+`report` reads `test`, which no gate decision has touched, and refuses a
+second read against the same group. It reports a number and does not decide,
+so a loop that branches on it has turned the last honest measurement into one
+more selection step.
 
 Exit codes follow ADR-035:
 
@@ -90,6 +99,14 @@ from _optimizer_core import (  # noqa: E402
 )
 
 _GATE_GROUP = "sel"
+_GATE_LEDGER_SUFFIX = ".ledger"
+
+# The group `report` reveals, and how many times it may ever be revealed. One,
+# because a group read twice is a group selection has touched, and the whole
+# reason this group exists is that nothing has.
+_REPORT_GROUP = "test"
+_REPORT_BUDGET = 1
+_REPORT_LEDGER_SUFFIX = ".test-ledger"
 
 EXIT_OK = 0
 EXIT_LOGIC = 1
@@ -1453,7 +1470,7 @@ def _ledger_root() -> Path:
     return Path(state) / "ai-agents-eval" / "ledgers"
 
 
-def _holdout_key(split: dict[str, Any]) -> str:
+def _holdout_key(split: dict[str, Any], group: str = _GATE_GROUP) -> str:
     """The identity of the held-out group itself, which is what a budget counts.
 
     Three earlier versions keyed the ledger on something upstream of the group:
@@ -1482,12 +1499,20 @@ def _holdout_key(split: dict[str, Any]) -> str:
     provenance would work and needs a seam that carries one; the seam here
     carries task ids and pass booleans. Sharing is the conservative direction,
     so the collision is accepted rather than reopened.
+
+    `group` is a parameter because there are two withheld groups and each has
+    its own budget: the gate spends consultations against `sel`, and `report`
+    spends its single reveal against `test`. Keying both on membership means
+    the two keys differ whenever the two groups differ, which is always, so an
+    exhausted selection budget cannot block the one-time report and a spent
+    report cannot block the gate. The default is the gate's group because that
+    is the caller this function was written for.
     """
-    sel = sorted(str(task_id) for task_id in _group_ids(split, _GATE_GROUP))
+    members = sorted(str(task_id) for task_id in _group_ids(split, group))
     # JSON rather than a NUL join: joining is not injective when an id may
     # itself contain the separator, and ["a", "b\0c"] would key the same
     # budget as ["a\0b", "c"].
-    canonical = json.dumps(sel, separators=(",", ":"), ensure_ascii=True)
+    canonical = json.dumps(members, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -1668,9 +1693,17 @@ def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
         _ACTIVE_HOLDOUT_KEY.reset(token)
 
 
-def _ledger_path(holdout_key: str) -> Path:
-    """Where the budget for one held-out group lives."""
-    return _ledger_root() / f"{holdout_key}.ledger"
+def _ledger_path(holdout_key: str, suffix: str = _GATE_LEDGER_SUFFIX) -> Path:
+    """Where the budget for one held-out group lives.
+
+    The suffix separates the gate's consultation budget from the report's
+    single reveal. Keying alone would almost separate them, since the two
+    groups never share membership, but almost is the wrong word for a budget:
+    one split's `sel` group can be another split's `test` group, and then both
+    budgets land on one filename under two incompatible schemas. The suffix
+    makes that impossible rather than unlikely.
+    """
+    return _ledger_root() / f"{holdout_key}{suffix}"
 
 
 def _blocking_ancestor(lock: Path) -> Path | None:
@@ -2409,6 +2442,137 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    """Read the test group once, at the end, and never gate on it.
+
+    `split` has drawn this group since the loop was written and no command
+    scored it. `extract --split --group test` could emit its per-task outcomes,
+    uncharged, which is a loophole the trusted controller in ADR-087 Open
+    Requirement 1 closes, not this command; what was missing here was a read
+    that produces a number and pays for it. The gap surfaced through its
+    symptom: an exhausted-budget refusal advised the operator to report on the
+    test group, an invocation the parser rejected statically, and PR #3478
+    removed the advice rather than weaken the boundary that made it false. This
+    is the first branch of ADR-087 Open Requirement 7, which asked for the
+    reveal or for the group to be dropped from the design.
+
+    No `--group`. `score` refuses every group but `opt` and `gate` reads `sel`
+    by definition; offering a choice here would hand back the unmetered read
+    those two restrictions exist to prevent. This command reads `test` and
+    nothing else, once.
+
+    It reports rather than decides, so a passing run emits `score` and no
+    `decision` field. A caller that branches on this number is selecting on the
+    one group no selection decision has touched, which is the property the
+    group exists to hold.
+    """
+    split = _read_split(args.split)
+    if _split_drifted(split):
+        # Raised rather than emitted as a refusal, for the reason `cmd_score`
+        # gives: a hand-edited split is a malformed report, and this command's
+        # caller is an operator reading one number at the end rather than a
+        # loop branching on a verdict document.
+        raise ConfigError(
+            f"{args.split} does not match its own recorded inputs; the groups "
+            "or the seed were edited after the split was drawn. Reporting on "
+            "it would publish a number under a fingerprint that no longer "
+            "names it. Re-split and re-baseline."
+        )
+    test_ids = _group_ids(split, _REPORT_GROUP)
+    if not test_ids:
+        # A config error rather than a score of zero over nothing. The split
+        # was drawn with --test-ratio 0, so there is no reserved group, and
+        # the fix is upstream at the split rather than here.
+        raise ConfigError(
+            f"{args.split} holds an empty test group, so there is nothing "
+            "reserved to report on. Re-split with --test-ratio above zero, "
+            "run the loop against that split, and report at the end."
+        )
+    holdout_key = _holdout_key(split, _REPORT_GROUP)
+    # The lock spans the read, the compare, and the write, so two reports
+    # started together cannot both find an unspent budget and both reveal.
+    with _ledger_held(holdout_key):
+        return _report_reveal(args, split, holdout_key, test_ids)
+
+
+def _report_reveal(
+    args: argparse.Namespace,
+    split: dict[str, Any],
+    holdout_key: str,
+    test_ids: list[str],
+) -> int:
+    """Spend the one reveal and report what it bought."""
+    ledger = _ledger_path(holdout_key, _REPORT_LEDGER_SUFFIX)
+    try:
+        with _digest_scrubbed(holdout_key):
+            spent = _read_ledger(ledger, holdout_key, _REPORT_BUDGET, None)
+    except LedgerMismatchError as exc:
+        _emit({
+            "decision": "REFUSE",
+            "reason": str(exc),
+            "reported": False,
+            "group": _REPORT_GROUP,
+            "fingerprint": split["fingerprint"],
+        })
+        return EXIT_LOGIC
+
+    if spent >= _REPORT_BUDGET:
+        _emit({
+            "decision": "REFUSE",
+            "reason": (
+                "this test group has already been reported. A second read is "
+                "a second look at the one group no selection decision has "
+                "touched, which is the whole of what it was reserved for. "
+                "Re-split to draw a new one, and expect to re-run the loop: "
+                "a group reported against one artifact is not held out from "
+                "the next."
+            ),
+            "reported": False,
+            "group": _REPORT_GROUP,
+            "fingerprint": split["fingerprint"],
+        })
+        return EXIT_LOGIC
+
+    # Read before the charge, so a file that never parsed is a config error
+    # rather than a spent budget. `cmd_gate` orders its own read the same way.
+    results = _read_results(args.results).results
+
+    # Charge before reading the group, not after emitting a number. A crash
+    # between the two would otherwise leave the group read and the reveal
+    # unrecorded, and the retry would get it free.
+    with _digest_scrubbed(holdout_key):
+        _write_ledger(ledger, holdout_key, spent + 1, _REPORT_BUDGET, None)
+
+    if not _covers_holdout(results, test_ids):
+        _emit({
+            "decision": "REFUSE",
+            "reason": (
+                "the results do not cover the test group; score the artifact "
+                "over the whole task set and report again. Which tasks are "
+                "missing is withheld: naming them would name the group. This "
+                "attempt spent the one report this group ever answers, so "
+                "reporting again needs a new split."
+            ),
+            "reported": False,
+            "group": _REPORT_GROUP,
+            "fingerprint": split["fingerprint"],
+        })
+        return EXIT_LOGIC
+
+    _emit({
+        "score": _score_group(results, split, _REPORT_GROUP),
+        "group": _REPORT_GROUP,
+        "n": len(test_ids),
+        "fingerprint": split["fingerprint"],
+    })
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
 # buffer
 # ---------------------------------------------------------------------------
 
@@ -3017,6 +3181,25 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     gate_cmd.set_defaults(func=cmd_gate)
+
+    report_cmd = sub.add_parser("report", help="read the test group once, at the end")
+    report_cmd.add_argument(
+        "--results",
+        type=Path,
+        required=True,
+        help="extract output holding per-task pass or fail",
+    )
+    report_cmd.add_argument(
+        "--split",
+        type=Path,
+        required=True,
+        help="split output; the report reads the test group",
+    )
+    # No --group, for the reason `score_cmd` gives above: a free-standing score
+    # on a withheld group is the unmetered read the budget exists to count.
+    # This command reads `test` by definition and charges for it, which is what
+    # makes it a reveal rather than an exemption.
+    report_cmd.set_defaults(func=cmd_report)
 
     check = sub.add_parser("buffer-check", help="has this edit already been rejected")
     check.add_argument("--buffer", type=Path, required=True, help="rejected-edit buffer to consult")

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -2722,6 +2722,107 @@ class TestTheTestGroupIsReadOnceByReport:
             _run(capsys, "report", "--results", cand, "--split", split_path,
                  "--group", "opt")
 
+    # -- the corpus pin, which the gate already honours ----------------------
+
+    def _pinned_split(self, tmp_path, capsys, corpus, *, seed="s1"):
+        """The split with a corpus pin written in, as `split --corpus` records it.
+
+        The pin sits outside the fingerprint, so writing it after the draw
+        produces the same file `split --results` writes from an enveloped
+        source. `TestOneCorpusOrNoComparison` edits the same key the same way.
+        """
+        split_path, record, tasks = self._split_fixture(tmp_path, capsys, seed=seed)
+        record["corpus"] = corpus
+        split_path.write_text(json.dumps(record), encoding="utf-8")
+        return split_path, record, tasks
+
+    def _enveloped_candidate(self, tmp_path, corpus, *, name="cand.json"):
+        verdicts = {f"t{i:02d}": True for i in range(20)}
+        return _write(tmp_path, name, _enveloped(corpus, verdicts, name=name))
+
+    def test_a_results_file_from_another_corpus_is_refused(self, tmp_path, capsys):
+        """`cmd_gate` refuses a corpus disagreement; this read must too.
+
+        A gate that compares across a corpus change measures the change as
+        well as the edit. A report over the wrong corpus is worse: nothing
+        downstream compares it against anything, so the number ships as the
+        final honest one under a fingerprint naming other tasks.
+        """
+        split_path, _, _ = self._pinned_split(tmp_path, capsys, _SHA_A)
+        cand = self._enveloped_candidate(tmp_path, _SHA_B)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (code, out["decision"], out["reported"]) == (EXIT_LOGIC, "REFUSE", False)
+        assert "corpus" in out["reason"]
+        assert "score" not in out
+
+    def test_a_corpus_refusal_does_not_spend_the_report(self, tmp_path, capsys):
+        """Decidable from a header, so it costs nothing, as at `cmd_gate`.
+
+        The stake is higher here than there: the gate's budget is whatever cap
+        the run opened with, and this one is one. Charging a mistyped path
+        would cost a re-split and a re-run of the whole loop.
+        """
+        split_path, _, _ = self._pinned_split(tmp_path, capsys, _SHA_A)
+        wrong = self._enveloped_candidate(tmp_path, _SHA_B, name="wrong.json")
+        right = self._enveloped_candidate(tmp_path, _SHA_A, name="right.json")
+
+        refused_code, _ = self._report(capsys, wrong, split_path)
+        code, out = self._report(capsys, right, split_path)
+
+        assert refused_code == EXIT_LOGIC
+        assert (code, out["group"], out["score"]) == (EXIT_OK, "test", 1.0)
+
+    def test_a_stripped_envelope_beside_a_pin_is_refused(self, tmp_path, capsys):
+        """Omission is the bypass the pair rule closes: stripping the envelope
+        turns a digest into an unknown, and an unknown beside a pin is a
+        disagreement rather than a blank."""
+        split_path, _, _ = self._pinned_split(tmp_path, capsys, _SHA_A)
+        bare = self._candidate(tmp_path, name="bare.json")
+
+        code, out = self._report(capsys, bare, split_path)
+
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REFUSE")
+        assert "corpus" in out["reason"]
+
+    def test_a_matching_corpus_reports_and_says_the_check_ran(self, tmp_path, capsys):
+        split_path, _, _ = self._pinned_split(tmp_path, capsys, _SHA_A)
+        cand = self._enveloped_candidate(tmp_path, _SHA_A)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (code, out["score"]) == (EXIT_OK, 1.0)
+        assert out["corpus_verified"] is True
+
+    def test_an_unpinned_split_still_reports_and_says_the_check_never_ran(
+        self, tmp_path, capsys
+    ):
+        """The rule and hook paths publish no corpus identity at all, so the
+        report stays available there, flagged rather than refused."""
+        split_path, _, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (code, out["score"]) == (EXIT_OK, 1.0)
+        assert out["corpus_verified"] is False
+
+    def test_a_corpus_with_nothing_to_check_it_against_is_not_verified(
+        self, tmp_path, capsys
+    ):
+        """A split drawn from a task list pins nothing, so one named corpus is
+        not a conflict and is also not a check that passed. `_UNPINNED` is a
+        sentinel rather than `None` for exactly this row, and the verdict must
+        not read it as a match."""
+        split_path, _, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._enveloped_candidate(tmp_path, _SHA_A)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (code, out["score"]) == (EXIT_OK, 1.0)
+        assert out["corpus_verified"] is False
+
 
 class TestConsultationLedgerIsHeldByTheGate:
     """A budget the caller passes in is not a budget.

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -205,7 +205,7 @@ def _translated_argv(argv: tuple[str | Path, ...]) -> list[str]:
                 translated += ["--corpus", str(corpus)]
         except (OSError, ValueError, RecursionError):
             pass
-    if command in {"gate", "score"}:
+    if command in {"gate", "score", "report"}:
         for flag in ("--incumbent", "--candidate", "--results"):
             if flag in translated:
                 index = translated.index(flag)
@@ -2539,6 +2539,188 @@ class TestHeldOutGroupsAreNotReadable:
         code, out = _run(capsys, "score", "--results", self._tasks(tmp_path),
                          "--split", out_path)
         assert code == 0 and out["group"] == "opt" and out["score"] == 1.0
+
+
+class TestTheTestGroupIsReadOnceByReport:
+    """`split` drew a third group and no command could read it.
+
+    Round twenty of adversarial review found the gap through its symptom: the
+    exhausted-budget refusal advised the operator to report on the test group,
+    an invocation the parser rejected statically, and PR #3478 removed the
+    advice rather than widen `score --group` and hand the loop an unmetered
+    read. `report` is the first branch of ADR-087 Open Requirement 7: one
+    budgeted read of the group no gate decision has touched, refusing the
+    second. Refs #3552.
+    """
+
+    def _split_fixture(self, tmp_path, capsys, *, seed="s1", test_ratio="0.2"):
+        tasks = _write(tmp_path, "tasks.json", {f"t{i:02d}": True for i in range(20)})
+        split_path = tmp_path / "split.json"
+        _run(capsys, "split", "--results", tasks, "--seed", seed,
+             "--sel-ratio", "0.4", "--test-ratio", test_ratio, "--out", split_path)
+        record = json.loads(split_path.read_text(encoding="utf-8"))
+        return split_path, record, tasks
+
+    def _candidate(self, tmp_path, *, failing=(), missing=(), name="cand.json"):
+        verdicts = {f"t{i:02d}": True for i in range(20)}
+        for task_id in failing:
+            verdicts[task_id] = False
+        for task_id in missing:
+            verdicts.pop(task_id)
+        return _write(tmp_path, name, verdicts)
+
+    def _report(self, capsys, results, split_path):
+        return _run(capsys, "report", "--results", results, "--split", split_path)
+
+    def test_report_scores_the_test_group(self, tmp_path, capsys):
+        split_path, record, _ = self._split_fixture(tmp_path, capsys)
+        held_out = record["test"]
+        assert held_out, "the fixture must draw a test group for this to measure anything"
+        cand = self._candidate(tmp_path, failing=held_out[:1])
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert code == EXIT_OK
+        assert out["group"] == "test"
+        assert out["n"] == len(held_out)
+        assert out["score"] == pytest.approx((len(held_out) - 1) / len(held_out))
+        assert out["fingerprint"] == record["fingerprint"]
+        assert "decision" not in out, "a report states a number, it does not gate"
+
+    def test_a_second_report_against_the_same_group_is_refused(self, tmp_path, capsys):
+        split_path, _, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path)
+        first_code, _ = self._report(capsys, cand, split_path)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert first_code == EXIT_OK
+        assert (code, out["decision"], out["reported"]) == (EXIT_LOGIC, "REFUSE", False)
+        assert "score" not in out, "the refusal must not hand back the number it withheld"
+
+    def test_an_empty_test_group_is_a_config_error(self, tmp_path, capsys):
+        """The default `--test-ratio` of 0 draws nothing; the fix is at the split."""
+        split_path, record, _ = self._split_fixture(tmp_path, capsys, test_ratio="0.0")
+        assert record["test"] == []
+        cand = self._candidate(tmp_path)
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert code == EXIT_CONFIG
+        assert "--test-ratio" in out["error"]
+
+    def test_a_drifted_split_is_refused_before_any_number(self, tmp_path, capsys):
+        split_path, record, _ = self._split_fixture(tmp_path, capsys)
+        moved = dict(record)
+        moved["opt"] = [*record["opt"], record["test"][0]]
+        moved["test"] = record["test"][1:]
+        drifted = _write(tmp_path, "drifted.json", moved)
+        cand = self._candidate(tmp_path)
+
+        code, out = self._report(capsys, cand, drifted)
+
+        assert code == EXIT_CONFIG
+        assert "Re-split" in out["error"]
+        assert "score" not in out
+
+    def test_results_missing_the_test_group_are_refused_and_still_charged(
+        self, tmp_path, capsys
+    ):
+        """A free coverage probe would be an oracle over the group it withholds."""
+        split_path, record, _ = self._split_fixture(tmp_path, capsys)
+        short = self._candidate(tmp_path, missing=record["test"][:1], name="short.json")
+        full = self._candidate(tmp_path, name="full.json")
+
+        code, out = self._report(capsys, short, split_path)
+        retry_code, retry = self._report(capsys, full, split_path)
+
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REFUSE")
+        assert not any(task_id in out["reason"] for task_id in record["test"])
+        assert (retry_code, retry["decision"]) == (EXIT_LOGIC, "REFUSE")
+        assert "already been reported" in retry["reason"]
+
+    def test_an_exhausted_gate_budget_does_not_block_the_report(self, tmp_path, capsys):
+        """Two withheld groups, two budgets. One running out must not close the other."""
+        split_path, record, tasks = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path, failing=record["opt"][:1])
+        _run_gate(capsys, tmp_path, "--incumbent", tasks, "--candidate", cand,
+                  "--split", split_path, "--max-consultations", "1")
+        spent_code, spent = _run_gate(capsys, tmp_path, "--incumbent", tasks,
+                                      "--candidate", cand, "--split", split_path,
+                                      "--max-consultations", "1")
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (spent_code, spent["compared"]) == (EXIT_LOGIC, False)
+        assert (code, out["group"], out["score"]) == (EXIT_OK, "test", 1.0)
+
+    def test_the_report_does_not_spend_the_gate_budget(self, tmp_path, capsys):
+        split_path, record, tasks = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path, failing=record["opt"][:1])
+        self._report(capsys, cand, split_path)
+
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", tasks,
+                              "--candidate", cand, "--split", split_path,
+                              "--max-consultations", "1")
+
+        assert out["compared"] is True
+        assert out["sel_consultations"] == 1
+        assert code in (EXIT_OK, EXIT_LOGIC)
+
+    def test_the_two_budgets_live_in_different_files(self, tmp_path, capsys):
+        """Keyed on membership and suffixed by role, so neither can be the other."""
+        split_path, record, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path)
+        self._report(capsys, cand, split_path)
+
+        gate_key = oa._holdout_key(record)
+        report_key = oa._holdout_key(record, oa._REPORT_GROUP)
+
+        assert gate_key != report_key
+        assert oa._ledger_path(report_key, oa._REPORT_LEDGER_SUFFIX).exists()
+        assert not oa._ledger_path(gate_key).exists()
+        assert not oa._ledger_path(report_key).exists()
+
+    def test_a_ledger_moved_under_this_group_is_refused(self, tmp_path, capsys):
+        """A record under another group's name is a moved file, not a redraw."""
+        split_path, record, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path)
+        report_key = oa._holdout_key(record, oa._REPORT_GROUP)
+        planted = oa._ledger_path(report_key, oa._REPORT_LEDGER_SUFFIX)
+        planted.parent.mkdir(parents=True, exist_ok=True)
+        planted.write_text(
+            json.dumps({"consultations": 0, "holdout": "0" * 64,
+                        "max_consultations": 1, "max_p": None}),
+            encoding="utf-8",
+        )
+
+        code, out = self._report(capsys, cand, split_path)
+
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REFUSE")
+        assert "score" not in out
+        assert report_key not in out["reason"], "the refusal must not print the key"
+
+    def test_an_unreadable_results_file_does_not_spend_the_report(self, tmp_path, capsys):
+        """Read before charge: a typo in a path must not burn the one reveal."""
+        split_path, _, _ = self._split_fixture(tmp_path, capsys)
+        broken = tmp_path / "broken.json"
+        broken.write_text("{not json", encoding="utf-8")
+        good = self._candidate(tmp_path, name="good.json")
+
+        code, out = self._report(capsys, broken, split_path)
+        retry_code, retry = self._report(capsys, good, split_path)
+
+        assert code == EXIT_CONFIG
+        assert "error" in out
+        assert (retry_code, retry["group"], retry["score"]) == (EXIT_OK, "test", 1.0)
+
+    def test_report_offers_no_group_flag(self, tmp_path, capsys):
+        """Widening the choice is the unmetered read `score --group opt` refuses."""
+        split_path, _, _ = self._split_fixture(tmp_path, capsys)
+        cand = self._candidate(tmp_path)
+        with pytest.raises(SystemExit):
+            _run(capsys, "report", "--results", cand, "--split", split_path,
+                 "--group", "opt")
 
 
 class TestConsultationLedgerIsHeldByTheGate:


### PR DESCRIPTION
Fixes #3552

## Summary

The adjacent contract the diff broke is the corpus pin. `cmd_gate` (scripts/eval/optimize-artifact.py:2108-2124) refuses when the split and its inputs name more than one corpus, because a comparison across a corpus change measures the change as well as the edit. That guard exists because of the 2026-07-27 architect-spike incident: two runs with identical task ids and different `fixture_set_sha` were gated against each other and the accept was published before the mismatch was found. The new `report` command reads a results file and publishes a number over the test group, and asked nothing about the corpus. A split pinned to one fixture set plus a results file scored against another returned exit 0 with a score, under a fingerprint naming other tasks.

The gap is worse at `report` than at `gate`. A gate verdict is one step in a loop that keeps measuring; this is the last number, nothing downstream compares it, and there is exactly one attempt per test group.

Fix (commit 2ac9a6838, 3 files):
- `cmd_report` reads the results file's corpus header and refuses through the gate's own predicate. No second copy of the rule: `_corpus_conflict` counts distinct declared identities, so the single header goes in on both sides and the set collapses it.
- Placement copies the gate: header only, before the ledger lock, so the refusal charges nothing. That matters more here because burning the one reveal on a mistyped path costs a re-split and a re-run of the loop.
- The verdict gains `corpus_verified`. One field, not the gate's two: `corpus_pinned` and `corpus_verified` differ there only in the unpinned pair that agrees with itself, and one file has no such pair.
- README section updated ("Four things bound it" to five, plus the new payload field and the free-vs-charged distinction).

Verified no adjacent caller breaks. `_holdout_key` and `_ledger_path` both gained defaulted parameters in the parent commit; every pre-existing call site passes through unchanged. The parser-walking fences (`_subcommand_options` at tests/eval/test_optimize_artifact_cli.py:11394, `_MINIMUM_ARGV` at 7516) already cover or correctly exclude `report`. mypy clean, ruff clean, markdownlint clean, `checks_dash.py` and `check_adr_uniqueness.py` exit 0.

Not fixed, and I am naming it rather than hiding it: ADR-087 Open Requirement 7 and Decision Requirement 1 still say no command reads the test group, which `report` made false. See `disagreement`.

Two things I saw and left, both pre-existing and neither created by this diff:
- `_ledger_held` (optimize-artifact.py:1886) builds its lock as `{key}.lock` with no role suffix, and its contention message says "another gate holds a lock" and "consultations". A `report` that hits contention reads a message about the wrong command. The remediation advice (remove the lock file) stays correct, and threading a noun through a shared context manager to fix wording is not worth the parameter.
- `_holdout_key` mixes in no corpus namespace, so two unrelated corpora with identical task ids and identical test membership share one report budget. That is the conservative direction (refuse a second report rather than grant one), it is already named in ADR-087 Open Requirement 12, and my change does not move it.

Files (absolute):
/home/richard/src/GitHub/rjmurillo/ai-agents2/.claude/worktrees/wf_fb319713-387-1/scripts/eval/optimize-artifact.py
/home/richard/src/GitHub/rjmurillo/ai-agents2/.claude/worktrees/wf_fb319713-387-1/tests/eval/test_optimize_artifact_cli.py
/home/richard/src/GitHub/rjmurillo/ai-agents2/.claude/worktrees/wf_fb319713-387-1/scripts/eval/README.md

Branch `fix/issue-3552` now carries two commits. Not pushed, no PR.

## Verification

Six new tests, all seen failing before the fix existed.

BEFORE (fix absent, tests present):
  tests/eval/test_optimize_artifact_cli.py ...........FFFFF   [100%]
  test_a_results_file_from_another_corpus_is_refused
    assert (code, out["decision"], out["reported"]) == (EXIT_LOGIC, "REFUSE", False)
    E   KeyError: 'decision'
  test_a_corpus_refusal_does_not_spend_the_report
    assert refused_code == EXIT_LOGIC
    E   assert 0 == 1
  test_a_stripped_envelope_beside_a_pin_is_refused
    E   KeyError: 'decision'
  test_a_matching_corpus_reports_and_says_the_check_ran
    assert out["corpus_verified"] is True
    E   KeyError: 'corpus_verified'
  test_an_unpinned_split_still_reports_and_says_the_check_never_ran
    E   KeyError: 'corpus_verified'
  ================= 5 failed, 11 passed, 784 deselected in 2.16s =================

The `assert 0 == 1` is the defect itself: a report over corpus B against a split pinned to corpus A returned EXIT_OK with a score.

AFTER:
  ====================== 16 passed, 784 deselected in 0.50s ======================

Full touched suites after the sixth test was added:
  uv run --frozen pytest tests/eval/test_optimize_artifact_cli.py tests/eval/test_optimize_artifact_durability.py -q
  ======================= 815 passed, 3 skipped in 11.64s ========================
  uv run --frozen pytest tests/test_eval_optimizer_core.py -q
  ============================= 462 passed in 3.59s ==============================

Two mutations, run to prove placement rather than presence.

Mutation 1, drop the `== pin` term (`"corpus_verified": results_file.corpus is not None`):
  test_a_corpus_with_nothing_to_check_it_against_is_not_verified
    assert out["corpus_verified"] is False
    E   assert True is False
  ================= 1 failed, 88 passed, 712 deselected in 1.61s =================

Mutation 2, charge the ledger before the corpus refusal:
  test_a_corpus_refusal_does_not_spend_the_report
    assert (code, out["group"], out["score"]) == (EXIT_OK, "test", 1.0)
    E   KeyError: 'score'
  ====================== 1 failed, 800 deselected in 0.46s =======================
(the retry hit "this test group has already been reported", which is the whole point of putting the check before the charge)

Lint and types:
  uv run --frozen ruff check scripts/eval/optimize-artifact.py tests/eval/test_optimize_artifact_cli.py
  All checks passed!
  uv run --frozen mypy scripts/eval/optimize-artifact.py
  Success: no issues found in 1 source file
  npx markdownlint-cli2 scripts/eval/README.md
  Summary: 0 issues in 0 files
  uv run --frozen python scripts/validation/checks_dash.py     -> exit 0
  uv run --frozen python scripts/validation/validate_python_syntax.py -> exit 0
  git diff | grep -cP '^\+.*[\x{2014}\x{2013}]'  ->  0

Full repository suite, and proof the residual failures are not mine:
  at HEAD (fix/issue-3552, 2ac9a6838):
    uv run --frozen pytest tests/ci/test_validation_scripts_are_reachable.py tests/test_skill_bundle_suites_run.py -q
    ============= 114 failed, 34 passed, 2 skipped in 62.01s (0:01:02) =============
  at HEAD~2 (63a8e9b45, the branch base, before either commit on this branch):
    ============= 114 failed, 34 passed, 2 skipped in 60.61s (0:01:00) =============
Identical counts, so all 114 are pre-existing. Whole suite at HEAD: 114 failed, 20963 passed, 30 skipped; every FAILED line is in tests/ci/test_validation_scripts_are_reachable.py or tests/test_skill_bundle_suites_run.py, none under tests/eval.

Commit 2ac9a6838, 3 files, conventional message, `Co-Authored-By: Claude Opus 5 (1M context)` trailer, all pre-commit hooks green (taste-lint file-size and snake_case findings are advisory and pre-existing on these files).

## Recorded disagreement

One reviewer-adjacent item I could not complete, and I am reporting it rather than quietly skipping it or faking the evidence it needed.

ADR-087 line 155 says the test group's lifecycle is "stated, not yet enforced: `--test-ratio` defaults to `0.0` and no command reveals the group", and Open Requirement 7 says "no command reads it: `score` accepts `--group opt` only, and `gate` always reads `sel`". The parent commit made both false. I wrote the correction (rewrote the Requirement 1 paragraph to name `report`, struck Open Requirement 7 and recorded what stays open under Open Requirement 1), staged it, and the commit was refused by two pre-commit hooks:

  ┃  group (4) ❯ session-policy ❯
  ERROR: staged .agents changes require a JSON session log
  exit status 1
  ┃  group (4) ❯ adr-review-policy ❯
  ERROR: ADR changes require adr-review evidence in today's session log
  exit status 1

Satisfying the second means writing a session log asserting an adr-review debate ran. I did not run one, so writing that would be manufactured evidence for a gate whose entire purpose is to stop exactly that. I reverted the ADR edit and left the two false sentences in place, with the reason recorded in the commit body.

This is the same call the parent commit made ("ADR-087 Open Requirement 7 says the same thing and is left for a change that can carry adr-review evidence"). I did not take it on faith; I tried the edit and the repository's own gates confirmed the deferral was correct. The correction is a real, separate, gated change: it needs an adr-review run and a session log, and it belongs in its own commit rather than smuggled into a bug fix.

Separately, on the reviewer's framing: I found one adjacent-contract break, not several. The parent commit's two signature changes (`_holdout_key` gaining `group`, `_ledger_path` gaining `suffix`) both default to the gate's prior behaviour, and every pre-existing call site is unchanged. The break was not in those signatures. It was in what the

## Review history

This branch was rejected once in adversarial review and amended. The reviewer's surviving concerns were addressed and the amended diff passed a second independent review.