### PR TITLE
fix(ci): always measure the instruction budget on a push to main

### DIFF
--- a/.claude/rules/ci-scripts.md
+++ b/.claude/rules/ci-scripts.md
@@ -62,6 +62,39 @@ uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
 
 **The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
+## Path filters gate the diff, never the tree
+
+A path filter states that the verdict cannot change unless those paths change.
+That is true for a check whose input is the diff. It is false for a check that
+scores the whole tree. When the filter misses on a whole-tree check, the gated
+job is skipped and its companion skip job reports success in its place. Nothing
+is inherited from a previous run. A fresh green tick is manufactured, and it
+asserts only that the diff was uninteresting.
+
+Decide by the check's input, not by which paths look related:
+
+| Check reads | Path filter | On `push` to `main` |
+| --- | --- | --- |
+| The diff | Correct | May skip |
+| The whole tree | Wrong on the mainline | MUST run |
+
+Force the mainline run in Python, not in a YAML `if:` (ADR-006).
+`scripts/workflows/determine_should_run_from_filters.py` reads
+`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
+determine step and leaves the job conditions alone.
+
+Do not reach for the concurrency group instead. Within one group GitHub keeps
+one run in flight and one queued, and a newly queued run cancels the previously
+queued one whatever `cancel-in-progress` says; that setting governs only the
+running run. Measured 2026-08-02: 21 commits to `main` in 45 seconds produced 20
+cancelled runs, each with `jobs=0` and a lifetime of 2 to 5 seconds.
+
+Cancellation alone is survivable for a whole-tree check, because the surviving
+run measures the tree as it now stands and nobody needs the intermediate states.
+It stopped being survivable because the survivor also skipped on the path
+filter. That window produced zero measurements and one green tick on a tree 201
+bytes over its ceiling.
+
 ## References
 
 - `.agents/architecture/ADR-006-thin-workflows-testable-modules.md`. Workflow pattern

--- a/.github/instructions/ci-scripts.instructions.md
+++ b/.github/instructions/ci-scripts.instructions.md
@@ -52,6 +52,39 @@ uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
 
 **The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
+## Path filters gate the diff, never the tree
+
+A path filter states that the verdict cannot change unless those paths change.
+That is true for a check whose input is the diff. It is false for a check that
+scores the whole tree. When the filter misses on a whole-tree check, the gated
+job is skipped and its companion skip job reports success in its place. Nothing
+is inherited from a previous run. A fresh green tick is manufactured, and it
+asserts only that the diff was uninteresting.
+
+Decide by the check's input, not by which paths look related:
+
+| Check reads | Path filter | On `push` to `main` |
+| --- | --- | --- |
+| The diff | Correct | May skip |
+| The whole tree | Wrong on the mainline | MUST run |
+
+Force the mainline run in Python, not in a YAML `if:` (ADR-006).
+`scripts/workflows/determine_should_run_from_filters.py` reads
+`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
+determine step and leaves the job conditions alone.
+
+Do not reach for the concurrency group instead. Within one group GitHub keeps
+one run in flight and one queued, and a newly queued run cancels the previously
+queued one whatever `cancel-in-progress` says; that setting governs only the
+running run. Measured 2026-08-02: 21 commits to `main` in 45 seconds produced 20
+cancelled runs, each with `jobs=0` and a lifetime of 2 to 5 seconds.
+
+Cancellation alone is survivable for a whole-tree check, because the surviving
+run measures the tree as it now stands and nobody needs the intermediate states.
+It stopped being survivable because the survivor also skipped on the path
+filter. That window produced zero measurements and one green tick on a tree 201
+bytes over its ceiling.
+
 ## References
 
 - `.agents/architecture/ADR-006-thin-workflows-testable-modules.md`. Workflow pattern

--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -8,7 +8,9 @@
 # Exit codes: 0 = pass, 1 = budget exceeded, 2 = config error (ADR-035).
 #
 # IMPORTANT: This workflow runs on ALL PRs to satisfy required status checks,
-# but skips actual validation when no relevant files are changed.
+# but skips actual validation when no relevant files are changed. A push to
+# main always validates, because the budget scores the whole corpus and the
+# skip path reports a fresh green tick without measuring the tree.
 
 name: Instruction Budget
 
@@ -60,6 +62,12 @@ jobs:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
           FILTER_KEYS: rules,validator
           OUTPUT_NAME: should-run-budget
+          # The budget scores the whole .github/instructions corpus, not the
+          # diff, so a push to main must always measure it. When the filter
+          # misses, Validate budget is skipped and Skip budget reports success
+          # in its place, which is a green tick that asserts nothing about the
+          # tree. See the should_run docstring for the measured case.
+          FORCE_RUN_EVENTS: push
         run: python3 scripts/workflows/determine_should_run_from_filters.py
 
   validate-budget:

