### PR TITLE
docs(ci): record that a count baseline may only fall

### DIFF
--- a/.claude/rules/ci-scripts.md
+++ b/.claude/rules/ci-scripts.md
@@ -18,8 +18,8 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 
 ## MUST
 
-1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
+1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `uv run python` invocation for validation scripts, and the actual test suite for helpers.
+2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.

--- a/.claude/rules/ci-scripts.md
+++ b/.claude/rules/ci-scripts.md
@@ -19,7 +19,7 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 ## MUST
 
 1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
+2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.
@@ -39,6 +39,21 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 1. MUST NOT put branching logic inside YAML workflow steps (ADR-006).
 2. MUST NOT commit changes that silently change validator behavior without an ADR; validators are authoritative.
 3. MUST NOT skip pre-push validation when touching CI paths.
+4. MUST NOT raise a count baseline (`scripts/ci/*_count_baseline.txt`) to clear a blocked push. Those ratchets exist to refuse a new error-severity violation; raising the number defeats the gate rather than satisfying it. Fix the violation, split the file, or use the rule's documented escape (`# taste-lint: ignore <rule>` with a reason, issue #3779).
+
+## Count ratchets
+
+A count ratchet may only fall. Two consequences follow, and both bite in practice.
+
+**A real improvement MUST be recorded.** An unrecorded improvement leaves slack, so the next regression up to the stale number passes silently. Lower it with the per-ratchet updater, not the shared module:
+
+```bash
+uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
+```
+
+`scripts/ci/count_ratchet.py --update <name>` reports success and changes nothing. Verify the file afterwards rather than trusting the message.
+
+**The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
 ## References
 

--- a/.github/instructions/ci-scripts.instructions.md
+++ b/.github/instructions/ci-scripts.instructions.md
@@ -9,7 +9,7 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 ## MUST
 
 1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
+2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.
@@ -29,6 +29,21 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 1. MUST NOT put branching logic inside YAML workflow steps (ADR-006).
 2. MUST NOT commit changes that silently change validator behavior without an ADR; validators are authoritative.
 3. MUST NOT skip pre-push validation when touching CI paths.
+4. MUST NOT raise a count baseline (`scripts/ci/*_count_baseline.txt`) to clear a blocked push. Those ratchets exist to refuse a new error-severity violation; raising the number defeats the gate rather than satisfying it. Fix the violation, split the file, or use the rule's documented escape (`# taste-lint: ignore <rule>` with a reason, issue #3779).
+
+## Count ratchets
+
+A count ratchet may only fall. Two consequences follow, and both bite in practice.
+
+**A real improvement MUST be recorded.** An unrecorded improvement leaves slack, so the next regression up to the stale number passes silently. Lower it with the per-ratchet updater, not the shared module:
+
+```bash
+uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
+```
+
+`scripts/ci/count_ratchet.py --update <name>` reports success and changes nothing. Verify the file afterwards rather than trusting the message.
+
+**The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
 ## References
 

--- a/.github/instructions/ci-scripts.instructions.md
+++ b/.github/instructions/ci-scripts.instructions.md
@@ -8,8 +8,8 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 
 ## MUST
 
-1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
+1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `uv run python` invocation for validation scripts, and the actual test suite for helpers.
+2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.

