### PR TITLE
docs(memory): record six fleet session traps, including stale PR merge refs

### DIFF
--- a/.serena/memories/bash/bash-anchor-grep-patterns-on-test-logs.md
+++ b/.serena/memories/bash/bash-anchor-grep-patterns-on-test-logs.md
@@ -112,16 +112,46 @@ git merge-base --is-ancestor origin/<branch> HEAD && echo "local is ahead or equ
 git rev-parse HEAD origin/<branch>     # equal means the work is on the remote
 ```
 
+Do not read the pre-push hook's success banner as push completion. This repo's
+hook prints
+
+```
+RESULT: All validations passed
+
+Ready to create pull request!
+```
+
+and that text appears in the push log roughly two minutes in, while the ref
+transfer has not started. Misread once on 2026-08-02: `ls-remote` came back
+empty right after that banner, which looked like a failed push and was actually
+a push still running. The only completion signals are a non empty
+`git ls-remote origin <branch>` matching local `HEAD`, or the `REAL_EXIT=` line
+the wrapper appends after `git push` returns.
+
 Better than detecting the race is preventing it. Serialize pushes through a
-lockfile, which also keeps concurrent agents from running several full pytest
-suites at once on the same machine:
+lockfile, keyed on the branch:
 
 ```bash
-flock /tmp/aiagents-push.lock git push -u origin <branch>
+BR=<branch>
+SLUG=$(printf '%s' "$BR" | tr '/' '-')
+flock "/tmp/push-lock-$SLUG.lock" git push -u origin "$BR"
 ```
 
 `flock` waits for the lock rather than failing, so a queued push runs when the
 one ahead of it finishes instead of racing it.
+
+Key the lock on the branch, not on the repo. The collision that actually
+happens is two agents pushing the SAME ref; two pushes to different refs never
+contended. A single global lock (`/tmp/aiagents-push.lock`) serializes every
+push behind an 11 minute pre-push hook it did not need to wait for. See
+`git/git-lock-pushes-per-branch-not-globally.md` for the measurement.
+
+Every agent must name the lock identically or it excludes nothing. Measured
+2026-08-02: three schemes were live at once (`/tmp/aiagents-push.lock`,
+`/tmp/aiagents-push-$SLOT.lock` hashed into four slots, and the per branch
+path above), and one branch had two concurrent pushes running under two
+different lock names. `flock` only excludes processes that agree on the path,
+so the extra schemes bought nothing and hid the race.
 
 ## Evidence
 

--- a/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
+++ b/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
@@ -1,0 +1,88 @@
+# Skill: Deciding whether a red check belongs to your branch (95%)
+
+## Statement
+
+A failing check on your PR is not evidence that the fault is in your PR. CI runs
+your branch merged with `main`, so a defect on `main` fails on every open PR at
+once. Attribute the failure only after checking whether `main` is red the same
+way.
+
+Check `main` first. It costs one command and it is the discriminator.
+
+```bash
+gh run list --branch main --workflow "<Workflow Name>" --limit 5 \
+  --json conclusion,headSha,createdAt \
+  -q '.[] | "\(.conclusion)\t\(.headSha[0:10])\t\(.createdAt)"'
+```
+
+If `main` is failing the same workflow, your branch is a bystander. Merge
+`origin/main` once the fix lands and re-run. Change nothing.
+
+## Corollary: two differently named red checks can be one bug
+
+Check names are job names, not causes. Two jobs that run the same underlying
+script fail together and look like two independent problems.
+
+Measured 2026-08-02: every open PR in the repo showed both `Validate PR` and
+`Run Python Tests` red. They were one bug. The taste count ratchet had drifted
+to 602 against a baseline of 601, and two separate jobs consume that number:
+
+| Check name | Failing step | What it runs |
+|---|---|---|
+| `Validate PR` | `Run taste-lint error-count ratchet` | `scripts/ci/taste_count_ratchet.py --base-ref FETCH_HEAD` |
+| `Run Python Tests` | `Run pytest` | `tests/ci/test_count_ratchet_against_real_git.py::test_the_shipped_baseline_matches_the_tracked_tree` |
+
+One suppression restored the count to 601 and both went green together.
+
+`Validate PR` in particular does not validate the PR description, despite the
+name. Reading the name and inferring the purpose is how the wrong conclusion
+gets reached.
+
+## Recipe: get the failing step and node ids, never the check name alone
+
+```bash
+BR=$(gh pr view <PR> --json headRefName -q .headRefName)
+RID=$(gh run list --branch "$BR" --limit 40 --json databaseId,workflowName \
+      -q '[.[]|select(.workflowName=="<Workflow Name>")][0].databaseId')
+
+gh run view "$RID" --log-failed > ~/src/scratch/<pr>-failed.log
+
+# which STEP failed, not which check
+awk -F'\t' '{print $2}' ~/src/scratch/<pr>-failed.log | sort -u
+
+# for pytest, the actual node ids
+grep -oE "(FAILED|ERROR) tests/[^ ]+" ~/src/scratch/<pr>-failed.log | sort -u
+```
+
+`gh run list --workflow` takes the workflow NAME, and the check context shown on
+the PR is the JOB name. They frequently differ, so look the run up by
+`workflowName` rather than by the failing context string.
+
+The log is large. The run above was 3.8 MB, so redirect it to a file and filter,
+rather than reading it inline.
+
+## Evidence
+
+2026-08-02. Six mergeable PRs (#4284, #4102, #4271, #4273, #4274, #4280) all
+showed `Validate PR` failing. The same check PASSED on #4290, the branch
+carrying the ratchet fix. That contrast proved the gate was working and the
+tree was red, rather than the six PRs each being at fault.
+
+`main` runs confirmed it independently: `Python Tests` was `failure` at
+`9933b7dbbb` and `77e305c6ed`, and `success` at `15f8756f08` immediately
+before. After #4290 merged as `c02f61ddd2`, both checks went green with no
+change to any of the six PRs.
+
+## Anti-Pattern
+
+Editing a baseline, adding an unrelated suppression to a file you happen to be
+touching, or passing a skip flag, in order to clear a check that is red because
+`main` is red. It hides the real defect and a baseline may only fall.
+
+Equally wrong in the other direction: assuming a failure is inherited without
+checking. The rule is to measure `main`, not to pick a default.
+
+## Related
+
+- `ci-count-ratchet-never-names-the-offending-file.md` (locating the offender once you own the failure)
+- `ci-file-size-ratchet-line-numbers-shift.md` (why violation identities move)

--- a/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
+++ b/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
@@ -73,6 +73,39 @@ tree was red, rather than the six PRs each being at fault.
 before. After #4290 merged as `c02f61ddd2`, both checks went green with no
 change to any of the six PRs.
 
+## Fixing `main` does not fix your PR until the merge ref moves
+
+CI for a `pull_request` event checks out `refs/pull/N/merge`, a ref GitHub
+computes by merging your branch into the base. That ref is cached. When `main`
+gains a fix, your PR keeps running against the pre-fix tree until something
+forces a recompute, so the same check keeps failing for a cause that no longer
+exists on `main`.
+
+Three ways of forcing it were measured on 2026-08-02 after `c02f61ddd2` landed.
+All three failed:
+
+| Attempt | Result |
+| --- | --- |
+| `gh run rerun` / `--failed` | Replays the original event payload. Same tree. |
+| `gh pr edit --body-file` (fires `edited`) | New run, merge ref unchanged. |
+| `gh api repos/O/R/pulls/N` | Returns the cached `merge_commit_sha` when `mergeable` is already `true`. |
+
+What worked was a push to the branch, which fires `synchronize`. #4284 pushed a
+`Merge origin/main` commit 51 seconds after the fix landed and got a fresh ref.
+#4271, #4274, and #4102 had not pushed since before the fix and all three were
+still stale over fifteen minutes later.
+
+Verify rather than assume, because the check name will not tell you:
+
+```bash
+git fetch origin refs/pull/<N>/merge:refs/tmp/m<N> -f
+git merge-base --is-ancestor <fix-sha> refs/tmp/m<N> && echo FRESH || echo STALE
+```
+
+Do not use `gh run view --json headSha` for this. On a `pull_request` run that
+field is the branch tip, not the merge commit, so it is unchanged by a rerun and
+unchanged by a base move. It cannot distinguish the two cases.
+
 ## Anti-Pattern
 
 Editing a baseline, adding an unrelated suppression to a file you happen to be

--- a/.serena/memories/ci/ci-file-size-ratchet-line-numbers-shift.md
+++ b/.serena/memories/ci/ci-file-size-ratchet-line-numbers-shift.md
@@ -1,0 +1,70 @@
+# Skill: Isolating which file broke the taste count ratchet (95%)
+
+## Statement
+
+`taste_count_ratchet.py` reports a delta and never names the file:
+
+```
+taste count ratchet: REGRESSION. 602 violations > baseline 601 (+1).
+```
+
+The obvious next step, enumerate violations on both refs and diff the two
+lists, produces a **false answer** if you diff them naively. On a real +1
+regression the naive diff showed **six** new violations and **five**
+disappeared.
+
+The cause: the `file-size` rule reports at the line where the file crosses the
+ceiling, so its reported line number moves whenever the file grows or shrinks
+anywhere above that point. Five of the six were the same violation on the same
+file at a shifted line. Only one was real.
+
+## Recipe
+
+Enumerate error-severity violations on both refs, then diff **on file plus
+rule, dropping the line number**:
+
+```bash
+# in each checkout
+uv run --frozen python - <<'PY' > ~/src/scratch/taste-<ref>.txt
+import json,subprocess,sys,pathlib
+files=[f for f in subprocess.run(["git","ls-files"],capture_output=True,text=True).stdout.split()
+       if pathlib.Path(f).exists()]
+out=set()
+for i in range(0,len(files),400):
+    p=subprocess.run([sys.executable,".claude/skills/taste-lints/scripts/taste_lints.py",
+                      "--format","json","--",*files[i:i+400]],capture_output=True,text=True)
+    if p.returncode not in (0,10):
+        continue
+    for v in json.loads(p.stdout).get("violations",[]):
+        if str(v.get("severity","")).lower()=="error":
+            out.add(f"{v.get('file')}:{v.get('rule')}")   # NO line number
+for k in sorted(out): print(k)
+PY
+
+LC_ALL=C sort ~/src/scratch/taste-main.txt > ~/src/scratch/a && LC_ALL=C sort ~/src/scratch/taste-branch.txt > ~/src/scratch/b
+LC_ALL=C comm -13 ~/src/scratch/a ~/src/scratch/b     # genuinely new
+```
+
+`LC_ALL=C` on both `sort` calls is required. Python's string sort and the
+shell's locale collation disagree, and `comm` prints `file 1 is not in sorted
+order` and then silently returns wrong rows.
+
+The taste linter exits **10** when it finds violations, not 1, so a `check=True`
+subprocess call throws on a normal run. Accept `{0, 10}`.
+
+Expect the key count to be **lower** than the ratchet count: dropping the line
+number collapses several violations of the same rule in the same file into one
+key. On the measured run the ratchet said 601 and 602 while the key sets held
+581 and 582. That is correct behavior, not a broken enumeration. The keys
+answer "which file regressed", not "how many violations exist". Keep the
+line-numbered lists too if you need to locate the violation inside the file
+once you know which file it is.
+
+## Generalization
+
+A violation identifier that embeds a position is not stable under edits
+elsewhere in the file. Diff on the stable part of the key. The same shape
+applies to any diff of ruff, mypy, or semgrep output across two refs: strip the
+line number before comparing, or you will chase moved rows as new ones.
+
+Related: `.serena/memories/ci/ci-count-ratchet-never-names-the-offending-file.md`

--- a/.serena/memories/ci/ci-which-parity-gate-missed-an-agent-change.md
+++ b/.serena/memories/ci/ci-which-parity-gate-missed-an-agent-change.md
@@ -1,0 +1,92 @@
+# Skill: Attributing a missed change to the right agent-parity gate (90%)
+
+## Statement
+
+Two different gates guard the six copies of a shared agent, and they split the
+work in a way that leaves a documented seam. Blaming the wrong one wastes an
+investigation and can produce a duplicate issue against intentional behavior.
+
+The six copies of a shared agent `<n>`:
+
+```
+templates/agents/<n>.shared.md          generated source
+.claude/agents/<n>.md                   hand-maintained
+.github/agents/<n>.agent.md             hand-maintained
+src/claude/<n>.md                       hand-maintained
+src/copilot-cli/agents/<n>.agent.md     GENERATED from the template
+src/vs-code-agents/<n>.agent.md         GENERATED from the template
+```
+
+`build/AGENTS.md` states the split outright:
+
+> `validate_install_parity.py`: when one member of a shared-agent group changes,
+> every other member must change in the same diff. **It does NOT check content
+> similarity.**
+> `detect_agent_drift.py`: adds the semantic-similarity check that parity
+> enforcement omits.
+
+So parity answers "were they all touched", drift answers "do they still say the
+same thing". Neither answers "did THIS addition reach all six".
+
+## The trap
+
+`_added_sections` and `_missing_siblings_already_current` in
+`validate_install_parity.py` look like the culprit: `_added_sections` returns
+`None` for a preamble edit, a removed or renamed section, or a body edit to a
+section that already existed at base.
+
+**They are not.** Read the caller before blaming them. Both FAIL CLOSED:
+`_missing_siblings_already_current` returns `False` whenever the answer cannot
+be established, and its own docstring says so. They form a carve-out that only
+ever RELAXES the gate, and only when it can prove the missing siblings already
+carry the content. A `None` from `_added_sections` makes the gate stricter, not
+weaker.
+
+## What actually lets a change reach one copy
+
+`.claude/agents/`, `.github/agents/`, and `src/claude/` are classified
+hand-maintained, and parity **skips a diff that touches only those paths**. The
+exemption is deliberate, from issue #2882, to unblock catch-up backfills.
+
+The comparison that would notice, `.claude/agents` versus `.github/agents`, is
+ADVISORY by default and threshold based at 80 percent similarity, so a small
+addition to a large file cannot trip it.
+
+Measured instance, PR #4280 at `c0428c19229ee0`: a mandatory "PR identity gate"
+landed in `.claude/agents/analyst.md` alone. `templates/agents/analyst.shared.md`
+exists, so all six were in scope. All six had zero occurrences of the new text on
+`main`, so it was not a backfill. `Agent Drift Detection: SUCCESS` anyway.
+
+Tracked in issue #4082 (OPEN). Do not file a duplicate.
+
+## Recipe
+
+```bash
+# Is this a shared agent at all?
+ls templates/agents/<n>.shared.md
+
+# How many of the six did the PR touch?
+gh pr view <pr> --json files -q '.files[].path' | grep -i <n>
+
+# Do the untouched copies already carry the content, or is this real divergence?
+for f in templates/agents/<n>.shared.md .claude/agents/<n>.md \
+         .github/agents/<n>.agent.md src/claude/<n>.md \
+         src/copilot-cli/agents/<n>.agent.md src/vs-code-agents/<n>.agent.md; do
+  printf "%-48s %s\n" "$f" "$(git show origin/main:$f | grep -c '<marker>')"
+done
+```
+
+When propagating, edit `templates/agents/<n>.shared.md` and regenerate with
+`uv run --frozen python build/generate_agents.py` (NOT
+`build/scripts/generate_agents.py`, which does not exist). Hand-edit only the
+three hand-maintained copies. The six are not byte identical by design: the
+`.claude` copy writes `mcp__context7__*` where others write `Context7`, so match
+local style rather than pasting one body into all six.
+
+## Generalization
+
+When a gate misses something, find the code path that actually ran before
+indicting the one that looks guilty. A fail-closed helper cannot be the reason
+something passed. Check the exemption list first: most "the gate missed it"
+findings are an exemption doing exactly what it was written to do, and the
+governing documentation usually says so.

--- a/.serena/memories/coding/coding-size-ceiling-on-a-registration-list.md
+++ b/.serena/memories/coding/coding-size-ceiling-on-a-registration-list.md
@@ -1,0 +1,59 @@
+# Skill: When a size ceiling fires on a registration list (85%)
+
+## Statement
+
+`scripts/validation/pre_pr_sequence.py` holds one function whose body is 48
+ordered `run_validation(...)` calls. When it crossed the 500 line `file-size`
+ceiling, the rule's own remediation text proposed extracting helper functions.
+
+That advice is wrong for this file, and the file itself proves it. Its
+docstring reads:
+
+> Ordered pre-PR validation sequence (extracted from `pre_pr.py`, Issue #3073).
+> [...] Extracted so `pre_pr.py` stays under the module size ceiling while a new
+> governance gate is added.
+
+So this file exists **because** `pre_pr.py` hit the same ceiling. The
+extraction reset the counter without reducing anything, and the extracted file
+then hit the ceiling itself. A second extraction produces a third file with the
+same property.
+
+## The contradiction
+
+Conventional wisdom: a long file is a complexity signal, so split it.
+
+First principles: for a registration list, the line count tracks **how many
+gates the project has**, not how hard the module is to read. Adding a gate is
+supposed to add lines. Splitting the list also destroys the one property the
+file exists to express, which is ordering: the sequence is deliberately ordered
+so the cheapest push-blocking signal arrives first, and that ordering stops
+being local the moment it spans two modules.
+
+## What to do instead
+
+The repo's own code-quality rule already names the right fix, under
+"Table-Driven Logic": replace the call sites with a table and one loop, so
+adding a gate is a one line edit. That takes the file far under the ceiling and
+makes the ordering readable as data. Filed as issue #4285.
+
+Until that lands, suppress with a rationale, per the code-quality rule's
+last-resort guidance: `# taste-lint: ignore file-size` in the **first 10 lines**
+of the file, followed by a comment stating what the check wants, why the
+idiomatic fix does not apply, and the issue that will remove the suppression.
+Precedent: `.claude/skills/orphan-ref-validator/scripts/scan.py`.
+
+Verify the suppression took effect rather than assuming it:
+
+```bash
+uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py \
+  --format json -- <file>          # want "error_count": 0
+uv run --frozen python scripts/ci/taste_count_ratchet.py --base-ref origin/main
+```
+
+## Generalization
+
+Before obeying a size ceiling, ask what the count measures. If the file is a
+list whose length tracks the size of the domain rather than the difficulty of
+the code, extraction is a rename. Convert the list to data, or suppress with a
+reason. Do not extract, because the next author inherits the same wall one file
+further out.

