### PR TITLE
fix(memory): correct the budget worked example, and name the plugin gap

### DIFF
--- a/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
+++ b/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
@@ -75,9 +75,10 @@ Ext     Files     Bytes   Ceiling    Usage   Free
 
 A rule whose `applyTo` is `**` counts against all four languages at once, so the
 binding constraint is the smallest headroom. **The largest always-on rule that
-can be added today is 397 bytes**, which is smaller than the frontmatter plus
-heading of an empty rule file. The next always-on rule addition breaks the
-build.
+can be added today is 397 bytes.** That is not zero: a file carrying frontmatter,
+a heading, and one MUST sentence measures 58 bytes and passes at 99.6%. What it
+rules out is a rule of ordinary size. Every existing always-on rule is far larger
+than 397 bytes, so in practice the next real one fails unless it is scoped.
 
 The earlier revision of this memory recorded the `.md` figure as 1378 bytes.
 Headroom has since fallen to 397, and the `.md` ceiling is 83000 while the other
@@ -92,18 +93,45 @@ The instinct on a budget failure is to compress the rule or raise
 only universally scoped files, so a rule moved to a narrower `applyTo` costs
 zero bytes rather than fewer bytes.
 
-Worked example, `.agents/**` session-log mechanics:
+Worked example, `.agents/**` session-log mechanics. The same material was first
+written into `universal.md`, then moved to its own scoped rule:
 
 | Placement | Always-on cost | Gate |
 |---|---|---|
-| `universal.md`, `applyTo: **` | +855 bytes against 397 free | FAIL at 100.8% |
+| appended to `universal.md`, `applyTo: **` | +855 bytes against 397 free | FAIL at 100.6% |
 | `session-logs.md`, `applyTo: .agents/**` | 0 bytes, 82603 before and after | PASS |
 
-Identical prose, identical mirrors, identical enforcement. The only change was
-the frontmatter glob. Before compressing anything, ask whether the rule was ever
-universal: a rule that describes what happens when a change touches one tree
-never was. Raising a ceiling to clear a violation you introduced is forbidden
-regardless, since it converts a real signal into a silent one.
+The 855 figure is the text removed from `universal.instructions.md` when the
+material was pulled back out, measured at commit `4dff685ba` (5185 before, 4330
+after). It is not the size of the rule that replaced it. The standalone scoped
+file is 1754 bytes, so writing the same rule universally today would land at
+101.6%. The prose is not identical either; a standalone rule needs its own
+frontmatter and heading. What is identical is the enforcement: the scoped rule
+fires on exactly the paths the universal text described.
+
+Before compressing anything, ask whether the rule was ever universal: a rule that
+describes what happens when a change touches one tree never was. Raising a
+ceiling to clear a violation you introduced is forbidden regardless, since it
+converts a real signal into a silent one.
+
+### Free at the gate is not free downstream
+
+Verified 2026-08-02, and the reason this section says "free at the gate" rather
+than "free". `instruction_budget_constants.py:5` sets
+`INSTRUCTIONS_SUBDIR = ".github/instructions"`, so the gate never reads
+`src/copilot-cli/instructions/`. `build/scripts/generate_rules.py:321-337` strips
+internal-only globs from the plugin artifact, and when that leaves the scope
+empty it synthesizes `**` so the rule still ships.
+
+So a rule scoped entirely to internal paths becomes universal in the plugin. Of
+26 canonical rules, three are in that state: `governance`, `secret-redaction`,
+and `session-logs`. The first two are on `main` today. The gate reports zero
+added bytes while the shipped plugin gains an always-on rule about a directory
+its consumers do not have.
+
+Scoping is still the right move, and the gate result is still honest about what
+the gate measures. Do not read it as a claim about total context cost. Tracked as
+issue #4317.
 
 That is also why this note is a memory and not a rule. Documenting the budget in
 an always-on rule file would consume the budget it documents, and there is not

--- a/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
+++ b/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
@@ -63,19 +63,47 @@ either number.
 
 ## The headroom is the story
 
-Subtracting current from ceiling:
+Re-measured on `origin/main` at `ede9fd1fe`, 2026-08-02:
 
 ```text
-.cs    1520 bytes free
-.md    1378 bytes free
-.ps1   1688 bytes free
-.py    1397 bytes free
+Ext     Files     Bytes   Ceiling    Usage   Free
+.cs        11     95599     99000    96.6%   3401
+.md         9     82603     83000    99.5%    397
+.ps1       11     95431     99000    96.4%   3569
+.py        11     95722     99000    96.7%   3278
 ```
 
 A rule whose `applyTo` is `**` counts against all four languages at once, so the
 binding constraint is the smallest headroom. **The largest always-on rule that
