### PR TITLE
docs(memory): six push and CI signals that lie, each measured under fleet load

### DIFF
--- a/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
+++ b/.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md
@@ -7,6 +7,10 @@ your branch merged with `main`, so a defect on `main` fails on every open PR at
 once. Attribute the failure only after checking whether `main` is red the same
 way.
 
+The same reasoning covers a rejected `git push`. The pre-push hook runs the
+repo's full gate set, so a red `main` blocks any branch that has merged it,
+locally and before any PR exists.
+
 Check `main` first. It costs one command and it is the discriminator.
 
 ```bash
@@ -17,6 +21,118 @@ gh run list --branch main --workflow "<Workflow Name>" --limit 5 \
 
 If `main` is failing the same workflow, your branch is a bystander. Merge
 `origin/main` once the fix lands and re-run. Change nothing.
+
+## Red `main` blocks `git push`, not just CI
+
+The same defect surfaces locally, where there is no PR and no run to inspect.
+The pre-push hook runs `scripts/validation/pre_pr.py` and
+`scripts/validation/git_hook_policy.py pytest`, so a branch carrying a red
+`main` is rejected until it repairs every inherited failure. Each rejection
+costs about seventeen minutes.
+
+Read the rejection before assuming your own change caused it. It names the gate
+that failed, which is the same discriminator the `gh run list` recipe gives you
+on the CI side.
+
+That `gh run list --branch main` check is still the cheapest first move. When it
+comes back inconclusive, because the run was cancelled or the gate is
+local-only, measure `origin/main` directly. Fetch first: a worktree's
+`origin/main` is only as fresh as its last fetch, and probing a stale tree
+answers the wrong question.
+
+```bash
+git fetch origin main
+PROBE=~/src/scratch/mainprobe-$$
+git worktree add --detach "$PROBE" FETCH_HEAD
+cd "$PROBE"
+uv run --frozen python -m pytest <failing node ids> -q
+uv run --frozen python scripts/validation/instruction_budget.py
+cd - && git worktree remove "$PROBE"
+```
+
+Give the probe an unused path. `git worktree add` refuses a path that is already
+registered, and a probe left behind from last time will block the next one.
+
+A clean checkout of `main` that reproduces your failure proves you inherited it.
+Fix `main` on its own branch. Do not bury the fix inside an unrelated change,
+which is what a blocked push tempts you into.
+
+Measured 2026-08-02: `main` at `a72ee868c` failed the pytest gate and the
+always-on instruction budget at the same time.
+
+### Two breakages on `main` deadlock the single fix
+
+Each single fix still trips the other gate. A branch fixing only the pytest
+failure was rejected on the budget at `83201/83000`; a branch fixing only the
+budget was rejected on the same two pytest assertions. Neither could land alone.
+
+The rejections are informative, so this is recoverable in one round trip: each
+one names the gate the other fix left broken. The smallest landable unit is both
+fixes in one push. Keep them as separate commits so review stays atomic, but do
+not try to split the push.
+
+### A branch that predates the breakage pushes cleanly
+
+A branch cut before the breaking commit never runs the gate against it, so that
+defect cannot block its push. This proves nothing else. The branch may still
+fail other gates, and its CI fails as soon as `refs/pull/N/merge` is recomputed
+against a red `main`. Until that recompute it can even show green, for the
+caching reason in "Fixing `main` does not fix your PR until the merge ref moves"
+below.
+
+So a clean push is not evidence that `main` is green. Check explicitly:
+
+```bash
+git merge-base --is-ancestor <breaking-sha> <your-branch>
+case $? in
+  0) echo "contains the breaking commit" ;;
+  1) echo "predates it, so that gate never ran" ;;
+  *) echo "git error, resolve the refs first" ;;
+esac
+```
+
+Do not collapse this into `&& ... || ...`. `git merge-base` exits 128 on an
+unknown ref, and the `||` arm would report that as "predates it".
+
+Measured 2026-08-02: `fix/instruction-budget-dedup` pushed without complaint
+because it predated the breaking commit, while a branch cut from current `main`
+minutes later was rejected.
+
+### `cancel-in-progress: false` does not mean every run completes
+
+A merge burst can leave a defect with no CI evidence at all, which is why the
+local probe above is sometimes the only way to see it.
+
+Within one concurrency group GitHub keeps at most one run in flight and one
+queued. A newly queued run supersedes the previously queued one and cancels it.
+That happens whatever `cancel-in-progress` says, because the setting only
+governs whether the RUNNING run is killed.
+
+Measured 2026-08-02 on the Instruction Budget workflow, whose concurrency sets
+`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`, which is `false`
+for a push to `main`:
+
+| Window | Commits pushed to `main` | Runs cancelled | Runs measured |
+| --- | --- | --- | --- |
+| 21:45:35 to 21:46:20 | 21 | 20 | 1 |
+
+Every cancelled run reported `jobs=0` and lived 2 to 5 seconds, so none of them
+started a job. Confirm that rather than inferring it:
+
+```bash
+gh run view <run-id> --json conclusion,startedAt,updatedAt,jobs \
+  -q '"\(.conclusion) jobs=\(.jobs|length)"'
+```
+
+For a whole-tree check this is survivable on its own. The surviving run measures
+the tree as it now stands, and nobody needs the intermediate states. It stops
+being survivable when the surviving run also skips, which is what a path filter
+does when the final commit happens to touch none of the filtered paths. In the
+window above the one surviving run skipped `Validate budget`, so 21 consecutive
+commits produced zero budget measurements and one green tick.
+
+Treat cancellation and filtering as one failure together, not two separately
+tolerable ones.
 
 ## Corollary: two differently named red checks can be one bug
 

--- a/.serena/memories/ci/ci-spec-coverage-fails-without-checked-acceptance-boxes.md
+++ b/.serena/memories/ci/ci-spec-coverage-fails-without-checked-acceptance-boxes.md
@@ -1,0 +1,84 @@
+# Skill: Validate Spec Coverage fails without checked acceptance boxes in the PR body (98%)
+
+## Statement
+
+`Validate Spec Coverage` returns `NEEDS_REVIEW` with reason
+`closed-loop:external-signal-inconclusive` when the pull request body has no
+acceptance-criteria checkbox list. The quality of the implementation does not
+enter into it. Nothing in the job name, the check name, or the pull request
+comment says the body is the problem.
+
+`scripts/external_signals/gate_aggregator.py:106` requires at least one signal
+of kind `external` whose verdict is passing or warning. The only external signal
+the spec gate emits is `acceptance-criteria`, extracted by
+`scripts/quality_gate/spec_external_signal_gate.py` from `PR_BODY_FILE`. With no
+criteria found it reports `UNKNOWN`, the external set is empty, and the gate
+refuses.
+
+Measured 2026-08-02 on PR #4294, whose two model signals were `trace=PASS` and
+`completeness=PARTIAL`, both healthy, while the job still exited 1.
+
+## The comment lies
+
+The job posts its verdict as a pull request comment marked
+`<!-- AI-SPEC-VALIDATION -->`, and the poster skips when a comment with that
+marker already exists:
+
+```text
+Comment with marker 'AI-SPEC-VALIDATION' already exists. Skipping.
+```
+
+So the visible comment is whatever the first run said. On PR #4294 it read
+`Final Verdict: PASS`, `Requirements Traceability PASS`,
+`Implementation Completeness PASS`, `5 of 5 covered, no gaps`, while the check
+itself was red. Read the job log, never the comment:
+
+```bash
+gh run view --job "$JOB_ID" --log | sed 's/\x1b\[[0-9;]*m//g' \
+  | grep -P 'VERDICT|"verdict"|"reason"'
+```
+
+## Format that parses
+
+The heading regex is `^#{1,6}\s*acceptance(?:\s+criteria)?\s*$`, case
+insensitive, and items must be Markdown task list checkboxes. All boxes checked
+gives `PASS`, any box unchecked gives `FAIL`, no section at all gives `UNKNOWN`.
+
+```markdown
+## Acceptance criteria
+
+- [x] first criterion
+- [x] second criterion
+```
+
+A numbered list does not parse. Issue #4257 writes its criteria as `1.` through
+`5.`, so copying the issue verbatim still yields `UNKNOWN`. The signal reads the
+pull request body, not the issue, so putting checkboxes only on the issue does
+nothing.
+
+## Reproduce locally in seconds
+
+The gate is deterministic and makes no model calls, so the whole verdict can be
+computed offline against a candidate body. This turns a three minute CI round
+trip into one command.
+
+```bash
+gh pr view "$PR" --json body --jq .body > body.md
+PR_BODY_FILE=body.md TRACE_VERDICT=PASS COMPLETENESS_VERDICT=PARTIAL \
+  uv run --frozen python scripts/quality_gate/spec_external_signal_gate.py
+```
+
+Measured on PR #4294 with the verdicts CI actually produced:
+
+| Body | Exit | Verdict | Reason |
+|---|---|---|---|
+| as filed | 1 | `NEEDS_REVIEW` | `closed-loop:external-signal-inconclusive` |
+| plus checked criteria | 0 | `WARN` | `warnings-present` |
+
+## Generalization
+
+This gate is a closed-loop guard, and its refusal is the intended behavior. Two
+signals from the same model agreeing with each other is one measurement, not
+two, so the gate declines to decide on model output alone and demands one
+deterministic signal it can compute itself. The fix is to supply that signal,
+never to argue the model into a better verdict.

