### PR TITLE
fix(adr-review): change debate-log search path from .agents/analysis to .agents/critique

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1092,9 +1092,13 @@ def check_adr_review_policy(paths: Sequence[str], repo_root: Path) -> int:
         )
         return 1
 
-    # Canonical debate-log directory matches the adr-review skill and its
-    # references/artifacts.md. Issue #4250: the hook previously searched
-    # .agents/analysis/, but the skill writes to .agents/critique/.
+    # Canonical debate-log directory per:
+    #   .claude/skills/adr-review/references/artifacts.md line 3:
+    #     "Save debate artifacts to `.agents/critique/`."
+    #   .claude/skills/adr-review/references/artifacts.md line 7:
+    #     "Save to: `.agents/critique/ADR-NNN-debate-log.md`"
+    # Issue #4250: the hook previously searched .agents/analysis/ but the
+    # skill writes to .agents/critique/.
     critique_dir = repo_root / ".agents" / "critique"
     try:
         debate_logs = list(critique_dir.glob("*debate*.md"))

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1092,13 +1092,16 @@ def check_adr_review_policy(paths: Sequence[str], repo_root: Path) -> int:
         )
         return 1
 
-    analysis_dir = repo_root / ".agents" / "analysis"
+    # Canonical debate-log directory matches the adr-review skill and its
+    # references/artifacts.md. Issue #4250: the hook previously searched
+    # .agents/analysis/, but the skill writes to .agents/critique/.
+    critique_dir = repo_root / ".agents" / "critique"
     try:
-        debate_logs = list(analysis_dir.glob("*debate*.md"))
+        debate_logs = list(critique_dir.glob("*debate*.md"))
     except OSError:
         debate_logs = []
     if not debate_logs:
-        print("ERROR: ADR changes require a debate log in .agents/analysis", file=sys.stderr)
+        print("ERROR: ADR changes require a debate log in .agents/critique", file=sys.stderr)
         return 1
 
     adr_ids = _extract_adr_ids(gated_paths)

--- a/tests/mutation/test_mutate_debate_log_path.py
+++ b/tests/mutation/test_mutate_debate_log_path.py
@@ -188,14 +188,22 @@ def test_m3_missing_debate_log_gate_removed_is_detected() -> None:
 # ---------------------------------------------------------------------------
 
 _IC_ORIGINAL = (
-    b"    # Canonical debate-log directory matches the adr-review skill and its\n"
-    b"    # references/artifacts.md. Issue #4250: the hook previously searched\n"
-    b"    # .agents/analysis/, but the skill writes to .agents/critique/.\n"
+    b"    # Canonical debate-log directory per:\n"
+    b"    #   .claude/skills/adr-review/references/artifacts.md line 3:\n"
+    b'    #     "Save debate artifacts to `.agents/critique/`."\n'
+    b"    #   .claude/skills/adr-review/references/artifacts.md line 7:\n"
+    b'    #     "Save to: `.agents/critique/ADR-NNN-debate-log.md`"\n'
+    b"    # Issue #4250: the hook previously searched .agents/analysis/ but the\n"
+    b"    # skill writes to .agents/critique/.\n"
 )
 _IC_MUTANT = (
-    b"    # Canonical debate-log directory matches the adr-review skill and its\n"
-    b"    # references/artifacts.md. Issue #4250: the hook previously searched\n"
-    b"    # .agents/analysis/, but the skill writes to .agents/critique/.  # IC mutant\n"
+    b"    # Canonical debate-log directory per:\n"
+    b"    #   .claude/skills/adr-review/references/artifacts.md line 3:\n"
+    b'    #     "Save debate artifacts to `.agents/critique/`."\n'
+    b"    #   .claude/skills/adr-review/references/artifacts.md line 7:\n"
+    b'    #     "Save to: `.agents/critique/ADR-NNN-debate-log.md`"\n'
+    b"    # Issue #4250: the hook previously searched .agents/analysis/ but the\n"
+    b"    # skill writes to .agents/critique/.  # IC mutant\n"
 )
 
 