-can be added today is 1,378 bytes.** A rule file with frontmatter and any real
-content exceeds that. The next always-on rule addition breaks the build.
+can be added today is 397 bytes**, which is smaller than the frontmatter plus
+heading of an empty rule file. The next always-on rule addition breaks the
+build.
+
+The earlier revision of this memory recorded the `.md` figure as 1378 bytes.
+Headroom has since fallen to 397, and the `.md` ceiling is 83000 while the other
+three sit at 99000. Re-measure before quoting any number in this section. The
+memory that warns an analysis note is a claim about a date rather than about the
+tree is subject to its own rule.
+
+## Scoping is free, and it is the fix
+
+The instinct on a budget failure is to compress the rule or raise
+`DEFAULT_CEILINGS_BYTES`. Both are usually wrong. `instruction_budget.py` counts
+only universally scoped files, so a rule moved to a narrower `applyTo` costs
+zero bytes rather than fewer bytes.
+
+Worked example, `.agents/**` session-log mechanics:
+
+| Placement | Always-on cost | Gate |
+|---|---|---|
+| `universal.md`, `applyTo: **` | +855 bytes against 397 free | FAIL at 100.8% |
+| `session-logs.md`, `applyTo: .agents/**` | 0 bytes, 82603 before and after | PASS |
+
+Identical prose, identical mirrors, identical enforcement. The only change was
+the frontmatter glob. Before compressing anything, ask whether the rule was ever
+universal: a rule that describes what happens when a change touches one tree
+never was. Raising a ceiling to clear a violation you introduced is forbidden
+regardless, since it converts a real signal into a silent one.
 
 That is also why this note is a memory and not a rule. Documenting the budget in
 an always-on rule file would consume the budget it documents, and there is not

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -83,7 +83,7 @@
 [Memory and Context]
 |context engineering token optimization progressive disclosure just-in-time: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)
 |passive context AGENTS.md skills decision-point retrieval-led compression: [memory/passive-context-vs-skills-vercel-research](memory/passive-context-vs-skills-vercel-research.md) (447), [claude/claude-md-anthropic-best-practices](claude/claude-md-anthropic-best-practices.md) (683), [claude/claude-code-skills-official-guidance](claude/claude-code-skills-official-guidance.md) (623)
-|instruction budget always-on ceiling applyTo scope headroom rule authoring: [decision-the-instruction-budget-gate-already-exists](decision-the-instruction-budget-gate-already-exists.md) (1450)
+|instruction budget always-on ceiling applyTo scope headroom rule authoring: [decision-the-instruction-budget-gate-already-exists](decision-the-instruction-budget-gate-already-exists.md) (1856)
 
 [Root Cause Patterns (PR #908)]
 |governance enforcement ADR limits commits files programmatic gate: [root-cause-governance-enforcement](root-cause-governance-enforcement.md) (603)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -83,6 +83,7 @@
 [Memory and Context]
 |context engineering token optimization progressive disclosure just-in-time: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)
 |passive context AGENTS.md skills decision-point retrieval-led compression: [memory/passive-context-vs-skills-vercel-research](memory/passive-context-vs-skills-vercel-research.md) (447), [claude/claude-md-anthropic-best-practices](claude/claude-md-anthropic-best-practices.md) (683), [claude/claude-code-skills-official-guidance](claude/claude-code-skills-official-guidance.md) (623)
+|instruction budget always-on ceiling applyTo scope headroom rule authoring: [decision-the-instruction-budget-gate-already-exists](decision-the-instruction-budget-gate-already-exists.md) (1450)
 
 [Root Cause Patterns (PR #908)]
 |governance enforcement ADR limits commits files programmatic gate: [root-cause-governance-enforcement](root-cause-governance-enforcement.md) (603)


### PR DESCRIPTION
## Summary

Corrects a memory about the always-on instruction budget. Two claims in it were wrong, and
one section it did not have turned out to matter more than anything it did have.

## What was wrong

**The worked example mixed two different numbers.** It presented 855 bytes as the size of a
rule being added, then computed 100.8% headroom from it. 855 is a historical removal delta
from an earlier change, not the size of any rule. The rule the example is about is 1754 bytes,
which puts the ceiling at 101.6%, not 100.8%. The arithmetic was also off by 0.2 points on
its own terms.

**It claimed no always-on rule could fit.** That is false. With 397 bytes of headroom, a
58-byte rule fits at 99.6%. The claim generalized from one oversized rule to all rules.

## What was missing

The memory said scoping a rule is free. Measured at the gate, that is true:
`instruction_budget_constants.py:5` sets `INSTRUCTIONS_SUBDIR = ".github/instructions"`, so
the gate never reads `src/copilot-cli/instructions/`. A scoped rule costs zero there.

It is not free downstream. `generate_rules.py:321-337` strips internal-only globs from the
plugin artifact, and when that empties the scope it synthesizes `applyTo: '**'` so the rule
"still ships rather than landing with `applyTo: ''`". The narrower you scope a rule in
source, the more likely the plugin ships it universally.

I audited all 26 canonical rules. Three are in that state: `governance`,
`secret-redaction`, and `session-logs`. Two are already on `main`, so this is not a
regression from this branch. Plugin consumers have no `.agents/` tree, so those rules load on
every file and can never apply.

Filed as #4317. The memory now carries a section naming the gap rather than repeating
"scoping is free" unqualified.

## Verification

```
$ uv run --frozen python scripts/validation/instruction_budget.py
.md   9   82603   83000   21788   99.5%   PASS
```

Every number above was measured, not recalled. The 855-versus-1754 error is exactly the kind
this memory exists to prevent, which is why the correction is explicit rather than a silent
edit.

Refs #4317