--- a/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
+++ b/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
@@ -45,7 +45,43 @@ ps -eo pid,etime,args | grep "git push" | grep -v grep
 An absent log file five seconds in means the launch failed, not that the push
 is quiet.
 
-## Two adjacent traps
+The log alone cannot tell you which of four states you are in. Read it together
+with the process table and the `REAL_EXIT` sentinel.
+
+| Log | `REAL_EXIT` | Process | State |
+|---|---|---|---|
+| missing | absent | none | launch failed, the redirect had nowhere to write |
+| growing | absent | alive | still working, leave it alone |
+| full, ends on a success line | absent | none | killed midway, relaunch is correct |
+| any | present | none | finished, read the code |
+
+Measured on 2026-08-02: a 78 KB push log ended on `pre_pr.py` printing
+`Ready to create pull request!`, which reads exactly like completion. There was
+no `REAL_EXIT` line, no process, and `git ls-remote` still showed the old head.
+The push had been killed under machine load with the whole test suite still to
+run. The sentinel is the only completion signal in the log that means anything.
+
+Detect the process by the branch name, never by the refspec. The command is
+usually written `git push origin HEAD:<branch>`, so a grep for
+`git push origin <branch>` matches nothing while the push is very much alive.
+That miss reads as "the push died" and invites a relaunch, which queues behind
+the first one on the flock and doubles the machine load.
+
+```bash
+# reliable: the branch alone, plus the worktree the push runs in
+ps -eo pid,etimes,args | grep "$BR" | grep -v grep
+for p in $(ps -eo pid --no-headers); do
+  case "$(readlink /proc/$p/cwd 2>/dev/null)" in
+    *"$(basename "$WT")"*) echo "$p $(tr '\0' ' ' < /proc/$p/cmdline)";;
+  esac
+done
+```
+
+Measured on 2026-08-02: `grep 'git push origin docs/memory'` returned nothing
+against a push that had been running for 650 seconds as
+`git push origin HEAD:docs/memory-red-main-blocks-push`.
+
+## Three adjacent traps
 
 Use `nohup setsid`. An async process merely backgrounded from the agent session
 is killed when that session shuts down, for example at context compaction. Two