--- a/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
+++ b/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
@@ -1,0 +1,71 @@
+# Skill: A detached process dies silently when its log directory disappears (90%)
+
+## Statement
+
+A long push in this repo takes roughly 660 seconds, so the working pattern is
+to detach it and poll a log:
+
+```bash
+nohup setsid bash -c "flock /tmp/push-lock-$SLUG.lock git push origin $BR \
+  > /tmp/r16/push.log 2>&1; echo REAL_EXIT=\$? >> /tmp/r16/push.log" >/dev/null 2>&1 &
+```
+
+If the log directory is under `/tmp` and `/tmp` is cleaned while the session is
+running, the redirect has nowhere to write and **the command never starts**.
+There is no error anywhere, because the only channel that would have carried
+one was the redirect that failed. Polling the log looks identical to a push
+that is still working: no `REAL_EXIT` line, no output.
+
+Measured on 2026-08-02: a P0 push was believed in flight for about ten minutes.
+`/tmp/r16` had been removed mid-session. `ls -la /tmp/r16/` returned
+`No such file or directory` and `ps` showed no `git push` process at all.
+
+## Recipe
+
+Write scratch files and logs to `~/src/scratch/`, never `/tmp`. Keep the lock
+file itself at `/tmp/push-lock-<slug>.lock`: a lock is a live kernel object, not
+an artifact, and every agent must agree on one path for mutual exclusion to
+work. Only the log moves.
+
+```bash
+S=~/src/scratch; mkdir -p "$S"
+BR=<branch>; SLUG=$(printf '%s' "$BR" | tr '/' '-')
+nohup setsid bash -c "flock /tmp/push-lock-$SLUG.lock git push origin $BR \
+  > $S/push-$SLUG.log 2>&1; echo REAL_EXIT=\$? >> $S/push-$SLUG.log" >/dev/null 2>&1 &
+```
+
+Then verify the process actually exists before trusting the wait:
+
+```bash
+sleep 5
+test -f "$S/push-$SLUG.log" || echo "log missing, the redirect failed"
+ps -eo pid,etime,args | grep "git push" | grep -v grep
+```
+
+An absent log file five seconds in means the launch failed, not that the push
+is quiet.
+
+## Two adjacent traps
+
+Use `nohup setsid`. An async process merely backgrounded from the agent session
+is killed when that session shuts down, for example at context compaction. Two
+pushes were lost that way before the detached form was adopted.
+
+Never confirm a push from its log alone. Compare the refs:
+
+```bash
+git ls-remote origin "$BR" | awk '{print $1}'
+git rev-parse HEAD
+```
+
+An empty `git ls-remote` result for a branch that should exist is worth a second
+look rather than a conclusion: after a squash merge GitHub deletes the source
+branch, so "no remote ref" can mean "already merged" rather than "never pushed".
+Check `gh pr view <n> --json state,headRefOid` before concluding anything.
+
+## Generalization
+
+A watcher that reports through the same channel it is watching cannot report
+that channel's failure. Whenever the evidence of liveness and the mechanism of
+liveness share a dependency, verify liveness by a second, independent route:
+here, `ps` and `git ls-remote` rather than the log the process writes.


