### PR TITLE
fix(validation): unbreak main by lowering the taste count, not the bar

### DIFF
--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
@@ -27,10 +27,6 @@ from active_plan_closeout import validate_active_plan_closeout
 from check_doc_interpreter_portability import (  # noqa: E402
     validate_doc_interpreter_portability,
 )
-from check_duplicate_test_helpers import validate_duplicate_test_helpers
-from check_nested_tests import validate_no_nested_tests
-from check_test_tree_writes import validate_test_tree_writes
-from check_unreachable_code import validate_unreachable_code
 from checks_coverage import (  # noqa: E402
     validate_review_marker,
 )
@@ -44,7 +40,6 @@ from checks_plugin import (  # noqa: E402
     validate_shipped_skill_routes,
     validate_workflow_local_run,
 )
-from checks_ratchet import validate_count_ratchets  # noqa: E402
 from checks_spec import (  # noqa: E402
     validate_agent_catalog,
     validate_build_gates,
@@ -74,29 +69,22 @@ from checks_tooling import (  # noqa: E402
     validate_workflow_yaml,
     validate_yaml_style,
 )
+from pre_pr_sequence_fast import (  # noqa: E402
+    ValidationStateLike as _ValidationStateLike,
+)
+from pre_pr_sequence_fast import (  # noqa: E402
+    run_fast_gates,
+)
 from stale_script_refs import validate_stale_script_refs  # noqa: E402
 from validate_argument_hint import validate_argument_hint  # noqa: E402
 from validate_design_review import validate_design_review_frontmatter  # noqa: E402
 from validate_no_orphaned_build_deferrals import (  # noqa: E402
     validate_no_orphaned_build_deferrals,
 )
-from validate_python_syntax import validate_python_syntax  # noqa: E402
 
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Callable
-
-
-class _ValidationStateLike(Protocol):
-    """Structural view of ``pre_pr.ValidationState`` the sequence writes to.
-
-    Typed structurally rather than imported from ``pre_pr`` so this module never
-    references ``pre_pr``. ``pre_pr`` imports this module; a back-reference would
-    make mypy resolve ``pre_pr`` under two module names (Issue #3073).
-    """
-
-    total: int
-    skipped: int
 
 
 def run_all_validations(
@@ -113,52 +101,7 @@ def run_all_validations(
     """
     quick = args.quick
 
-    # 0. Python Syntax (issue #2655). Blocking parse gate over every tracked
-    # .py file. A SyntaxError in a hook module wedges the CLI (PreToolUse
-    # dispatcher fails closed on import), and ruff/pytest never caught PR #2640
-    # because ruff is advisory and nothing imports those modules. Runs first
-    # and fast so the cheapest, highest-impact defect is caught before anything
-    # slower.
-    run_validation(
-        "Python Syntax (compile gate)",
-        state,
-        lambda: validate_python_syntax(repo_root),
-    )
-
-    # 0.5. Count ratchets (issue #4251). Four sub-second checks that gate the
-    # push. Before this ran here, a contributor saw pre_pr.py pass, pushed, and
-    # learned 674 seconds later that a 0.21 second ratchet had failed, because
-    # the ratchets ran only in the pre-push group alongside the full suite.
-    # Placed second so the cheapest push-blocking signal arrives first.
-    run_validation(
-        "Count Ratchets",
-        state,
-        lambda: validate_count_ratchets(repo_root),
-    )
-
-    run_validation(
-        "Nested Test Detection",
-        state,
-        lambda: validate_no_nested_tests(repo_root),
-    )
-
-    run_validation(
-        "Duplicate Test Helper Detection",
-        state,
-        lambda: validate_duplicate_test_helpers(repo_root),
-    )
-
-    run_validation(
-        "Unreachable Code Detection",
-        state,
-        lambda: validate_unreachable_code(repo_root),
-    )
-
-    run_validation(
-        "Test Working Tree Writes",
-        state,
-        lambda: validate_test_tree_writes(repo_root),
-    )
+    run_fast_gates(repo_root, state, run_validation)
 
     # 1. Session End
     run_validation(

--- a/scripts/validation/pre_pr_sequence_fast.py
+++ b/scripts/validation/pre_pr_sequence_fast.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fast structural gates that open the pre-PR sequence (issue #4251).
+
+Six sub-second, repo-wide checks that run before anything slower. They share a
+property the rest of the sequence does not: each one scans the whole tracked
+tree, costs well under a second, and blocks the push on its own. Running them
+first means the cheapest push-blocking signal arrives before a contributor
+spends minutes on the full suite.
+
+Extracted from ``pre_pr_sequence`` when that module crossed the 500-line taste
+ceiling. The grouping is by cost and blast radius, not by convenience: adding a
+seventh whole-tree sub-second gate belongs here, and a slow or narrowly scoped
+check does not.
+
+Validators are imported from the ``check*`` sibling modules rather than from
+``pre_pr``, which runs as ``__main__`` when invoked as a script; importing it by
+name would load a second copy of that module. ``run_validation`` and ``state``
+are injected by the caller for the same reason.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from check_duplicate_test_helpers import validate_duplicate_test_helpers  # noqa: E402
+from check_nested_tests import validate_no_nested_tests  # noqa: E402
+from check_test_tree_writes import validate_test_tree_writes  # noqa: E402
+from check_unreachable_code import validate_unreachable_code  # noqa: E402
+from checks_ratchet import validate_count_ratchets  # noqa: E402
+from validate_python_syntax import validate_python_syntax  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ["ValidationStateLike", "run_fast_gates"]
+
+
+class ValidationStateLike(Protocol):
+    """Structural view of ``pre_pr.ValidationState`` the sequence writes to.
+
+    Typed structurally rather than imported from ``pre_pr`` so neither this
+    module nor ``pre_pr_sequence`` references ``pre_pr``. ``pre_pr`` imports the
+    sequence; a back-reference would make mypy resolve ``pre_pr`` under two
+    module names (Issue #3073).
+    """
+
+    total: int
+    skipped: int
+
+
+def run_fast_gates(
+    repo_root: Path,
+    state: ValidationStateLike,
+    run_validation: Callable[..., bool],
+) -> None:
+    """Run the six whole-tree sub-second gates, recording into ``state``.
+
+    Takes no ``args``: none of these gates is skippable. A gate cheap enough to
+    always run has no reason to read ``--quick`` or ``--skip-tests``, and
+    threading the namespace through would invite one to start.
+    """
+    # Blocking parse gate over every tracked .py file (issue #2655). A
+    # SyntaxError in a hook module wedges the CLI, because the PreToolUse
+    # dispatcher fails closed on import. Ruff and pytest never caught PR #2640:
+    # ruff is advisory and nothing imports those modules. Runs first because it
+    # is both the cheapest and the highest-impact defect in the set.
+    run_validation(
+        "Python Syntax (compile gate)",
+        state,
+        lambda: validate_python_syntax(repo_root),
+    )
+
+    # Count ratchets (issue #4251). Before these ran here, a contributor saw
+    # pre_pr.py pass, pushed, and learned 674 seconds later that a 0.21 second
+    # ratchet had failed, because the ratchets ran only in the pre-push group
+    # alongside the full suite.
+    run_validation(
+        "Count Ratchets",
+        state,
+        lambda: validate_count_ratchets(repo_root),
+    )
+
+    run_validation(
+        "Nested Test Detection",
+        state,
+        lambda: validate_no_nested_tests(repo_root),
+    )
+
+    run_validation(
+        "Duplicate Test Helper Detection",
+        state,
+        lambda: validate_duplicate_test_helpers(repo_root),
+    )
+
+    run_validation(
+        "Unreachable Code Detection",
+        state,
+        lambda: validate_unreachable_code(repo_root),
+    )
+
+    run_validation(
+        "Test Working Tree Writes",
+        state,
+        lambda: validate_test_tree_writes(repo_root),
+    )

--- a/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
+++ b/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
@@ -27,6 +27,8 @@ Coverage:
 
 from __future__ import annotations
 
+import inspect
+import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -47,6 +49,7 @@ if str(_VALIDATION_DIR) not in sys.path:
     sys.path.insert(0, str(_VALIDATION_DIR))
 import checks_ratchet  # noqa: E402
 import pre_pr_sequence  # noqa: E402
+import pre_pr_sequence_fast  # noqa: E402
 
 _GATE_NAME = "Count Ratchets"
 
@@ -193,6 +196,52 @@ class TestWiredIntoTheSequence:
         """
         recorded = self._recorded_names()
         assert recorded[1] == _GATE_NAME, recorded[:4]
+
+    def test_the_fast_gates_lead_the_sequence(self) -> None:
+        """The extracted group is a contiguous prefix, not a scattered set.
+
+        ``run_fast_gates`` was split out of ``run_all_validations`` when that
+        module crossed the 500-line taste ceiling. The split is only honest if
+        the grouping means something: these six are the whole-tree sub-second
+        gates, and their value is that they report before anything slower. A
+        later edit that appends a slow check to ``run_fast_gates``, or that
+        interleaves a sequence step between two of them, keeps every other
+        assertion green while destroying the property the group names.
+        """
+        expected = self._fast_gate_names()
+        assert len(expected) == 6, expected
+        assert self._recorded_names()[: len(expected)] == expected
+
+    def test_moving_a_fast_gate_later_is_detected(self) -> None:
+        """The group's membership is pinned, so a gate cannot quietly leave it.
+
+        The prefix assertion above reads its expectation from the production
+        source, which makes it blind to a reorder *inside* the group (both
+        sides move together). That blindness is deliberate: ordering inside the
+        group is covered by ``test_gate_runs_second``. What source-reading
+        cannot catch is a gate being moved out of ``run_fast_gates`` into the
+        slower tail of the sequence, or a slow gate being added to the group.
+        Pinning the membership here catches both. A deliberate change to the
+        group must edit this list, which is the point.
+        """
+        assert self._fast_gate_names() == [
+            "Python Syntax (compile gate)",
+            "Count Ratchets",
+            "Nested Test Detection",
+            "Duplicate Test Helper Detection",
+            "Unreachable Code Detection",
+            "Test Working Tree Writes",
+        ]
+
+    @staticmethod
+    def _fast_gate_names() -> list[str]:
+        """Gate names ``run_fast_gates`` emits, read from the module it lives in.
+
+        Read from source rather than hard-coded here so this test cannot drift
+        into asserting a stale list that the production module no longer emits.
+        """
+        source = inspect.getsource(pre_pr_sequence_fast.run_fast_gates)
+        return re.findall(r'\n\s+"([^"]+)",\n\s+state,', source)
 
 
 class TestValidatorBehaviour:


### PR DESCRIPTION
## Problem

Pristine `origin/main` fails the taste count ratchet at 602 violations against a baseline of 601. The taste ratchet runs in the pre-push lefthook group, so every branch in the repository was push-blocked, and four PRs (\#4256, \#4271, \#4273, \#4284) were failing `Run Python Tests` on an inherited failure none of their authors caused.

Two independent investigations reached this root cause separately, which is the corroboration this claim rests on rather than a single measurement.

## Root cause

The baseline is a bare count, so a direct diff cannot say which file moved. Bisected per-file instead: the baseline was last set by `aea3a49cd`, and diffing per-file taste errors between that commit and main shows `scripts/validation/pre_pr_sequence.py` going from 0 errors to 1. It had grown past the taste-lint 500-line file ceiling.

PR \#4272, titled "run the count ratchets in the pre-PR gate", is the PR that broke the count ratchet.

It merged green because the default-branch ruleset has `strict_required_status_checks_policy` set to false, so a PR merges without re-testing against the main it will land on. That gap is already tracked as issue \#4057; this PR does not attempt to close it.

## Changes

Fix by extraction, not by raising the baseline. The ratchet's own rule is that a baseline may only fall, and a suppression comment was considered and rejected: the repo's own code-quality rule treats suppressions as a last resort, and nothing here made the idiomatic fix impossible.

- `scripts/validation/pre_pr_sequence.py` sheds the six whole-tree sub-second gates, going from 512 lines to 455. Emission order is unchanged.
- `scripts/validation/pre_pr_sequence_fast.py` is new and holds `run_fast_gates` plus the `ValidationStateLike` protocol.
- `tests/ci/test_pre_pr_runs_lefthook_ratchets.py` gains two tests that guard the property the new module name claims.

The grouping is cost and blast radius, not convenience. These six are the gates cheap enough to always run, and their value is reporting before anything slower. `run_fast_gates` deliberately takes no `args` because none of them is skippable; threading the namespace through would invite one to start.

## Testing

Both new tests are guards against different failure modes, because one alone would be a tautology.

The prefix test reads its expectation from production source, so it cannot assert a stale list, but that also makes it blind to a reorder inside the group. That blindness is covered by the pre-existing `test_gate_runs_second`. What source-reading cannot catch is a gate moved out of the group into the slower tail, so the second test pins group membership against a hard-coded list.

Negative control: a mutant that moves `Test Working Tree Writes` out of `run_fast_gates` into the caller, leaving the emitted gate sequence byte-identical and changing only the grouping, is caught by both new tests while all 16 pre-existing tests in that file pass it. A test that a plausible mutant survives is not evidence, so this is the check that makes the new tests load-bearing.

Ratchet trio, run against `origin/main`:

```
taste count ratchet: OK (count == baseline 601).
type-ignore count ratchet: OK (count == baseline 44).
ruff count ratchet: OK. 323 violations <= baseline 326 (-3 slack).
```

The same taste command reports `REGRESSION` at 602 on pristine main, which is the before half of that pair.

Full pre-push suite passed on this branch, including `python-tests` at 839 seconds and `taste-count-ratchet` at 2.26 seconds. 124 tests pass across the two pre-PR suites. `ruff check` and `ruff format --check` are clean.

Refs \#4272
Refs \#4057