@@ -62,6 +98,26 @@ An empty `git ls-remote` result for a branch that should exist is worth a second
 look rather than a conclusion: after a squash merge GitHub deletes the source
 branch, so "no remote ref" can mean "already merged" rather than "never pushed".
 Check `gh pr view <n> --json state,headRefOid` before concluding anything.
+
+Put the `cd` inside the process you launch. Writing
+`cd "$WT" && nohup setsid ... &` backgrounds the entire `&&` list, so the `cd`
+happens in the subshell and the parent shell never moves. Every command after
+it in the same invocation runs in the original directory. With several
+worktrees sharing one repository that is silent and dangerous: `git rev-parse
+HEAD` answers for a different branch and the output looks completely normal.
+
+```bash
+# wrong: the cd is backgrounded along with everything else
+cd "$WT" && nohup setsid bash -c "git push origin $BR > $S/p.log 2>&1" &
+
+# right: the cd belongs to the launched shell, and follow-ups name the path
+nohup setsid bash -c "cd '$WT' && git push origin $BR > $S/p.log 2>&1; \
+  echo REAL_EXIT=\$? >> $S/p.log" >/dev/null 2>&1 &
+git -C "$WT" rev-parse HEAD
+```
+
+Demonstrated 2026-08-02: `cd alpha && sleep 0.2 &` followed by `pwd` in the
+same invocation printed `beta`, the starting directory.
 
 ## Generalization
 

