### PR TITLE
fix(validation): suppress taste file-size violation in pre_pr_sequence.py

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-02-session-4220-taste-ratchet-fix.json
+++ b/.agents/memory/episodes/episode-2026-08-02-session-4220-taste-ratchet-fix.json
@@ -48,8 +48,21 @@
       "timestamp": "2026-08-02T00:00:00+00:00",
       "type": "test",
       "content": "All ratchets OK. 21612 passed, 0 failed.",
-      "caused_by": [],
+      "caused_by": [
+        "e006"
+      ],
       "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 636042664c",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ],
       "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
     }
   ],
@@ -58,7 +71,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-02-session-4220-taste-ratchet-fix.json
+++ b/.agents/memory/episodes/episode-2026-08-02-session-4220-taste-ratchet-fix.json
@@ -1,0 +1,65 @@
+{
+  "id": "episode-2026-08-02-session-4220-taste-ratchet-fix",
+  "session": "2026-08-02-session-4220-taste-ratchet-fix",
+  "timestamp": "2026-08-02T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Diagnose why Run Python Tests fails on four open PRs (#4256, #4271, #4273, #4284), identify root cause (red main vs shared flake vs four separate bugs), and fix the root cause.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Red-main diagnostic: created worktree at /home/richard/src/GitHub/rjmurillo/ai-agents-probe-main and ran full pytest suite",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bisected commits to find which PR introduced the violation",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added reasoned taste-lint ignore comment to first 10 lines of scripts/validation/pre_pr_sequence.py",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran all three count ratchets and full pytest suite (21612 tests)",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-02T00:00:00+00:00",
+      "type": "test",
+      "content": "All ratchets OK. 21612 passed, 0 failed.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-02-session-4220-taste-ratchet-fix"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-08-02-session-4220-taste-ratchet-fix.json
+++ b/.agents/sessions/2026-08-02-session-4220-taste-ratchet-fix.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4220,
+    "date": "2026-08-02",
+    "branch": "fix/taste-ratchet-pre-pr-sequence",
+    "startingCommit": "77e305c6e",
+    "objective": "Diagnose why Run Python Tests fails on four open PRs (#4256, #4271, #4273, #4284), identify root cause (red main vs shared flake vs four separate bugs), and fix the root cause."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "No Serena MCP tools exposed in this Copilot CLI session."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena unavailable."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read HANDOFF.md via git."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": ".agents/sessions/2026-08-02-session-4220-taste-ratchet-fix.json"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "fix/taste-ratchet-pre-pr-sequence"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "fix/taste-ratchet-pre-pr-sequence != main."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "This log records the objective, the evidence, the fix, and the follow-ups."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": ".agents/HANDOFF.md read only, not modified."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Fix committed; endingCommit recorded in follow-up commit per issue #3618."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "All 3 ratchets OK. 21612 passed, 0 failed in full pytest run."
+      },
+      "checklistComplete": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Violation found, suppressed with reasoned ignore comment, tests green."
+      },
+      "markdownLintRun": {
+        "level": "SHOULD",
+        "complete": true,
+        "evidence": "No Markdown files changed on this branch."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena unavailable in this session."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": 1,
+      "action": "Red-main diagnostic: created worktree at /home/richard/src/GitHub/rjmurillo/ai-agents-probe-main and ran full pytest suite",
+      "outcome": "MAIN IS RED. test_the_shipped_baseline_matches_the_tracked_tree fails: taste count ratchet baseline=601 but current tree=602."
+    },
+    {
+      "step": 2,
+      "action": "Bisected commits to find which PR introduced the violation",
+      "outcome": "PR #4272 (fix(validation): run the count ratchets in the pre-PR gate) introduced scripts/validation/pre_pr_sequence.py at 512 lines, 12 over the 500-line ceiling, without updating the taste baseline."
+    },
+    {
+      "step": 3,
+      "action": "Added reasoned taste-lint ignore comment to first 10 lines of scripts/validation/pre_pr_sequence.py",
+      "outcome": "Taste violation cleared. uv run --frozen python .claude/skills/taste-lints/scripts/taste_lints.py reports 0 violations."
+    },
+    {
+      "step": 4,
+      "action": "Ran all three count ratchets and full pytest suite (21612 tests)",
+      "outcome": "All ratchets OK. 21612 passed, 0 failed."
+    }
+  ],
+  "nextSteps": [
+    "Push branch and open PR referencing #4256, #4271, #4273, #4284"
+  ],
+  "endingCommit": ""
+}

--- a/.agents/sessions/2026-08-02-session-4220-taste-ratchet-fix.json
+++ b/.agents/sessions/2026-08-02-session-4220-taste-ratchet-fix.json
@@ -103,5 +103,5 @@
   "nextSteps": [
     "Push branch and open PR referencing #4256, #4271, #4273, #4284"
   ],
-  "endingCommit": ""
+  "endingCommit": "636042664c"
 }

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# taste-lint: ignore file-size -- file is 512 lines, 12 over the 500-line ceiling;
+# it exists solely as an extraction from pre_pr.py to keep that module under the
+# ceiling (issue #3073). Further splitting for 12 lines creates more churn than value.
 """Ordered pre-PR validation sequence (extracted from ``pre_pr.py``, Issue #3073).
 
 Holds ``run_all_validations``: the ordered list of ``run_validation`` calls that


### PR DESCRIPTION
## Summary

Main is red. `test_the_shipped_baseline_matches_the_tracked_tree` fails on
pristine `origin/main` with:

```
taste count ratchet: baseline is 601 but current tree has 602 violations
```

Every open PR that runs `Run Python Tests` inherits this failure. None of the
four PR authors caused it. This PR fixes it.

## Root Cause

PR #4272 added `scripts/validation/pre_pr_sequence.py` at 512 lines. The
500-line taste-lint ceiling fires at 501 lines. The file landed without a
`# taste-lint: ignore` comment, so it added 1 violation to the tree count
while the baseline stayed at 601. Bisection confirmed the regression sits
between `origin/main~2` (count == baseline) and `origin/main~1` (regression).

The file is an extraction from `pre_pr.py` to keep that module under the same
ceiling (issue #3073). It is 12 lines over the limit. Splitting it further for
12 lines creates more churn than value.

## Fix

Add a reasoned `# taste-lint: ignore file-size` comment in the first 10 lines
of `scripts/validation/pre_pr_sequence.py` per the ratchet's documented
remediation path (issue #3779). No other files changed.

## Verification

```
taste count ratchet: OK (count == baseline 601)
ruff count ratchet:  OK. 323 violations <= baseline 326 (-3 slack)
type-ignore ratchet: OK (count == baseline 44)
pytest tests/: 21612 passed, 0 failed
```

## Unblocks

Fixes the `Run Python Tests` failure on:
- \#4256
- \#4271
- \#4273
- \#4284

## Changes

- `scripts/validation/pre_pr_sequence.py` -- taste-lint ignore comment added
