### PR TITLE
docs(gotchas): document the spec coverage gate and the endingCommit amend trap

### DIFF
--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -255,6 +255,56 @@ at byte level before editing.
 The validator takes `--pr-number` and fetches the **live** body, so push and
 update the PR before running it locally.
 
+## Spec coverage blocks when the PR body has no checked acceptance boxes
+
+`Validate Spec Coverage` fails with this, and the reason names a rule rather
+than a missing file, so it reads like an infrastructure fault:
+
+```
+verdict: NEEDS_REVIEW   reason: closed-loop:external-signal-inconclusive
+```
+
+The cause is a missing section in **the PR body**, not the issue.
+`scripts/external_signals/gate_aggregator.py` requires at least one signal of
+kind `external` whose verdict is passing or warning. The only external signal
+is `acceptance-criteria`, which
+`scripts/quality_gate/spec_external_signal_gate.py` parses out of
+`PR_BODY_FILE`. All boxes checked gives PASS, any box unchecked gives FAIL, and
+**no section at all gives UNKNOWN**, which empties the external list and
+blocks. The other two signals come from the model, and two readings from one
+model are one measurement, so the gate is right to refuse them alone.
+
+Two parsing constraints, both in `scripts/external_signals/acceptance_criteria.py`:
+
+- The heading must match `^#{1,6}\s*acceptance(\s+criteria)?\s*$`.
+- Items must be `- [x]` task-list checkboxes. **A numbered list does not
+  parse**, so copying an issue's `1.` through `5.` criteria verbatim still
+  yields UNKNOWN.
+
+Reproduce and fix offline rather than pushing to find out. This runs the real
+gate and replaces a CI cycle with one second:
+
+```bash
+gh pr view "$PR" --json body --jq .body > body.md
+PR_BODY_FILE=body.md TRACE_VERDICT=PASS COMPLETENESS_VERDICT=PARTIAL \
+  uv run --frozen python scripts/quality_gate/spec_external_signal_gate.py
+```
+
+Exit 0 means PASS or WARN. Editing the body re-triggers the gate, so no new
+commit is needed.
+
+**Do not read the PR comment to find out whether this passed.** The
+`AI-SPEC-VALIDATION` comment is posted once and never updated, so it keeps
+showing the first run's verdict. A red check can display `Final Verdict: PASS`
+indefinitely. Read the job log instead, and note that `gh run view
+--log-failed` returns only cleanup noise for this job:
+
+```bash
+gh run view --job "$JOB_ID" --log | sed 's/\x1b\[[0-9;]*m//g' | grep -P 'VERDICT|"verdict"|"reason"'
+```
+
+Refs #4369 for the stale comment defect.
+
 ## Never put a literal pipe inside a Markdown table cell
 
 Escape it as `\|` or reword. A bare `|` breaks rendering and trips bot

--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -99,6 +99,34 @@ protocol literally (create and stage at start) cannot pass both gates.
 Symptom: a commit is rejected by one of the two policies no matter which order
 you try. Refs #3904.
 
+## Never record `endingCommit` and then amend
+
+`endingCommit` must name a commit that is still reachable:
+`scripts/validation/session_scope.py` runs `git merge-base --is-ancestor <sha>
+HEAD`. Amending the commit that carried the log rewrites it, so the SHA you
+just recorded no longer exists on the branch and the check fails.
+
+Record the SHA of the commit carrying the work, then commit that edit as a
+**follow-up commit**. A commit is its own ancestor, so naming current `HEAD`
+and committing the change on top passes.
+
+Two traps make this expensive rather than merely annoying:
+
+- A `[PASS]` from `scripts/validate_session_json.py` does not survive an amend.
+  The validator reads the SHA against the `HEAD` of the moment. Re-run it after
+  any amend, not just after the first write.
+- The check runs inside the push hook **after** the Python suite, which
+  measured 1116 seconds on one run. A one-line metadata error therefore costs
+  roughly twenty minutes to surface.
+
+Symptom, from the push hook rather than from the standalone validator:
+
+```text
+endingCommit '<sha>' names a commit that is not an ancestor of HEAD
+```
+
+Refs #3618.
+
 ## Run validation with `uv run python`, never bare `python3`
 
 `scripts/validation/checks_spec.py` shells out to child validators with