--- a/.serena/memories/ci/ci-count-ratchet-never-names-the-offending-file.md
+++ b/.serena/memories/ci/ci-count-ratchet-never-names-the-offending-file.md
@@ -1,0 +1,53 @@
+# Skill: Locating the file a count ratchet is failing on (95%)
+
+## Statement
+
+The count ratchets report a delta and never name the file. `taste count ratchet: baseline is 602 but current tree has 603 violations` tells you nothing about where. The suggested remedy command prints the same aggregate.
+
+Find the offender by diffing per-file violation counts against `origin/main`. Do not bisect.
+
+## Recipe
+
+```bash
+L=.claude/skills/taste-lints/scripts/taste_lints.py
+for tree in <branch-worktree> <main-worktree>; do
+  (cd "$tree" && uv run --frozen python "$L" --format json -- $(git ls-files) \
+    | python3 -c "
+import json,sys,collections
+d=json.load(sys.stdin); rows=d if isinstance(d,list) else d.get('violations',[])
+print(json.dumps(collections.Counter(
+    r['file'] for r in rows if str(r.get('severity','')).lower()=='error')))
+") > "cnt_$(basename $tree).json"
+done
+# then diff the two Counters; the file whose count rose is the offender
+```
+
+The linter needs `--format json -- <files>`; with no file arguments it scans nothing and reports zero, which reads as a clean tree.
+
+## Evidence
+
+2026-08-01: four separate branches blocked by this in one session. Each cost a manual offender diff to locate, because the failure names no path.
+
+- `lefthook.yml` sat at exactly 500 lines on `main`, so the next hook added crossed the limit
+- three branches crossed it with their own new test files (513, 507, 552 lines)
+
+Attribution is worth proving rather than inferring: `git rm --cached <suspect>` then re-running the ratchet returns `OK` if that file is the whole delta.
+
+## Gotcha: the updater is not the checker
+
+`scripts/ci/count_ratchet.py --update ruff` reports success and leaves the baseline unchanged. The working updater is the per-ratchet script:
+
+```bash
+uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
+# -> ruff count ratchet: improved 329 -> 326 (-3). Baseline lowered.
+```
+
+## Anti-Pattern
+
+Raising the baseline to clear the block. The gate exists to refuse a new error-severity violation; raising it defeats the purpose. Split the file or fix the violation. Lowering a baseline after a genuine improvement is required, though: an unrecorded improvement leaves slack that lets the next regression up to the stale number pass silently.
+
+## Related
+
+- Issue #4207 (the ceiling plus the missing filename in the message)
+- Issue #3902 (show new violations when the ratchet fails)
+- Issue #3779 (`# taste-lint: ignore <rule>` escape with a reason)

--- a/.serena/memories/ci/ci-mergeability-is-not-computed-until-you-ask.md
+++ b/.serena/memories/ci/ci-mergeability-is-not-computed-until-you-ask.md
@@ -1,0 +1,56 @@
+# Skill: Reading PR mergeability requires forcing its computation (98%)
+
+## Statement
+
+`gh pr list --json mergeStateStatus` returns `UNKNOWN` for most PRs. GitHub computes mergeability lazily and does **not** compute it because you asked for the status field. Request `mergeable` in the same query and the server computes both.
+
+Querying `mergeStateStatus` alone does not under-report by a little. It under-reports by an order of magnitude.
+
+## Evidence
+
+2026-08-01, 46 open PRs, same repository, seconds apart:
+
+```bash
+$ gh pr list --json number,mergeStateStatus --jq '... group_by(.mergeStateStatus)'
+BLOCKED=5 DIRTY=2 UNKNOWN=40
+
+$ gh pr list --json number,mergeable,mergeStateStatus --jq '... group_by(.mergeable)'
+CONFLICTING=35 MERGEABLE=11
+```
+
+The first reading says 2 PRs conflict. The truth is 35. I reported the wrong number from the first query and a verification pass caught it.
+
+## EUREKA: the documented recipe is the broken one
+
+`.serena/memories/jq/jq-pr-operation-patterns.md:18` recommends exactly the under-reporting form:
+
+```bash
+gh pr list --json number,mergeStateStatus | jq '.[] | select(.mergeStateStatus == "BLOCKED")'
+```
+
+That selects from a field that is mostly `UNKNOWN`, so it silently misses most BLOCKED PRs. The conventional pattern in this repo's own memory is the defect. Fix is one word: add `mergeable` to the `--json` list. The jq stays the same.
+
+## Anti-Pattern
+
+Reading conflict or block counts from `mergeStateStatus` alone, then reporting them as fact. `UNKNOWN` is not "no conflict"; it is "nobody asked".
+
+## Correct Usage
+
+```bash
+# Forces computation. mergeable is the field that triggers it; keep it even if
+# you only read mergeStateStatus.
+gh pr list --state open --limit 100 --json number,mergeable,mergeStateStatus
+```
+
+Or skip the server entirely, which needs no lazily-computed state:
+
+```bash
+git merge-tree --write-tree --name-only origin/main <pr-head>
+```
+
+`merge-tree` also names the conflicting paths, which `mergeStateStatus` never does. It writes a tree object and reports conflicts without touching the index or working tree, so it is safe to run against a repository with other work in flight.
+
+## Related
+
+- `.serena/memories/jq/jq-pr-operation-patterns.md` (contains the under-reporting form)
+- `.serena/memories/tasks/issue-2637-merge-pr-reject-unknown.md` (treats UNKNOWN as not-ready at merge time, which is the correct downstream behaviour)