--- a/scripts/workflows/determine_should_run_from_filters.py
+++ b/scripts/workflows/determine_should_run_from_filters.py
@@ -7,22 +7,52 @@ import json
 import os
 import re
 import sys
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from pathlib import Path
 
 _OUTPUT_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 
 
 def should_run(
-    event_name: str, filter_outputs: Mapping[str, object], filter_keys: list[str]
+    event_name: str,
+    filter_outputs: Mapping[str, object],
+    filter_keys: list[str],
+    force_run_events: Collection[str] = (),
 ) -> bool:
-    if event_name == "workflow_dispatch":
+    """Decide whether the gated job runs for this event.
+
+    ``force_run_events`` names events that bypass the path filter. A path filter
+    encodes the claim that the verdict cannot change unless those paths change.
+    That holds for a check whose input is the diff. It fails for a whole-tree
+    check on the mainline: when the filter misses, the gated job is skipped and
+    its companion skip job reports success in its place, so the workflow goes
+    green without measuring anything. Nothing carries over from the previous
+    run. A fresh green tick is manufactured, and it asserts only that the diff
+    was uninteresting.
+
+    Measured 2026-08-02: ``main`` at ``a72ee868c`` was 201 bytes over the
+    always-on instruction ceiling while the Instruction Budget workflow reported
+    success, because ``Validate budget`` was skipped and ``Skip budget (no
+    changes)`` passed in its place. The commit that caused the breach had its own
+    run cancelled in a merge burst, so no run ever measured the breach.
+
+    List ``push`` here for a whole-tree check so the mainline is always measured.
+    Leave it empty for a diff-scoped check, where re-running on an unrelated push
+    buys nothing.
+    """
+    if event_name == "workflow_dispatch" or event_name in force_run_events:
         return True
     return any(filter_outputs.get(key) == "true" for key in filter_keys)
 
 
 def parse_filter_keys(raw_filter_keys: str) -> list[str]:
     return [key.strip() for key in raw_filter_keys.split(",") if key.strip()]
+
+
+def parse_force_run_events(raw_force_run_events: str) -> frozenset[str]:
+    return frozenset(
+        event.strip() for event in raw_force_run_events.split(",") if event.strip()
+    )
 
 
 def parse_filter_outputs(raw_filter_outputs: str) -> dict[str, object]:
@@ -50,7 +80,8 @@ def main() -> int:
         event_name = os.environ.get("GH_EVENT_NAME", "")
         filter_keys = parse_filter_keys(os.environ.get("FILTER_KEYS", ""))
         filter_outputs = parse_filter_outputs(os.environ.get("FILTER_OUTPUTS", "{}"))
