### PR TITLE
docs(memory): two new_pr.py traps that each cost a session

### DIFF
--- a/.serena/memories/tools/github-skill-scripts-reference.md
+++ b/.serena/memories/tools/github-skill-scripts-reference.md
@@ -53,6 +53,74 @@ The scripts listed in this reference are primarily PR-related, so most are under
 
 `new_pr.py` does NOT accept `--owner` or `--repo`. It infers the repo from the current git remote. If you pass `--owner`, it exits with error code 2.
 
+### Gotcha: pass `--base origin/main`, not the default
+
+`--base` defaults to the literal string `main`, which git resolves to the LOCAL
+branch. In a worktree that has not fetched recently, local `main` lags
+`origin/main`, and `new_pr.py` computes its changed-file set from
+`git diff <base>...HEAD` at line 288. A stale base makes that range include every
+file the real base gained since the local ref was last updated.
+
+The visible symptom is an opaque failure that names nothing:
+
+```
+[1/6] Checking Session End protocol...
+Session End validation failed
+```
+
+Mechanism: the spurious changed-file set contains `.agents/` paths the branch
+never touched, so `agents_changed` is true (line 299). The script then sorts the
+session logs it found and validates the newest one (line 318). That log belongs
+to someone else's session on `main`. Your PR is rejected for a file you did not
+write.
+
+Measured on `docs/eval-fixture-provenance`, whose real diff touches zero
+`.agents/` files:
+
+| Base | `.agents/` files in range |
+|---|---|
+| `main` (local, `05a4a5677`) | 100+, oldest dated 2026-01-03 |
+| `origin/main` (`5ee7a95d5`) | 0 |
+
+Passing `--base origin/main` cleared all six validations on the same branch with
+no other change. Fetching would also work, but the explicit remote ref does not
+depend on remembering to fetch.
+
+This is the general two-dot and stale-base hazard with a concrete consequence:
+you cannot open a PR, and the error names a file unrelated to your work.
+
+### Gotcha: GraphQL and REST have separate rate-limit pools
+
+`gh pr create`, and therefore `new_pr.py`, creates the PR through GraphQL. The
+GraphQL and REST quotas are counted separately, so GraphQL can be fully spent
+while REST still has thousands of calls left:
+
+```
+$ gh api rate_limit --jq '{core: .resources.core, graphql: .resources.graphql}'
+{"core":{"limit":5000,"remaining":4948,...},"graphql":{"limit":5000,"remaining":0,...}}
+```
+
+With GraphQL at 0 the script fails after passing every validation:
+
+```
+All pre-creation validations passed!
+Creating PR...
+GraphQL: API rate limit already exceeded for user ID 6811113.
+```
+
+The REST endpoint draws from the `core` pool and still works:
+
+```bash
+printf '%s' "$JSON" | gh api --method POST /repos/OWNER/REPO/pulls --input -
+```
+
+Confirmed by creating PR #4320 this way while GraphQL read 0 remaining. Waiting
+for the GraphQL reset also works; the reset time is in
+`gh api rate_limit --jq '.resources.graphql.reset'` as a Unix timestamp.
+
+Prefer `new_pr.py`. Reach for REST only when GraphQL is exhausted, and re-run
+the script's validations first, since the raw endpoint performs none of them.
+
 ### Missing Script: PR Approval
 
 There is currently NO dedicated approve script in this skill set.


### PR DESCRIPTION
## Summary

Two `new_pr.py` traps, each of which cost a session. Both found by hitting them. Both extend
the existing `new_pr.py` gotcha section rather than starting a new memory, since the reader who
needs them is already there.

## Trap 1: `--base` defaults to the local `main`

`--base` defaults to the literal string `main`, which git resolves to the local branch, not
`origin/main`. `new_pr.py` computes its changed-file set from `git diff <base>...HEAD`, so a
lagging local `main` injects every `.agents/` path the real base gained since that ref was last
updated. The script then sorts the session logs in that set and validates the newest, which
belongs to someone else's session.

The error names nothing:

```
[1/6] Checking Session End protocol...
Session End validation failed
```

Measured: 100+ spurious `.agents/` files against local `main` at `05a4a5677`, zero against
`origin/main` at `5ee7a95d5`. Passing `--base origin/main` cleared all six validations with no
other change.

## Trap 2: GraphQL and REST draw from separate quotas

`gh pr create`, and so `new_pr.py`, creates through GraphQL. The GraphQL and REST pools are
separate. Measured `graphql.remaining=0` while `core.remaining=4948`. The script then fails
after passing every validation, which reads like a script bug rather than a quota:

```
GraphQL: API rate limit already exceeded
```

The REST pulls endpoint draws from core and still works. PR #4320 was created that way while
GraphQL was exhausted.

## Shape

Each entry leads with the observed symptom, because the symptom is what the next reader will
have and neither error names its cause.