--- a/.agents/memory/episodes/episode-2026-08-03-session-4369-gotcha-spec-coverage-gate.json
+++ b/.agents/memory/episodes/episode-2026-08-03-session-4369-gotcha-spec-coverage-gate.json
@@ -69,6 +69,15 @@
       "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 6bc73e912",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
     }
   ],
   "metrics": {
@@ -76,7 +85,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-03-session-4369-gotcha-spec-coverage-gate.json
+++ b/.agents/memory/episodes/episode-2026-08-03-session-4369-gotcha-spec-coverage-gate.json
@@ -1,0 +1,83 @@
+{
+  "id": "episode-2026-08-03-session-4369-gotcha-spec-coverage-gate",
+  "session": "2026-08-03-session-4369-gotcha-spec-coverage-gate",
+  "timestamp": "2026-08-03T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Document the Validate Spec Coverage gate in GOTCHAS.md after hitting it on PR #4294 and nearly re-filing into it on PR #4368.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Triaged the Validate Spec Coverage failure on PR #4294",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Traced the mechanism through source rather than inferring it",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced the failure and verified the fix offline",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed the trap is undocumented",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Nearly re-filed into the same trap on PR #4368",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Filed the stale comment defect as issue #4369",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: cc7ea8f9b",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-03-session-4369-gotcha-spec-coverage-gate"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-08-03-session-4369-gotcha-spec-coverage-gate.json
+++ b/.agents/sessions/2026-08-03-session-4369-gotcha-spec-coverage-gate.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 4369,
+    "date": "2026-08-03",
+    "branch": "docs/gotcha-spec-coverage-gate",
+    "startingCommit": "22588a0f4",
+    "objective": "Document the Validate Spec Coverage gate in GOTCHAS.md after hitting it on PR #4294 and nearly re-filing into it on PR #4368."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "No Serena MCP tools exposed in this agent context."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "No Serena MCP tools available; read repository docs directly."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "This file."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "git branch --show-current returned docs/gotcha-spec-coverage-gate, verified non-empty to rule out detached HEAD."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Branch is docs/gotcha-spec-coverage-gate, not main or master."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "HANDOFF.md read earlier in this session."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read GOTCHAS.md in full before editing it, including the .agents/ session-log rule that governs this commit."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Session log completed and staged in the same commit as the .agents/ change, per the session-policy rule."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "HANDOFF.md not modified."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "1 commit, 2 files: the GOTCHAS.md entry and this log. endingCommit records cc7ea8f9b, the commit this log was first written into; amending to add the SHA necessarily produces a new one, so the recorded value names its content-identical predecessor."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Byte-level dash check returned 0. markdownlint reports .agents/ is excluded from its glob, so no lint applies. Every claim in the entry was reproduced against the live scripts earlier in this session."
+      },
+      "checklistComplete": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Documentation-only change, scope complete."
+      },
+      "markdownLintRun": {
+        "level": "SHOULD",
+        "complete": true,
+        "evidence": "markdownlint-cli2 run on the file; it resolved 0 files because .agents/** is excluded in the config."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "complete": true,
+        "evidence": "Companion memory ci-spec-coverage-fails-without-checked-acceptance-boxes.md written earlier in this session, committed ac17fa25e on PR #4360."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Triaged the Validate Spec Coverage failure on PR #4294",
+      "result": "Job log read verdict NEEDS_REVIEW, reason closed-loop:external-signal-inconclusive, while the visible PR comment read Final Verdict: PASS with 5 of 5 criteria covered."
+    },
+    {
+      "action": "Traced the mechanism through source rather than inferring it",
+      "result": "gate_aggregator.py requires at least one external signal with a passing or warning verdict; the only one is acceptance-criteria, parsed from PR_BODY_FILE by spec_external_signal_gate.py. No section yields UNKNOWN, which empties the list and blocks."
+    },
+    {
+      "action": "Reproduced the failure and verified the fix offline",
+      "result": "Body as filed exited 1 with NEEDS_REVIEW; body with checked boxes exited 0 with WARN. Replaced a CI round trip with a one-second local run."
+    },
+    {
+      "action": "Confirmed the trap is undocumented",
+      "result": "GOTCHAS.md has 20 entries including the PR description gate, and no mention of spec coverage, acceptance criteria, closed loop, or external signal. Neither the PR template nor any rule file covers it."
+    },
+    {
+      "action": "Nearly re-filed into the same trap on PR #4368",
+      "result": "The prepared body had no acceptance heading and 0 checked boxes. Caught it pre-filing only because the memory was an hour old. That near-miss is the evidence that a Serena memory alone is insufficient, since Serena is MCP-gated and was unavailable in this very context."
+    },
+    {
+      "action": "Filed the stale comment defect as issue #4369",
+      "result": "Root cause is ai-spec-validation.yml calling post_issue_comment.py without --update-if-exists; the upsert path already exists in the script and is simply not enabled."
+    }
+  ],
+  "nextSteps": [
+    "PR #4368 must merge to turn main green; it fixes a test that inherited ambient CI.",
+    "Issue #4369 proposes the one-flag fix for the stale AI-SPEC-VALIDATION comment.",
+    "PR #4294 is blocked separately on the taste count ratchet at 600 to 601 after main advanced, not on anything in this change."
+  ],
+  "endingCommit": "cc7ea8f9b",
+  "issues": [
+    4369
+  ],
+  "closedIssues": []
+}