-        value = should_run(event_name, filter_outputs, filter_keys)
+        force_run_events = parse_force_run_events(os.environ.get("FORCE_RUN_EVENTS", ""))
+        value = should_run(event_name, filter_outputs, filter_keys, force_run_events)
         write_output(output_path, output_name, value)
     except (KeyError, OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/src/copilot-cli/instructions/ci-scripts.instructions.md
+++ b/src/copilot-cli/instructions/ci-scripts.instructions.md
@@ -52,6 +52,39 @@ uv run --frozen --extra dev python scripts/ci/ruff_count_ratchet.py --update
 
 **The failure never names the offending file.** It reports a delta, and the remediation command it suggests prints the same aggregate. Locate the offender by diffing per-file counts against `origin/main`; the linter needs `--format json -- <files>` because with no file arguments it scans nothing and reports zero, which reads as a clean tree. Prove attribution instead of inferring it: `git rm --cached <suspect>` and re-run; if the ratchet returns OK, that file was the whole delta.
 
+## Path filters gate the diff, never the tree
+
+A path filter states that the verdict cannot change unless those paths change.
+That is true for a check whose input is the diff. It is false for a check that
+scores the whole tree. When the filter misses on a whole-tree check, the gated
+job is skipped and its companion skip job reports success in its place. Nothing
+is inherited from a previous run. A fresh green tick is manufactured, and it
+asserts only that the diff was uninteresting.
+
+Decide by the check's input, not by which paths look related:
+
+| Check reads | Path filter | On `push` to `main` |
+| --- | --- | --- |
+| The diff | Correct | May skip |
+| The whole tree | Wrong on the mainline | MUST run |
+
+Force the mainline run in Python, not in a YAML `if:` (ADR-006).
+`scripts/workflows/determine_should_run_from_filters.py` reads
+`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
+determine step and leaves the job conditions alone.
+
+Do not reach for the concurrency group instead. Within one group GitHub keeps
+one run in flight and one queued, and a newly queued run cancels the previously
+queued one whatever `cancel-in-progress` says; that setting governs only the
+running run. Measured 2026-08-02: 21 commits to `main` in 45 seconds produced 20
+cancelled runs, each with `jobs=0` and a lifetime of 2 to 5 seconds.
+
+Cancellation alone is survivable for a whole-tree check, because the surviving
+run measures the tree as it now stands and nobody needs the intermediate states.
+It stopped being survivable because the survivor also skipped on the path
+filter. That window produced zero measurements and one green tick on a tree 201
+bytes over its ceiling.
+
 ## References
 
 - `.agents/architecture/ADR-006-thin-workflows-testable-modules.md`. Workflow pattern

--- a/tests/workflows/test_determine_should_run_from_filters.py
+++ b/tests/workflows/test_determine_should_run_from_filters.py
@@ -9,6 +9,7 @@ import pytest
 from scripts.workflows.determine_should_run_from_filters import (
     main,
     parse_filter_keys,
+    parse_force_run_events,
     should_run,
     write_output,
 )
@@ -34,6 +35,46 @@ class TestShouldRun:
 
     def test_missing_filters_skip(self) -> None:
         assert not should_run("pull_request", {}, ["context"])
+
+
+class TestShouldRunForceRunEvents:
+    """A whole-tree check must measure the mainline even when the diff misses it."""
+
+    def test_forced_event_runs_despite_false_filters(self) -> None:
+        assert should_run("push", {"rules": "false"}, ["rules"], {"push"})
+
+    def test_forced_event_runs_when_filters_absent(self) -> None:
+        assert should_run("push", {}, ["rules"], {"push"})
+
+    def test_unlisted_event_still_skips(self) -> None:
+        assert not should_run("pull_request", {"rules": "false"}, ["rules"], {"push"})
+
+    def test_listed_event_does_not_force_a_different_event(self) -> None:
+        assert not should_run("schedule", {"rules": "false"}, ["rules"], {"push"})
+
+    def test_default_empty_preserves_prior_behavior(self) -> None:
+        assert not should_run("push", {"rules": "false"}, ["rules"])
+
+    def test_true_filter_still_runs_for_an_unlisted_event(self) -> None:
+        assert should_run("pull_request", {"rules": "true"}, ["rules"], {"push"})
+
+    def test_workflow_dispatch_runs_with_force_list_present(self) -> None:
+        assert should_run("workflow_dispatch", {"rules": "false"}, ["rules"], {"push"})
+
+
+class TestParseForceRunEvents:
+    def test_splits_and_strips(self) -> None:
+        assert parse_force_run_events("push, schedule") == frozenset(
+            {"push", "schedule"}
+        )
+
+    def test_empty_string_yields_empty_set(self) -> None:
+        assert parse_force_run_events("") == frozenset()
+
+    def test_drops_blank_entries(self) -> None:
+        assert parse_force_run_events("push,, ,schedule") == frozenset(
+            {"push", "schedule"}
+        )
 
 
 class TestParseFilterKeys:
@@ -95,3 +136,35 @@ class TestMain:
         monkeypatch.setenv("FILTER_OUTPUTS", "{")
 
         assert main() == 2
+
+    def test_force_run_events_env_overrides_false_filters(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        output = tmp_path / "github_output"
+        monkeypatch.setenv("OUTPUT_NAME", "should-run-budget")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        monkeypatch.setenv("GH_EVENT_NAME", "push")
+        monkeypatch.setenv("FILTER_KEYS", "rules,validator")
+        monkeypatch.setenv("FILTER_OUTPUTS", '{"rules":"false","validator":"false"}')
+        monkeypatch.setenv("FORCE_RUN_EVENTS", "push")
+
+        rc = main()
+
+        assert rc == 0
+        assert output.read_text(encoding="utf-8") == "should-run-budget=true\n"
+
+    def test_absent_force_run_events_env_leaves_push_gated(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        output = tmp_path / "github_output"
+        monkeypatch.setenv("OUTPUT_NAME", "should-run-budget")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        monkeypatch.setenv("GH_EVENT_NAME", "push")
+        monkeypatch.setenv("FILTER_KEYS", "rules,validator")
+        monkeypatch.setenv("FILTER_OUTPUTS", '{"rules":"false","validator":"false"}')
+        monkeypatch.delenv("FORCE_RUN_EVENTS", raising=False)
+
+        rc = main()
+
+        assert rc == 0
+        assert output.read_text(encoding="utf-8") == "should-run-budget=false\n"


### PR DESCRIPTION
## Summary

The Instruction Budget check reported success on a tree that was **201 bytes
over its ceiling**. This makes the check actually run on every push to `main`.

Refs #3419

## What happened

`main` at `a72ee868c` measured `83201/83000` locally and the Instruction Budget
workflow was green for that exact commit. Run `30768626850` shows why:

| Job | Conclusion |
| --- | --- |
| Detect changes | success |
| **Validate budget** | **skipped** |
| Skip budget (no changes) | success |

The budget scores the whole `.github/instructions/*.instructions.md` corpus, but
it was gated behind a `dorny/paths-filter` on `.claude/rules/**` and
`.github/instructions/**`. `a72ee868c` touches neither, so the filter never
fired, `Validate budget` was skipped, and the companion skip job reported
success in its place.

That green tick is not inherited from an earlier run. It is **freshly
manufactured** by the skip job, and it asserts only that the diff was
uninteresting. That distinction is the whole bug: an inherited verdict would at
least have been true once.

## The commit that caused the breach never reported at all

Twenty-one commits landed on `main` between 21:45:35 and 21:46:20, 45 seconds.

| Runs in that window | Count |
| --- | --- |
| Cancelled with `jobs=0`, lifetime 2 to 5s | **20** |
| Reached a job | 1 (`a72ee868c`, which then skipped) |

`cancel-in-progress` is not the cause. It is
`${{ github.ref != 'refs/heads/main' }}`, which evaluates to **false** for a push
to `main`, and it governs only the *running* run in any case. The cancellations
come from GitHub's pending-run supersession: one run in flight and one queued per
concurrency group, and a newly queued run cancels the previously queued one.

Net: **21 consecutive commits, zero budget measurements, one green tick.** The
breach surfaced days later in a local pre-push rejection instead of in CI.

## Why the fix is one environment variable and not a merge queue

The conventional move is to stop the cancellation: merge queue, drop the
concurrency group, serialize merges. All expensive, all disruptive.

For a **whole-tree** check nobody needs the intermediate states. The surviving
run measures the tree as it now stands, which is the only question the budget
asks. So cancellation is survivable on its own. It became fatal only because the
survivor *also* skipped.

Fix the half that matters. Force the measurement on `push`, leave concurrency
alone.

The general rule, now recorded in `.claude/rules/ci-scripts.md`:

> A path filter asserts the verdict cannot change unless those paths change.
> True when the check's input is the diff. False when the check scores the whole
> tree.

## The change

`should_run()` gains an optional `force_run_events` collection, read from a new
`FORCE_RUN_EVENTS` environment variable. `instruction-budget.yml` sets it to
`push` on the `determine` step.

The job-level `if:` conditions are **deliberately untouched**, so no branching
logic moves into YAML (ADR-006).

## Blast radius

`determine_should_run_from_filters.py` is shared by four workflows:

| Workflow | Sets `FORCE_RUN_EVENTS`? | Behavior |
| --- | --- | --- |
| `instruction-budget` | yes, `push` | changed, intentionally |
| `skill-passive-compliance` | no | unchanged |
| `memory-health` | no | unchanged |
| `passive-context-budget` | no | unchanged |

The flag is opt-in and defaults to an empty frozenset. The other three look like
whole-tree checks too and probably want the same flag, but the defect was only
*demonstrated* here, so they are left alone rather than changed on a guess.

## Verification

- 24 tests pass, including 10 new ones: positive, negative, edge, backward
  compatibility, and two at the `main()` and environment level.
- `ruff` clean, `mypy` clean, workflow YAML parses, `actionlint` clean.
- Budget unchanged by the rule addition: `82992/83000` before and after, because
  `ci-scripts.md` is path-scoped rather than always-on.

## Adversarial review

Two reviews, two model families other than the author's.

**Correctness review** returned 0 bugs and 3 risks, all the same overclaim, all
accepted. The first draft said a skipped run leaves the verdict "inherited" and
that it "carries over". Both are wrong about the mechanism. Rewritten: the skip
path manufactures a fresh success.

**Security review** returned 0 findings across 5 checks, risk 1/10, confidence
95%:

- `FORCE_RUN_EVENTS` is a static literal; a fork author can trigger
  `pull_request` but cannot forge `push`.
- The gate is monotonic. Old result was `dispatch OR filter`; new is
  `dispatch OR forced OR filter`, so no prior `TRUE` can become `FALSE`.
- No injection path. Output names are regex-validated, values are fixed to
  `true` or `false`, and exactly one line reaches `GITHUB_OUTPUT`, so a newline
  or `::set-output` payload cannot forge an output.
- `contents: read` is the only permission; all five actions are SHA-pinned.
- Confirmed by reading all three sibling workflows that none sets the variable.

## Commits

1. `fix(ci)`: the workflow and script change, with tests.
2. `docs(rules)`: the class-level rule plus both regenerated mirrors.

Split because 6 files exceeds the 5-file commit cap.
