### PR TITLE
feat(pre-push): detect and block non-fast-forward pushes

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -4923,9 +4923,88 @@ def _fetch_origin_main(repo_root: Path) -> None:
         print("WARNING: could not refresh origin/main; using local ref", file=sys.stderr)
 
 
+# Environment variable that allows force-pushing a branch the actor owns.
+# Set to "1" for a single push of a personal feature branch that has been
+# deliberately rebased.  universal.md MUST NOT #1 still applies: this escape
+# is for branches only the author has touched.  Use the 4-slot semaphore
+# described in AGENTS.md to serialize, not this env var.
+FORCE_PUSH_OK_ENV = "FORCE_PUSH_OK"
+
+
+def _check_non_fast_forward(push_ref: PushRef, repo_root: Path) -> int:
+    """Return 1 when push_ref rewrites published history on a branch ref.
+
+    Detects a force push by testing whether the current remote tip
+    (remote_sha) is reachable from what is about to land (local_sha).  If it
+    is not reachable, the push discards commits the remote already has.
+
+    Returns:
+        0 - fast-forward, new branch, deletion, non-branch ref, or env-var
+            escape active.
+        1 - non-fast-forward detected (history rewrite).
+        2 - remote object absent locally; fetch first.
+    """
+    # Only guard branch refs.
+    if _branch_name(push_ref.remote_ref) is None:
+        return 0
+
+    # Deletions and new branches do not rewrite history.
+    if push_ref.is_deletion or push_ref.is_new:
+        return 0
+
+    if os.environ.get(FORCE_PUSH_OK_ENV) == "1":
+        print(
+            f"WARNING: force-push check bypassed via {FORCE_PUSH_OK_ENV}=1 "
+            f"for {push_ref.remote_ref}",
+            file=sys.stderr,
+        )
+        return 0
+
+    # The remote tip must be present locally before we can test ancestry.
+    # merge-base --is-ancestor exits non-zero both for "not an ancestor" and
+    # for "unknown object", so we must distinguish those two cases first.
+    if not _commit_ref_exists(repo_root, push_ref.remote_sha):
+        print(
+            f"ERROR: remote tip {push_ref.remote_sha[:12]} for "
+            f"{push_ref.remote_ref} is not present in the local object store. "
+            "Run 'git fetch' and retry.",
+            file=sys.stderr,
+        )
+        return 2
+
+    result = _run_git(
+        repo_root,
+        ["merge-base", "--is-ancestor", push_ref.remote_sha, push_ref.local_sha],
+    )
+    if result.returncode == 0:
+        # remote_sha is an ancestor of local_sha: fast-forward push.
+        return 0
+
+    # returncode == 1 means not-an-ancestor; anything else is a git error.
+    # Fail closed in both cases.
+    print(
+        f"ERROR: push to {push_ref.remote_ref} is not a fast-forward. "
+        f"Remote tip {push_ref.remote_sha[:12]} is not reachable from "
+        f"{push_ref.local_sha[:12]}. "
+        "This rewrites published history, which universal.md MUST NOT #1 forbids. "
+        f"To override for a personal branch you own, set {FORCE_PUSH_OK_ENV}=1.",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def _protected_push_destination(push_ref: PushRef) -> str | None:
     branch = _branch_name(push_ref.remote_ref)
     return branch if branch in {"main", "master"} else None
+
+
+def _check_all_non_fast_forward(refs: list[PushRef], repo_root: Path) -> int:
+    """Run _check_non_fast_forward for each ref; return first non-zero result."""
+    for push_ref in refs:
+        result = _check_non_fast_forward(push_ref, repo_root)
+        if result != 0:
+            return result
+    return 0
 
 
 def check_push_refs(stream: TextIO, repo_root: Path) -> int:
@@ -4950,6 +5029,9 @@ def check_push_refs(stream: TextIO, repo_root: Path) -> int:
     if protected is not None:
         print(f"ERROR: cannot delete or update protected branch '{protected}'", file=sys.stderr)
         return 1
+    nff_result = _check_all_non_fast_forward(refs, repo_root)
+    if nff_result != 0:
+        return nff_result
     active_refs = [push_ref for push_ref in refs if not push_ref.is_deletion]
     if active_refs:
         warn_if_push_files_incomplete(active_refs, repo_root)

--- a/tests/mutation/mutation_harness_4293.py
+++ b/tests/mutation/mutation_harness_4293.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Mutation harness for _check_non_fast_forward (issue #4293).
+
+Verifies that each load-bearing line in the force-push detection guard is
+individually necessary. Each mutation removes or inverts one condition; the
+targeted tests must catch it.
+
+Exit codes:
+    0  - all mutations killed, baseline restored green
+    1  - one or more mutations survived (test suite does not catch a defect)
+    2  - configuration error (file not found, mutation did not apply, etc.)
+
+Run from the worktree root:
+    uv run --frozen python tests/mutation/mutation_harness_4293.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+TARGET_FILE = Path("scripts/validation/git_hook_policy.py")
+BACKUP_FILE = Path("scripts/validation/git_hook_policy.py.mutation_bak")
+TARGET_TESTS = [
+    "tests/test_lefthook_integration.py::test_non_fast_forward_passes_on_fast_forward_push",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_blocks_history_rewrite",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_passes_new_branch",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_passes_deletion",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_returns_2_when_remote_object_absent",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_skips_non_branch_refs",
+    "tests/test_lefthook_integration.py::test_non_fast_forward_env_var_bypasses_block",
+    "tests/test_lefthook_integration.py::test_check_push_refs_blocks_force_push_end_to_end",
+    "tests/test_lefthook_integration.py::test_check_push_refs_multi_ref_catches_second_rewrite",
+]
+
+MUTATIONS: list[tuple[str, str, str]] = [
+    # (name, original_fragment, replacement_fragment)
+    (
+        "drop_non_branch_guard",
+        "    if _branch_name(push_ref.remote_ref) is None:\n        return 0\n",
+        "    if False:  # MUTANT: dropped non-branch guard\n        return 0\n",
+    ),
+    (
+        "drop_new_branch_and_deletion_guard",
+        "    if push_ref.is_deletion or push_ref.is_new:\n        return 0\n",
+        "    if False:  # MUTANT: dropped new-branch/deletion guard\n        return 0\n",
+    ),
+    (
+        "invert_absent_object_check",
+        "    if not _commit_ref_exists(repo_root, push_ref.remote_sha):\n",
+        "    if _commit_ref_exists(repo_root, push_ref.remote_sha):  # MUTANT\n",
+    ),
+    (
+        "flip_ancestry_return",
+        (
+            "    if result.returncode == 0:\n"
+            "        # remote_sha is an ancestor of local_sha: fast-forward push.\n"
+            "        return 0\n"
+        ),
+        (
+            "    if result.returncode != 0:  # MUTANT: flipped ancestry check\n"
+            "        # remote_sha is an ancestor of local_sha: fast-forward push.\n"
+            "        return 0\n"
+        ),
+    ),
+    # Inverted control: a mutation that MUST survive (changing non-load-bearing
+    # warning text does not affect test outcomes).
+    (
+        "SURVIVOR_change_warning_text",
+        '            f"WARNING: force-push check bypassed via {FORCE_PUSH_OK_ENV}=1 "\n',
+        '            f"INFO: force-push check bypassed via {FORCE_PUSH_OK_ENV}=1 "\n',
+    ),
+]
+
+
+def _run_pytest(tests: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["uv", "run", "--frozen", "python", "-m", "pytest", *tests, "-q", "--tb=no"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _apply_mutation(content: str, original: str, replacement: str) -> tuple[str, int]:
+    count = content.count(original)
+    if count == 0:
+        return content, 0
+    return content.replace(original, replacement, 1), count
+
+
+def _verify_baseline() -> None:
+    result = _run_pytest(TARGET_TESTS)
+    if result.returncode != 0:
+        print("ABORT: baseline is not green before mutation.", file=sys.stderr)
+        print(result.stdout[-2000:], file=sys.stderr)
+        sys.exit(2)
+    # Verify test names appear in output (guards against "no tests ran").
+    if "no tests ran" in result.stdout.lower() or "collected 0" in result.stdout:
+        print("ABORT: no tests collected for baseline run.", file=sys.stderr)
+        sys.exit(2)
+    print(f"Baseline green: {result.stdout.strip().splitlines()[-1]}")
+
+
+def _record_result(
+    name: str,
+    test_failed: bool,
+    killed: list[str],
+    survivors: list[str],
+) -> None:
+    is_survivor_control = name.startswith("SURVIVOR_")
+    if is_survivor_control:
+        if test_failed:
+            print(f"  UNEXPECTED KILL on survivor control '{name}' -- harness error.")
+            survivors.append(name)
+        else:
+            print(f"  OK (survived as expected): {name}")
+            killed.append(f"(survived_control) {name}")
+    elif test_failed:
+        print(f"  KILLED: {name}")
+        killed.append(name)
+    else:
+        print(f"  SURVIVED (tests did not catch mutation): {name}")
+        survivors.append(name)
+
+
+def main() -> None:
+    if not TARGET_FILE.exists():
+        print(f"ERROR: {TARGET_FILE} not found. Run from the worktree root.", file=sys.stderr)
+        sys.exit(2)
+
+    original_content = TARGET_FILE.read_text(encoding="utf-8")
+    shutil.copy2(TARGET_FILE, BACKUP_FILE)
+
+    _verify_baseline()
+
+    survivors: list[str] = []
+    killed: list[str] = []
+
+    for name, original, replacement in MUTATIONS:
+        mutated, apply_count = _apply_mutation(original_content, original, replacement)
+
+        if apply_count == 0:
+            print(f"ABORT: mutation '{name}' did not apply (fragment not found).", file=sys.stderr)
+            TARGET_FILE.write_text(original_content, encoding="utf-8")
+            BACKUP_FILE.unlink(missing_ok=True)
+            sys.exit(2)
+
+        # Verify the file actually changed.
+        if mutated == original_content:
+            print(f"ABORT: mutation '{name}' left file byte-identical.", file=sys.stderr)
+            TARGET_FILE.write_text(original_content, encoding="utf-8")
+            BACKUP_FILE.unlink(missing_ok=True)
+            sys.exit(2)
+
+        TARGET_FILE.write_text(mutated, encoding="utf-8")
+        result = _run_pytest(TARGET_TESTS)
+
+        # Restore immediately.
+        TARGET_FILE.write_text(original_content, encoding="utf-8")
+
+        # Sanity: no tests ran at all means the harness is broken.
+        if result.returncode == 4 or "no tests ran" in result.stdout.lower():
+            print(
+                f"ABORT: mutation '{name}' caused pytest to collect no tests "
+                f"(rc={result.returncode}).",
+                file=sys.stderr,
+            )
+            BACKUP_FILE.unlink(missing_ok=True)
+            sys.exit(2)
+
+        test_failed = result.returncode != 0
+
+        _record_result(name, test_failed, killed, survivors)
+
+    # Final baseline verification.
+    final = _run_pytest(TARGET_TESTS)
+    if final.returncode != 0:
+        print(
+            "ERROR: baseline is red after mutation run -- file was not restored.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    print(f"Final baseline green: {final.stdout.strip().splitlines()[-1]}")
+
+    BACKUP_FILE.unlink(missing_ok=True)
+
+    real_survivors = [s for s in survivors if not s.startswith("(survived_control)")]
+    if real_survivors:
+        print(
+            f"\nFAIL: {len(real_survivors)} mutation(s) survived: {real_survivors}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    killed_count = len([k for k in killed if not k.startswith("(survived_control)")])
+    print(f"\nPASS: all {killed_count} mutations killed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -5022,8 +5022,9 @@ def test_push_policy_blocks_main_and_preserves_destination_branch(
 ) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
-    head = "1" * 40
-    remote = "2" * 40
+    # Use real commits so the non-fast-forward check can resolve the objects.
+    remote = _commit_file(repo, "tracked", "base\n")
+    head = _commit_file(repo, "tracked", "head\n")
     destinations: list[str | None] = []
 
     def capture_limit(update: policy.PushUpdate, _root: Path) -> int:
@@ -5066,6 +5067,213 @@ def test_new_branch_uses_origin_main_for_policy_bases(tmp_path: Path) -> None:
     assert update.base == base
     assert update.head == head
     assert update.range_spec == f"{base}..{head}"
+
+
+# ---------------------------------------------------------------------------
+# _check_non_fast_forward tests (issue #4293)
+# ---------------------------------------------------------------------------
+
+
+def _make_push_ref(
+    local_sha: str,
+    remote_sha: str,
+    remote_ref: str = "refs/heads/feature/test",
+    local_ref: str = "refs/heads/feature/test",
+) -> policy.PushRef:
+    return policy.PushRef(local_ref, local_sha, remote_ref, remote_sha)
+
+
+def test_non_fast_forward_passes_on_fast_forward_push(tmp_path: Path) -> None:
+    """Fast-forward push: remote_sha is an ancestor of local_sha."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    remote_sha = _commit_file(repo, "f.txt", "v1\n")
+    local_sha = _commit_file(repo, "f.txt", "v2\n")
+    push_ref = _make_push_ref(local_sha, remote_sha)
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 0
+
+
+def test_non_fast_forward_blocks_history_rewrite(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Force push: local_sha does not descend from remote_sha."""
+    monkeypatch.delenv("FORCE_PUSH_OK", raising=False)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    base = _commit_file(repo, "f.txt", "base\n")
+    # Two divergent branches from base.
+    _git(repo, "checkout", "-q", "-b", "side")
+    side_sha = _commit_file(repo, "f.txt", "side\n")
+    _git(repo, "checkout", "-q", "feature/test")
+    feature_sha = _commit_file(repo, "f.txt", "feature\n")
+    # Push feature as if remote is on side (not an ancestor).
+    push_ref = _make_push_ref(feature_sha, side_sha)
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "not a fast-forward" in err
+    assert "universal.md" in err
+    assert base  # suppress unused-variable warning
+
+
+def test_non_fast_forward_passes_new_branch(tmp_path: Path) -> None:
+    """New branch: remote_sha is all zeros, nothing to rewrite."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    local_sha = _commit_file(repo, "f.txt", "v1\n")
+    push_ref = _make_push_ref(local_sha, "0" * 40)
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 0
+
+
+def test_non_fast_forward_passes_deletion(tmp_path: Path) -> None:
+    """Branch deletion (local_sha all zeros) is not a force push."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    remote_sha = _commit_file(repo, "f.txt", "v1\n")
+    push_ref = _make_push_ref("0" * 40, remote_sha)
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 0
+
+
+def test_non_fast_forward_returns_2_when_remote_object_absent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing remote object: guard fails closed, not a false positive."""
+    monkeypatch.delenv("FORCE_PUSH_OK", raising=False)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    local_sha = _commit_file(repo, "f.txt", "v1\n")
+    # A plausible-looking SHA that is not present in the repo.
+    absent_sha = "abcdef1234567890abcdef1234567890abcdef12"
+    push_ref = _make_push_ref(local_sha, absent_sha)
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 2
+    err = capsys.readouterr().err
+    assert "not present in the local object store" in err
+    assert "git fetch" in err
+
+
+def test_non_fast_forward_skips_non_branch_refs(tmp_path: Path) -> None:
+    """Tag refs and other non-branch refs are out of scope.
+
+    The remote_sha and local_sha are on divergent branches (neither is an
+    ancestor of the other), so without the non-branch guard this test would
+    fail.  The guard must fire first and return 0 before the ancestry check.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    base = _commit_file(repo, "f.txt", "base\n")
+    # Create two divergent branches from base.
+    _git(repo, "checkout", "-q", "-b", "branch-a")
+    branch_a_sha = _commit_file(repo, "f.txt", "branch-a\n")
+    _git(repo, "checkout", "-q", base)
+    _git(repo, "checkout", "-q", "-b", "branch-b")
+    branch_b_sha = _commit_file(repo, "f.txt", "branch-b\n")
+    # local=branch_b, remote=branch_a: genuinely divergent (non-ancestor).
+    # If the branch guard were absent, this would reach the ancestry check
+    # and return 1.  The guard must fire and return 0 first.
+    push_ref = _make_push_ref(
+        branch_b_sha, branch_a_sha, remote_ref="refs/tags/v1.0.0"
+    )
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 0
+    assert base  # suppress unused-variable warning
+
+
+def test_non_fast_forward_env_var_bypasses_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """FORCE_PUSH_OK=1 allows a rewrite with a warning."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    base = _commit_file(repo, "f.txt", "base\n")
+    _git(repo, "checkout", "-q", "-b", "side")
+    side_sha = _commit_file(repo, "f.txt", "side\n")
+    _git(repo, "checkout", "-q", "feature/test")
+    feature_sha = _commit_file(repo, "f.txt", "feature\n")
+    push_ref = _make_push_ref(feature_sha, side_sha)
+    monkeypatch.setenv("FORCE_PUSH_OK", "1")
+
+    result = policy._check_non_fast_forward(push_ref, repo)
+
+    assert result == 0
+    err = capsys.readouterr().err
+    assert "bypassed" in err
+    assert base  # suppress unused-variable warning
+
+
+def test_check_push_refs_blocks_force_push_end_to_end(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """check_push_refs end-to-end: force push is caught."""
+    monkeypatch.delenv("FORCE_PUSH_OK", raising=False)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    base = _commit_file(repo, "f.txt", "base\n")
+    _git(repo, "checkout", "-q", "-b", "side")
+    side_sha = _commit_file(repo, "f.txt", "side\n")
+    _git(repo, "checkout", "-q", "feature/test")
+    feature_sha = _commit_file(repo, "f.txt", "feature\n")
+    monkeypatch.setattr(policy, "_fetch_origin_main", lambda _repo_root: None)
+    monkeypatch.setattr(policy, "warn_if_push_files_incomplete", lambda *_args: None)
+    stream = io.StringIO(
+        f"refs/heads/feature/test {feature_sha} refs/heads/feature/test {side_sha}\n"
+    )
+
+    result = policy.check_push_refs(stream, repo)
+
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "not a fast-forward" in err
+    assert base  # suppress unused-variable warning
+
+
+def test_check_push_refs_multi_ref_catches_second_rewrite(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple refs: only the second is a rewrite; the first is a new branch."""
+    monkeypatch.delenv("FORCE_PUSH_OK", raising=False)
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _commit_file(repo, "f.txt", "base\n")
+    _git(repo, "checkout", "-q", "-b", "side")
+    side_sha = _commit_file(repo, "f.txt", "side\n")
+    _git(repo, "checkout", "-q", "feature/test")
+    feature_sha = _commit_file(repo, "f.txt", "feature\n")
+    monkeypatch.setattr(policy, "_fetch_origin_main", lambda _repo_root: None)
+    monkeypatch.setattr(policy, "warn_if_push_files_incomplete", lambda *_args: None)
+    zero = "0" * 40
+    stream = io.StringIO(
+        # First ref: new branch (zero remote), passes.
+        f"refs/heads/new-branch {feature_sha} refs/heads/new-branch {zero}\n"
+        # Second ref: force push, blocked.
+        f"refs/heads/feature/test {feature_sha} refs/heads/feature/test {side_sha}\n"
+    )
+
+    result = policy.check_push_refs(stream, repo)
+
+    assert result == 1
+    assert "not a fast-forward" in capsys.readouterr().err
 
 
 def test_commit_limit_queries_the_destination_branch(


### PR DESCRIPTION
## Summary

Fixes #4293. The pre-push hook parsed `remote_sha` but never compared
it to `local_sha` for ancestry. A force push passed every local gate.

## Triage

Confirmed the premise against current `origin/main`. Every use of
`remote_sha` in `scripts/validation/git_hook_policy.py`:

| Line | Use |
|---|---|
| 470 | dataclass field declaration |
| 478 | `_is_zero_sha` deletion test |
| 4815 | object id shape validation |
| 4875 | diff base assignment |
| 4964 | Lefthook file-coverage warning |

No ancestry comparison existed anywhere. `check_push_refs` had no call
to `merge-base --is-ancestor` involving `push_ref.remote_sha` and
`push_ref.local_sha`.

## Policy Decision

Block always with `FORCE_PUSH_OK=1` escape hatch (option c).

Warning-only (option b) provides no protection: warnings are already
being ignored in this repo. Shared-branch detection (option a) races in
a multi-agent workflow where the same branch can receive pushes within
seconds of each other.

`universal.md` MUST NOT \#1 says "shared branches." A branch is shared
once it has been pushed: another agent may have already fetched it. The
escape hatch covers legitimate rebases of personal branches.

## Implementation

New function `_check_non_fast_forward(push_ref, repo_root)`:

1. Skip non-branch refs (`refs/tags/`, etc.). Rule is `refs/heads/` only.
2. Skip new branches (`remote_sha` all zeros, `is_new` property). No history to rewrite.
3. Skip deletions (`local_sha` all zeros, `is_deletion` property). Not a force push.
4. If `FORCE_PUSH_OK=1`, warn and pass. Documents the escape in the warning text.
5. Check object exists locally with `_commit_ref_exists` (uses `git rev-parse --verify`).
   If absent, return 2 and say "run git fetch." This is the false-positive trap: without
   this check, `merge-base --is-ancestor` returns non-zero for both
   "not an ancestor" and "unknown object," and an unfetched ref would
   block every push on a freshly cloned machine.
6. Call `git merge-base --is-ancestor remote_sha local_sha`. rc=0 means
   fast-forward. rc=1 or any error: fail closed, print actionable message.

`_check_all_non_fast_forward` wraps the loop so `check_push_refs` stays
under the cyclomatic complexity ceiling.

## Changes

- `scripts/validation/git_hook_policy.py` -- `FORCE_PUSH_OK_ENV`, `_check_non_fast_forward`, `_check_all_non_fast_forward`, wired into `check_push_refs`
- `tests/test_lefthook_integration.py` -- 9 new tests, 1 existing test fixed
- `tests/mutation/mutation_harness_4293.py` -- mutation proof

## Tests

9 new tests, all passing:

| Test | What it proves |
|---|---|
| `test_non_fast_forward_passes_on_fast_forward_push` | fast-forward passes |
| `test_non_fast_forward_blocks_history_rewrite` | rewrite blocked, message includes "universal.md" |
| `test_non_fast_forward_passes_new_branch` | zero remote_sha passes |
| `test_non_fast_forward_passes_deletion` | zero local_sha passes |
| `test_non_fast_forward_returns_2_when_remote_object_absent` | missing object returns 2, not 1 |
| `test_non_fast_forward_skips_non_branch_refs` | tag ref with divergent SHAs passes |
| `test_non_fast_forward_env_var_bypasses_block` | FORCE_PUSH_OK=1 passes with warning |
| `test_check_push_refs_blocks_force_push_end_to_end` | end-to-end through check_push_refs |
| `test_check_push_refs_multi_ref_catches_second_rewrite` | second ref in a multi-ref push caught |

Also fixed `test_push_policy_blocks_main_and_preserves_destination_branch` to
use real commits. The old test used synthetic SHAs (`"1" * 40`, `"2" * 40`)
that are not present in the local object store, which now correctly triggers
the missing-object path and returns 2 instead of 0.

## Mutation Proof

```
Baseline green: 9 passed in 0.60s
  KILLED: drop_non_branch_guard
  KILLED: drop_new_branch_and_deletion_guard
  KILLED: invert_absent_object_check
  KILLED: flip_ancestry_return
  OK (survived as expected): SURVIVOR_change_warning_text
Final baseline green: 9 passed in 0.67s

PASS: all 4 mutations killed.
```

Each mutation removes or inverts one load-bearing condition. The
survivor control (`SURVIVOR_change_warning_text`) changes warning text
with no behavioral effect and must survive; it did.

## Verification

```
taste count ratchet:    OK (count == baseline 600)
type-ignore ratchet:    OK (count == baseline 44)
ruff count ratchet:     OK. 312 violations <= baseline 315
```