### PR DESCRIPTION
## Summary

### What

Adds five Serena memories and extends a sixth, all recording traps measured
during a long multi agent fleet session. Documentation only. No code, no
workflow, no gate behaviour changes.

### Why

Each entry cost real debugging time in session, and each is re derivable only by
repeating the same wrong turn. Six files:

| File | Records |
|---|---|
| `ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md` | A red check on your PR is not evidence the fault is in your PR, plus the merge ref mechanism below |
| `ci/ci-file-size-ratchet-line-numbers-shift.md` | Why a file size ratchet violation moves when unrelated lines are added above it |
| `ci/ci-which-parity-gate-missed-an-agent-change.md` | Which parity gate catches a one copy change to a mirrored tree, and which does not |
| `bash/bash-anchor-grep-patterns-on-test-logs.md` | Anchoring grep patterns on test logs so a substring cannot match the wrong field |
| `coding/coding-size-ceiling-on-a-registration-list.md` | A size ceiling on a registration list measures the domain, not the code |
| `git/git-detached-push-dies-if-log-dir-vanishes.md` | A detached push dies silently when its log directory is removed underneath it |

The largest entry carries the finding that cost the most: **fixing `main` does
not fix your PR until the merge ref moves.** `refs/pull/N/merge` is recomputed
on a branch push, not on a rerun, not on a PR body edit, and not on a
`gh api .../pulls/N` read. Measured after the taste ratchet fix landed on main:
the one PR that had pushed a merge commit afterwards was fresh, and three that
had not were still stale sixteen minutes later, all four reporting the same
already fixed failure.

The same entry warns that `gh run view --json headSha` on a `pull_request` run is
the branch tip rather than the merge commit, so it cannot distinguish a stale
merge ref from a fresh one. That misreading is what produced the wrong diagnosis
the memory now corrects.

One commit is a retraction rather than an addition: `9eff6720f0` removes a
superseded global push lock recipe. A single global lock serialised every agent
in the fleet behind one push. The per branch lock that replaced it is recorded
in its place.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4283 | Per branch push lock, whose retraction this documents |

Documentation PR, so no spec is required per the template guidance.

## Testing

Markdown only. Verified no em dashes or en dashes across all six files, and
`taste_lints.py` exits 0 on the changed set. `git merge origin/main` reports
already up to date, so the branch carries no conflict.

## Notes for Reviewers

The value here is negative results. Three of the entries exist to stop a future
agent from repeating a probe that looks authoritative and proves nothing. If a
claim in any entry reads as over general, say so: these were written from a
single session and are stated with the population they were measured on.