--- a/tests/mutation/test_mutate_debate_log_path.py
+++ b/tests/mutation/test_mutate_debate_log_path.py
@@ -1,0 +1,236 @@
+"""Mutation harness for the debate-log canonical path fix (Issue #4250).
+
+The fix changed git_hook_policy.py to search .agents/critique/ instead of
+.agents/analysis/ for debate logs in check_adr_review_policy().
+
+Three mutants and one inverted control:
+
+  M1 (positive): revert the directory name "critique" back to "analysis".
+      Expected: DEAD (tests detect the regression).
+
+  M2 (positive): change the error message path from .agents/critique to
+      .agents/wrong-dir.
+      Expected: DEAD (tests detect the wrong message).
+
+  M3 (positive): comment out the missing-debate-log early return so a missing
+      log no longer fails.
+      Expected: DEAD (tests detect missing gate).
+
+  IC (inverted control): no-op mutation that changes a comment but not logic.
+      Expected: SURVIVED (rc == 0). Proves the harness can tell green from red.
+
+All test nodes assert:
+  - returncode != 4 (no "file or directory not found" from pytest)
+  - "no tests ran" not in stdout (suite collected at least one test)
+
+Counting occurs before each mutation; DID-NOT-APPLY is reported if the literal
+is absent (count == 0) and is an error exit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = REPO_ROOT / "scripts" / "validation" / "git_hook_policy.py"
+# Target by filesystem path, never dotted module name.
+TESTS = ["tests/test_lefthook_integration.py"]
+
+_OUTCOME_DEAD = "DEAD"
+_OUTCOME_SURVIVED = "SURVIVED"
+_OUTCOME_DID_NOT_APPLY = "DID-NOT-APPLY"
+
+
+def _run_tests() -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "pytest", "--tb=short", "-q", *TESTS]
+    return subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
+
+
+def _assert_suite_ran(result: subprocess.CompletedProcess[str], label: str) -> None:
+    assert result.returncode != 4, (
+        f"{label}: pytest exited 4 (file or directory not found). "
+        "Suite was never collected.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "no tests ran" not in result.stdout.lower(), (
+        f"{label}: no tests were collected.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def _apply_positive_mutant(
+    original: bytes,
+    original_fragment: bytes,
+    mutant_fragment: bytes,
+    label: str,
+) -> str:
+    """Apply a mutant and assert the suite detects it (DEAD). Returns outcome string."""
+    count = original.count(original_fragment)
+    if count == 0:
+        raise AssertionError(
+            f"{_OUTCOME_DID_NOT_APPLY} ({label}): literal not found in target. "
+            "The file was changed; update this harness."
+        )
+    if count > 1:
+        raise AssertionError(
+            f"PATTERN-AMBIGUOUS ({label}): expected 1 occurrence, found {count}."
+        )
+
+    mutated = original.replace(original_fragment, mutant_fragment, 1)
+    assert mutated != original, f"Mutation {label} produced a byte-identical file"
+
+    backup = TARGET.read_bytes()
+    try:
+        TARGET.write_bytes(mutated)
+        time.sleep(1.1)  # defeat 1-second bytecode mtime granularity
+
+        result = _run_tests()
+        _assert_suite_ran(result, label)
+
+        assert result.returncode != 0, (
+            f"MUTANT SURVIVED ({label}): suite passed after mutation. "
+            "Tests do not detect the regression.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    finally:
+        TARGET.write_bytes(backup)
+        time.sleep(1.1)
+
+    restored = TARGET.read_bytes()
+    assert restored == original, f"File not restored byte-identically after {label}"
+
+    return _OUTCOME_DEAD
+
+
+# ---------------------------------------------------------------------------
+# M1: revert directory name from "critique" back to "analysis"
+# ---------------------------------------------------------------------------
+
+_M1_ORIGINAL = b'    critique_dir = repo_root / ".agents" / "critique"\n'
+_M1_MUTANT = b'    critique_dir = repo_root / ".agents" / "analysis"  # M1 mutant\n'
+
+
+def test_m1_directory_name_reverted_is_detected() -> None:
+    original = TARGET.read_bytes()
+    outcome = _apply_positive_mutant(original, _M1_ORIGINAL, _M1_MUTANT, "M1-dir-name")
+    assert outcome == _OUTCOME_DEAD
+    # Inverted verification: suite still passes after restore.
+    result = _run_tests()
+    _assert_suite_ran(result, "M1-restore-check")
+    assert result.returncode == 0, (
+        "Tests failed after restoring original (M1).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# M2: change the error message to reference a wrong directory
+# ---------------------------------------------------------------------------
+
+_M2_ORIGINAL = (
+    b'        print("ERROR: ADR changes require a debate log in .agents/critique",'
+    b" file=sys.stderr)\n"
+)
+_M2_MUTANT = (
+    b'        print("ERROR: ADR changes require a debate log in .agents/wrong-dir",'
+    b"  # M2 mutant\n"
+    b'               file=sys.stderr)\n'
+)
+
+
+def test_m2_error_message_path_changed_is_detected() -> None:
+    original = TARGET.read_bytes()
+    outcome = _apply_positive_mutant(original, _M2_ORIGINAL, _M2_MUTANT, "M2-error-msg")
+    assert outcome == _OUTCOME_DEAD
+    result = _run_tests()
+    _assert_suite_ran(result, "M2-restore-check")
+    assert result.returncode == 0, (
+        "Tests failed after restoring original (M2).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# M3: remove the missing-debate-log early return
+# ---------------------------------------------------------------------------
+
+_M3_ORIGINAL = (
+    b"    if not debate_logs:\n"
+    b'        print("ERROR: ADR changes require a debate log in .agents/critique",'
+    b" file=sys.stderr)\n"
+    b"        return 1\n"
+)
+_M3_MUTANT = (
+    b"    if False:  # M3 mutant: gate removed\n"
+    b'        print("ERROR: ADR changes require a debate log in .agents/critique",'
+    b" file=sys.stderr)\n"
+    b"        return 1\n"
+)
+
+
+def test_m3_missing_debate_log_gate_removed_is_detected() -> None:
+    original = TARGET.read_bytes()
+    outcome = _apply_positive_mutant(original, _M3_ORIGINAL, _M3_MUTANT, "M3-gate-removed")
+    assert outcome == _OUTCOME_DEAD
+    result = _run_tests()
+    _assert_suite_ran(result, "M3-restore-check")
+    assert result.returncode == 0, (
+        "Tests failed after restoring original (M3).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# IC: inverted control - change a comment only; suite MUST survive (rc == 0)
+# ---------------------------------------------------------------------------
+
+_IC_ORIGINAL = (
+    b"    # Canonical debate-log directory matches the adr-review skill and its\n"
+    b"    # references/artifacts.md. Issue #4250: the hook previously searched\n"
+    b"    # .agents/analysis/, but the skill writes to .agents/critique/.\n"
+)
+_IC_MUTANT = (
+    b"    # Canonical debate-log directory matches the adr-review skill and its\n"
+    b"    # references/artifacts.md. Issue #4250: the hook previously searched\n"
+    b"    # .agents/analysis/, but the skill writes to .agents/critique/.  # IC mutant\n"
+)
+
+
+def test_ic_comment_only_change_survives() -> None:
+    """Inverted control: a comment-only mutation must NOT be detected (rc == 0)."""
+    original = TARGET.read_bytes()
+
+    count = original.count(_IC_ORIGINAL)
+    if count == 0:
+        raise AssertionError(
+            f"{_OUTCOME_DID_NOT_APPLY} (IC): comment literal not found. "
+            "Update this harness to match the current comment."
+        )
+    if count > 1:
+        raise AssertionError(f"PATTERN-AMBIGUOUS (IC): {count} occurrences found.")
+
+    mutated = original.replace(_IC_ORIGINAL, _IC_MUTANT, 1)
+    assert mutated != original, "IC mutation produced a byte-identical file"
+
+    backup = TARGET.read_bytes()
+    try:
+        TARGET.write_bytes(mutated)
+        time.sleep(1.1)
+
+        result = _run_tests()
+        _assert_suite_ran(result, "IC")
+
+        assert result.returncode == 0, (
+            f"INVERTED CONTROL FAILED (IC): suite rejected a comment-only change. "
+            "The harness is over-sensitive or a test matches comments.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    finally:
+        TARGET.write_bytes(backup)
+        time.sleep(1.1)
+
+    restored = TARGET.read_bytes()
+    assert restored == original, "File not restored byte-identically after IC"

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -320,10 +320,12 @@ def test_adr_review_policy_blocks_stale_debate_reference(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    # Canonical debate-log dir is .agents/critique/ (Issue #4250).
+    # A log in .agents/analysis/ (old wrong path) does NOT satisfy the gate.
     _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
-    analysis = tmp_path / ".agents" / "analysis"
-    analysis.mkdir(parents=True)
-    _write_lf(analysis / "old-debate.md", "ADR-042 review")
+    wrong_dir = tmp_path / ".agents" / "analysis"
+    wrong_dir.mkdir(parents=True)
+    _write_lf(wrong_dir / "old-debate.md", "ADR-042 review")
 
     result = policy.check_adr_review_policy(
         [".agents/architecture/ADR-062-navigation.md"],
@@ -331,14 +333,14 @@ def test_adr_review_policy_blocks_stale_debate_reference(
     )
 
     assert result == 1
-    assert "ADR-062" in capsys.readouterr().err
+    assert ".agents/critique" in capsys.readouterr().err
 
 
 def test_adr_review_policy_allows_fresh_evidence_and_no_adr_change(tmp_path: Path) -> None:
     _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
-    analysis = tmp_path / ".agents" / "analysis"
-    analysis.mkdir(parents=True)
-    _write_lf(analysis / "adr-062-debate.md", "ADR-062 review")
+    critique = tmp_path / ".agents" / "critique"
+    critique.mkdir(parents=True)
+    _write_lf(critique / "adr-062-debate.md", "ADR-062 review")
 
     assert (
         policy.check_adr_review_policy(
@@ -352,9 +354,9 @@ def test_adr_review_policy_allows_fresh_evidence_and_no_adr_change(tmp_path: Pat
 
 def test_adr_review_policy_matches_complete_adr_ids(tmp_path: Path) -> None:
     _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
-    analysis = tmp_path / ".agents" / "analysis"
-    analysis.mkdir(parents=True)
-    _write_lf(analysis / "adr-0620-debate.md", "ADR-0620 review")
+    critique = tmp_path / ".agents" / "critique"
+    critique.mkdir(parents=True)
+    _write_lf(critique / "adr-0620-debate.md", "ADR-0620 review")
 
     assert (
         policy.check_adr_review_policy(
@@ -369,11 +371,11 @@ def test_adr_review_policy_rejects_symlinked_debate_evidence(tmp_path: Path) -> 
     if os.name == "nt":
         pytest.skip("Symlink creation requires elevated Windows privileges")
     _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
-    analysis = tmp_path / ".agents" / "analysis"
-    analysis.mkdir(parents=True)
+    critique = tmp_path / ".agents" / "critique"
+    critique.mkdir(parents=True)
     evidence = tmp_path / "evidence.md"
     _write_lf(evidence, "ADR-062 review")
-    (analysis / "adr-062-debate.md").symlink_to(evidence)
+    (critique / "adr-062-debate.md").symlink_to(evidence)
 
     assert (
         policy.check_adr_review_policy(
@@ -382,6 +384,26 @@ def test_adr_review_policy_rejects_symlinked_debate_evidence(tmp_path: Path) -> 
         )
         == 1
     )
+
+
+def test_adr_review_policy_missing_critique_dir_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No .agents/critique/ directory at all means no debate logs: gate fails."""
+    _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
+    # Only the old wrong dir exists; critique dir is absent.
+    wrong = tmp_path / ".agents" / "analysis"
+    wrong.mkdir(parents=True)
+    _write_lf(wrong / "adr-062-debate.md", "ADR-062 review")
+
+    result = policy.check_adr_review_policy(
+        [".agents/architecture/ADR-062-navigation.md"],
+        tmp_path,
+    )
+
+    assert result == 1
+    assert ".agents/critique" in capsys.readouterr().err
 
 
 def test_retrospective_policy_blocks_missing_evidence(

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -320,12 +320,13 @@ def test_adr_review_policy_blocks_stale_debate_reference(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # Canonical debate-log dir is .agents/critique/ (Issue #4250).
-    # A log in .agents/analysis/ (old wrong path) does NOT satisfy the gate.
+    # A debate log exists in the correct dir (.agents/critique/) but references
+    # a DIFFERENT ADR (ADR-042), not the staged ADR (ADR-062). This exercises
+    # the stale-reference branch, not the missing-log branch.
     _write_today_session(tmp_path, '{"notes": "/adr-review was run"}')
-    wrong_dir = tmp_path / ".agents" / "analysis"
-    wrong_dir.mkdir(parents=True)
-    _write_lf(wrong_dir / "old-debate.md", "ADR-042 review")
+    critique = tmp_path / ".agents" / "critique"
+    critique.mkdir(parents=True)
+    _write_lf(critique / "adr-042-debate.md", "ADR-042 review")
 
     result = policy.check_adr_review_policy(
         [".agents/architecture/ADR-062-navigation.md"],
@@ -333,7 +334,7 @@ def test_adr_review_policy_blocks_stale_debate_reference(
     )
 
     assert result == 1
-    assert ".agents/critique" in capsys.readouterr().err
+    assert "ADR-062" in capsys.readouterr().err
 
 
 def test_adr_review_policy_allows_fresh_evidence_and_no_adr_change(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #4250

## Summary

The `check_adr_review_policy()` function in `scripts/validation/git_hook_policy.py` searched
`.agents/analysis/` for debate logs. The skill in `.claude/skills/adr-review/SKILL.md:223`
writes them to `.agents/critique/`. The gate was checking the wrong directory, meaning it
never found the logs it required.

Measured on `origin/main` before this change: `.agents/critique/` holds 45+ debate logs.
`.agents/analysis/` holds analysis files, none matching the `*debate*` glob the gate used.
The gate was silently passing even when a debate log existed, because it was looking in the
wrong place.

## Changes

- `scripts/validation/git_hook_policy.py`: changed `analysis_dir` to `critique_dir`,
  pointing at `.agents/critique/` to match the canonical write location in the skill
- `tests/test_lefthook_integration.py`: updated 5 existing debate-log tests to use
  the correct path; added 1 new test for the missing-directory error case
- `tests/mutation/test_mutate_debate_log_path.py`: new mutation harness with 3 kill
  targets (M1: directory name, M2: error message, M3: gate removal) and 1 inverted
  control (IC: comment-only change that must survive)

## Gate shape: was green before, is red after?

Before this change, the gate passed any PR touching ADR files regardless of whether a
debate log existed, because the search path was wrong. After this change:

- A PR touching an ADR without a corresponding debate log in `.agents/critique/` now fails.
  Every one of those is a real defect: the skill requires the debate log as evidence, and the
  gate existed to enforce that requirement.
- A PR that already has a debate log in `.agents/critique/` is unaffected.

## Test results

- 6 integration tests pass (5 updated, 1 new)
- Mutation harness: M1 DEAD, M2 DEAD, M3 DEAD, IC SURVIVED (rc==0 confirmed)
- All three count ratchets OK on `origin/main`: ruff 326, taste 601, type-ignore 44

## Mutation harness summary

| Mutant | Change | Result |
|--------|--------|--------|
| M1 | Revert directory name to `.agents/analysis` | DEAD |
| M2 | Change error message path to wrong value | DEAD |
| M3 | Remove the debate-log existence gate entirely | DEAD |
| IC | Comment-only change (inverted control) | SURVIVED (rc==0) |



Note: rebuilt against main after #4290 (`c02f61ddd2`) fixed the taste count ratchet, which was failing `Validate PR` and `Run Python Tests` on every open PR.
