### PR TITLE
fix(memory): repair backwards commit chains in 12 shipped episodes

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-21-session-3290-mypy-diff-line-ratchet.json
+++ b/.agents/memory/episodes/episode-2026-07-21-session-3290-mypy-diff-line-ratchet.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Reworked run_mypy into a diff-line ratchet: added _changed_line_map (git diff --unified=0 base...HEAD parsing), _parse_mypy_error_locations (error-severity only), _mypy_result_blocks (block only errors on changed lines of pushed files; block fatal no-error-line invocations; fall back to block-on-any when the diff base is unresolved), a MYPY_RATCHET_BASE_REF env override with zero-SHA guard and origin/main fallback, and a rationale comment recording the invocation-dependence finding.",
-      "caused_by": [
-        "e011"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e003"
       ]
     },
     {
@@ -23,19 +21,25 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Added 10 tests (pos+neg+edge): _parse_added_lines hunk mapping incl. pure-deletion; _parse_mypy_error_locations error-vs-note-vs-column; base-ref env/zero-SHA/default; real-git _changed_line_map integration + base-unresolved None; ratchet blocks new-line error; passes pre-existing unchanged-line error; new-file blocks all; fatal-no-error-line blocks; base-unresolved falls back to block-all; ignores errors in non-pushed imported files.",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e003"
       ]
     },
     {
       "id": "e003",
-      "timestamp": "2026-07-21T00:00:00+00:00",
+      "timestamp": "2026-07-22T13:26:22+00:00",
       "type": "commit",
       "content": "Commit: 184ec83eeb38a56f54f954e02617ebdfe00c0a1c",
-      "caused_by": [],
+      "caused_by": [
+        "e001",
+        "e002",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e009"
+      ],
       "leads_to": [
         "e008"
       ]
@@ -45,11 +49,9 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Fixed a coupled branch-context merge-guard defect in check_branch_context: it treated an in-progress merge as a policy violation and blocked legitimate merge commits; now exempts merge state.",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e003"
       ]
     },
     {
@@ -57,11 +59,9 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Fixed the coupled workflow-local-run gate (same #2993 root defect: judging unchanged content). It ran act against every workflow in lefthook's two-dot push range, which after a rebase imports the base branch workflows. Added _select_pushed_workflows/_pushed_workflow_paths to filter to workflows changed versus the merge base (git diff --name-only base...HEAD), a WORKFLOW_LOCAL_BASE_REF env override, and a clean skip when the delta is empty; unresolved base validates all provided workflows (fail-safe). Added 7 tests.",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e003"
       ]
     },
     {
@@ -69,11 +69,9 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Addressed Copilot review: normalized path separators in _normalize_ratchet_path so mypy backslash paths on Windows match the forward-slash pushed set and changed-line map (the ratchet would otherwise let a real error on a changed line slip past on Windows). Added 3 tests (parser, normalizer, end-to-end backslash-blocks). Updated the PR description with a Coupled fixes section per reviewer request.",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e003"
       ]
     },
     {
@@ -81,23 +79,21 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Normalized causal-graph.json indentation (union-merge left two six-space object braces) by re-serializing with the canonical save_causal_graph call (json.dumps indent=2); node and edge counts and key order preserved.",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e009"
+        "e003"
       ]
     },
     {
       "id": "e008",
-      "timestamp": "2026-07-21T00:00:00+00:00",
+      "timestamp": "2026-07-22T15:09:32+00:00",
       "type": "commit",
       "content": "Commit: 9bd7facdd9249154901de8cb80d1994bcad90504",
       "caused_by": [
         "e003"
       ],
       "leads_to": [
-        "e010"
+        "e011"
       ]
     },
     {
@@ -105,33 +101,31 @@
       "timestamp": "2026-07-21T00:00:00+00:00",
       "type": "milestone",
       "content": "Addressed Copilot re-review on b55d135888: renamed the mypy ratchet helper _parse_added_lines -> _parse_changed_lines (it returns post-image added-and-modified lines, matching _changed_line_map), documented why deletion-only (+N,0) and pure-rename hunks intentionally contribute no changed lines (crediting a neighbor line would re-flag unchanged code, the #2993 false-positive class), and added a rename-only test. The reviewer's second thread (deletion cascade) was declined as correct-by-design and already covered by the deletion-only assertion.",
+      "caused_by": [],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-22T15:38:36+00:00",
+      "type": "commit",
+      "content": "Commit: cd6b7d11720b7437f8a78c44caf425195c82e54e",
       "caused_by": [
-        "e007"
+        "e011"
       ],
       "leads_to": []
     },
     {
-      "id": "e010",
-      "timestamp": "2026-07-21T00:00:00+00:00",
+      "id": "e011",
+      "timestamp": "2026-07-22T15:25:08+00:00",
       "type": "commit",
-      "content": "Commit: cd6b7d11720b7437f8a78c44caf425195c82e54e",
+      "content": "Commit: b55d135888",
       "caused_by": [
         "e008"
       ],
       "leads_to": [
-        "e011"
-      ]
-    },
-    {
-      "id": "e011",
-      "timestamp": "2026-07-21T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: b55d135888",
-      "caused_by": [
         "e010"
-      ],
-      "leads_to": [
-        "e001"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-25-session-3328-prose-sha-provenance.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3328-prose-sha-provenance.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Issue #3328 offers three options and calls option 2, verifying each prose SHA is a descendant of the starting commit, accurate. Implemented it first because it looked free: the extractor already shells out to git for staged-file counts, so it adds no dependency, and all 140 existing tests passed unchanged because their fixture SHAs are not git objects and fail open.",
-      "caused_by": [
-        "e009"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e009"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Passing tests were not enough evidence, so the rule was replayed against all 916 session logs in the repo. It changed 13 of them. Every case inspected was wrong. This repo squash-merges, and a squash commit discards the branch's parentage, so a session's own merge commit is not a descendant of the branch base it came from. Option 2 as written drops exactly the commits it is supposed to keep.",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e009"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Inverted the test. A commit already reachable from the starting commit existed before the session began, so the session cannot have produced it. That is a tautology, which is what makes it safe, and it cannot misfire on a squash merge because a squash merge comes after the base rather than before it. Checked the discriminator against the SHA named in the issue report and against the three squash cases: the report SHA is an ancestor of its session's base, and none of the squash cases are.",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e009"
       ]
     },
     {
@@ -47,11 +41,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-swept all 878 logs that carry a work log. Nine change, all downward, and reading the prose around each dropped SHA confirms every one is a citation rather than a session commit: another PR's merge commit, a different branch's tip, a git-blame result, and a version-pin reference. Zero false positives. Fails open on an unresolvable SHA, a missing starting commit, or no git, so the metric degrades to today's behavior rather than silently dropping real commits.",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e009"
       ]
     },
     {
@@ -59,11 +51,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Six regression cases added, including one that pins the squash-merge behavior directly so the descendant form cannot be reintroduced without a red test, and one that asserts the event stream and the metric agree so the causal graph cannot carry a commit node the metric does not.",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e009"
       ]
     },
     {
@@ -71,43 +61,47 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Replace the unsound ancestry discriminator with a committer-date floor",
-      "caused_by": [
-        "e005"
-      ],
-      "leads_to": [
-        "e008"
-      ]
-    },
-    {
-      "id": "e007",
-      "timestamp": "2026-07-25T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: a2038a99017058e99f45de015e6b1886bb538e65",
       "caused_by": [],
       "leads_to": [
         "e009"
       ]
     },
     {
-      "id": "e008",
-      "timestamp": "2026-07-25T00:00:00+00:00",
-      "type": "milestone",
-      "content": "Address the remaining Copilot review threads on PR #3334",
+      "id": "e007",
+      "timestamp": "2026-07-25T09:55:31+00:00",
+      "type": "commit",
+      "content": "Commit: a2038a99017058e99f45de015e6b1886bb538e65",
       "caused_by": [
-        "e006"
+        "e009"
       ],
       "leads_to": []
     },
     {
-      "id": "e009",
+      "id": "e008",
       "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Address the remaining Copilot review threads on PR #3334",
+      "caused_by": [],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-25T04:00:48+00:00",
       "type": "commit",
       "content": "Commit: 3669adec84",
       "caused_by": [
-        "e007"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e008"
       ],
       "leads_to": [
-        "e001"
+        "e007"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-2612.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-2612.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Measure all four causal-graph issues against live main",
-      "caused_by": [
-        "e016"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e013"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Fix #3375 without tombstones",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e013"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Verify the delete-beats-modify premise",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e013"
       ]
     },
     {
@@ -47,11 +41,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Establish that the 13 bad ids are unrecoverable (#3367 AC 1)",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e013"
       ]
     },
     {
@@ -59,11 +51,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Repair the 13 ids (#3367)",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e013"
       ]
     },
     {
@@ -71,11 +61,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Add the guard #3367 AC 3 asks for",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e013"
       ]
     },
     {
@@ -83,11 +71,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Search before building on #3350",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e008"
+        "e013"
       ]
     },
     {
@@ -95,11 +81,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Find and fix a defect the backfill would have shipped",
-      "caused_by": [
-        "e007"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e009"
+        "e013"
       ]
     },
     {
@@ -107,11 +91,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reconcile the graph (#3350)",
-      "caused_by": [
-        "e008"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e010"
+        "e013"
       ]
     },
     {
@@ -119,11 +101,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Negative controls",
-      "caused_by": [
-        "e009"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e011"
+        "e013"
       ]
     },
     {
@@ -131,28 +111,38 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reject a false lead",
-      "caused_by": [
-        "e010"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e012",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 39b754c79a",
       "caused_by": [],
       "leads_to": [
         "e013"
       ]
     },
     {
+      "id": "e012",
+      "timestamp": "2026-07-26T23:22:40+00:00",
+      "type": "commit",
+      "content": "Commit: 39b754c79a",
+      "caused_by": [
+        "e016"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e013",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T23:03:29+00:00",
       "type": "commit",
       "content": "Commit: 43bb0487d1",
       "caused_by": [
-        "e012"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e011"
       ],
       "leads_to": [
         "e014"
@@ -160,7 +150,7 @@
     },
     {
       "id": "e014",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T23:13:25+00:00",
       "type": "commit",
       "content": "Commit: 06a666f466",
       "caused_by": [
@@ -172,7 +162,7 @@
     },
     {
       "id": "e015",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T23:13:46+00:00",
       "type": "commit",
       "content": "Commit: 988aee1e5b",
       "caused_by": [
@@ -184,14 +174,14 @@
     },
     {
       "id": "e016",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T23:22:15+00:00",
       "type": "commit",
       "content": "Commit: e595d2b647",
       "caused_by": [
         "e015"
       ],
       "leads_to": [
-        "e001"
+        "e012"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3342-autofix-3354-review-threads-merge.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3342-autofix-3354-review-threads-merge.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Run the live-state and comment inventory gates",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e007"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Address all five unresolved review threads",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e007"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reconcile concurrent remote changes",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e007"
       ]
     },
     {
@@ -47,40 +41,42 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Run targeted and required validation",
-      "caused_by": [
-        "e003"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e005",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "test",
-      "content": "30 targeted tests; build_all check exit 0; plugin-version-bump OK; pre_pr 30 passed, 0 failed, 4 skipped; full pytest 13,869 passed, 23 skipped, 45 xfailed.",
-      "caused_by": [
-        "e009"
-      ],
-      "leads_to": [
-        "e001"
-      ]
-    },
-    {
-      "id": "e006",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 2e153a9eda",
       "caused_by": [],
       "leads_to": [
         "e007"
       ]
     },
     {
-      "id": "e007",
+      "id": "e005",
       "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "test",
+      "content": "30 targeted tests; build_all check exit 0; plugin-version-bump OK; pre_pr 30 passed, 0 failed, 4 skipped; full pytest 13,869 passed, 23 skipped, 45 xfailed.",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-26T05:46:07+00:00",
+      "type": "commit",
+      "content": "Commit: 2e153a9eda",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-26T05:22:06+00:00",
       "type": "commit",
       "content": "Commit: 827a4c699c",
       "caused_by": [
-        "e006"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005"
       ],
       "leads_to": [
         "e008"
@@ -88,7 +84,7 @@
     },
     {
       "id": "e008",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T05:26:28+00:00",
       "type": "commit",
       "content": "Commit: f673788d4b",
       "caused_by": [
@@ -100,14 +96,14 @@
     },
     {
       "id": "e009",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T05:45:39+00:00",
       "type": "commit",
       "content": "Commit: 58bd9ce0dd",
       "caused_by": [
         "e008"
       ],
       "leads_to": [
-        "e005"
+        "e006"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3342-harness-reference-size.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3342-harness-reference-size.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Audit the duplication before cutting anything",
-      "caused_by": [
-        "e007"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e021"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Replace the duplicate with a repository-policy section",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e021"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Give the one orphaned vendor fact a home in the sidecar",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e021"
       ]
     },
     {
@@ -47,11 +41,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Repoint the content-pin tests at the owning file",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e021"
       ]
     },
     {
@@ -59,11 +51,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "test",
       "content": "30 passed across tests/build_scripts/test_hook_contract_knowledge.py and .claude/skills/agent-harness-reference/tests/. Assertions that span a wrapped line now run through _normalized_text so a reflow cannot turn them red without a fact changing.",
-      "caused_by": [
-        "e026"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e021"
       ]
     },
     {
@@ -71,11 +61,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Negative controls",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e008"
+        "e021"
       ]
     },
     {
@@ -83,11 +71,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "test",
       "content": "Deleting each of 'Omitting decision permits completion.', the Timeout fail-open row, 'implementation-only SDK types', and 'performs one JSON.parse' from the sidecar turned 2 tests red each (the repointed pin plus the canonical-versus-mirror byte compare). Deleting 'Failed-observer partial output is discarded.' from SKILL.md turned 2 red. Appending one line to the generated mirror turned 1 red. Restoring every file returned 25 passed.",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e001"
+        "e021"
       ]
     },
     {
@@ -95,11 +81,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Take the autofix bot's corrections",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e009"
+        "e021"
       ]
     },
     {
@@ -107,11 +91,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Correct the session number the autofix bot moved the wrong way",
-      "caused_by": [
-        "e008"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e010"
+        "e021"
       ]
     },
     {
@@ -119,11 +101,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Address the PR #3354 review round",
-      "caused_by": [
-        "e009"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e011"
+        "e021"
       ]
     },
     {
@@ -131,11 +111,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reword the SKILL.md pointer and re-extract the episode",
-      "caused_by": [
-        "e010"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e012"
+        "e021"
       ]
     },
     {
@@ -143,11 +121,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reconcile the manifest version with the PR description",
-      "caused_by": [
-        "e011"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e013"
+        "e021"
       ]
     },
     {
@@ -155,11 +131,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Correct the false session.number claim in the PR-3354 retrospective",
-      "caused_by": [
-        "e012"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e014"
+        "e021"
       ]
     },
     {
@@ -167,11 +141,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Purge the disproven branch-name invariant from this log",
-      "caused_by": [
-        "e013"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e015"
+        "e021"
       ]
     },
     {
@@ -179,11 +151,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Attribute the shared Stop shape to both vendor references",
-      "caused_by": [
-        "e014"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e016"
+        "e021"
       ]
     },
     {
@@ -191,11 +161,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reconcile every recorded manifest version with what the branch ships",
-      "caused_by": [
-        "e015"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e017"
+        "e021"
       ]
     },
     {
@@ -203,11 +171,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Make the module's negative assertions survive a rewrap",
-      "caused_by": [
-        "e016"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e018"
+        "e021"
       ]
     },
     {
@@ -215,11 +181,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Regenerate memory artifacts after the final review fixes",
-      "caused_by": [
-        "e017"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e019"
+        "e021"
       ]
     },
     {
@@ -227,28 +191,46 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Merge current main and resolve plugin manifest versions",
-      "caused_by": [
-        "e018"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e020",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 199a5c04c",
       "caused_by": [],
       "leads_to": [
         "e021"
       ]
     },
     {
+      "id": "e020",
+      "timestamp": "2026-07-26T07:56:31+00:00",
+      "type": "commit",
+      "content": "Commit: 199a5c04c",
+      "caused_by": [
+        "e026"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e021",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T02:25:18+00:00",
       "type": "commit",
       "content": "Commit: b09c57cfe1",
       "caused_by": [
-        "e020"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e011",
+        "e012",
+        "e013",
+        "e014",
+        "e015",
+        "e016",
+        "e017",
+        "e018",
+        "e019"
       ],
       "leads_to": [
         "e022"
@@ -256,7 +238,7 @@
     },
     {
       "id": "e022",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T02:25:42+00:00",
       "type": "commit",
       "content": "Commit: da5401a16f",
       "caused_by": [
@@ -268,7 +250,7 @@
     },
     {
       "id": "e023",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T03:07:43+00:00",
       "type": "commit",
       "content": "Commit: 618d8e1a7",
       "caused_by": [
@@ -280,7 +262,7 @@
     },
     {
       "id": "e024",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T03:53:48+00:00",
       "type": "commit",
       "content": "Commit: 006a88767",
       "caused_by": [
@@ -292,7 +274,7 @@
     },
     {
       "id": "e025",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T05:22:06+00:00",
       "type": "commit",
       "content": "Commit: 827a4c699",
       "caused_by": [
@@ -304,14 +286,14 @@
     },
     {
       "id": "e026",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T05:26:28+00:00",
       "type": "commit",
       "content": "Commit: f673788d4",
       "caused_by": [
         "e025"
       ],
       "leads_to": [
-        "e005"
+        "e020"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3347-resolve-remaining-3347-review-threads.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3347-resolve-remaining-3347-review-threads.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran check_pr_live_state.py gate for PR #3347; Data.action=ACT (not SKIP), proceeded.",
-      "caused_by": [
-        "e043"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e020"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Verified head SHA d5937f2a6c matched the live snapshot; the shared primary checkout was mutated by concurrent work mid-session, so created an isolated git worktree at /home/richard/src/GitHub/rjmurillo/ai-agents-pr3347 for this task.",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e020"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Fetched PR metadata and all 13 review threads via get_pr_review_threads.py: 10 resolved, 3 unresolved (all authored by copilot-pull-request-reviewer, all on scripts/validate_session_json.py).",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e020"
       ]
     },
     {
@@ -47,11 +41,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Triaged the 3 unresolved threads: (1) REQUIRED_SESSION_FIELDS duplicate/over-rejection finding was already fixed by the branch's last commit (d5937f2a6c) before this session started, verified by diffing validate_session_section across commits; (2) 'nothing was checked' schema-load-failure message is misleading because validate_session_log still runs protocol checks afterward, a real wording bug; (3) validate_against_schema does not catch jsonschema.exceptions.SchemaError and sorts by raw list(e.absolute_path), which raises TypeError when errors' paths share a prefix but diverge between str and int elements, a real crash-class bug reproduced locally before fixing.",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e020"
       ]
     },
     {
@@ -59,11 +51,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Implemented fixes in scripts/validate_session_json.py: reworded the schema-load-failure message to 'schema layer skipped' (scoped, not absolute); wrapped validator construction and iter_errors in try/except SchemaError with a readable message; changed the sort key to tuple(str(part) for part in e.absolute_path).",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e020"
       ]
     },
     {
@@ -71,11 +61,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Added 3 regression tests in tests/test_validate_session_json.py: message no longer claims total silence while protocol checks still surface errors; SchemaError from a monkeypatched validator_for is caught and reported, not raised; a fake validator returning ValidationErrors with mixed int/str path elements at the same depth sorts without raising TypeError.",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e020"
       ]
     },
     {
@@ -83,11 +71,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran ruff check --fix (import sort only), manually wrapped two long lines to satisfy E501, re-ran ruff (clean) and mypy (clean).",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e008"
+        "e020"
       ]
     },
     {
@@ -95,11 +81,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran full tests/test_validate_session_json.py (132 passed) and the broader session-related suite (tests/ -k session: 678 passed, 1 skipped, 6 xfailed).",
-      "caused_by": [
-        "e007"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e010"
+        "e020"
       ]
     },
     {
@@ -108,10 +92,10 @@
       "type": "test",
       "content": "Ran full tests/test_validate_session_json.py (132 passed) and the broader session-related suite (tests/ -k session: 678 passed, 1 skipped, 6 xfailed).",
       "caused_by": [
-        "e053"
+        "e052"
       ],
       "leads_to": [
-        "e016"
+        "e020"
       ]
     },
     {
@@ -119,11 +103,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-verified local HEAD matched origin/fix/3346-session-schema-enforcement (no concurrent push) before committing and again before pushing.",
-      "caused_by": [
-        "e008"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e011"
+        "e020"
       ]
     },
     {
@@ -131,11 +113,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Committed 'fix(validation): stop overclaiming schema silence and crashing on bad schemas' as ebb6cf9365, with Refs #3346 and the branch's established Co-Authored-By: Copilot / Copilot-Session trailers (session ID from COPILOT_AGENT_SESSION_ID).",
-      "caused_by": [
-        "e010"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e012"
+        "e020"
       ]
     },
     {
@@ -143,11 +123,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Pushed as a fast-forward (no force).",
-      "caused_by": [
-        "e011"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e013"
+        "e020"
       ]
     },
     {
@@ -155,11 +133,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Replied to and resolved all 3 unresolved threads via add_pr_review_thread_reply.py --resolve, each citing commit ebb6cf9365 and the specific fix (or, for the already-fixed finding, the prior commit).",
-      "caused_by": [
-        "e012"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e014"
+        "e020"
       ]
     },
     {
@@ -167,11 +143,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Confirmed 0 unresolved threads via get_pr_review_threads.py.",
-      "caused_by": [
-        "e013"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e015"
+        "e020"
       ]
     },
     {
@@ -179,11 +153,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Waited for and confirmed all CI checks green via get_pr_checks.py --wait (83 passed, 0 failed, including all required checks: Validate PR, Run Python Tests, CodeQL, Security/Analyst/Architect/QA Review, etc.).",
-      "caused_by": [
-        "e014"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e017"
+        "e020"
       ]
     },
     {
@@ -192,10 +164,10 @@
       "type": "test",
       "content": "Waited for and confirmed all CI checks green via get_pr_checks.py --wait (83 passed, 0 failed, including all required checks: Validate PR, Run Python Tests, CodeQL, Security/Analyst/Architect/QA Review, etc.).",
       "caused_by": [
-        "e009"
+        "e052"
       ],
       "leads_to": [
-        "e025"
+        "e020"
       ]
     },
     {
@@ -203,11 +175,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Checked live merge state: mergeStateStatus=BLOCKED, mergeable=MERGEABLE, reviewDecision=null, blocked by required review approval (branch protection), not by threads or CI; did not request or perform approval, and did not merge or enable auto-merge, per instructions.",
-      "caused_by": [
-        "e015"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e018"
+        "e020"
       ]
     },
     {
@@ -215,11 +185,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran scripts/validation/pre_pr.py --quick: all validations passed (advisory-only warnings for unrelated bundle coverage and review-marker notes).",
-      "caused_by": [
-        "e017"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e019"
+        "e020"
       ]
     },
     {
@@ -227,33 +195,73 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Updated .serena/memories/pr-review/pr-comment-responder-skills with cumulative reviewer stats and a new PR #3347 breakdown.",
-      "caused_by": [
-        "e018"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e022"
+        "e020"
       ]
     },
     {
       "id": "e020",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:08:02+00:00",
       "type": "commit",
       "content": "Commit: ebb6cf9365decd450d7b26c6aedd49ef3264b326",
-      "caused_by": [],
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e011",
+        "e012",
+        "e013",
+        "e014",
+        "e015",
+        "e016",
+        "e017",
+        "e018",
+        "e019",
+        "e022",
+        "e023",
+        "e024",
+        "e025",
+        "e026",
+        "e027",
+        "e028",
+        "e029",
+        "e030",
+        "e031",
+        "e032",
+        "e033",
+        "e034",
+        "e035",
+        "e036",
+        "e037",
+        "e038",
+        "e039",
+        "e040",
+        "e041",
+        "e042",
+        "e043"
+      ],
       "leads_to": [
         "e021"
       ]
     },
     {
       "id": "e021",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:08:02+00:00",
       "type": "commit",
       "content": "Commit: ebb6cf9365",
       "caused_by": [
         "e020"
       ],
       "leads_to": [
-        "e044"
+        "e045"
       ]
     },
     {
@@ -261,11 +269,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "After pushing ebb6cf9365 and a28649c5e1, re-queried review threads and found a 4th unresolved thread (PRRT_kwDOQoWRls6TzlCz, copilot-pull-request-reviewer): validate_against_schema() built its validator without a format_checker, so the schema's format: \"date-time\" on developmentPhase.history[].timestamp was never enforced (jsonschema treats format as annotation-only by default). Confirmed real: the base jsonschema.FormatChecker lacks a date-time checker without the rfc3339-validator package, which is not a project dependency.",
-      "caused_by": [
-        "e019"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e023"
+        "e020"
       ]
     },
     {
@@ -273,11 +279,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Registered a stdlib-only date-time format checker using datetime.fromisoformat (Python >=3.14 required by this project) instead of adding a new dependency, and passed it to the validator via validator_for(schema)(schema, format_checker=_FORMAT_CHECKER). Verified via a scripted scan of .agents/sessions/*.json that no committed session log uses developmentPhase.history, so enforcing the format introduces zero regressions on historical logs. Added test_malformed_history_timestamp_is_rejected and test_valid_history_timestamp_passes to tests/test_validate_session_json.py.",
-      "caused_by": [
-        "e022"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e024"
+        "e020"
       ]
     },
     {
@@ -285,11 +289,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "uv run pytest tests/test_validate_session_json.py: 134 passed. ruff check and mypy clean. Broader uv run pytest tests/ -k session: 680 passed, 1 skipped, 6 xfailed. Ran scripts/validation/pre_pr.py --quick: all passed.",
-      "caused_by": [
-        "e023"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e026"
+        "e020"
       ]
     },
     {
@@ -298,10 +300,10 @@
       "type": "test",
       "content": "uv run pytest tests/test_validate_session_json.py: 134 passed. ruff check and mypy clean. Broader uv run pytest tests/ -k session: 680 passed, 1 skipped, 6 xfailed. Ran scripts/validation/pre_pr.py --quick: all passed.",
       "caused_by": [
-        "e016"
+        "e052"
       ],
       "leads_to": [
-        "e031"
+        "e020"
       ]
     },
     {
@@ -309,11 +311,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-verified local HEAD matched origin (a28649c5e1) before committing; staged scripts/validate_session_json.py and tests/test_validate_session_json.py; committed as fix(validation): enforce date-time format on schema-declared timestamps with Refs #3346 and Copilot trailers -> 15d6ae2bc44968de01efaa0a0493ad8a89e3d222. Re-verified no concurrent push, then pushed (pre-push hook: 13798 tests passed).",
-      "caused_by": [
-        "e024"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e027"
+        "e020"
       ]
     },
     {
@@ -321,11 +321,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Replied to and resolved PRRT_kwDOQoWRls6TzlCz citing the fixing commit. Made a transcription error in the first reply (fabricated a full SHA instead of using the real one from git rev-parse); caught it immediately and posted a correction comment with the verified SHA before proceeding. Thread remained resolved throughout.",
-      "caused_by": [
-        "e026"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e028"
+        "e020"
       ]
     },
     {
@@ -333,11 +331,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-checked threads after the push and found a 5th unresolved thread (PRRT_kwDOQoWRls6TzpOY, copilot-pull-request-reviewer) on tests/test_validate_session_json.py: the TestMainNarrowsOnThePayload class docstring claimed main() branches on data is None, not on error, which is backwards from the actual implementation (main() branches on error is not None, letting a JSON null root reach schema validation). Confirmed by reading main().",
-      "caused_by": [
-        "e027"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e029"
+        "e020"
       ]
     },
     {
@@ -345,11 +341,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Fixed the docstring to state the correct condition (error is not None, not data is None). Single-line, single-file documentation fix; no behavior change.",
-      "caused_by": [
-        "e028"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e030"
+        "e020"
       ]
     },
     {
@@ -357,11 +351,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "uv run pytest tests/test_validate_session_json.py: 134 passed. ruff check clean.",
-      "caused_by": [
-        "e029"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e032"
+        "e020"
       ]
     },
     {
@@ -370,10 +362,10 @@
       "type": "test",
       "content": "uv run pytest tests/test_validate_session_json.py: 134 passed. ruff check clean.",
       "caused_by": [
-        "e025"
+        "e052"
       ],
       "leads_to": [
-        "e037"
+        "e020"
       ]
     },
     {
@@ -381,11 +373,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-verified HEAD matched origin (15d6ae2bc4) before committing; committed as docs(tests): fix stale branching claim in TestMainNarrowsOnThePayload with Refs #3346 and Copilot trailers -> 31e3058e907671d75306e9d2efbd891fb450328c. Re-verified no concurrent push, then pushed.",
-      "caused_by": [
-        "e030"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e033"
+        "e020"
       ]
     },
     {
@@ -393,11 +383,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Replied to and resolved PRRT_kwDOQoWRls6TzpOY citing the verified commit SHA (read from a file written by git rev-parse, not retyped by hand, after the earlier transcription error).",
-      "caused_by": [
-        "e032"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e034"
+        "e020"
       ]
     },
     {
@@ -405,11 +393,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-checked threads after the push and found a 6th unresolved thread (PRRT_kwDOQoWRls6Tzr_g, copilot-pull-request-reviewer) on the new _check_date_time function: datetime.fromisoformat accepts a timestamp with no UTC offset, but RFC 3339 section 5.6 (what format: \"date-time\" means) requires one. Confirmed the project's requires-python (>=3.14) already made the Z-suffix concern moot, but the offset-optional acceptance was a real gap.",
-      "caused_by": [
-        "e033"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e035"
+        "e020"
       ]
     },
     {
@@ -417,11 +403,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Tightened _check_date_time to reject a parse that comes back timezone-naive (parsed.tzinfo is not None). Added test_offset_naive_history_timestamp_is_rejected; the existing valid-timestamp test already used a Z-suffixed value so it needed no change.",
-      "caused_by": [
-        "e034"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e036"
+        "e020"
       ]
     },
     {
@@ -429,11 +413,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "uv run pytest tests/test_validate_session_json.py: 135 passed. ruff check and mypy clean. Broader uv run pytest tests/ -k session: 681 passed, 1 skipped, 6 xfailed. Ran scripts/validation/pre_pr.py --quick: all passed.",
-      "caused_by": [
-        "e035"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e038"
+        "e020"
       ]
     },
     {
@@ -442,10 +424,10 @@
       "type": "test",
       "content": "uv run pytest tests/test_validate_session_json.py: 135 passed. ruff check and mypy clean. Broader uv run pytest tests/ -k session: 681 passed, 1 skipped, 6 xfailed. Ran scripts/validation/pre_pr.py --quick: all passed.",
       "caused_by": [
-        "e031"
+        "e052"
       ],
       "leads_to": [
-        "e041"
+        "e020"
       ]
     },
     {
@@ -453,11 +435,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Re-verified HEAD matched origin (31e3058e90) before committing; committed as fix(validation): reject offset-naive timestamps in date-time format check with Refs #3346 and Copilot trailers -> ecebb1d5acb2d25a0b44fa1e2048837d0e1092c8. Re-verified no concurrent push, then pushed (pre-push hook: full suite green).",
-      "caused_by": [
-        "e036"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e039"
+        "e020"
       ]
     },
     {
@@ -465,11 +445,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Replied to and resolved PRRT_kwDOQoWRls6Tzr_g citing the verified commit SHA.",
-      "caused_by": [
-        "e038"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e040"
+        "e020"
       ]
     },
     {
@@ -477,11 +455,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Waited and re-queried unresolved threads twice more after the final push: 0 unresolved both times. Ran get_pr_checks.py --wait: OverallState SUCCESS, 85 passed, 0 failed, 0 pending, AllPassing true. Ran check_pr_live_state.py: action=ACT, state=OPEN, not merged/closed/superseded. Final gh pr view: headRefOid=ecebb1d5ac (matches final push), mergeStateStatus=BLOCKED, mergeable=MERGEABLE, reviewDecision empty -- same pre-existing branch-protection gap (missing approving review), unchanged from before this session's work and explicitly out of scope.",
-      "caused_by": [
-        "e039"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e042"
+        "e020"
       ]
     },
     {
@@ -490,10 +466,10 @@
       "type": "test",
       "content": "Waited and re-queried unresolved threads twice more after the final push: 0 unresolved both times. Ran get_pr_checks.py --wait: OverallState SUCCESS, 85 passed, 0 failed, 0 pending, AllPassing true. Ran check_pr_live_state.py: action=ACT, state=OPEN, not merged/closed/superseded. Final gh pr view: headRefOid=ecebb1d5ac (matches final push), mergeStateStatus=BLOCKED, mergeable=MERGEABLE, reviewDecision empty -- same pre-existing branch-protection gap (missing approving review), unchanged from before this session's work and explicitly out of scope.",
       "caused_by": [
-        "e037"
+        "e052"
       ],
       "leads_to": [
-        "e043"
+        "e020"
       ]
     },
     {
@@ -501,10 +477,10 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Before committing this update, git fetch on fix/3346-session-schema-enforcement found the remote had moved to 109453ecab (2 commits ahead of my last push ecebb1d5ac), pushed by a second, concurrent agent session (Copilot-Session 0cd84ba3, the branch's original session ID) working the same PR in parallel. That session's commit 22917af15a substantively revised the same function I had touched: (1) replaced the SchemaError-around-iter_errors handler with validator_cls.check_schema(schema) up front, because most malformed schemas raise UnknownType or AttributeError rather than SchemaError, so my handler alone still let the gate crash on two of three malformed-schema shapes; (2) reverted the error sort key from a stringified path back to the raw list(e.absolute_path), arguing the mixed str/int comparison my fix guarded against is unreachable (paths only compare past a shared prefix, whose child keys are then uniformly str or uniformly int), and that stringifying broke numeric ordering for indices >= 10; (3) deleted REQUIRED_SESSION_FIELDS as dead code; (4) replaced two monkeypatched-validator tests with tests driven by real malformed schemas. My format_checker/date-time work (4th and 6th threads) was left as written and cited as already covering 925 committed logs with zero rejections. Verified compatibility: git merge --ff-only origin/fix/3346-session-schema-enforcement fast-forwarded cleanly (no conflicts, since it only builds on top of my last commit); re-ran the full test file (138 passed, up from 135: the other session's tests plus mine both present), ruff, mypy, and the broader session-tagged suite (684 passed) -- all green with both sessions' changes combined. Did not re-litigate the sort-key disagreement: the other session's reasoning is sound (a shared path prefix cannot mix child key types) and its replacement tests exercise real schemas instead of a synthetic monkeypatch, which is the stronger test design; deferred to it rather than reverting or force-pushing over it.",
-      "caused_by": [
-        "e040"
-      ],
-      "leads_to": []
+      "caused_by": [],
+      "leads_to": [
+        "e020"
+      ]
     },
     {
       "id": "e043",
@@ -512,31 +488,31 @@
       "type": "test",
       "content": "Before committing this update, git fetch on fix/3346-session-schema-enforcement found the remote had moved to 109453ecab (2 commits ahead of my last push ecebb1d5ac), pushed by a second, concurrent agent session (Copilot-Session 0cd84ba3, the branch's original session ID) working the same PR in parallel. That session's commit 22917af15a substantively revised the same function I had touched: (1) replaced the SchemaError-around-iter_errors handler with validator_cls.check_schema(schema) up front, because most malformed schemas raise UnknownType or AttributeError rather than SchemaError, so my handler alone still let the gate crash on two of three malformed-schema shapes; (2) reverted the error sort key from a stringified path back to the raw list(e.absolute_path), arguing the mixed str/int comparison my fix guarded against is unreachable (paths only compare past a shared prefix, whose child keys are then uniformly str or uniformly int), and that stringifying broke numeric ordering for indices >= 10; (3) deleted REQUIRED_SESSION_FIELDS as dead code; (4) replaced two monkeypatched-validator tests with tests driven by real malformed schemas. My format_checker/date-time work (4th and 6th threads) was left as written and cited as already covering 925 committed logs with zero rejections. Verified compatibility: git merge --ff-only origin/fix/3346-session-schema-enforcement fast-forwarded cleanly (no conflicts, since it only builds on top of my last commit); re-ran the full test file (138 passed, up from 135: the other session's tests plus mine both present), ruff, mypy, and the broader session-tagged suite (684 passed) -- all green with both sessions' changes combined. Did not re-litigate the sort-key disagreement: the other session's reasoning is sound (a shared path prefix cannot mix child key types) and its replacement tests exercise real schemas instead of a synthetic monkeypatch, which is the stronger test design; deferred to it rather than reverting or force-pushing over it.",
       "caused_by": [
-        "e041"
+        "e052"
       ],
       "leads_to": [
-        "e001"
+        "e020"
       ]
     },
     {
       "id": "e044",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:42:52+00:00",
       "type": "commit",
       "content": "Commit: ecebb1d5acb2d25a0b44fa1e2048837d0e1092c8",
       "caused_by": [
-        "e021"
+        "e049"
       ],
       "leads_to": [
-        "e045"
+        "e050"
       ]
     },
     {
       "id": "e045",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:19:14+00:00",
       "type": "commit",
       "content": "Commit: a28649c5e1",
       "caused_by": [
-        "e044"
+        "e021"
       ],
       "leads_to": [
         "e046"
@@ -544,7 +520,7 @@
     },
     {
       "id": "e046",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:30:25+00:00",
       "type": "commit",
       "content": "Commit: 15d6ae2bc44968de01efaa0a0493ad8a89e3d222",
       "caused_by": [
@@ -556,7 +532,7 @@
     },
     {
       "id": "e047",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:30:25+00:00",
       "type": "commit",
       "content": "Commit: 15d6ae2bc4",
       "caused_by": [
@@ -568,7 +544,7 @@
     },
     {
       "id": "e048",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:36:05+00:00",
       "type": "commit",
       "content": "Commit: 31e3058e907671d75306e9d2efbd891fb450328c",
       "caused_by": [
@@ -580,62 +556,64 @@
     },
     {
       "id": "e049",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:36:05+00:00",
       "type": "commit",
       "content": "Commit: 31e3058e90",
       "caused_by": [
         "e048"
       ],
       "leads_to": [
-        "e050"
+        "e044"
       ]
     },
     {
       "id": "e050",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T01:42:52+00:00",
       "type": "commit",
       "content": "Commit: ecebb1d5ac",
       "caused_by": [
-        "e049"
-      ],
-      "leads_to": [
-        "e051"
-      ]
-    },
-    {
-      "id": "e051",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 109453ecab",
-      "caused_by": [
-        "e050"
-      ],
-      "leads_to": [
-        "e052"
-      ]
-    },
-    {
-      "id": "e052",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 0cd84ba3",
-      "caused_by": [
-        "e051"
+        "e044"
       ],
       "leads_to": [
         "e053"
       ]
     },
     {
-      "id": "e053",
+      "id": "e051",
+      "timestamp": "2026-07-26T01:54:25+00:00",
+      "type": "commit",
+      "content": "Commit: 109453ecab",
+      "caused_by": [
+        "e053"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e052",
       "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 0cd84ba3",
+      "caused_by": [],
+      "leads_to": [
+        "e009",
+        "e016",
+        "e025",
+        "e031",
+        "e037",
+        "e041",
+        "e043"
+      ]
+    },
+    {
+      "id": "e053",
+      "timestamp": "2026-07-26T01:53:33+00:00",
       "type": "commit",
       "content": "Commit: 22917af15a",
       "caused_by": [
-        "e052"
+        "e050"
       ],
       "leads_to": [
-        "e009"
+        "e051"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3358-autofix-3358-review-threads-validate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3358-autofix-3358-review-threads-validate.json
@@ -12,10 +12,10 @@
       "type": "milestone",
       "content": "Ran the live-state gate and created an isolated worktree at remote head 9f1e0b949a.",
       "caused_by": [
-        "e017"
+        "e007"
       ],
       "leads_to": [
-        "e002"
+        "e008"
       ]
     },
     {
@@ -24,10 +24,10 @@
       "type": "milestone",
       "content": "Corrected session 3351 evidence, regenerated its episode and graph contribution, and fixed the collision claim.",
       "caused_by": [
-        "e001"
+        "e007"
       ],
       "leads_to": [
-        "e003"
+        "e008"
       ]
     },
     {
@@ -36,10 +36,10 @@
       "type": "milestone",
       "content": "Stopped the first push when the remote SHA changed from 9f1e0b949a to e503aaff56.",
       "caused_by": [
-        "e002"
+        "e007"
       ],
       "leads_to": [
-        "e004"
+        "e008"
       ]
     },
     {
@@ -48,10 +48,10 @@
       "type": "milestone",
       "content": "Replied to and resolved all three current review threads.",
       "caused_by": [
-        "e003"
+        "e007"
       ],
       "leads_to": [
-        "e005"
+        "e008"
       ]
     },
     {
@@ -60,56 +60,72 @@
       "type": "milestone",
       "content": "Completed local and remote validation.",
       "caused_by": [
-        "e004"
-      ],
-      "leads_to": [
-        "e010"
-      ]
-    },
-    {
-      "id": "e006",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 6610eb791f6ca5429d4a7266aba11d8fdb58f438",
-      "caused_by": [],
-      "leads_to": [
         "e007"
-      ]
-    },
-    {
-      "id": "e007",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: b2c8a534",
-      "caused_by": [
-        "e006"
       ],
       "leads_to": [
         "e008"
       ]
     },
     {
-      "id": "e008",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "id": "e006",
+      "timestamp": "2026-07-26T05:24:58+00:00",
       "type": "commit",
-      "content": "Commit: e503aaff56",
+      "content": "Commit: 6610eb791f6ca5429d4a7266aba11d8fdb58f438",
       "caused_by": [
-        "e007"
+        "e008"
       ],
       "leads_to": [
         "e009"
       ]
     },
     {
+      "id": "e007",
+      "timestamp": "2026-07-25T07:09:37+00:00",
+      "type": "commit",
+      "content": "Commit: b2c8a534",
+      "caused_by": [],
+      "leads_to": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e010",
+        "e011",
+        "e014",
+        "e016"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-26T05:12:18+00:00",
+      "type": "commit",
+      "content": "Commit: e503aaff56",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e010",
+        "e011",
+        "e014",
+        "e016"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
       "id": "e009",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T05:24:58+00:00",
       "type": "commit",
       "content": "Commit: 6610eb791f",
       "caused_by": [
-        "e008"
+        "e006"
       ],
       "leads_to": [
-        "e012"
+        "e013"
       ]
     },
     {
@@ -118,10 +134,10 @@
       "type": "milestone",
       "content": "Stopped a second push when the remote SHA changed to 2781ce15e3.",
       "caused_by": [
-        "e005"
+        "e007"
       ],
       "leads_to": [
-        "e011"
+        "e008"
       ]
     },
     {
@@ -130,34 +146,34 @@
       "type": "milestone",
       "content": "Removed the duplicate nested ending commit and completed review round 3.",
       "caused_by": [
-        "e010"
+        "e007"
       ],
       "leads_to": [
-        "e014"
+        "e008"
       ]
     },
     {
       "id": "e012",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T06:30:51+00:00",
       "type": "commit",
       "content": "Commit: 48d32a4e47a668fed0dec221cd439d620c532745",
       "caused_by": [
-        "e009"
+        "e013"
       ],
       "leads_to": [
-        "e013"
+        "e015"
       ]
     },
     {
       "id": "e013",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T06:05:26+00:00",
       "type": "commit",
       "content": "Commit: 2781ce15e3",
       "caused_by": [
-        "e012"
+        "e009"
       ],
       "leads_to": [
-        "e015"
+        "e012"
       ]
     },
     {
@@ -166,19 +182,19 @@
       "type": "milestone",
       "content": "Handled valid non-object graph JSON in review round 4.",
       "caused_by": [
-        "e011"
+        "e007"
       ],
       "leads_to": [
-        "e016"
+        "e008"
       ]
     },
     {
       "id": "e015",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T07:15:22+00:00",
       "type": "commit",
       "content": "Commit: 5e1cc81eedff747d075c6fa9e48d3c4e02693700",
       "caused_by": [
-        "e013"
+        "e012"
       ],
       "leads_to": [
         "e017"
@@ -190,21 +206,21 @@
       "type": "milestone",
       "content": "Closed malformed-JSON data loss and memory scope findings in review round 5.",
       "caused_by": [
-        "e014"
+        "e007"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e008"
+      ]
     },
     {
       "id": "e017",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T07:59:14+00:00",
       "type": "commit",
       "content": "Commit: 0c0298d127e14253ce9a83d0d75370cf7d819aae",
       "caused_by": [
         "e015"
       ],
-      "leads_to": [
-        "e001"
-      ]
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-26-session-3383-log-contamination.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3383-log-contamination.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Measure all four guards the issue proposes across every committed log before writing any",
-      "caused_by": [
-        "e011"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e011"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Test guard 3, that startingCommit must resolve in the repo",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e011"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Decide which tier the agreement checks belong to",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e011"
       ]
     },
     {
@@ -47,11 +41,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Attempt to adjudicate the 10 contradictions with git so they could be corrected",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e011"
       ]
     },
     {
@@ -59,11 +51,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Implement the three shippable checks with one function owning cross-field agreement",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e011"
       ]
     },
     {
@@ -71,11 +61,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Fix the crash a robustness case surfaced next door",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e011"
       ]
     },
     {
@@ -83,11 +71,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Calibrate the branch check against the corpus instead of trusting a four-row sample",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e008"
+        "e011"
       ]
     },
     {
@@ -95,11 +81,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Prove the checks bite",
-      "caused_by": [
-        "e007"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e009"
+        "e011"
       ]
     },
     {
@@ -107,31 +91,39 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Reland after PR #3401 merged mid-flight",
-      "caused_by": [
-        "e008"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e010",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 740890409fd1e15f8e9aa63adb37d2d17b740ea2",
       "caused_by": [],
       "leads_to": [
         "e011"
       ]
     },
     {
+      "id": "e010",
+      "timestamp": "2026-07-26T22:06:36+00:00",
+      "type": "commit",
+      "content": "Commit: 740890409fd1e15f8e9aa63adb37d2d17b740ea2",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e011",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T22:02:25+00:00",
       "type": "commit",
       "content": "Commit: 668afae6b9",
       "caused_by": [
-        "e010"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009"
       ],
       "leads_to": [
-        "e001"
+        "e010"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3400-orphaned-test-hardening.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3400-orphaned-test-hardening.json
@@ -11,31 +11,31 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Both improvements are on a branch off main rather than lost with their deleted source branches",
-      "caused_by": [
-        "e003"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e002",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: af7c0a453b",
       "caused_by": [],
       "leads_to": [
         "e003"
       ]
     },
     {
+      "id": "e002",
+      "timestamp": "2026-07-26T21:21:19+00:00",
+      "type": "commit",
+      "content": "Commit: af7c0a453b",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e003",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-26T21:20:59+00:00",
       "type": "commit",
       "content": "Commit: 5b69d082cb",
       "caused_by": [
-        "e002"
+        "e001"
       ],
       "leads_to": [
-        "e001"
+        "e002"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-26-session-3423-archive-stale-execution-plans.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3423-archive-stale-execution-plans.json
@@ -11,11 +11,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "12 of 13 plans verified complete or superseded; spec-005 carries a real residual defect",
-      "caused_by": [
-        "e015"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e002"
+        "e006"
       ]
     },
     {
@@ -23,11 +21,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": ".agents/plans/active/ is empty except .gitkeep; nothing deleted",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e006"
       ]
     },
     {
@@ -35,11 +31,9 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Issues #3424, #3425, #3426 opened with reproduction commands and file-line evidence",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e006"
       ]
     },
     {
@@ -47,52 +41,55 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Ran the pre-PR gate and cleared both failures. The dash gate flagged 165 pre-existing dashes in 1574-stage1-claude-kit-vendor.md and req-003-multi-tool-artifact-build.md, surfaced only because git mv put them in the branch diff. Considered a .agents/archive/ carve-out in checks_dash.py and rejected it: it would expand a docs-only change into a validator plus rule plus two mirrors plus a plugin manifest bump, and the dashes are ordinary prose, not bytes the archive needs to preserve. Replaced them instead, semantically neutral: label glosses take a colon, ID ranges take a hyphen, clause breaks take a comma or period.",
-      "caused_by": [
-        "e003"
-      ],
-      "leads_to": []
-    },
-    {
-      "id": "e005",
-      "timestamp": "2026-07-26T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 19d4a761",
       "caused_by": [],
       "leads_to": [
         "e006"
       ]
     },
     {
-      "id": "e006",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "id": "e005",
+      "timestamp": "2026-07-27T04:07:45+00:00",
       "type": "commit",
-      "content": "Commit: ae8be1c0",
+      "content": "Commit: 19d4a761",
       "caused_by": [
-        "e005"
+        "e014"
       ],
       "leads_to": [
-        "e007"
+        "e015"
       ]
     },
     {
-      "id": "e007",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "id": "e006",
+      "timestamp": "2026-07-27T03:57:18+00:00",
       "type": "commit",
-      "content": "Commit: 9f1df6b3",
+      "content": "Commit: ae8be1c0",
       "caused_by": [
-        "e006"
+        "e001",
+        "e002",
+        "e003",
+        "e004"
       ],
       "leads_to": [
         "e008"
       ]
     },
     {
+      "id": "e007",
+      "timestamp": "2026-07-27T04:14:13+00:00",
+      "type": "commit",
+      "content": "Commit: 9f1df6b3",
+      "caused_by": [
+        "e015"
+      ],
+      "leads_to": []
+    },
+    {
       "id": "e008",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:57:32+00:00",
       "type": "commit",
       "content": "Commit: f2094108",
       "caused_by": [
-        "e007"
+        "e006"
       ],
       "leads_to": [
         "e009"
@@ -100,7 +97,7 @@
     },
     {
       "id": "e009",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:57:54+00:00",
       "type": "commit",
       "content": "Commit: c74c8b07",
       "caused_by": [
@@ -112,7 +109,7 @@
     },
     {
       "id": "e010",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:23+00:00",
       "type": "commit",
       "content": "Commit: 0809412c",
       "caused_by": [
@@ -124,7 +121,7 @@
     },
     {
       "id": "e011",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:41+00:00",
       "type": "commit",
       "content": "Commit: 50860bf0",
       "caused_by": [
@@ -136,7 +133,7 @@
     },
     {
       "id": "e012",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:58:41+00:00",
       "type": "commit",
       "content": "Commit: 53f220e9",
       "caused_by": [
@@ -148,7 +145,7 @@
     },
     {
       "id": "e013",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T03:59:01+00:00",
       "type": "commit",
       "content": "Commit: 48c2b938",
       "caused_by": [
@@ -160,26 +157,26 @@
     },
     {
       "id": "e014",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T04:01:52+00:00",
       "type": "commit",
       "content": "Commit: 3f40fac7",
       "caused_by": [
         "e013"
       ],
       "leads_to": [
-        "e015"
+        "e005"
       ]
     },
     {
       "id": "e015",
-      "timestamp": "2026-07-26T00:00:00+00:00",
+      "timestamp": "2026-07-27T04:09:54+00:00",
       "type": "commit",
       "content": "Commit: 1bf125d7",
       "caused_by": [
-        "e014"
+        "e005"
       ],
       "leads_to": [
-        "e001"
+        "e007"
       ]
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-27-session-3429-pr-autofix.json
+++ b/.agents/memory/episodes/episode-2026-07-27-session-3429-pr-autofix.json
@@ -8,23 +8,23 @@
   "events": [
     {
       "id": "e001",
-      "timestamp": "2026-07-27T00:00:00+00:00",
+      "timestamp": "2026-07-27T05:46:04+00:00",
       "type": "commit",
       "content": "Commit: 63ed646fb9",
-      "caused_by": [],
-      "leads_to": [
+      "caused_by": [
         "e002"
-      ]
+      ],
+      "leads_to": []
     },
     {
       "id": "e002",
-      "timestamp": "2026-07-27T00:00:00+00:00",
+      "timestamp": "2026-07-27T05:18:43+00:00",
       "type": "commit",
       "content": "Commit: d996ad73",
-      "caused_by": [
+      "caused_by": [],
+      "leads_to": [
         "e001"
-      ],
-      "leads_to": []
+      ]
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-28-session-3651-marketplace-mirror-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-28-session-3651-marketplace-mirror-gate.json
@@ -13,7 +13,7 @@
       "content": "Traced the drift the gate exists to catch. git show 2043c39863 proves the count-stripping sweep in PR #2187 changed descriptions only in the two marketplace files. It touched two plugin.json files for version alone and never touched src/claude/.claude-plugin/plugin.json, which still opened with '25 specialized agent definitions'. The two strings in that pair are the same sentence with the count removed from one copy, which is what identifies the omission as an incomplete transformation rather than an intended difference.",
       "caused_by": [],
       "leads_to": [
-        "e002"
+        "e012"
       ]
     },
     {
@@ -21,11 +21,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Resolved a Chesterton's Fence before writing any gate. validate_plugin_version_bump.py carries a docstring line recording that validate_marketplace_counts.py was deliberately retired in the same PR #2187, because it compared a hard-coded count against the filesystem and therefore went red on every PR that added a component. The mirror check compares two checked-in strings and derives nothing, so it cannot fire on unrelated work. Recorded the distinction in the module docstring and in a Serena memory so a future reader who finds the retired validator's grave does not re-litigate it.",
-      "caused_by": [
-        "e001"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e003"
+        "e012"
       ]
     },
     {
@@ -33,11 +31,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Added check_marketplace_mirrors() to build/scripts/check_plugin_manifest_parity.py, comparing each marketplace entry's name and description against the plugin.json at its source directory, with 34 tests. Wired both marketplace files into the path filters of validate-generated-agents.yml and agent-drift-detection.yml so an edit to a marketplace alone runs the gate.",
-      "caused_by": [
-        "e002"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e004"
+        "e012"
       ]
     },
     {
@@ -45,11 +41,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Mutation-tested the suite rather than trusting a green run. Removing 'description' from _MIRRORED_FIELDS killed 5 tests and short-circuiting _compare_entry killed 6, so the original tests were not vacuous. A later adversarial review found a mutation that did survive: skipping the last configured marketplace. Added a two-marketplace fixture in both drift directions plus a CLI test that derives the expected entry count from the checked-in files. That mutation now kills 3 tests.",
-      "caused_by": [
-        "e003"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e005"
+        "e012"
       ]
     },
     {
@@ -57,11 +51,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "A cross-model security review by gemini-3.1-pro-preview reported one LOW finding, a path traversal in the source join. Verifying it myself showed the reviewer had found one of two vectors: './/etc/passwd' escapes because the join goes absolute, and './../../etc' escapes by walking out, which the reviewer missed. '/etc/passwd' was already safe. Added a resolve() plus is_relative_to() containment guard checked before .exists(), with three tests that plant a real readable manifest outside the root so a permissive implementation returns 0 and the test fails. Forcing the guard to return True kills exactly the two escape tests.",
-      "caused_by": [
-        "e004"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e006"
+        "e012"
       ]
     },
     {
@@ -69,11 +61,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "One of those new tests failed and the test was wrong, not the code. It used './sub/../plug' where 'sub' never existed, so .exists() failed before containment mattered. Fixing the fixture exposed a second defect in my own reporting: config errors printed under the staleness header with the staleness advice, which tells a reader with a bad path to 'edit whichever copy is wrong so both carry the same string'. Split the header and the fix line by failure class.",
-      "caused_by": [
-        "e005"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e007"
+        "e012"
       ]
     },
     {
@@ -81,11 +71,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "A cross-model adversarial review by gpt-5.6-sol returned 2 BLOCKING, 4 MAJOR and 1 MINOR. Three were real defects in the comparison itself. 'entry.get(f) != data.get(f)' read absent-on-both as agreement, so name is now required on both sides per upstream while description stays optional. _local_source_dir returned None for any string not starting with './', so a dropped prefix or a deleted source silently evaded the gate; upstream defines a string source as always a relative path and every remote source as an object, so non-conforming strings are now config errors and metadata.pluginRoot is honored. _read_manifest did not catch UnicodeDecodeError, so invalid UTF-8 crashed with exit 1 instead of the ADR-035 config code 2. Each fix was mutation-tested and each mutation killed exactly its own test.",
-      "caused_by": [
-        "e006"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e008"
+        "e012"
       ]
     },
     {
@@ -93,11 +81,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Verifying the review's MINOR finding proved my own commit message false and nearly overturned the change. The message claimed the sweep had cleaned both marketplace files and both project-toolkit manifests; git show disproved it. Tracing further showed the mirror has never held on disk for two of the three pairs, so history of agreement cannot justify the gate. Consulting the upstream marketplace specification confirmed it does not require an entry to repeat its manifest's text. What re-established the premise was textual identity: each marketplace description is the same sentence as its manifest description with the counts removed. The gate enforces a repository convention, and the docstring and memory now say so explicitly instead of implying a specification rule.",
-      "caused_by": [
-        "e007"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e009"
+        "e012"
       ]
     },
     {
@@ -105,11 +91,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Recomputed the version targets independently rather than taking the reviewer's numbers. Fetching all 21 open PR heads and reading every manifest showed the parity pair tops out at 0.6.152 in PR #3643, not the 0.6.151 the reviewer reported, and the src/claude 0.3.x line tops out at 0.3.48 in PR #3613. Set 0.6.153 and 0.3.49. PR #3638 carries 0.6.147 in src/claude, a cross-version-line collision already flagged on that PR, excluded from the 0.3.x maximum.",
-      "caused_by": [
-        "e008"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e010"
+        "e012"
       ]
     },
     {
@@ -117,30 +101,57 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Discovered mid-session that origin/main had moved and had already fixed half the change. PR #3559 landed 22 minutes after the original data commit and restored the Copilot description to the exact string its marketplace entry publishes. Rebuilt the branch on current main with three clean commits, dropped the now-redundant Copilot hunk, and closed #3645 with the evidence rather than shipping a duplicate fix. The independent convergence on the same string is now cited as evidence the convention is real.",
-      "caused_by": [
-        "e009"
-      ],
-      "leads_to": [
-        "e014"
-      ]
-    },
-    {
-      "id": "e011",
-      "timestamp": "2026-07-28T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 37a42bb7e0",
       "caused_by": [],
       "leads_to": [
         "e012"
       ]
     },
     {
+      "id": "e011",
+      "timestamp": "2026-07-28T10:01:33+00:00",
+      "type": "commit",
+      "content": "Commit: 37a42bb7e0",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": [
+        "e024"
+      ]
+    },
+    {
       "id": "e012",
-      "timestamp": "2026-07-28T00:00:00+00:00",
+      "timestamp": "2026-07-28T10:00:47+00:00",
       "type": "commit",
       "content": "Commit: a7169cb800",
       "caused_by": [
-        "e011"
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e014",
+        "e015",
+        "e016",
+        "e017",
+        "e018",
+        "e019",
+        "e020",
+        "e021",
+        "e022",
+        "e023",
+        "e025",
+        "e026",
+        "e027",
+        "e028",
+        "e029",
+        "e030",
+        "e031",
+        "e032"
       ],
       "leads_to": [
         "e013"
@@ -148,14 +159,14 @@
     },
     {
       "id": "e013",
-      "timestamp": "2026-07-28T00:00:00+00:00",
+      "timestamp": "2026-07-28T10:01:11+00:00",
       "type": "commit",
       "content": "Commit: 76ad4621e3",
       "caused_by": [
         "e012"
       ],
       "leads_to": [
-        "e024"
+        "e011"
       ]
     },
     {
@@ -163,11 +174,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Reproduce the stale count and confirm it is still live on main",
-      "caused_by": [
-        "e010"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e015"
+        "e012"
       ]
     },
     {
@@ -175,11 +184,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Date the regression against the sweep that caused it",
-      "caused_by": [
-        "e014"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e016"
+        "e012"
       ]
     },
     {
@@ -187,11 +194,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "First design: require each marketplace entry to mirror its manifest",
-      "caused_by": [
-        "e015"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e017"
+        "e012"
       ]
     },
     {
@@ -199,11 +204,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Adversarial review round 1 (gemini-3.1-pro security, gpt-5.6-sol rubber-duck)",
-      "caused_by": [
-        "e016"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e018"
+        "e012"
       ]
     },
     {
@@ -211,11 +214,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Discover main had moved and half the change was already shipped",
-      "caused_by": [
-        "e017"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e019"
+        "e012"
       ]
     },
     {
@@ -223,11 +224,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Adversarial review round 2 refuted the design",
-      "caused_by": [
-        "e018"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e020"
+        "e012"
       ]
     },
     {
@@ -235,11 +234,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Verify the refutation against upstream rather than accept it",
-      "caused_by": [
-        "e019"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e021"
+        "e012"
       ]
     },
     {
@@ -247,11 +244,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Rebuild around the invariant the evidence supports",
-      "caused_by": [
-        "e020"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e022"
+        "e012"
       ]
     },
     {
@@ -259,11 +254,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Prove the new tests constrain the new code",
-      "caused_by": [
-        "e021"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e023"
+        "e012"
       ]
     },
     {
@@ -271,20 +264,18 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Align the workflows with the check they run",
-      "caused_by": [
-        "e022"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e025"
+        "e012"
       ]
     },
     {
       "id": "e024",
-      "timestamp": "2026-07-28T00:00:00+00:00",
+      "timestamp": "2026-07-28T10:34:21+00:00",
       "type": "commit",
       "content": "Commit: 5f9317fdf8",
       "caused_by": [
-        "e013"
+        "e011"
       ],
       "leads_to": [
         "e033"
@@ -295,11 +286,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Send the redesign for a third adversarial pass",
-      "caused_by": [
-        "e023"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e026"
+        "e012"
       ]
     },
     {
@@ -307,11 +296,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Reproduce the pattern counterexamples before fixing anything",
-      "caused_by": [
-        "e025"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e027"
+        "e012"
       ]
     },
     {
@@ -319,11 +306,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Restructure the pattern around real component categories",
-      "caused_by": [
-        "e026"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e028"
+        "e012"
       ]
     },
     {
@@ -331,11 +316,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Kill the surviving mutation and the one it exposed",
-      "caused_by": [
-        "e027"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e029"
+        "e012"
       ]
     },
     {
@@ -343,11 +326,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Verify the historical claims instead of correcting them from the report",
-      "caused_by": [
-        "e028"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e030"
+        "e012"
       ]
     },
     {
@@ -355,11 +336,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Trace when the count actually went wrong",
-      "caused_by": [
-        "e029"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e031"
+        "e012"
       ]
     },
     {
@@ -367,11 +346,9 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Guard the gate's own file list",
-      "caused_by": [
-        "e030"
-      ],
+      "caused_by": [],
       "leads_to": [
-        "e032"
+        "e012"
       ]
     },
     {
@@ -379,14 +356,14 @@
       "timestamp": "2026-07-28T00:00:00+00:00",
       "type": "milestone",
       "content": "Rebuild the branch on current main a third time",
-      "caused_by": [
-        "e031"
-      ],
-      "leads_to": []
+      "caused_by": [],
+      "leads_to": [
+        "e012"
+      ]
     },
     {
       "id": "e033",
-      "timestamp": "2026-07-28T00:00:00+00:00",
+      "timestamp": "2026-07-28T11:04:33+00:00",
       "type": "commit",
       "content": "Commit: f2a851b1ee458861df9c977041deaba95236ca7e",
       "caused_by": [

--- a/.agents/memory/episodes/episode-2026-08-02-session-4219-red-main-episode-store.json
+++ b/.agents/memory/episodes/episode-2026-08-02-session-4219-red-main-episode-store.json
@@ -13,9 +13,7 @@
       "type": "milestone",
       "content": "Bisected the failing test. c7a401c7a8~1 passes in 0.24s, c7a401c7a8 (PR #4219) fails in 5.15s, so #4219 merged red and every branch that merges main inherits the failure.",
       "caused_by": [],
-      "leads_to": [
-        "e006"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
     },
     {
@@ -24,9 +22,7 @@
       "type": "milestone",
       "content": "Triaged the 14 violations before repairing rather than baselining them. The validator docstring names the root cause: the pre-#3638 linker chained commits by list position while _collect_shas put the session's last commit first, so an episode recorded an effect as its own cause.",
       "caused_by": [],
-      "leads_to": [
-        "e006"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
     },
     {
@@ -35,9 +31,7 @@
       "type": "milestone",
       "content": "Measured the repair against git ground truth. 64 of 64 original commit timestamps were synthetic midnight placeholders; 63 of 63 repaired timestamps equal git's committer instant. The 64th SHA belongs to a squash-merged branch and no longer resolves, which the validator documents and skips.",
       "caused_by": [],
-      "leads_to": [
-        "e006"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
     },
     {
@@ -46,9 +40,7 @@
       "type": "milestone",
       "content": "Proved non-destructiveness field by field: 0 events added or dropped, 0 id sequences changed, 0 narrative content fields rewritten, 0 leads_to edges lost, top-level metadata identical. Only caused_by, leads_to, and timestamp differ.",
       "caused_by": [],
-      "leads_to": [
-        "e006"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
     },
     {
@@ -57,22 +49,27 @@
       "type": "milestone",
       "content": "Ran extract_session_episode.py --validate --fix, then re-validated: 381 validated, 0 violations, 12 repaired.",
       "caused_by": [],
-      "leads_to": [
-        "e006"
-      ],
+      "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
     },
     {
       "id": "e006",
-      "timestamp": "2026-08-02T04:52:55+00:00",
+      "timestamp": "2026-08-02T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: c7a401c7a8",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 74896f00463e",
       "caused_by": [
-        "e001",
-        "e002",
-        "e003",
-        "e004",
-        "e005"
+        "e006"
       ],
       "leads_to": [],
       "_source_session": "2026-08-02-session-4219-red-main-episode-store"
@@ -83,7 +80,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 14
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-02-session-4219-red-main-episode-store.json
+++ b/.agents/memory/episodes/episode-2026-08-02-session-4219-red-main-episode-store.json
@@ -1,0 +1,90 @@
+{
+  "id": "episode-2026-08-02-session-4219-red-main-episode-store",
+  "session": "2026-08-02-session-4219-red-main-episode-store",
+  "timestamp": "2026-08-02T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Repair the 14 backwards commit-to-commit edges in the committed episode store that PR #4219 gated on but never cleaned, so main stops failing test_the_committed_episode_store_is_clean and every open PR can push again.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bisected the failing test. c7a401c7a8~1 passes in 0.24s, c7a401c7a8 (PR #4219) fails in 5.15s, so #4219 merged red and every branch that merges main inherits the failure.",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Triaged the 14 violations before repairing rather than baselining them. The validator docstring names the root cause: the pre-#3638 linker chained commits by list position while _collect_shas put the session's last commit first, so an episode recorded an effect as its own cause.",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured the repair against git ground truth. 64 of 64 original commit timestamps were synthetic midnight placeholders; 63 of 63 repaired timestamps equal git's committer instant. The 64th SHA belongs to a squash-merged branch and no longer resolves, which the validator documents and skips.",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Proved non-destructiveness field by field: 0 events added or dropped, 0 id sequences changed, 0 narrative content fields rewritten, 0 leads_to edges lost, top-level metadata identical. Only caused_by, leads_to, and timestamp differ.",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran extract_session_episode.py --validate --fix, then re-validated: 381 validated, 0 violations, 12 repaired.",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-02T04:52:55+00:00",
+      "type": "commit",
+      "content": "Commit: c7a401c7a8",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4219-red-main-episode-store"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 14
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-08-02-session-4219-red-main-episode-store.json
+++ b/.agents/sessions/2026-08-02-session-4219-red-main-episode-store.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4219,
+    "date": "2026-08-02",
+    "branch": "fix/episode-store-backwards-chains",
+    "startingCommit": "d82b5e37ee3a",
+    "objective": "Repair the 14 backwards commit-to-commit edges in the committed episode store that PR #4219 gated on but never cleaned, so main stops failing test_the_committed_episode_store_is_clean and every open PR can push again."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "No Serena MCP tools exposed in this Copilot CLI session; used the repository tree and git directly."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena unavailable, so initial_instructions could not be called."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "This file."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "git branch --show-current = fix/episode-store-backwards-chains."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "fix/episode-store-backwards-chains != main."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read .agents/HANDOFF.md; it is read-only per ADR-014 and was not modified."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "complete": true,
+        "evidence": "Branch created at d82b5e37ee3a, the origin/main tip at session start."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read AGENTS.md, .claude/rules/universal.md, .claude/rules/knowledge-persistence.md, and .claude/rules/ci-scripts.md before acting."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "This log records the objective, the evidence, and the follow-ups."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": ".agents/HANDOFF.md read only, not modified."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Repair and this log committed together; endingCommit recorded in a follow-up commit per issue #3618."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "extract_session_episode.py --validate reports 381 validated, 0 violations. pytest tests/skills/memory/test_extract_session_episode.py = 244 passed, including test_the_committed_episode_store_is_clean which fails on main."
+      },
+      "checklistComplete": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Store clean, module green, non-destructiveness measured field by field before commit."
+      },
+      "markdownLintRun": {
+        "level": "SHOULD",
+        "complete": true,
+        "evidence": "No Markdown files changed on this branch; the change is 12 episode JSON files plus this log."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena unavailable; the durable lesson was stored as a Copilot repository memory instead."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Bisected the failing test. c7a401c7a8~1 passes in 0.24s, c7a401c7a8 (PR #4219) fails in 5.15s, so #4219 merged red and every branch that merges main inherits the failure."
+    },
+    {
+      "step": "Triaged the 14 violations before repairing rather than baselining them. The validator docstring names the root cause: the pre-#3638 linker chained commits by list position while _collect_shas put the session's last commit first, so an episode recorded an effect as its own cause."
+    },
+    {
+      "step": "Measured the repair against git ground truth. 64 of 64 original commit timestamps were synthetic midnight placeholders; 63 of 63 repaired timestamps equal git's committer instant. The 64th SHA belongs to a squash-merged branch and no longer resolves, which the validator documents and skips."
+    },
+    {
+      "step": "Proved non-destructiveness field by field: 0 events added or dropped, 0 id sequences changed, 0 narrative content fields rewritten, 0 leads_to edges lost, top-level metadata identical. Only caused_by, leads_to, and timestamp differ."
+    },
+    {
+      "step": "Ran extract_session_episode.py --validate --fix, then re-validated: 381 validated, 0 violations, 12 repaired."
+    }
+  ],
+  "nextSteps": [
+    "Record this commit's SHA as endingCommit in a follow-up commit.",
+    "Re-push PR #4109 and PR #4164 once this lands; both were failing pre-push on nothing but this test.",
+    "File an issue on the branch-protection gap that let PR #4219 merge with a red required test."
+  ],
+  "endingCommit": ""
+}

--- a/.agents/sessions/2026-08-02-session-4219-red-main-episode-store.json
+++ b/.agents/sessions/2026-08-02-session-4219-red-main-episode-store.json
@@ -106,9 +106,8 @@
     }
   ],
   "nextSteps": [
-    "Record this commit's SHA as endingCommit in a follow-up commit.",
     "Re-push PR #4109 and PR #4164 once this lands; both were failing pre-push on nothing but this test.",
     "File an issue on the branch-protection gap that let PR #4219 merge with a red required test."
   ],
-  "endingCommit": ""
+  "endingCommit": "74896f00463e"
 }


### PR DESCRIPTION
## Summary

`main` is red. The episode store validator rejects the committed corpus, so
every pre-push run in every worktree fails `python-tests` and no branch in the
fleet can push. This repairs the corpus and turns the gate green.

Twelve shipped episodes carry backwards commit chains: an event references a
commit that precedes the one its predecessor references. The validator treats a
non-monotonic chain as an unusable event id, which is correct. The data was
wrong, not the check.

## What changed

Twelve episode files are rewritten so their commit chains move forward. No
validator logic changed, so the gate keeps exactly the strictness it had. A
session log for the repair is added, and a follow-up commit records its
`endingCommit`.

The `endingCommit` lands as a second commit rather than an amend, per the
practice in issue #3618: amending would orphan the SHA the log itself names.

## Verification

Ran the owning test module by explicit path on this branch:

```
uv run --frozen pytest tests/skills/memory/test_extract_session_episode.py -p no:cacheprovider -q
244 passed in 12.70s
```

`TestValidateModeRejectsUnusableEventIds::test_the_committed_episode_store_is_clean`
is the test that fails on `main` and passes here.

Evidence that this is the only blocker: a full suite run on an unrelated branch
finished `1 failed, 21188 passed, 31 skipped, 50 deselected` with that same test
as the single failure.

## Risk

Data-only. If a rewritten chain were still wrong the validator would reject it,
so the gate that caught the problem also proves the repair.

Fixes #4219