--- a/.serena/memories/jq/jq-pr-operation-patterns.md
+++ b/.serena/memories/jq/jq-pr-operation-patterns.md
@@ -15,13 +15,16 @@ Validated JQ patterns for PR operations (tested, working):
 ### Filter BLOCKED PRs
 
 ```bash
-gh pr list --json number,mergeStateStatus | jq '.[] | select(.mergeStateStatus == "BLOCKED")'
+# `mergeable` is not decoration: without it GitHub leaves mergeStateStatus at
+# UNKNOWN for most PRs, and this select silently misses them. See
+# .serena/memories/ci/ci-mergeability-is-not-computed-until-you-ask.md
+gh pr list --json number,mergeable,mergeStateStatus | jq '.[] | select(.mergeStateStatus == "BLOCKED")'
 ```
 
 ### Extract PR numbers from status
 
 ```bash
-gh pr list --json number,mergeStateStatus | jq -r '.[] | select(.mergeStateStatus == "BLOCKED") | .number'
+gh pr list --json number,mergeable,mergeStateStatus | jq -r '.[] | select(.mergeStateStatus == "BLOCKED") | .number'
 ```
 
 ### Count PRs by status

--- a/src/copilot-cli/instructions/ci-scripts.instructions.md
+++ b/src/copilot-cli/instructions/ci-scripts.instructions.md
@@ -9,7 +9,7 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 ## MUST
 
 1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
+2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.
@@ -29,6 +29,21 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 1. MUST NOT put branching logic inside YAML workflow steps (ADR-006).
 2. MUST NOT commit changes that silently change validator behavior without an ADR; validators are authoritative.
 3. MUST NOT skip pre-push validation when touching CI paths.
+4. MUST NOT raise a count baseline (`scripts/ci/*_count_baseline.txt`) to clear a blocked push. Those ratchets exist to refuse a new error-severity violation; raising the number defeats the gate rather than satisfying it. Fix the violation, split the file, or use the rule's documented escape (`# taste-lint: ignore <rule>` with a reason, issue #3779).
+
+## Count ratchets
+
+A count ratchet may only fall. Two consequences follow, and both bite in practice.
+
+**A real improvement MUST be recorded.** An unrecorded improvement leaves slack, so the next regression up to the stale number passes silently. Lower it with the per-ratchet updater, not the shared module:
+
+```bash
+uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
+```
+
+`scripts/ci/count_ratchet.py --update <name>` reports success and changes nothing. Verify the file afterwards rather than trusting the message.
+
+**The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
 ## References
 

--- a/src/copilot-cli/instructions/ci-scripts.instructions.md
+++ b/src/copilot-cli/instructions/ci-scripts.instructions.md
@@ -8,8 +8,8 @@ Scripts under `scripts/validation/`, `build/`, and `.github/workflows/` gate eve
 
 ## MUST
 