--- a/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
+++ b/.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md
@@ -55,6 +55,10 @@ with the process table and the `REAL_EXIT` sentinel.
 | full, ends on a success line | absent | none | killed midway, relaunch is correct |
 | any | present | none | finished, read the code |
 
+The table answers whether the push finished, never what it carried. A clean
+`REAL_EXIT=0` on a detached worktree pushes the wrong commit and looks identical
+to success; see `git-empty-hook-run-means-an-empty-push` for the content check.
+
 Measured on 2026-08-02: a 78 KB push log ended on `pre_pr.py` printing
 `Ready to create pull request!`, which reads exactly like completion. There was
 no `REAL_EXIT` line, no process, and `git ls-remote` still showed the old head.

--- a/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
+++ b/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
@@ -1,0 +1,78 @@
+# Skill: A pre-push run that skips every hook means the push carries no commits (95%)
+
+## Statement
+
+Lefthook reports `(skip) no matching push files` for a step when the pushed
+range contains no file matching that step's glob. When *every* step reports it,
+including `python-tests`, `pre-pr-validation`, `security-scan` and
+`build-all-check`, the range itself is empty. The push is a no-op.
+
+That reads like a validation bypass. It is not one. The hooks are right and the
+push is wrong.
+
+Measured 2026-08-02: a push reported `* [new branch] HEAD -> fix/...` and
+`REAL_EXIT=0` in ten seconds, on a repository where the previous push of a
+comparable branch took roughly 660 seconds. Every lefthook step skipped.
+`gh pr create` then refused the branch with `No commits between main and
+fix/...`, and `git ls-remote` showed the new branch and `main` at the same sha.
+
+## Cause
+
+The worktree was in detached HEAD at the tip of `main`:
+
+```text
+9c1c25c21  commit: fix(tests): stop the CI env var choosing the assertion
+22588a0f4  checkout: moving from fix/command-size-test-ci-env-leak to HEAD~1
+```
+
+The detach was a deliberate verification step: check out the parent commit,
+confirm the test fails without the fix, prove the fix is load bearing. The
+checkout back to the branch never happened. Pushing `HEAD` then sent `main`'s
+tip under the feature branch name, which is a legal operation that git reports
+as success.
+
+Every signal that normally confirms a push agreed with itself. `git rev-parse
+HEAD` returned a plausible sha, `git ls-remote` returned the same sha, and the
+log ended in `REAL_EXIT=0`. All three were true statements about the wrong
+commit.
+
+## Recipe
+
+Check the branch, not the sha. A detached worktree returns an empty string,
+while `git rev-parse HEAD` looks perfectly healthy.
+
+```bash
+test -n "$(git -C "$WT" branch --show-current)" || echo "DETACHED, do not push"
+```
+
+Then confirm the push has content. This one check catches detached HEAD, an
+accidentally reset branch, and an already merged branch together.
+
+```bash
+git -C "$WT" rev-list --count origin/main..HEAD   # ahead count, must be > 0
+git -C "$WT" diff --stat origin/main...HEAD       # must list only your files
+```
+
+The diff needs three dots and the count needs two. Three dots diff from the
+merge base, which is what the pull request shows. Two dots diff from the current
+tip of `main`, so the moment `main` advances they report every change you have
+not merged yet as though you were reverting it. Measured 2026-08-02 on a branch
+three commits behind: two dots reported 29 files and 1315 deletions, three dots
+reported the 5 files actually changed, and `gh pr view --json files` agreed with
+the three dot answer.
+
+Recovery does not need a force push. `git checkout $BR` reattaches, and because
+the wrongly pushed commit is an ancestor of the real one, a plain
+`git push origin $BR` fast forwards. Prove it first:
+
+```bash
+git merge-base --is-ancestor "$WRONG_SHA" HEAD && echo fast-forward-safe
+```
+
+## Generalization
+
+`REAL_EXIT=0` answers whether the push finished, never what it carried.
+Completion and content are different measurements, and the push workflow
+supplies only the first. The hook summary is the cheapest content signal
+available for free: a run where nothing matched is a run where nothing was
+sent.

