### PR TITLE
fix(renovate): rebase stale dependency branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": false,
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

- Add top-level `rebaseWhen` set to `behind-base-branch` in `renovate.json`.
- Leave ratchet logic, baselines, package rules, and automerge policy unchanged.

## Scope choice

I set the option at the top level because stale-base ratchet failures apply to any Renovate branch, not only the two current non-automerge CLI packages. The package-specific rule would fix today's measured packages, but it would recreate the bug for the next non-automerge dependency stream. The cost is extra Renovate branch pushes when main moves.

## Validation

- `renovate.json` validates against https://docs.renovatebot.com/renovate-schema.json.
- Searched for tests that assert Renovate config. The matching regression suite is the nightly CLI smoke security test.
- `uv run --frozen pytest tests/ -x -k nightly_cli_smoke_security`: 8 passed, 21491 deselected.
- `uv run --frozen python scripts/validation/pre_pr.py`: passed.
- `uv run --frozen ruff check .`: failed on existing analysis script import ordering, unrelated to this one-file diff.
- Ratchets before push: type-ignore OK at 44, ruff OK at 326, taste OK at 601.
- Push hook completed and branch pushed.

Fixes #4253
