### PR TITLE
fix(eval): pin BEFORE_REF to pre-#2127 SHA; fail loud on identical arms

### DIFF
--- a/scripts/eval/eval_skill_router.py
+++ b/scripts/eval/eval_skill_router.py
@@ -10,7 +10,9 @@ sibling more often than the old ones did.
 For each fixture (a verbatim user request plus 2-4 candidate sibling skills) and
 each VARIANT in {before, after}, the scorer:
   1. Resolves every candidate's description text:
-       - before : `git show origin/main:<path>` (the pre-#2127 description)
+       - before : `git show fd379f0a85e0dc4362c3960a84a7ad5632270239:<path>`
+                  (the immutable first-parent of the #2127 merge commit 817e466f8;
+                  this is the state of main the instant before #2127 landed).
        - after  : the working-tree file (the rewritten description)
   2. Builds a router prompt that lists ONLY the candidate descriptions plus the
      user query, and instructs the model to reply with EXACTLY one candidate name.
@@ -47,9 +49,12 @@ Usage:
 
 Exit codes:
     0 ok
-    2 config (fixtures file invalid, candidate description failed to load, or
-              missing ANTHROPIC_API_KEY - a missing env var is config per ADR-035)
-    3 external (API failure)
+1 identical-arms (before and after descriptions are byte-identical for every
+  candidate in every fixture; the eval cannot measure any change and exits
+  loudly so the caller knows the result is not a null finding)
+2 config (fixtures file invalid, candidate description failed to load, or
+          missing ANTHROPIC_API_KEY - a missing env var is config per ADR-035)
+3 external (API failure)
 """
 
 from __future__ import annotations
@@ -65,7 +70,13 @@ from typing import Any, cast
 from _anthropic_api import call_api, load_api_key_for_selected_provider
 
 MODEL = "claude-sonnet-4-6"
-BEFORE_REF = "origin/main"
+# Immutable first-parent of the #2127 merge commit (817e466f8).
+# This is the exact state of main the instant before #2127 landed.
+# Do NOT change this to a branch name: a moving ref makes both arms
+# read identical bytes once the target commit is on that branch, and
+# a zero delta reads as "no improvement" when it actually means
+# "nothing was compared" (issue #4304).
+BEFORE_REF = "fd379f0a85e0dc4362c3960a84a7ad5632270239"
 MAX_TOKENS = 64
 
 REQUIRED_FIXTURE_FIELDS = {"id", "query", "candidates", "correct"}
@@ -368,6 +379,8 @@ def build_plan(fixtures: list[dict[str, Any]], repo_root: Path) -> list[dict[str
             {
                 "fixture": fx,
                 "paths": paths,
+                "before_desc": before_desc,
+                "after_desc": after_desc,
                 "prompts": {
                     "before": build_router_prompt(fx["query"], candidates, before_desc),
                     "after": build_router_prompt(fx["query"], candidates, after_desc),
@@ -375,6 +388,24 @@ def build_plan(fixtures: list[dict[str, Any]], repo_root: Path) -> list[dict[str
             }
         )
     return plan
+
+
+def check_identical_arms(plan: list[dict[str, Any]]) -> list[str]:
+    """Return a list of (fixture_id, candidate) pairs where before==after description.
+
+    An empty list means the two arms differ somewhere (healthy). A non-empty list
+    means those specific candidates read identical bytes in both variants. When
+    ALL candidates in EVERY fixture are identical the eval is a no-op and must
+    exit non-zero (exit 1) so the caller cannot mistake zero-delta for a null
+    finding (issue #4304).
+    """
+    identical_pairs: list[str] = []
+    for item in plan:
+        fx_id = item["fixture"]["id"]
+        for name in item["fixture"]["candidates"]:
+            if item["before_desc"][name] == item["after_desc"][name]:
+                identical_pairs.append(f"{fx_id}/{name}")
+    return identical_pairs
 
 
 def run_eval(plan: list[dict[str, Any]], api_key: str) -> dict[str, Any]:
@@ -475,6 +506,32 @@ def main() -> int:
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
+
+    # Detect identical arms: if before and after descriptions are byte-identical
+    # for every candidate in every fixture, the eval measures nothing. Exit 1
+    # loudly so the caller cannot mistake a zero-delta result for a null finding.
+    # Partial overlap (some candidates identical, some differ) is reported as a
+    # warning but does not abort, because a partial change is still measurable.
+    identical_pairs = check_identical_arms(plan)
+    total_candidate_slots = sum(len(item["fixture"]["candidates"]) for item in plan)
+    if identical_pairs and len(identical_pairs) == total_candidate_slots:
+        print(
+            "ERROR: identical arms detected. Before and after descriptions are "
+            "byte-identical for every candidate in every fixture. "
+            f"BEFORE_REF={BEFORE_REF!r} resolves to the same content as the "
+            "working tree for all candidates, so no change is being measured. "
+            "Fix BEFORE_REF to point to the immutable pre-change commit.",
+            file=sys.stderr,
+        )
+        return 1
+    if identical_pairs:
+        print(
+            f"WARNING: {len(identical_pairs)}/{total_candidate_slots} candidate slots "
+            "have identical before/after descriptions and will not contribute signal: "
+            + ", ".join(identical_pairs[:10])
+            + ("..." if len(identical_pairs) > 10 else ""),
+            file=sys.stderr,
+        )
 
     if args.dry_run:
         planned_calls = len(plan) * 2  # one before + one after per fixture

--- a/scripts/eval/eval_skill_router.py
+++ b/scripts/eval/eval_skill_router.py
@@ -11,8 +11,8 @@ For each fixture (a verbatim user request plus 2-4 candidate sibling skills) and
 each VARIANT in {before, after}, the scorer:
   1. Resolves every candidate's description text:
        - before : `git show fd379f0a85e0dc4362c3960a84a7ad5632270239:<path>`
-                  (the immutable first-parent of the #2127 merge commit 817e466f8;
-                  this is the state of main the instant before #2127 landed).
+                  (the immutable first-parent of the #2127 merge commit 817e466f8
+                  -- this is the state of main the instant before #2127 landed).
        - after  : the working-tree file (the rewritten description)
   2. Builds a router prompt that lists ONLY the candidate descriptions plus the
      user query, and instructs the model to reply with EXACTLY one candidate name.
@@ -391,7 +391,7 @@ def build_plan(fixtures: list[dict[str, Any]], repo_root: Path) -> list[dict[str
 
 
 def check_identical_arms(plan: list[dict[str, Any]]) -> list[str]:
-    """Return a list of (fixture_id, candidate) pairs where before==after description.
+    """Return a list of "fixture_id/candidate" strings where before==after description.
 
     An empty list means the two arms differ somewhere (healthy). A non-empty list
     means those specific candidates read identical bytes in both variants. When

--- a/tests/eval/test_eval_skill_router.py
+++ b/tests/eval/test_eval_skill_router.py
@@ -1,0 +1,260 @@
+"""Tests for eval_skill_router.py (issue #4304).
+
+Covers:
+- BEFORE_REF is an immutable SHA, not a moving branch name.
+- check_identical_arms detects when both eval arms read the same bytes.
+- main() exits 1 when all arms are identical (loud failure, not silent zero).
+- main() exits 0 (dry-run) when arms differ.
+- Partial identical coverage emits a warning but does not abort.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure scripts/eval is importable.
+_EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
+if str(_EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(_EVAL_DIR))
+
+import eval_skill_router as router
+
+# ---------------------------------------------------------------------------
+# BEFORE_REF is a fixed SHA (not a branch name)
+# ---------------------------------------------------------------------------
+
+class TestBeforeRefIsImmutable:
+    def test_before_ref_is_a_full_sha(self) -> None:
+        """BEFORE_REF must be a 40-hex-char commit SHA, not a branch/tag name."""
+        ref = router.BEFORE_REF
+        assert len(ref) == 40, (
+            f"BEFORE_REF={ref!r} is {len(ref)} chars; expected a 40-char SHA. "
+            "A moving branch name makes both eval arms read identical bytes "
+            "once the target commit lands on that branch (issue #4304)."
+        )
+        assert all(c in "0123456789abcdef" for c in ref.lower()), (
+            f"BEFORE_REF={ref!r} contains non-hex characters; not a valid SHA."
+        )
+
+    def test_before_ref_is_not_origin_main(self) -> None:
+        ref = router.BEFORE_REF
+        assert ref != "origin/main", (
+            "BEFORE_REF must be a pinned commit SHA. "
+            "'origin/main' is a moving ref; after PR #2127 merged it points to "
+            "post-#2127 content and makes both arms identical (issue #4304)."
+        )
+
+    def test_before_ref_does_not_contain_slash(self) -> None:
+        """A SHA never contains a slash; a branch/remote ref always does."""
+        assert "/" not in router.BEFORE_REF, (
+            f"BEFORE_REF={router.BEFORE_REF!r} looks like a remote ref, not a SHA."
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_identical_arms
+# ---------------------------------------------------------------------------
+
+def _make_plan_item(
+    fx_id: str,
+    candidates: list[str],
+    before_descs: dict[str, str],
+    after_descs: dict[str, str],
+) -> dict[str, Any]:
+    return {
+        "fixture": {"id": fx_id, "candidates": candidates, "query": "q", "correct": candidates[0]},
+        "before_desc": before_descs,
+        "after_desc": after_descs,
+        "paths": {c: f".claude/skills/{c}/SKILL.md" for c in candidates},
+        "prompts": {"before": "bp", "after": "ap"},
+    }
+
+
+class TestCheckIdenticalArms:
+    def test_all_identical_returns_all_pairs(self) -> None:
+        plan = [
+            _make_plan_item("f1", ["a", "b"],
+                            {"a": "desc-a", "b": "desc-b"},
+                            {"a": "desc-a", "b": "desc-b"}),
+        ]
+        result = router.check_identical_arms(plan)
+        assert set(result) == {"f1/a", "f1/b"}
+
+    def test_all_differ_returns_empty(self) -> None:
+        plan = [
+            _make_plan_item("f1", ["a", "b"],
+                            {"a": "old-a", "b": "old-b"},
+                            {"a": "new-a", "b": "new-b"}),
+        ]
+        assert router.check_identical_arms(plan) == []
+
+    def test_partial_identical_returns_only_identical(self) -> None:
+        plan = [
+            _make_plan_item("f1", ["a", "b"],
+                            {"a": "same", "b": "old-b"},
+                            {"a": "same", "b": "new-b"}),
+        ]
+        result = router.check_identical_arms(plan)
+        assert result == ["f1/a"]
+        assert "f1/b" not in result
+
+    def test_multiple_fixtures_all_identical(self) -> None:
+        plan = [
+            _make_plan_item("f1", ["x"], {"x": "d"}, {"x": "d"}),
+            _make_plan_item("f2", ["y"], {"y": "e"}, {"y": "e"}),
+        ]
+        result = router.check_identical_arms(plan)
+        assert set(result) == {"f1/x", "f2/y"}
+
+    def test_empty_plan_returns_empty(self) -> None:
+        assert router.check_identical_arms([]) == []
+
+
+# ---------------------------------------------------------------------------
+# main() exits 1 when all arms are identical
+# ---------------------------------------------------------------------------
+
+def _write_fixture(tmp_path: Path, candidates: list[str]) -> str:
+    fx = [{"id": "f1", "query": "what", "candidates": candidates, "correct": candidates[0]}]
+    p = tmp_path / "fx.json"
+    p.write_text(json.dumps(fx))
+    return str(p)
+
+
+def _make_skill_files(repo: Path, names: list[str], content: str) -> None:
+    """Create minimal SKILL.md files with the given description."""
+    for name in names:
+        d = repo / ".claude" / "skills" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(
+            f"---\ndescription: {content}\n---\n# {name}\n"
+        )
+
+
+class TestMainIdenticalArmsExits1:
+    def test_exits_1_when_all_arms_identical(self, tmp_path: Path) -> None:
+        """main() must exit 1, not 0, when before==after for every candidate."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_skill_files(repo, ["skill-a", "skill-b"], "shared description")
+
+        fx_path = _write_fixture(tmp_path, ["skill-a", "skill-b"])
+
+        # Patch git show to return the same content as the working tree.
+        def fake_git_show(cmd: list[str], **kwargs: Any) -> MagicMock:
+            # cmd is: git -C <repo> show <ref>:<path>
+            rel = cmd[-1].split(":", 1)[1]
+            content = (repo / rel).read_text()
+            m = MagicMock()
+            m.stdout = content
+            m.returncode = 0
+            return m
+
+        with patch("subprocess.run", side_effect=fake_git_show):
+            with patch("sys.argv", ["eval_skill_router.py",
+                                    "--fixtures", fx_path,
+                                    "--repo-root", str(repo),
+                                    "--dry-run"]):
+                rc = router.main()
+
+        assert rc == 1, f"Expected exit 1 (identical arms), got {rc}"
+
+    def test_exits_0_dry_run_when_arms_differ(self, tmp_path: Path) -> None:
+        """main() exits 0 on --dry-run when before and after differ."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_skill_files(repo, ["skill-a", "skill-b"], "new description")
+
+        fx_path = _write_fixture(tmp_path, ["skill-a", "skill-b"])
+
+        def fake_git_show(cmd: list[str], **kwargs: Any) -> MagicMock:
+            m = MagicMock()
+            m.stdout = "---\ndescription: old description\n---\n# skill\n"
+            m.returncode = 0
+            return m
+
+        with patch("subprocess.run", side_effect=fake_git_show):
+            with patch("sys.argv", ["eval_skill_router.py",
+                                    "--fixtures", fx_path,
+                                    "--repo-root", str(repo),
+                                    "--dry-run"]):
+                rc = router.main()
+
+        assert rc == 0, f"Expected exit 0 (arms differ, dry-run), got {rc}"
+
+    def test_partial_identical_does_not_abort(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Partial identical arms emit a warning but do not exit 1."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # skill-a: same before/after; skill-b: differs
+        _make_skill_files(repo, ["skill-a"], "same desc")
+        _make_skill_files(repo, ["skill-b"], "new desc for b")
+
+        fx_path = _write_fixture(tmp_path, ["skill-a", "skill-b"])
+
+        call_count = [0]
+
+        def fake_git_show(cmd: list[str], **kwargs: Any) -> MagicMock:
+            rel = cmd[-1].split(":", 1)[1]
+            m = MagicMock()
+            if "skill-a" in rel:
+                m.stdout = "---\ndescription: same desc\n---\n"
+            else:
+                m.stdout = "---\ndescription: old desc for b\n---\n"
+            m.returncode = 0
+            call_count[0] += 1
+            return m
+
+        with patch("subprocess.run", side_effect=fake_git_show):
+            with patch("sys.argv", ["eval_skill_router.py",
+                                    "--fixtures", fx_path,
+                                    "--repo-root", str(repo),
+                                    "--dry-run"]):
+                rc = router.main()
+
+        assert rc == 0, f"Partial identical should not abort; got rc={rc}"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "skill-a" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Negative control: the old BEFORE_REF="origin/main" would trigger exit 1
+# ---------------------------------------------------------------------------
+
+class TestOldBehaviorWouldFail:
+    def test_origin_main_triggers_identical_arms_detection(self, tmp_path: Path) -> None:
+        """Regression proof: if BEFORE_REF were 'origin/main', check_identical_arms
+        would detect identical descriptions and force exit 1. This test patches
+        BEFORE_REF to the old value and verifies the guard catches it."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_skill_files(repo, ["skill-x", "skill-y"], "some description")
+
+        fx_path = _write_fixture(tmp_path, ["skill-x", "skill-y"])
+
+        def fake_git_show_same(cmd: list[str], **kwargs: Any) -> MagicMock:
+            rel = cmd[-1].split(":", 1)[1]
+            content = (repo / rel).read_text()
+            m = MagicMock()
+            m.stdout = content
+            return m
+
+        with patch.object(router, "BEFORE_REF", "origin/main"):
+            with patch("subprocess.run", side_effect=fake_git_show_same):
+                with patch("sys.argv", ["eval_skill_router.py",
+                                        "--fixtures", fx_path,
+                                        "--repo-root", str(repo),
+                                        "--dry-run"]):
+                    rc = router.main()
+
+        assert rc == 1, (
+            "With BEFORE_REF='origin/main' and working-tree==origin/main content, "
+            "main() must exit 1 (identical arms). The guard is not firing."
+        )

--- a/tests/eval/test_eval_skill_router.py
+++ b/tests/eval/test_eval_skill_router.py
@@ -123,7 +123,7 @@ class TestCheckIdenticalArms:
 def _write_fixture(tmp_path: Path, candidates: list[str]) -> str:
     fx = [{"id": "f1", "query": "what", "candidates": candidates, "correct": candidates[0]}]
     p = tmp_path / "fx.json"
-    p.write_text(json.dumps(fx))
+    p.write_text(json.dumps(fx), encoding="utf-8")
     return str(p)
 
 
@@ -246,6 +246,7 @@ class TestOldBehaviorWouldFail:
             content = (repo / rel).read_text()
             m = MagicMock()
             m.stdout = content
+            m.returncode = 0
             return m
 
         with patch.object(router, "BEFORE_REF", "origin/main"):

--- a/tests/eval/test_eval_skill_router.py
+++ b/tests/eval/test_eval_skill_router.py
@@ -23,7 +23,7 @@ _EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
 if str(_EVAL_DIR) not in sys.path:
     sys.path.insert(0, str(_EVAL_DIR))
 
-import eval_skill_router as router
+import eval_skill_router as router  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # BEFORE_REF is a fixed SHA (not a branch name)
@@ -188,7 +188,9 @@ class TestMainIdenticalArmsExits1:
 
         assert rc == 0, f"Expected exit 0 (arms differ, dry-run), got {rc}"
 
-    def test_partial_identical_does_not_abort(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_partial_identical_does_not_abort(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Partial identical arms emit a warning but do not exit 1."""
         repo = tmp_path / "repo"
         repo.mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

### What

Fixes `scripts/eval/eval_skill_router.py` to compare against an immutable pre-\#2127 commit SHA instead of the moving `origin/main` branch. Adds a loud failure when both eval arms produce byte-identical output.

### Why

`BEFORE_REF = "origin/main"` was set when `origin/main` carried pre-\#2127 content. After \#2127 merged, `origin/main` and `HEAD` both carry post-\#2127 text. Comparing them gives `candidates=18, identical=18, differ=0`: a silent zero that reads as "no improvement" but actually means "nothing was compared."

Two fixes:

1. Pin `BEFORE_REF` to `fd379f0a85e0dc4362c3960a84a7ad5632270239`, the first parent of the \#2127 merge commit. A moving ref as an experimental control is the root bug.
2. Add `check_identical_arms()`. If all candidates are byte-identical between BEFORE and AFTER, the script exits 1 with a clear message. Zero-delta-equals-no-measurement is the failure mode being addressed.

## Changes

- `scripts/eval/eval_skill_router.py`: pin `BEFORE_REF`, add `check_identical_arms`, add identical-arms detection in `main()`
- `tests/eval/test_eval_skill_router.py`: 12 new tests covering SHA immutability, identical-arm detection, exit codes

## Testing

12 tests in `tests/eval/test_eval_skill_router.py`. All pass.

Fixes #4304