### PR TITLE
fix(ci): move ADR-006 ratchet out of bot-skip guard (Fixes #4151)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-26-session-3423-archive-stale-execution-plans.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3423-archive-stale-execution-plans.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "12 of 13 plans verified complete or superseded; spec-005 carries a real residual defect",
-      "caused_by": [
-        "e015"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e006"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": ".agents/plans/active/ is empty except .gitkeep; nothing deleted",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e006"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Issues #3424, #3425, #3426 opened with reproduction commands and file-line evidence",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e006"
       ]
     },
     {
@@ -47,52 +41,55 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran the pre-PR gate and cleared both failures. The dash gate flagged 165 pre-existing dashes in 1574-stage1-claude-kit-vendor.md and req-003-multi-tool-artifact-build.md, surfaced only because git mv put them in the branch diff. Considered a .agents/archive/ carve-out in checks_dash.py and rejected it: it would expand a docs-only change into a validator plus rule plus two mirrors plus a plugin manifest bump, and the dashes are ordinary prose, not bytes the archive needs to preserve. Replaced them instead, semantically neutral: label glosses take a colon, ID ranges take a hyphen, clause breaks take a comma or period.",
-      "caused_by": [
-        "e003"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e005",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 19d4a761",
       "caused_by": [],
       "leads_to": [
         "e006"
       ]
     },
     {
-      "id": "e006",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "id": "e005",
+      "timestamp": "2026-07-27T04:07:45+00:00",
       "type": "commit",
-      "content": "Commit: ae8be1c0",
+      "content": "Commit: 19d4a761",
       "caused_by": [
-        "e005"
+        "e014"
       ],
       "leads_to": [
-        "e007"
+        "e015"
       ]
     },
     {
-      "id": "e007",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "id": "e006",
+      "timestamp": "2026-07-27T03:57:18+00:00",
       "type": "commit",
-      "content": "Commit: 9f1df6b3",
+      "content": "Commit: ae8be1c0",
       "caused_by": [
-        "e006"
+        "e001",
+        "e002",
+        "e003",
+        "e004"
       ],
       "leads_to": [
         "e008"
       ]
     },
     {
+      "id": "e007",
+      "timestamp": "2026-07-27T04:14:13+00:00",
+      "type": "commit",
+      "content": "Commit: 9f1df6b3",
+      "caused_by": [
+        "e015"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e008",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:57:32+00:00",
       "type": "commit",
       "content": "Commit: f2094108",
       "caused_by": [
-        "e007"
+        "e006"
       ],
       "leads_to": [
         "e009"
@@ -100,7 +97,7 @@
     },
     {
       "id": "e009",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:57:54+00:00",
       "type": "commit",
       "content": "Commit: c74c8b07",
       "caused_by": [
@@ -112,7 +109,7 @@
     },
     {
       "id": "e010",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:23+00:00",
       "type": "commit",
       "content": "Commit: 0809412c",
       "caused_by": [
@@ -124,7 +121,7 @@
     },
     {
       "id": "e011",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:41+00:00",
       "type": "commit",
       "content": "Commit: 50860bf0",
       "caused_by": [
@@ -136,7 +133,7 @@
     },
     {
       "id": "e012",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:41+00:00",
       "type": "commit",
       "content": "Commit: 53f220e9",
       "caused_by": [
@@ -148,7 +145,7 @@
     },
     {
       "id": "e013",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:59:01+00:00",
       "type": "commit",
       "content": "Commit: 48c2b938",
       "caused_by": [
@@ -160,26 +157,26 @@
     },
     {
       "id": "e014",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T04:01:52+00:00",
       "type": "commit",
       "content": "Commit: 3f40fac7",
       "caused_by": [
         "e013"
       ],
       "leads_to": [
-        "e015"
+        "e005"
       ]
     },
     {
       "id": "e015",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T04:09:54+00:00",
       "type": "commit",
       "content": "Commit: 1bf125d7",
       "caused_by": [
-        "e014"
+        "e005"
       ],
       "leads_to": [
-        "e001"
+        "e007"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-27-session-3429-pr-autofix.json
+++ b/.agents/memory/episodes/episode-2026-07-27-session-3429-pr-autofix.json
@@ -8,23 +8,23 @@
   "events": [
     {
       "id": "e001",
-      "timestamp": "2026-07-27T00:00:00+00:00",
+      "timestamp": "2026-07-27T05:46:04+00:00",
       "type": "commit",
       "content": "Commit: 63ed646fb9",
-      "caused_by": [],
-      "leads_to": [
+      "caused_by": [
         "e002"
-      ]
+      ],
+      "leads_to": []
     },
     {
       "id": "e002",
-      "timestamp": "2026-07-27T00:00:00+00:00",
+      "timestamp": "2026-07-27T05:18:43+00:00",
       "type": "commit",
       "content": "Commit: d996ad73",
-      "caused_by": [
+      "caused_by": [],
+      "leads_to": [
         "e001"
-      ],
-      "leads_to": []
+      ]
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-08-02-session-4233-portability-git-hardening.json
+++ b/.agents/memory/episodes/episode-2026-08-02-session-4233-portability-git-hardening.json
@@ -1,0 +1,101 @@
+{
+  "id": "episode-2026-08-02-session-4233-portability-git-hardening",
+  "session": "2026-08-02-session-4233-portability-git-hardening",
+  "timestamp": "2026-08-02T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Close five verified fail-open holes in the portability floor's git reads, found by adversarial review, and repair the two episode files whose backwards commit chains blocked the push.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the full suite to find what failed the earlier push",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "test",
+      "content": "Ran the full suite to find what failed the earlier push   1   1 failed, 21324 passed. tests/skills/memory/test_extract_session_episode.py::test_the_committed_episode_store_is_clean, on data this branch never touched.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "error",
+      "content": "Ran the full suite to find what failed the earlier push   1   1 failed, 21324 passed. tests/skills/memory/test_extract_session_episode.py::test_the_committed_episode_store_is_clean, on data this branch never touched.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked whether the failure came from this branch",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reconciled that against CI, which is green on main",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Filed the blind spot and repaired the data",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Split portability_floor.py into a JSON half and a git half",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Closed the five holes: ls-tree prefix on any tree-ish, refs/replace substitution, refs deleted but commits in the object database, a committed symlink read as a file, and lossy tree-name decoding",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Pinned each fix and proved the pins can fail",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4233-portability-git-hardening"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 1,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-08-02-session-4233-portability-git-hardening.json
+++ b/.agents/sessions/2026-08-02-session-4233-portability-git-hardening.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4233,
+    "date": "2026-08-02",
+    "branch": "rjmurillo/harden-baseline-predecessor",
+    "startingCommit": "babf326d4",
+    "objective": "Close five verified fail-open holes in the portability floor's git reads, found by adversarial review, and repair the two episode files whose backwards commit chains blocked the push."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Copilot CLI harness; Serena MCP tools are not exposed in this session"
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not reachable without Serena activation"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md read-only; git status shows it unmodified per ADR-014"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file, staged with the commits it documents"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returns rjmurillo/harden-baseline-predecessor"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Working in worktree wt-zeroscan on a feature branch; main is protected by a ruleset"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mypy, ruff, and all four ratchets run and read; tests/validation green at 1819 passed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not staged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Four sections added to .serena/memories/git/git-absence-and-case-in-plumbing.md, plus two new memory files"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 run on the changed memory; .serena/** is excluded by config so it lints zero files"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Three atomic commits on rjmurillo/harden-baseline-predecessor"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "12 new tests pass; all 8 mutations killed, 2 controls killed 10 and 8"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #4240 filed for the clone-dependency defect found while unblocking the push"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Session continues; retrospective deferred to session end"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "One rework caught: the first mypy pass reported 8 errors in the new test file, fixed before commit"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Ran the full suite to find what failed the earlier push",
+      "result": "1 failed, 21324 passed. tests/skills/memory/test_extract_session_episode.py::test_the_committed_episode_store_is_clean, on data this branch never touched."
+    },
+    {
+      "step": 2,
+      "action": "Checked whether the failure came from this branch",
+      "result": "git diff origin/main...HEAD is empty for .agents/memory/, and the pin exists on main. Both inputs match main, so main carries the failure."
+    },
+    {
+      "step": 3,
+      "action": "Reconciled that against CI, which is green on main",
+      "result": "The validator only compares two commit events when git resolves both SHAs. 19d4a761 and ae8be1c0 are unreachable from main and survive only on the local branch chore/archive-stale-execution-plans, left behind by a squash merge. CI cannot resolve them and skips; this clone can and fails."
+    },
+    {
+      "step": 4,
+      "action": "Filed the blind spot and repaired the data",
+      "result": "Issue #4240. The two files repaired with the --fix that #4219 added; 244 memory tests pass."
+    },
+    {
+      "step": 5,
+      "action": "Split portability_floor.py into a JSON half and a git half",
+      "result": "portability_git.py at 298 lines, portability_floor.py down from 407 to 206. The five fixes would have carried the original past the 500-line taste ceiling."
+    },
+    {
+      "step": 6,
+      "action": "Closed the five holes: ls-tree prefix on any tree-ish, refs/replace substitution, refs deleted but commits in the object database, a committed symlink read as a file, and lossy tree-name decoding",
+      "result": "A probe with a control per attack shows all five defeated and every control intact."
+    },
+    {
+      "step": 7,
+      "action": "Pinned each fix and proved the pins can fail",
+      "result": "12 tests in test_portability_git_lookup.py. Anchors pre-verified unique, then every mutation killed by exactly one test; two always-refuse controls killed 10 and 8."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Resolve the two Copilot review threads on PR #4233 citing 0482ef6428, which is what holds the PR at BLOCKED",
+    "Rewrite the PR body to cover the module split, the five hardening fixes, and the episode repair",
+    "File the two low-severity findings the Opus reviewer raised: the now-dead reject_outside_root=False branch with its three-way sentinel decode, and load_baseline still using int() where _coerce_counts is strict",
+    "Run another reviewer round; every round so far has returned something real"
+  ]
+}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -199,16 +199,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python3 scripts/ci/enforce_pr_validation.py
 
-      # Issue #2967: ADR-006 forbids business logic in workflow `run:` blocks.
-      # The burn-down count (93 at audit time, 87 today) had no gate, so it could
-      # climb back silently between extraction PRs. This freezes it: the scanner
-      # exits 1 when the count exceeds --max. Lower --max after each extraction.
-      # Runs on every PR because workflow YAML can change in any PR, and pytest.yml
-      # (which hosts the ruff ratchets) only runs when Python files change.
-      - name: Run ADR-006 run-block ratchet
-        if: steps.should-run.outputs.skip != 'true'
-        run: python3 scripts/ci/adr006_run_block_scanner.py --max 58
-
       # Issue #3330: workflow *schema* validation had no required CI gate. YAML
       # Lint (yaml-lint.yml) does run on `**/*.yml` for PRs, but it runs yamllint,
       # which checks syntax and style. It does not know what a workflow is: it
@@ -244,6 +234,15 @@ jobs:
 
       - name: Validate workflow YAML
         run: uv run --frozen python3 scripts/validate_workflows.py
+
+      # Issue #2967: ADR-006 forbids business logic in workflow `run:` blocks.
+      # Unconditional (Issue #4151): Renovate and Dependabot open workflow-only
+      # PRs (action SHA bumps), which are exactly the PRs that could smuggle a
+      # new run block past this gate if it were skip-guarded. A gate that exempts
+      # the actors who author workflow changes is weaker than the hook it
+      # backstops, not equal to it.
+      - name: Run ADR-006 run-block ratchet
+        run: python3 scripts/ci/adr006_run_block_scanner.py --max 58
 
       # Issue #3779: taste-lints emits severity="error" and nothing could fail
       # because of one. The linter itself is correct (it exits 10 on an error),

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -236,6 +236,10 @@ jobs:
         run: uv run --frozen python3 scripts/validate_workflows.py
 
       # Issue #2967: ADR-006 forbids business logic in workflow `run:` blocks.
+      # The burn-down count started at 93 at audit time. This freezes the
+      # current ratchet ceiling at 58: the scanner exits 1 when the count
+      # exceeds --max. Lower --max after each extraction.
+      #
       # Unconditional (Issue #4151): Renovate and Dependabot open workflow-only
       # PRs (action SHA bumps), which are exactly the PRs that could smuggle a
       # new run block past this gate if it were skip-guarded. A gate that exempts

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -828,3 +828,122 @@ class TestTheCommitCountGateCanReadMainsTrunk:
         commit ceiling entirely.
         """
         assert "if" not in self._jobs()[self.HOST_JOB]
+
+
+class TestBotSkipGuardClassification:
+    """Every step behind the skip guard must have a documented classification.
+
+    Issue #4151: the skip guard exempts dependabot[bot], github-actions[bot],
+    and renovate[bot] for throughput reasons (dependency-bump PRs should not
+    pay for the full validation suite). That reasoning holds for expensive
+    advisory checks against the PR body or diff. It does not hold for gates
+    whose job is to catch a class of change regardless of who authored it.
+
+    Bots open workflow-only PRs (action SHA bumps). A correctness gate that is
+    skip-guarded is invisible to exactly those PRs. The ADR-006 run-block
+    ratchet was the only correctness gate still gated behind the skip guard; it
+    is now unconditional.
+
+    Classification rationale (throughput-motivated = OK to remain skip-guarded):
+    - Checkout repository: bot PRs receive a separate unconditional checkout
+    - Setup PowerShell: UI tooling for the skip-guarded steps
+    - Validate PR Description vs Diff: meaningless for a bot dep-bump PR body
+    - Validate PR Description Standards: same
+    - Check QA Report Exists: same
+    - Generate Validation Report: same
+    - Post PR Comment: same
+    - Set Job Summary: same
+    - Check PR commit count: a single-commit dep-bump is never blocked
+    - Enforce Blocking Issues: depends on outputs of skip-guarded steps above
+
+    Security/correctness gates that MUST be unconditional:
+    - Run ADR-006 run-block ratchet (moved here by Issue #4151 fix)
+    """
+
+    HOST_JOB = "validate-pr"
+    BOT_SKIP_GUARD = "steps.should-run.outputs.skip != 'true'"
+
+    @staticmethod
+    def _jobs() -> dict:
+        return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+    @classmethod
+    def _host_steps(cls) -> list:
+        return cls._jobs()[cls.HOST_JOB]["steps"]
+
+    @classmethod
+    def _skip_guarded_steps(cls) -> list[dict]:
+        return [
+            step
+            for step in cls._host_steps()
+            if step.get("if") == cls.BOT_SKIP_GUARD
+        ]
+
+    # Exactly these step names are permitted behind the skip guard.
+    # If this set grows, the new step must be justified as throughput-motivated.
+    _ALLOWED_BEHIND_GUARD: frozenset[str] = frozenset(
+        {
+            "Checkout repository",
+            "Setup PowerShell",
+            "Validate PR Description vs Diff",
+            "Validate PR Description Standards",
+            "Check QA Report Exists",
+            "Generate Validation Report",
+            "Post PR Comment",
+            "Set Job Summary",
+            "Check PR commit count",
+            "Enforce Blocking Issues",
+        }
+    )
+
+    def test_adr006_ratchet_is_unconditional(self) -> None:
+        """Positive: the ADR-006 gate must run for bot-authored PRs.
+
+        Renovate and Dependabot open workflow-only PRs. A run-block scanner
+        that is skip-guarded is invisible to the actors most likely to touch
+        workflow YAML. The comment in the workflow already says 'Runs on every
+        PR because workflow YAML can change in any PR'; this test pins that.
+        """
+        adr006_steps = [
+            step
+            for step in self._host_steps()
+            if "adr006_run_block_scanner.py" in str(step.get("run", ""))
+        ]
+        assert len(adr006_steps) == 1, "expected exactly one ADR-006 step"
+        step = adr006_steps[0]
+        assert "if" not in step, (
+            f"ADR-006 ratchet must be unconditional, found: if: {step.get('if')!r}"
+        )
+
+    def test_no_security_gate_is_skip_guarded(self) -> None:
+        """Negative: every skip-guarded step must be throughput-motivated.
+
+        A step whose name is not in _ALLOWED_BEHIND_GUARD and is behind the
+        skip guard is a new security/correctness gate that slipped past the
+        exemption check. Adding a name to _ALLOWED_BEHIND_GUARD requires a
+        written justification showing the step is throughput-motivated, not
+        correctness-motivated.
+        """
+        guarded = {str(step.get("name", "")) for step in self._skip_guarded_steps()}
+        unknown = guarded - self._ALLOWED_BEHIND_GUARD
+        assert unknown == set(), (
+            f"Steps behind the bot-skip guard without a throughput justification: {unknown!r}. "
+            "Add the name to _ALLOWED_BEHIND_GUARD with a comment explaining why it is "
+            "throughput-motivated, not a correctness or security gate."
+        )
+
+    def test_all_allowed_guarded_steps_are_present(self) -> None:
+        """Edge: the allowlist must not include names that no longer exist.
+
+        A step removed from the workflow without pruning the allowlist leaves
+        phantom permission in _ALLOWED_BEHIND_GUARD that is never exercised.
+        This test requires every allowed name to actually exist in the workflow,
+        either as a skip-guarded step or elsewhere in the job (the commit-count
+        label steps are conditional on a different output, not on skip).
+        """
+        all_step_names = {str(step.get("name", "")) for step in self._host_steps()}
+        for name in self._ALLOWED_BEHIND_GUARD:
+            assert name in all_step_names, (
+                f"_ALLOWED_BEHIND_GUARD contains {name!r} but no step with that name "
+                "exists in the workflow. Remove the stale entry."
+            )

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -876,8 +876,58 @@ class TestBotSkipGuardClassification:
         return [
             step
             for step in cls._host_steps()
-            if step.get("if") == cls.BOT_SKIP_GUARD
+            if cls._has_bot_skip_guard_component(step.get("if"))
         ]
+
+    @classmethod
+    def _has_bot_skip_guard_component(cls, condition: object) -> bool:
+        if not isinstance(condition, str):
+            return False
+
+        expression = condition.strip()
+        if expression.startswith("${{") and expression.endswith("}}"):
+            expression = expression[3:-2].strip()
+
+        return any(
+            component.strip().strip("()").strip() == cls.BOT_SKIP_GUARD
+            for component in expression.split("&&")
+        )
+
+    def test_skip_guard_classifier_detects_compound_conditions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive: a step can add a condition and still stay bot-skipped."""
+        guarded_step = {
+            "name": "Compound guarded step",
+            "if": f"{self.BOT_SKIP_GUARD} && github.event_name == 'push'",
+        }
+        monkeypatch.setattr(type(self), "_host_steps", classmethod(lambda cls: [guarded_step]))
+
+        assert self._skip_guarded_steps() == [guarded_step]
+
+    def test_skip_guard_classifier_rejects_negated_conditions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Negative: a negated occurrence is not a skip guard."""
+        unguarded_step = {
+            "name": "Negated guarded step",
+            "if": f"!({self.BOT_SKIP_GUARD}) && github.event_name == 'push'",
+        }
+        monkeypatch.setattr(type(self), "_host_steps", classmethod(lambda cls: [unguarded_step]))
+
+        assert self._skip_guarded_steps() == []
+
+    def test_skip_guard_classifier_accepts_wrapped_expression(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge: GitHub expressions may carry the optional wrapper."""
+        guarded_step = {
+            "name": "Wrapped guarded step",
+            "if": f"${{{{ ({self.BOT_SKIP_GUARD}) && github.event_name == 'push' }}}}",
+        }
+        monkeypatch.setattr(type(self), "_host_steps", classmethod(lambda cls: [guarded_step]))
+
+        assert self._skip_guarded_steps() == [guarded_step]
 
     # Exactly these step names are permitted behind the skip guard.
     # If this set grows, the new step must be justified as throughput-motivated.


### PR DESCRIPTION
## Summary

Fixes #4151.

This PR addresses #4151: the `validate-pr` job's bot-skip guard exempted
`dependabot[bot]`, `github-actions[bot]`, and `renovate[bot]` from every step gated by
`steps.should-run.outputs.skip != 'true'`, including the ADR-006 run-block ratchet. Bots
open workflow-only PRs (action SHA bumps), which are the PRs most likely to change
workflow YAML. A correctness gate that is skip-guarded for exactly those actors is weaker
than the local hook it backstops.

Issue #3964 was already resolved by PR #4232, which merged on 2026-08-02 with 39 jobs
in a grandfathered set. That issue is closed and this PR does not change that gate.

## Classification of every skip-guarded step

Per the issue's acceptance criteria, every step behind the skip guard is classified below.

**Throughput-motivated (keep guarded):**

| Step | Reason |
|------|--------|
| Checkout repository | Bot PRs receive a separate unconditional checkout for workflow validation |
| Setup PowerShell | UI plumbing for the skip-guarded section |
| Validate PR Description vs Diff | Parses the PR body against the diff; meaningless for a dep-bump PR |
| Validate PR Description Standards | Same |
| Check QA Report Exists | Same |
| Generate Validation Report | Same |
| Post PR Comment | Same |
| Set Job Summary | Same |
| Check PR commit count | A single-commit dep-bump is never blocked |
| Enforce Blocking Issues | Depends on outputs from skip-guarded steps above; inert without them |

**Security/correctness (moved to unconditional by this PR):**

| Step | Reason |
|------|--------|
| Run ADR-006 run-block ratchet | Workflow YAML can change in any PR, including bot dep-bump PRs |

## Changes

- `.github/workflows/pr-validation.yml`: Remove `if: steps.should-run.outputs.skip != 'true'` from `Run ADR-006 run-block ratchet`. Move the step to the unconditional section after `Validate workflow YAML`. Restore the operational rationale for `--max 58`.
- `tests/ci/test_pr_validation_workflow.py`: Add `TestBotSkipGuardClassification` coverage for compound guard conditions, negated occurrences, wrapped GitHub expressions, unconditional ADR-006 wiring, unknown guarded steps, and stale allowlist entries.

## What was green before that is red after

Only real defects:

- A PR from `dependabot[bot]`, `github-actions[bot]`, or `renovate[bot]` that adds a
  workflow `run:` block exceeding the ratchet limit now fails. Before this change it
  passed silently. Every such failure is a real violation of ADR-006.
- A future skip-guarded step with a compound condition now counts as skip-guarded and
  must appear in the throughput allowlist.

## Tests

Structural tests assert on `yaml.safe_load` parsed workflow data, not comments or raw substrings:

- `test_skip_guard_classifier_detects_compound_conditions` (positive): detects `steps.should-run.outputs.skip != 'true' && github.event_name == 'push'`.
- `test_skip_guard_classifier_rejects_negated_conditions` (negative): rejects `!(steps.should-run.outputs.skip != 'true') && github.event_name == 'push'`.
- `test_skip_guard_classifier_accepts_wrapped_expression` (edge): detects `${{ (steps.should-run.outputs.skip != 'true') && github.event_name == 'push' }}`.
- `test_adr006_ratchet_is_unconditional` (positive): the ADR-006 step has no `if:` field.
- `test_no_security_gate_is_skip_guarded` (negative): every skip-guarded step is in the throughput allowlist.
- `test_all_allowed_guarded_steps_are_present` (edge): the allowlist cannot carry stale entries.

## Mutation harness

| Mutant | Target | Result |
|--------|--------|--------|
| Revert compound classifier to exact equality | `test_skip_guard_classifier_detects_compound_conditions`, `test_skip_guard_classifier_accepts_wrapped_expression` | DEAD |
| Revert ADR-006 to skip-guarded | `test_adr006_ratchet_is_unconditional` | DEAD |
| Add new step behind skip guard | `test_no_security_gate_is_skip_guarded` | DEAD |
| Drop step from allowlist | `test_no_security_gate_is_skip_guarded` | DEAD |

No DID-NOT-APPLY outcomes: each mutation was verified to produce a non-identical file
before the test run, and files were restored byte-for-byte afterward.

## Validation

- `uv run --frozen pytest tests/ci/test_pr_validation_workflow.py::TestBotSkipGuardClassification -q`
- `uv run --frozen pytest tests/ci/test_pr_validation_workflow.py -q`
- `uv run --frozen --extra dev ruff check tests/ci/test_pr_validation_workflow.py`
- `uv run --frozen python3 scripts/validate_workflows.py`
- `uv run --frozen python3 scripts/ci/adr006_run_block_scanner.py --max 58`
- `uv run --frozen --extra dev python scripts/ci/ruff_ratchet.py`
- `uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --base-ref origin/main`
- `uv run --frozen python scripts/ci/taste_count_ratchet.py --base-ref origin/main`
- `uv run --frozen python scripts/ci/type_ignore_count_ratchet.py --base-ref origin/main`
- `uv run --frozen python scripts/validation/pre_pr.py`
- Pre-push hook: 21195 passed, 31 skipped, 50 deselected, 2 warnings, exit 0.
