### PR TITLE
fix(validation): unblock all pushes by suppressing the file-size violation main inherited

### DIFF
--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+# taste-lint: ignore file-size
+#
+# file-size suppression rationale: this module is a registration sequence, not
+# logic. It holds one function whose body is 48 ordered ``run_validation``
+# calls, so its line count tracks how many gates the project has, not how hard
+# the module is to read. The rule's own remediation (extract helpers) does not
+# apply: the docstring below records that this file was itself extracted from
+# ``pre_pr.py`` for the same ceiling, which reset the count without reducing
+# anything. A second extraction would do the same. The real fix is a
+# table-driven registry (issue #4285), which is out of scope for the change
+# that crossed the line. The file crossed the 500 line ceiling at 509 lines.
 """Ordered pre-PR validation sequence (extracted from ``pre_pr.py``, Issue #3073).
 
 Holds ``run_all_validations``: the ordered list of ``run_validation`` calls that
@@ -125,11 +136,8 @@ def run_all_validations(
         lambda: validate_python_syntax(repo_root),
     )
 
-    # 0.5. Count ratchets (issue #4251). Four sub-second checks that gate the
-    # push. Before this ran here, a contributor saw pre_pr.py pass, pushed, and
-    # learned 674 seconds later that a 0.21 second ratchet had failed, because
-    # the ratchets ran only in the pre-push group alongside the full suite.
-    # Placed second so the cheapest push-blocking signal arrives first.
+    # Placed second so the cheapest push-blocking signal arrives first. See the
+    # checks_ratchet module docstring for why these run here (issue #4251).
     run_validation(
         "Count Ratchets",
         state,

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -9,7 +9,7 @@
 # ``pre_pr.py`` for the same ceiling, which reset the count without reducing
 # anything. A second extraction would do the same. The real fix is a
 # table-driven registry (issue #4285), which is out of scope for the change
-# that crossed the line. The file crossed the 500 line ceiling at 509 lines.
+# that crossed the line.
 """Ordered pre-PR validation sequence (extracted from ``pre_pr.py``, Issue #3073).
 
 Holds ``run_all_validations``: the ordered list of ``run_validation`` calls that


### PR DESCRIPTION
## Summary

`main` is red. Every push in this repository fails right now, on any branch, regardless of content.

```
taste count ratchet: REGRESSION. 602 violations > baseline 601 (+1).
[ERROR] count ratchet(s) failed: taste-count-ratchet.
```

The pre-push hook runs the count ratchets, so this is not just a CI signal. It blocks work locally.

## Evidence that it is inherited, not branch-local

I pushed a branch whose entire diff is three new markdown files under `.serena/memories/`. Nothing else. It failed:

```
[FAIL] Count Ratchets completed in 4.95s
taste count ratchet: REGRESSION. 602 violations > baseline 601 (+1).
```

Every other validation in that run passed. A branch that adds only prose cannot add an error-severity taste violation, so the +1 came from `main`.

## Cause

PR #4272 added the count ratchets to the pre-PR gate and, in doing so, pushed `scripts/validation/pre_pr_sequence.py` past the 500 line `file-size` ceiling. That is the +1. The suppression meant to accompany it was written but never pushed before the PR merged, so `main` took the violation without the fix.

## What this changes

Adds an 11 line `# taste-lint: ignore file-size` block to `scripts/validation/pre_pr_sequence.py`, in the first 10 lines as the rule requires, stating what the check wants, why the idiomatic fix does not apply here, and the issue that will remove the suppression.

It also deletes a five line comment that restated the `checks_ratchet` module docstring, so the net addition is smaller than the suppression block.

## Why suppress rather than extract

`pre_pr_sequence.py` is one function whose body is 48 ordered `run_validation(...)` calls. The rule's own remediation text proposes extracting helpers. This file is the counterexample. Its docstring says:

> Ordered pre-PR validation sequence (extracted from `pre_pr.py`, Issue #3073). Extracted so `pre_pr.py` stays under the module size ceiling while a new governance gate is added.

So this file exists **because** `pre_pr.py` hit the same ceiling. The extraction reset the counter without reducing anything, and the extracted file then hit the ceiling itself. A second extraction produces a third file with the same property.

For a registration list, the line count tracks how many gates the project has, not how hard the module is to read. Splitting the list also destroys the property the file exists to express: the sequence is deliberately ordered so the cheapest push-blocking signal arrives first, and that ordering stops being local the moment it spans two modules.

The repository's own code-quality rule names the right fix under "Table-Driven Logic": replace the call sites with a table and one loop, so adding a gate becomes a one line edit. That is tracked in #4285 and is deliberately not in this PR, because this PR needs to be small enough to merge immediately.

Precedent for the suppression form: `.claude/skills/orphan-ref-validator/scripts/scan.py`.

## Verification

Measured on this branch:

```
$ uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py \
    --format json -- scripts/validation/pre_pr_sequence.py
"error_count": 0

$ uv run --frozen python scripts/ci/taste_count_ratchet.py --base-ref origin/main
taste count ratchet: OK (count == baseline 601)
```

Full pre-push validation passed on this branch, which is how it reached the remote at all while every other branch is blocked.

Refs #4285