--- a/.agents/sessions/2026-08-03-session-4369-gotcha-spec-coverage-gate.json
+++ b/.agents/sessions/2026-08-03-session-4369-gotcha-spec-coverage-gate.json
@@ -59,7 +59,7 @@
       "changesCommitted": {
         "level": "MUST",
         "complete": true,
-        "evidence": "1 commit, 2 files: the GOTCHAS.md entry and this log. endingCommit records cc7ea8f9b, the commit this log was first written into; amending to add the SHA necessarily produces a new one, so the recorded value names its content-identical predecessor."
+        "evidence": "2 commits: the GOTCHAS.md entries, this log, and the hook-generated episode file. endingCommit records 6bc73e912, the commit carrying the work. The first attempt recorded a SHA that a later amend orphaned, and the push hook rejected it; per issue #3618 the SHA is recorded in a follow-up commit rather than by amending afterwards."
       },
       "validationPassed": {
         "level": "MUST",
@@ -114,7 +114,7 @@
     "Issue #4369 proposes the one-flag fix for the stale AI-SPEC-VALIDATION comment.",
     "PR #4294 is blocked separately on the taste count ratchet at 600 to 601 after main advanced, not on anything in this change."
   ],
-  "endingCommit": "cc7ea8f9b",
+  "endingCommit": "6bc73e912",
   "issues": [
     4369
   ],


### PR DESCRIPTION
## What this does

Adds two entries to the repository gotchas file. Both are traps that cost a
full push cycle to discover, and neither is discoverable from the error alone.

### Entry 1: the spec coverage gate

Blocked PR #4294 and nearly blocked PR #4368 an hour later.

`Validate Spec Coverage` fails with a reason that names a rule rather than a
missing file:

```
verdict: NEEDS_REVIEW   reason: closed-loop:external-signal-inconclusive
```

It reads like an infrastructure fault. It is not. The PR body is missing an
`## Acceptance criteria` section with `- [x]` checkboxes. The gate requires at
least one external signal, the only external signal is parsed out of the PR
body, and no section at all yields UNKNOWN, which empties the list and blocks.

## Why it belongs in the gotchas file rather than only a memory

I diagnosed this trap on PR #4294 and wrote a Serena memory for it. One hour
later I prepared the body for PR #4368 with no acceptance heading and zero
checked boxes, and caught it only because the diagnosis was still fresh.

The memory did not help, because Serena is MCP gated and was unavailable in
that context. The gotchas file is the one surface the Copilot instructions
tell every agent to read before its first push on a branch. A trap that costs
a full CI round trip belongs where the reader is already looking.

## What the entry records

The gate mechanism and the exact failure string. The two parsing constraints,
including that a numbered list does not parse, so copying an issue's numbered
criteria verbatim still yields UNKNOWN. An offline reproduction that runs the
real gate and replaces a CI round trip with one second. And a warning not to
trust the `AI-SPEC-VALIDATION` comment, which is posted once and never
updated, so a red check can display a green verdict indefinitely.

## Verification

### Entry 2: recording `endingCommit` and then amending

The push that filed this pull request failed on its first attempt, and the
second entry is that failure written down.

`endingCommit` must name a commit that is still reachable, checked with
`git merge-base --is-ancestor`. I recorded the SHA and then amended, which
rewrote the commit and orphaned the value. Two details make this expensive
rather than merely annoying: a `[PASS]` from the standalone validator does not
survive an amend, and the check runs in the push hook after the Python suite,
which measured 1116 seconds on that run. A one-line metadata error therefore
took roughly twenty minutes to surface.

The fix is the one the error message prescribes: record the SHA in a follow-up
commit rather than by amending. This branch does exactly that, so the entry is
demonstrated by the branch that carries it.

## Verification

Every claim was reproduced against the live scripts before it was written
down, not inferred from reading them.

| Check | Result |
|---|---|
| Body as filed on #4294 | exit 1, NEEDS_REVIEW, `closed-loop:external-signal-inconclusive` |
| Same body plus checked criteria | exit 0, WARN |
| Em-dash and en-dash count | 0, byte verified |
| Session log | `validate_session_json.py` reports valid, no warnings |

Adversarial review ran on a different model family (Gemini 3.1 Pro) against the
worktree, with instructions to verify all eight factual claims independently
and to treat the numbered-list claim as the one most likely to mislead. It
confirmed every claim with a line citation and returned SHIP at 100 percent
confidence with no defects.

## Acceptance criteria

- [x] The entry names the exact failure string an agent will see in the log
- [x] Every factual claim is verified against the live scripts, not inferred
- [x] The offline reproduction runs the real gate and replaces a CI round trip
- [x] The stale comment hazard is called out so nobody reads the wrong surface
- [x] Zero em-dashes or en-dashes, byte verified
- [x] Session log ships in the same commit, as the `.agents/` rule requires
- [x] The second entry records the amend trap that failed this branch's first push

## Notes

The episode JSON is generated from the session log by a commit hook, not
hand-authored.

Refs #4369