--- a/.serena/memories/git/git-hooks-observations.md
+++ b/.serena/memories/git/git-hooks-observations.md
@@ -1,7 +1,7 @@
 # Skill Sidecar Learnings: Git Hooks
 
-**Last Updated**: 2026-03-01
-**Sessions Analyzed**: 2 (Sessions 1190, PR-1363)
+**Last Updated**: 2026-08-02
+**Sessions Analyzed**: 3 (Sessions 1190, PR-1363, fleet push triage 2026-08-02)
 
 ## Constraints (HIGH confidence)
 
@@ -40,6 +40,12 @@
   - Evidence: `build/generate_agents.py` line 228 converted to CRLF. `.gitattributes` line 59 enforces `eol=lf`. Hook regenerated CRLF, git normalized to LF on stage, hook detected change, regenerated CRLF again. Commit never completed.
   - Fix: Changed generator to output LF, matching .gitattributes. Historical context: CRLF was added before PR #902 (which introduced eol=lf).
 
+- `git push` runs the entire test suite, so a slow push is working, not hung (2026-08-02)
+  - Evidence: `lefthook.yml` pre-push stage `python-tests` runs `git_hook_policy.py pytest`. `_pytest_commands` at `scripts/validation/git_hook_policy.py:5528` passes `str(repo_root / "tests")` with `-m "not integration"`, the whole tree, not a changed-file subset. `pytest tests --collect-only -q` reports 22091 tests collected.
+  - Context: Budget is `TEST_SUITE_TIMEOUT_SECONDS = 1_740` at `git_hook_policy.py:395`, 29 minutes, under a `timeout: 30m` lefthook deadline. A 20 minute push is inside budget, not a fault.
+  - Context: Under fleet load the suites contend for CPU. Measured 2026-08-02 with roughly 10 sibling agents pushing: three of my own pushes sat at 18, 12, and 6 minutes simultaneously, each burning ~39% of a core in pytest while `git-remote-https` sat idle at 0%.
+  - Learning: Never relaunch a push that looks stuck, and never read the slowness as a network problem. A second push on the same branch just queues behind the first on the flock and doubles the machine load.
+
 ## Preferences (MED confidence)
 
 - BREAKING CHANGE commits use exclamation mark in conventional commit format (Session 1190, 2026-02-08)
@@ -64,6 +70,12 @@
 - GIT_TRACE=2 reveals full hook execution including where `set -e` exits (PR-1363, 2026-03-01)
   - Evidence: Standard commit output showed all checks passing. `GIT_TRACE=2` showed execution stopped after scope detector. `bash -x .githooks/pre-commit` confirmed HOOK_EXIT=1.
   - Technique: When commits fail silently, use `bash -x .githooks/pre-commit` first (faster), then `GIT_TRACE=2 git commit` for full git-level trace.
