### PR TITLE
docs(push-pr): state the acceptance-criteria gate where PR bodies are authored

### DIFF
--- a/.claude/commands/push-pr.md
+++ b/.claude/commands/push-pr.md
@@ -29,6 +29,7 @@ Based on the above changes:
    - **List** specific files changed, test coverage added, security impacts
    - **Do NOT** leave template comments like `<!-- Brief description -->` unfilled
    - **Do NOT** copy the template verbatim - adapt every section to your changes
+   - **Include** an `## Acceptance criteria` heading with `- [x]` checked bullets. The Validate Spec Coverage gate parses this out of the PR body, not the linked issue, and blocks when the section is absent. Items must use a `-` or `*` bullet, so copying an issue's numbered criteria verbatim still blocks.
 5. Create a pull request using the new_pr skill script:
 
    ```bash

--- a/src/copilot-cli/skills/push-pr/SKILL.md
+++ b/src/copilot-cli/skills/push-pr/SKILL.md
@@ -28,6 +28,7 @@ Based on the above changes:
    - **List** specific files changed, test coverage added, security impacts
    - **Do NOT** leave template comments like `<!-- Brief description -->` unfilled
    - **Do NOT** copy the template verbatim - adapt every section to your changes
+   - **Include** an `## Acceptance criteria` heading with `- [x]` checked bullets. The Validate Spec Coverage gate parses this out of the PR body, not the linked issue, and blocks when the section is absent. Items must use a `-` or `*` bullet, so copying an issue's numbered criteria verbatim still blocks.
 5. Create a pull request using the new_pr skill script:
 
    ```bash


### PR DESCRIPTION
## What this does

Puts the acceptance-criteria requirement in the file that tells an agent how to
author a PR body, instead of only in files an agent is told to go read.

The `Validate Spec Coverage` gate blocks a pull request whose body has no
acceptance-criteria section. The failure names a rule rather than a missing
field, so it reads as infrastructure breakage:

```text
verdict: NEEDS_REVIEW   reason: closed-loop:external-signal-inconclusive
```

## Why here, and not in a memory or a read-first file

I hit this gate, wrote a Serena memory for it, and then one hour later prepared
another PR body with no acceptance heading and zero checked boxes. The memory
did not fire, because Serena is MCP gated and was not loaded in that context.

So I escalated the knowledge into the repository gotchas file, which the
instructions name for every agent before its first push. That is better, and it
is still a pointer. In the same session, while editing that gotchas file, I
built a per-branch push lock by hand and broke it on a branch name containing a
slash. The correct pattern was already written down, four lines above where I
was typing, in the file I had open.

Pointers are underfollowed. This is measured, not felt: positional neglect in
long context (Liu et al., TACL 2023), tool-calling unreliability (Patil et al.
2023; Yao et al. 2024), silent omission under instruction density
(Jaroslawicz et al., arXiv:2507.11538), and context-knowledge conflict (Xie et
al., ICLR 2024). Four independent mechanisms, same outcome.

Inlining everything into always-on context is not the escape, because the same
density research caps what always-on can hold. A skill or command body is the
third option: it costs nothing when idle, and when invoked it arrives in
context rather than as a reference to context. Knowledge needed only while
performing one action belongs in the thing that performs it.

## Scope

One bullet, in the list that already describes what the PR body must contain.
The gh path in the ship command delegates to this same command, so one edit
covers both entry points rather than duplicating the rule.

The generated Copilot mirror was produced by running the generator, not by
hand.

## Verification

| Check | Result |
|---|---|
| Generator run, then `git diff --stat` | exactly the source and its mirror, no third file |
| `validate_plugin_version_bump.py` | `plugin-version-bump: OK`, exit 0 |
| Command generator tests | 38 passed |
| Em-dash and en-dash count, both files | 0, byte verified |

Every claim in the added bullet was checked against the live gate scripts, and
an adversarial review ran on a different model family with instructions to
empirically test the parsing variants rather than reason about the regexes.

## Acceptance criteria

- [x] The requirement sits where the PR body is authored, not in a read-first file
- [x] Both parsing constraints are stated, the heading and the bullet form
- [x] The generated mirror was regenerated, never hand-edited
- [x] The plugin bump gate was run rather than assumed
- [x] Zero em-dashes or en-dashes, byte verified
- [x] Adversarial review ran on a different model family

Refs #4384
