### PR TITLE
fix(tests): stop command_size test from inheriting ambient CI, unblocks red main

### DIFF
--- a/tests/test_validation_command_size.py
+++ b/tests/test_validation_command_size.py
@@ -34,6 +34,19 @@ def _body(n_lines: int, content: str = "- item") -> str:
     return "\n".join([content] * n_lines)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop the ambient environment from choosing the assertion.
+
+    ``main`` defaults ``--ci`` to the ``CI`` environment variable, so a call
+    that omits the flag inherits whatever the runner exports. Locally ``CI``
+    is unset and the lenient branch runs; on GitHub Actions ``CI=true`` and
+    the blocking branch runs instead. Clearing the variable makes every test
+    in this module assert the branch it names.
+    """
+    monkeypatch.delenv("CI", raising=False)
+
+
 class TestHasSizeException:
     def test_true_value_detected(self) -> None:
         content = "---\nsize-exception: true\n---\n"
@@ -167,6 +180,21 @@ class TestMain:
         f.write_text(_GOOD_FRONTMATTER + _body(COMMAND_SIZE_LIMIT + 50))
         result = main(["--path", str(tmp_path)])
         assert result == 0
+
+    def test_env_ci_true_blocks_without_the_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CI=true must block an over-size command even with no --ci flag.
+
+        This pins the environment default the autouse fixture clears. Without
+        it, a change that stopped reading CI would leave every workflow that
+        relies on the exported variable silently advisory.
+        """
+        monkeypatch.setenv("CI", "true")
+        f = tmp_path / "big.md"
+        f.write_text(_GOOD_FRONTMATTER + _body(COMMAND_SIZE_LIMIT + 50))
+        result = main(["--path", str(tmp_path)])
+        assert result == 1
 
     def test_exception_with_rationale_ci_exits_0(self, tmp_path: Path) -> None:
         f = tmp_path / "big.md"


### PR DESCRIPTION
## Summary

`main` is red. `tests/test_validation_command_size.py::TestMain::test_over_limit_no_ci_exits_0`
fails on every CI run and passes on every local run. This makes the test assert
the branch it names instead of the branch the runner happens to select.

Latest failing run on `main` (`0328ac674`): `1 failed, 22054 passed, 31 skipped`.
The same single failure appears on open pull requests, so every branch inherits
a red suite until this lands.

## Root cause

`scripts/validation/command_size.py` builds the `--ci` flag like this:

```python
parser.add_argument(
    "--ci",
    action="store_true",
    default=os.environ.get("CI", "").lower() in ("true", "1"),
    help="CI mode: exit non-zero on validation failure",
)
```

The flag defaults to the ambient `CI` environment variable. The test called
`main(["--path", str(tmp_path)])` with no `--ci` and asserted the lenient exit
code 0. Locally `CI` is unset, so the lenient branch ran and the test passed.
GitHub Actions exports `CI=true`, so `args.ci` was true, the over-size file
counted as a failure, and `main` returned 1.

The test never tested what its name claims. It tested whatever the runner
exported.

## Reproduction

Deterministic, not a flake:

```
CI unset   ->  24 passed
CI=true    ->  1 failed, 23 passed   (assert 1 == 0)
```

## Fix

An autouse fixture clears `CI` for the module, so each test asserts the branch
it names regardless of where it runs.

A new test, `test_env_ci_true_blocks_without_the_flag`, pins the environment
default itself. Without it, a later change that stopped reading `CI` would
silently make every workflow relying on the exported variable advisory, and no
test would notice.

## Verification

| Check | Result |
|---|---|
| Module tests, `CI` unset | 25 passed |
| Module tests, `CI=true` | 25 passed |
| `ruff check` on the changed file | All checks passed |
| Negative control | Replacing the env default with `default=False` fails only the new test, `assert 0 == 1` |

The negative control matters: it proves the new test is not vacuous and that it
targets exactly the behavior it claims.

## Scope

The CI run that surfaced this reported exactly one failure out of 22090, so this
was the only live instance. Sixteen scripts share the same argparse pattern, but
their tests either pass the flag or already clear the variable by hand. There are
34 hand written `monkeypatch.delenv("CI", raising=False)` calls across the suite,
so this trap has been hit and patched repeatedly, one test at a time.

## Why this file and not the other fifteen

`tests/validation/conftest.py` already clears `CI` for everything under
`tests/validation/`. This file is named `test_validation_command_size.py` but
lives in the `tests/` root, so that fixture never applies to it. Twelve files
share that shape: a `test_validation_` prefix that reads like membership in the
`tests/validation/` package, and a location outside it. `tests/conftest.py` does
not clear `CI`, so all twelve rely on individual authors remembering.

A repo-wide fix belongs in `tests/conftest.py`, but clearing `CI` for all 22090
tests is a behavior change across the whole suite and does not belong in a change
that exists to turn `main` green. Left as a follow-up.

Production behavior is untouched. This changes test isolation only.

## Review

Reviewed adversarially on a different model family (Gemini 3.1 Pro), which
checked fixture blast radius across all six test classes, monkeypatch ordering
and teardown, three alternative fixes, the single-instance claim, conftest
conflicts, and style compliance. Verdict SHIP at 100% confidence with no defects
found. Its one MEDIUM note, hoisting the fixture repo-wide, is recorded above as
a follow-up rather than done here.

## Acceptance criteria

- [x] `test_over_limit_no_ci_exits_0` passes with `CI` unset and with `CI=true`
- [x] All 25 tests in the file pass under both environments
- [x] A new test pins the env default so the branch is asserted, not assumed
- [x] `scripts/validation/command_size.py` is unchanged, the env default is intentional
- [x] Negative control: reverting the production default fails only the new test

Refs #4016