+
+- `ps --forest` tells a hook-bound push apart from a network-bound one (2026-08-02)
+  - Evidence: `ps -eo pid,ppid,etimes,stat,pcpu,args --forest` showed `git push` with two children: `git remote-https` at 0.0% CPU and `.git/hooks/pre-push` still alive at 1155s, whose own descendant chain ended in `python3 -m pytest -m not integration .../tests` at 39.1% CPU. The network child being idle while the hook child burns CPU is the whole diagnosis.
+  - Technique: `ps -eo pid,ppid,etimes,stat,pcpu,args --forest | awk -v p=<pid> 'BEGIN{f=0} $1==p{f=1} f'` prints one push and everything under it.
+  - Note: The hook resolves through the shared `.git/hooks/pre-push` of the primary clone even when the push runs from a linked worktree, but it executes that worktree's own `.venv`. A worktree with a stale venv fails here and nowhere else.
+  - Note: A push log that ends on `pre_pr.py` printing "Ready to create pull request!" has NOT finished. That is one lefthook step reporting, with the suite still to come. Judge by the process tree and by `git ls-remote`, never by the log tail.
 
 ## Related Memories
 

--- a/.serena/memories/git/git-working-tree-mutates-under-you-during-pre-push.md
+++ b/.serena/memories/git/git-working-tree-mutates-under-you-during-pre-push.md
@@ -1,0 +1,62 @@
+# Skill: Your working tree can mutate under you during a pre-push run (85%)
+
+## Statement
+
+While a pre-push hook is running the full test suite in a worktree, a tracked
+source file you never touched can appear as modified, then revert to clean a
+few minutes later.
+
+Observed on 2026-08-02 in a linked worktree during a live push:
+
+```diff
+-        print("ERROR: ADR changes require a debate log in .agents/critique", file=sys.stderr)
++        print("ERROR: ADR changes require a debate log in .agents/wrong-dir",  # M2 mutant
++               file=sys.stderr)
+```
+
+The file was `scripts/validation/git_hook_policy.py`. I made no edit to it. Two
+`git diff --stat` readings seconds apart disagreed on the line count, so it was
+being rewritten in place. Minutes later the file matched `HEAD` byte for byte
+and `grep -c mutant` returned 0. No `M2 mutant` or `wrong-dir` string exists
+anywhere under `tests/` or `scripts/` in the committed tree.
+
+The writer was not identified. The shape is a mutation check that edits a guard,
+asserts the guard fails, and restores the original. Treat the owner as unknown
+and the behavior as real, because the behavior is what costs you.
+
+## Why it is dangerous
+
+The window is exactly the window in which you are most likely to commit. A push
+takes about twenty minutes here, so the habit is to keep working, and a
+`git add -A` or `git commit -a` during that window silently captures a
+deliberately sabotaged validator. That change looks authored, passes review by
+eye, and disables a guard on `main`.
+
+## Recipe
+
+Stage by explicit path. Never `git add -A`, never `git commit -a`, in a
+worktree with a hook run in flight.
+
+```bash
+git add path/to/the/one/file.md
+git diff --cached --stat      # confirm only your files appear
+git status --porcelain        # anything unexpected here is not yours
+```
+
+If an unexpected modification shows up, do not revert it and do not commit it.
+Re-read it a minute later. A transient mutant reverts itself, and reverting it
+mid-check would make a running assertion fail for the wrong reason.
+
+## Corollary
+
+A guard that fails once, alone, with no code change to explain it is consistent
+with a transient mutant being live when that guard ran. This repo saw a single
+unexplained `adr_review_policy` failure earlier in the same session. That is a
+hypothesis the observation fits, not a proven cause, but it is enough reason to
+re-run a lone guard failure before investigating it as a real defect.
+
+## Generalization
+
+A working tree is shared mutable state whenever any automation runs against it.
+Treat `git status` as a reading taken at an instant, not as a fact about the
+session, and take it again immediately before the commit that depends on it.


### PR DESCRIPTION
## Summary

Six Serena memories about signals that lie to you during a push or a CI check.
Every one was measured this session while working under fleet load, and each
records a wrong conclusion I actually reached before the evidence corrected it.

## What each file records