-1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `python3` invocation for validation scripts, and the actual test suite for helpers.
-2. **Shift-left validation**. Before pushing, MUST run `python3 scripts/validation/pre_pr.py` and resolve any failures.
+1. **Local run before commit**. CI-critical scripts MUST be exercised locally before commit. Use `gh act` for workflows, direct `uv run python` invocation for validation scripts, and the actual test suite for helpers.
+2. **Shift-left validation**. Before pushing, MUST run `uv run python scripts/validation/pre_pr.py` and resolve any failures.
 3. **Python for new scripts**. New scripts MUST be Python per ADR-042. MUST NOT create new `*.sh` bash scripts.
 4. **Exit codes**. Scripts MUST follow the exit code contract: `0`=ok, `1`=logic, `2`=config, `3`=external, `4`=auth (`AGENTS.md`).
 5. **Tests required**. New validation scripts MUST ship with pytest or Pester coverage in `tests/` or `.claude/skills/<name>/tests/`.


### PR DESCRIPTION
## Summary

Records a convention that four separate branches violated in one session, and corrects two documented recipes that under-report.

## Why

Every branch blocked by a count ratchet faces the same tempting one-line move: raise the baseline. It is the wrong move. The ratchet exists to refuse a new error-severity violation, so raising the number defeats the gate rather than satisfying it. That is now a MUST NOT with the escape hatch named (`# taste-lint: ignore <rule>` with a reason, issue #3779).

The new `## Count ratchets` section carries the two things that actually cost time:

**A real improvement must be recorded.** Leaving it unrecorded creates slack, so the next regression up to the stale number passes silently. The updater is the per-ratchet script. `scripts/ci/count_ratchet.py --update <name>` reports success and changes nothing, which is worth knowing before you trust its output:

```
$ uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
ruff count ratchet: improved 329 -> 326 (-3). Baseline lowered.
```

**The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. The rule now carries the per-file offender diff and the `git rm --cached <suspect>` attribution check, which is what locating it actually took, four times.

## Also corrects a memory that documented the broken form

`.serena/memories/jq/jq-pr-operation-patterns.md` recommended:

```bash
gh pr list --json number,mergeStateStatus | jq '.[] | select(.mergeStateStatus == "BLOCKED")'
```

GitHub computes mergeability lazily and does not compute it because you asked for the status field, so that select reads a field that is mostly `UNKNOWN` and silently misses most matches. Measured on the same 46 open PRs, seconds apart:

```
--json number,mergeStateStatus            -> BLOCKED=5  DIRTY=2   UNKNOWN=40
--json number,mergeable,mergeStateStatus  -> CONFLICTING=35  MERGEABLE=11
```

Two conflicts reported where the truth was 35. Both recipes now request `mergeable`; the jq is unchanged. New memory `ci/ci-mergeability-is-not-computed-until-you-ask.md` records the measurement and points at `git merge-tree`, which needs no server-side state and also names the conflicting paths.

## Also corrects the interpreter named in MUST 1

MUST 1 told the reader to exercise validation scripts with "direct `python3`
invocation". That names an interpreter the scripts do not reliably run under.
`scripts/validation/pre_pr.py` imports PyYAML, which resolves in the project
venv, not under a bare `python3`. It appears to work on a workstation that
happens to carry PyYAML globally, so the failure lands on a fresh clone rather
than on the author. MUST 2, two lines below, already said `uv run python`, so
the file contradicted itself.

MUST 1 now says `uv run python`. Against `main` this is a net-new correction
rather than a restoration: the earlier sweep that fixed copy-pasteable commands
skipped this line because it reads as prose about invocation styles, not as a
command to run.

## Verification

Mirrors regenerated with `build/scripts/generate_rules.py`, never hand-edited; both carry the new section, the MUST NOT, and the MUST 1 interpreter correction. Zero prohibited dashes added. Taste ratchet OK.

Refs #4207, #3902, #3779.

