### PR TITLE
test(mutation): pin utf-8 on the debate-log harness pytest call

### DIFF
--- a/.agents/sessions/2026-08-02-session-4257-unblock-red-main-pinning-utf-8.json
+++ b/.agents/sessions/2026-08-02-session-4257-unblock-red-main-pinning-utf-8.json
@@ -73,13 +73,13 @@
     "sessionEnd": {
       "checklistComplete": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "All MUST items verified"
       },
       "handoffPreserved": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only respected)"
       },
       "serenaMemoryUpdated": {
         "level": "MUST",
@@ -88,18 +88,18 @@
       },
       "markdownLintRun": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "No markdown files changed"
       },
       "changesCommitted": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "All changes committed (HEAD: 90524a8ad)"
       },
       "validationPassed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit 0"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -110,10 +110,15 @@
         "level": "SHOULD",
         "Complete": false,
         "Evidence": ""
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "rework-warning: none"
       }
     }
   },
   "workLog": [],
-  "endingCommit": "",
+  "endingCommit": "90524a8ad",
   "nextSteps": []
 }

--- a/.agents/sessions/2026-08-02-session-4257-unblock-red-main-pinning-utf-8.json
+++ b/.agents/sessions/2026-08-02-session-4257-unblock-red-main-pinning-utf-8.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4257,
+    "date": "2026-08-02",
+    "branch": "fix/mutation-harness-utf8",
+    "startingCommit": "4ca67ad60",
+    "objective": "unblock red main by pinning utf-8 on the mutation harness pytest call"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__activate_project on the repo root; project ai-agents active"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions read this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md auto-loaded by the context-loader hook"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ls .claude/skills/ -> 99 skills; github/scripts/pr enumerated"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read; GitHub work routed through .claude/skills/github/scripts/"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "usage-mandatory, ci/ci-count-ratchet-never-names-the-offending-file, ci/measure-main-before-blaming-the-pr"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/mutation-harness-utf8"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/mutation-harness-utf8"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked before commit"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "4ca67ad60"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ci/measure-main-before-blaming-the-pr written this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/tests/mutation/test_mutate_debate_log_path.py
+++ b/tests/mutation/test_mutate_debate_log_path.py
@@ -46,7 +46,9 @@ _OUTCOME_DID_NOT_APPLY = "DID-NOT-APPLY"
 
 def _run_tests() -> subprocess.CompletedProcess[str]:
     cmd = [sys.executable, "-m", "pytest", "--tb=short", "-q", *TESTS]
-    return subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
+    return subprocess.run(
+        cmd, cwd=str(REPO_ROOT), capture_output=True, text=True, encoding="utf-8"
+    )
 
 
 def _assert_suite_ran(result: subprocess.CompletedProcess[str], label: str) -> None:


### PR DESCRIPTION
Fixes #4310

## Summary

`main` is red. `tests/test_subprocess_text_encoding.py::test_every_capturing_call_under_tests_pins_utf8` fails on a clean `origin/main` checkout, so every open PR that merges main inherits the failure and `Run Python Tests` goes red across the queue.

## Cause

`_run_tests` in `tests/mutation/test_mutate_debate_log_path.py` captured pytest output with `text=True` and no `encoding`, which decodes with `locale.getpreferredencoding(False)`. That is UTF-8 on the Linux runners and cp1252 on the Windows runner, where a non-ASCII byte in pytest output silently decodes to different characters.

The harness landed in #4274. The standing guard scans `tests/`, so the two only collided once both were on main.

## Changes

- `tests/mutation/test_mutate_debate_log_path.py`: pass `encoding="utf-8"` to the `subprocess.run` call in `_run_tests`.

`errors` stays at the strict default. The guard's own docstring states why: "`errors` is deliberately left to each call site: the default is `strict`, which fails loudly, and a lenient handler would reintroduce the silent corruption this guard exists to prevent."

## Verification

Before, on `origin/main` at `ede9fd1fe`:

```
FAILED tests/test_subprocess_text_encoding.py::test_every_capturing_call_under_tests_pins_utf8
 - AssertionError: text-capturing subprocess calls must pass encoding="utf-8":
   tests/mutation/test_mutate_debate_log_path.py:49
1 failed in 12.84s
```

After, same tree with this one-line change:

```
332 passed in 23.02s
```

## Type of change

Bug fix (CI unblock). No behavior change to the harness: the mutation logic, the inverted control, and the DID-NOT-APPLY reporting are untouched.