| File | The lie | The measurement |
|---|---|---|
| `.serena/memories/ci/ci-a-red-check-on-your-pr-may-be-inherited-from-main.md` | A red check on your PR is your fault | Red `main` blocks `git push` outright, and a merge burst leaves no CI evidence at all |
| `.serena/memories/git/git-hooks-observations.md` | A slow push is a network problem | The pre-push hook runs 22091 tests inside a 29 minute budget, so it is CPU bound |
| `.serena/memories/git/git-detached-push-dies-if-log-dir-vanishes.md` | The push died, relaunch it | A `ps` grep for the wrong refspec form misses a live push |
| `.serena/memories/git/git-working-tree-mutates-under-you-during-pre-push.md` | Nothing edits your tree but you | A tracked validator appeared mutated mid-push, then reverted itself |
| `.serena/memories/git/git-empty-hook-run-means-an-empty-push.md` | Every hook skipped, so validation was bypassed | The worktree was detached at `main`, so the push carried nothing and the hooks were right |
| `.serena/memories/ci/ci-spec-coverage-fails-without-checked-acceptance-boxes.md` | The check is red, so the implementation is wrong | Both model signals were healthy; the pull request body had no checkbox section |

## Why these are worth committing

The merge burst finding came from 21 commits landing in 45 seconds. Twenty of
those runs were cancelled with `jobs=0` at lifetimes between 2 and 5 seconds, so
the branch carried a green tick that no job had earned.

The refspec finding cost me a wrong verdict in this session. A push had been
running for 650 seconds as `git push origin HEAD:docs/memory-red-main-blocks-push`
while a grep for `git push origin docs/memory` returned nothing. I concluded the
push was dead. Relaunching would have queued a second push behind the first on
the flock and doubled the load on an already saturated machine. The file now
carries a four state table so the log tail, the sentinel, and the process table
are read together instead of separately.

The working tree finding is the one with teeth. A `git add -A` during a pre-push
window would have captured a deliberately sabotaged validator, and the resulting
commit would look authored and pass review by eye.

The empty push finding started as an alarm and ended as a diagnostic. A push
finished in ten seconds with every lefthook step reporting `(skip) no matching
push files`, including `python-tests` and `security-scan`. That looked like a
hole big enough to drive any change through. It was the opposite: a
`git checkout HEAD~1` used to prove a fix was load bearing had left the worktree
detached, so the push sent `main`'s tip under a feature branch name and the
hooks correctly matched nothing. `git rev-parse HEAD`, `git ls-remote`, and
`REAL_EXIT=0` all agreed with each other about the wrong commit. `gh pr create`
was the first thing to object, with `No commits between main and fix/...`.

That file also records a two dot versus three dot correction, because the first
content check I wrote for it was wrong in exactly the way it warns about. On a
branch three commits behind `main`, `git diff origin/main..HEAD` reported 29
files and 1315 deletions, while `git diff origin/main...HEAD` reported the 5
files actually changed and matched `gh pr view --json files`.

The spec coverage finding is the one that wastes the most time per occurrence.
`Validate Spec Coverage` failed on PR #4294 with
`closed-loop:external-signal-inconclusive` while its two model signals read
`trace=PASS` and `completeness=PARTIAL`. The cause was the pull request body:
the gate needs one deterministic external signal, the only one available is an
acceptance-criteria checkbox list parsed from the body, and a body without one
reports `UNKNOWN`. At the same moment the pull request carried a visible
`AI-SPEC-VALIDATION` comment reading `Final Verdict: PASS` with five of five
criteria covered, because that comment is posted once and never updated.

That gate is a closed-loop guard and its refusal is correct. Two signals from
the same model agreeing is one measurement, not two. The memory records the
offline reproduction, which computes the entire verdict in one command because
the gate makes no model calls: the body as filed exits 1, the body plus checked
criteria exits 0.

## Verification

Each memory states only what was measured. Where a cause could not be
demonstrated, the file says the owner is unknown rather than naming a mechanism.
`memory-skill-format`, `memory-index`, `memory-cross-reference` and
`memory-sync-advisory` all pass in the commit hook.

Refs #3419
