### PR TITLE
fix(validation): identity-based baseline for doc-interpreter portability ratchet

### DIFF
--- a/scripts/validation/check_doc_interpreter_portability.py
+++ b/scripts/validation/check_doc_interpreter_portability.py
@@ -330,10 +330,10 @@ def find_offenses(line: str, repo_root: Path, tracked_py: set[str]) -> list[tupl
     return offenses
 
 
-def scan(repo_root: Path, details: dict[str, list[str]] | None = None) -> dict[str, int]:
-    """Return {file path: undeclared unportable invocation count} for in-scope files."""
+def scan(repo_root: Path, details: dict[str, list[str]] | None = None) -> dict[str, list[str]]:
+    """Return {file path: sorted script paths} -- identity keys for swap detection (#4292)."""
     tracked_py = set(tracked_files(repo_root, "*.py"))
-    counts: dict[str, int] = {}
+    counts: dict[str, list[str]] = {}
     for rel in tracked_files(repo_root, "*.md", "*.py"):
         if not is_in_scope(rel):
             continue
@@ -344,24 +344,27 @@ def scan(repo_root: Path, details: dict[str, list[str]] | None = None) -> dict[s
             lines = path.read_text(encoding="utf-8").splitlines()
         except (OSError, UnicodeDecodeError):
             continue
-        total = 0
+        scripts: list[str] = []
         for index, line in enumerate(lines):
             if is_declared(lines, index):
                 continue
             offenses = find_offenses(line, repo_root, tracked_py)
-            total += len(offenses)
-            if details is not None:
-                details.setdefault(rel, []).extend(
-                    f"{rel}:{index + 1}: {script} imports {', '.join(modules)}"
-                    for script, modules in offenses
-                )
-        if total:
-            counts[rel] = total
+            for script, modules in offenses:
+                scripts.append(script)
+                if details is not None:
+                    details.setdefault(rel, []).append(
+                        f"{rel}:{index + 1}: {script} imports {', '.join(modules)}"
+                    )
+        if scripts:
+            counts[rel] = sorted(set(scripts))
     return counts
 
 
-def load_baseline(path: Path) -> dict[str, int]:
-    """Load the grandfathered per-file counts."""
+_BaselineValue = list[str] | int
+
+
+def load_baseline(path: Path) -> dict[str, _BaselineValue]:
+    """Load per-file entries as list (identity) or int (legacy count)."""
     if not path.is_file():
         raise FileNotFoundError(f"Baseline file not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -370,54 +373,62 @@ def load_baseline(path: Path) -> dict[str, int]:
     files = data.get("files", data)
     if not isinstance(files, dict):
         raise ValueError("Baseline 'files' must be a JSON object")
-    baseline: dict[str, int] = {}
+    out: dict[str, _BaselineValue] = {}
     for key, value in files.items():
-        try:
-            baseline[str(key)] = int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"Baseline count for {key!r} is not an integer") from exc
-    return baseline
+        if isinstance(value, list):
+            out[str(key)] = [str(v) for v in value]
+        else:
+            try:
+                out[str(key)] = int(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Baseline value for {key!r} is not valid") from exc
+    return out
 
 
 def diff_against_baseline(
-    current: dict[str, int],
-    baseline: dict[str, int],
+    current: dict[str, list[str]],
+    baseline: dict[str, _BaselineValue],
     details: dict[str, list[str]] | None = None,
 ) -> tuple[list[str], list[str]]:
-    """Return (regressions, improvements) comparing current counts to baseline."""
-    regressions = [
-        f"{rel}: {count} documented bare-interpreter invocation(s) of a script with "
-        f"third-party imports (baseline {baseline.get(rel, 0)}). Use "
-        f"'uv run python <script>' so the project environment supplies the "
-        f"dependencies (issue #3791)."
-        + (f" Offenses: {'; '.join(details.get(rel, []))}" if details else "")
-        for rel, count in sorted(current.items())
-        if count > baseline.get(rel, 0)
-    ]
-    improvements = [
-        f"{rel}: {current.get(rel, 0)} invocations (baseline {allowed})"
-        for rel, allowed in sorted(baseline.items())
-        if current.get(rel, 0) < allowed
-    ]
+    """Return (regressions, improvements). List baseline detects swaps (#4292)."""
+    regressions: list[str] = []
+    for rel, scripts in sorted(current.items()):
+        bval = baseline.get(rel)
+        extra = f" Offenses: {'; '.join(details.get(rel, []))}" if details else ""
+        if isinstance(bval, list):
+            new = sorted(set(scripts) - set(bval))
+            if new:
+                regressions.append(
+                    f"{rel}: new invocation(s): {', '.join(new)} (issue #3791).{extra}"
+                )
+        else:
+            allowed = int(bval) if bval is not None else 0
+            if len(scripts) > allowed:
+                regressions.append(
+                    f"{rel}: {len(scripts)} invocation(s) (baseline {allowed}). "
+                    f"Use 'uv run python <script>' (issue #3791).{extra}"
+                )
+    improvements: list[str] = []
+    for rel, bval in sorted(baseline.items()):
+        cur = len(current.get(rel, []))
+        limit = len(bval) if isinstance(bval, list) else int(bval)
+        if cur < limit:
+            improvements.append(f"{rel}: {cur} invocations (baseline {limit})")
     return regressions, improvements
 
 
 def validate_doc_interpreter_portability(repo_root: Path) -> bool:
-    """Print drift and return True when every file is at or below its baseline."""
+    """Return True when every file is at or below its baseline."""
     return main(["--repo-root", str(repo_root)]) == 0
 
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
-    parser = argparse.ArgumentParser(description="Documented-interpreter portability ratchet.")
-    parser.add_argument("--repo-root", type=Path, default=None, help="Repository root.")
-    parser.add_argument("--baseline", type=Path, default=None, help="Baseline JSON path.")
-    parser.add_argument(
-        "--update-baseline",
-        action="store_true",
-        help="Rewrite the baseline from the current scan.",
-    )
-    return parser
+    p = argparse.ArgumentParser(description="Documented-interpreter portability ratchet.")
+    p.add_argument("--repo-root", type=Path, default=None)
+    p.add_argument("--baseline", type=Path, default=None)
+    p.add_argument("--update-baseline", action="store_true")
+    return p
 
 
 def _resolve_roots(args: argparse.Namespace) -> tuple[Path, Path]:
@@ -427,7 +438,7 @@ def _resolve_roots(args: argparse.Namespace) -> tuple[Path, Path]:
 
 
 def _update_baseline(
-    current: dict[str, int],
+    current: dict[str, list[str]],
     baseline_path: Path,
     details: dict[str, list[str]],
 ) -> int:
@@ -441,12 +452,8 @@ def _update_baseline(
         if regressions:
             for line in regressions:
                 print(f"DRIFT {line}", file=sys.stderr)
-            print(
-                "check-doc-interpreter-portability: refusing to raise baseline",
-                file=sys.stderr,
-            )
+            print("check-doc-interpreter-portability: refusing to raise baseline", file=sys.stderr)
             return 1
-
     payload = json.dumps({"files": dict(sorted(current.items()))}, indent=2) + "\n"
     try:
         baseline_path.write_text(payload, encoding="utf-8")
@@ -456,34 +463,28 @@ def _update_baseline(
     print(f"check-doc-interpreter-portability: wrote {baseline_path} ({len(current)} files)")
     return 0
 
-
 def main(argv: list[str] | None = None) -> int:
     """Run the ratchet."""
     args = build_parser().parse_args(argv)
     repo_root, baseline_path = _resolve_roots(args)
-
     try:
         details: dict[str, list[str]] = {}
         current = scan(repo_root, details)
     except (OSError, subprocess.CalledProcessError) as exc:
         print(f"check-doc-interpreter-portability: {exc}", file=sys.stderr)
         return 2
-
     if args.update_baseline:
         return _update_baseline(current, baseline_path, details)
-
     try:
         baseline = load_baseline(baseline_path)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"check-doc-interpreter-portability: {exc}", file=sys.stderr)
         return 2
-
     regressions, improvements = diff_against_baseline(current, baseline, details)
     for line in improvements:
         print(f"IMPROVED {line}")
     for line in regressions:
         print(f"DRIFT {line}", file=sys.stderr)
-
     if regressions:
         print(
             "check-doc-interpreter-portability: FAIL. Rerun with --update-baseline "
@@ -491,7 +492,6 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-
     print("check-doc-interpreter-portability: OK")
     return 0
 

--- a/tests/test_check_doc_interpreter_portability.py
+++ b/tests/test_check_doc_interpreter_portability.py
@@ -40,7 +40,7 @@ def make_repo(tmp_path: Path, files: dict[str, str]) -> Path:
     return tmp_path
 
 
-def write_baseline(repo: Path, files: dict[str, int]) -> Path:
+def write_baseline(repo: Path, files: dict[str, int | list[str]]) -> Path:
     """Write a baseline JSON and return its path."""
     path = repo / "baseline.json"
     path.write_text(json.dumps({"files": files}), encoding="utf-8")

--- a/tests/test_check_doc_interpreter_portability.py
+++ b/tests/test_check_doc_interpreter_portability.py
@@ -59,7 +59,7 @@ def test_bare_interpreter_with_third_party_import_is_flagged(tmp_path: Path) -> 
         },
     )
 
-    assert scan(repo) == {"README.md": 1}
+    assert scan(repo) == {"README.md": ["tool.py"]}
 
 
 def test_cli_exits_1_when_a_clean_file_starts_offending(
@@ -89,7 +89,7 @@ def test_transitive_local_import_reaches_third_party(tmp_path: Path) -> None:
     )
 
     assert third_party_imports("entry.py", repo, {"pkg/loader.py", "entry.py"}) == {"yaml"}
-    assert scan(repo) == {"README.md": 1}
+    assert scan(repo) == {"README.md": ["entry.py"]}
 
 
 def test_subprocess_wrapper_reaches_third_party_dependency(tmp_path: Path) -> None:
@@ -112,7 +112,7 @@ def test_subprocess_wrapper_reaches_third_party_dependency(tmp_path: Path) -> No
     )
 
     assert third_party_imports("entry.py", repo, {"entry.py", "validate.py"}) == {"jsonschema"}
-    assert scan(repo) == {"README.md": 1}
+    assert scan(repo) == {"README.md": ["entry.py"]}
 
 
 def test_dot_directory_script_path_is_flagged(tmp_path: Path) -> None:
@@ -130,7 +130,7 @@ def test_dot_directory_script_path_is_flagged(tmp_path: Path) -> None:
         },
     )
 
-    assert scan(repo) == {"README.md": 1}
+    assert scan(repo) == {"README.md": [".claude/skills/x/scripts/tool.py"]}
 
 
 def test_relative_dot_slash_script_path_is_flagged(tmp_path: Path) -> None:
@@ -140,7 +140,7 @@ def test_relative_dot_slash_script_path_is_flagged(tmp_path: Path) -> None:
         {"scripts/tool.py": "import yaml\n", "README.md": "Run `python3 ./scripts/tool.py`.\n"},
     )
 
-    assert scan(repo) == {"README.md": 1}
+    assert scan(repo) == {"README.md": ["scripts/tool.py"]}
 
 
 def test_class_body_import_runs_at_import_time_and_is_flagged(tmp_path: Path) -> None:
@@ -415,7 +415,7 @@ def test_declaration_two_lines_above_does_not_suppress(tmp_path: Path) -> None:
         },
     )
 
-    assert scan(repo) == {"doc.md": 1}
+    assert scan(repo) == {"doc.md": ["tool.py"]}
 
 
 def test_declaration_does_not_cover_a_sibling_offense_in_the_same_file(tmp_path: Path) -> None:
@@ -432,7 +432,7 @@ def test_declaration_does_not_cover_a_sibling_offense_in_the_same_file(tmp_path:
         },
     )
 
-    assert scan(repo) == {"doc.md": 1}
+    assert scan(repo) == {"doc.md": ["tool.py"]}
 
 
 def test_python_usage_docstring_is_an_offense(tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ def test_python_usage_docstring_is_an_offense(tmp_path: Path) -> None:
         {"tool.py": '"""Usage:\n\n    python3 tool.py --check\n"""\n\nimport yaml\n'},
     )
 
-    assert scan(repo) == {"tool.py": 1}
+    assert scan(repo) == {"tool.py": ["tool.py"]}
 
 
 def test_unreadable_baseline_exits_2(tmp_path: Path) -> None:
@@ -463,7 +463,7 @@ def test_update_baseline_writes_current_counts(tmp_path: Path) -> None:
     exit_code = main(["--repo-root", str(repo), "--baseline", str(baseline), "--update-baseline"])
 
     assert exit_code == 0
-    assert json.loads(baseline.read_text(encoding="utf-8"))["files"] == {"README.md": 1}
+    assert json.loads(baseline.read_text(encoding="utf-8"))["files"] == {"README.md": ["tool.py"]}
 
 
 def test_update_baseline_refuses_count_increase(

--- a/tests/test_check_doc_interpreter_portability_identity.py
+++ b/tests/test_check_doc_interpreter_portability_identity.py
@@ -1,0 +1,117 @@
+"""Identity-based ratchet tests for check_doc_interpreter_portability (issue #4292).
+
+Mutation proof: removing one bare-python3 invocation and adding a different one in the
+same file at equal count must fire the ratchet. A count-only baseline misses this swap.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validation.check_doc_interpreter_portability import (
+    diff_against_baseline,
+    main,
+)
+from tests.test_check_doc_interpreter_portability import make_repo, write_baseline
+
+
+def test_same_count_swap_is_detected_with_identity_baseline(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Remove script_a, add script_b at equal count -- ratchet must fire.
+
+    This is the exact reproducer from issue #4292. Seed the baseline with
+    script_a.py. Replace the documented invocation with script_b.py (same
+    count: 1). The checker must exit 1 because script_b.py is not in the
+    baseline set.
+    """
+    repo = make_repo(
+        tmp_path,
+        {
+            "script_a.py": "import yaml\n",
+            "script_b.py": "import yaml\n",
+        },
+    )
+    baseline = write_baseline(repo, {"README.md": ["script_a.py"]})
+    (repo / "README.md").write_text("Run `python3 script_b.py`.\n", encoding="utf-8")
+    import subprocess
+
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "swap doc"], cwd=repo, check=True)
+
+    rc = main(["--repo-root", str(repo), "--baseline", str(baseline)])
+
+    assert rc == 1, "swap of same-count offense must be detected"
+    assert "script_b.py" in capsys.readouterr().err
+
+
+def test_no_swap_passes(tmp_path: Path) -> None:
+    """Negative control: same script in baseline and scan exits 0."""
+    repo = make_repo(
+        tmp_path,
+        {
+            "tool.py": "import yaml\n",
+            "README.md": "Run `python3 tool.py`.\n",
+        },
+    )
+    baseline = write_baseline(repo, {"README.md": ["tool.py"]})
+
+    rc = main(["--repo-root", str(repo), "--baseline", str(baseline)])
+
+    assert rc == 0
+
+
+def test_legacy_int_baseline_accepted(tmp_path: Path) -> None:
+    """A baseline with int values (old format) still loads and passes when count unchanged."""
+    repo = make_repo(
+        tmp_path,
+        {
+            "tool.py": "import yaml\n",
+            "README.md": "Run `python3 tool.py`.\n",
+        },
+    )
+    baseline_path = repo / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"files": {"README.md": 1}}, indent=2), encoding="utf-8"
+    )
+
+    rc = main(["--repo-root", str(repo), "--baseline", str(baseline_path)])
+
+    assert rc == 0
+
+
+def test_legacy_int_baseline_fires_on_count_rise(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A legacy int baseline still blocks when a new script is added above the baseline."""
+    repo = make_repo(
+        tmp_path,
+        {
+            "tool.py": "import yaml\n",
+            "other.py": "import yaml\n",
+            "README.md": "Run `python3 tool.py` and `python3 other.py`.\n",
+        },
+    )
+    baseline_path = repo / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"files": {"README.md": 1}}, indent=2), encoding="utf-8"
+    )
+
+    rc = main(["--repo-root", str(repo), "--baseline", str(baseline_path)])
+
+    assert rc == 1
+    assert "README.md" in capsys.readouterr().err
+
+
+def test_diff_against_baseline_swap_detection() -> None:
+    """Unit-level: diff_against_baseline fires when baseline has list values and current swaps."""
+    current = {"doc.md": ["script_b.py"]}
+    base = {"doc.md": ["script_a.py"]}
+    regressions, improvements = diff_against_baseline(current, base)
+    assert regressions, "swap must produce a regression"
+    assert "script_b.py" in regressions[0]
+    # script_b.py is present (count 1) and baseline has script_a.py (count 1).
+    # cur == limit, so no improvement entry is generated.
+    assert improvements == []

--- a/tests/test_check_doc_interpreter_portability_identity.py
+++ b/tests/test_check_doc_interpreter_portability_identity.py
@@ -107,8 +107,8 @@ def test_legacy_int_baseline_fires_on_count_rise(
 
 def test_diff_against_baseline_swap_detection() -> None:
     """Unit-level: diff_against_baseline fires when baseline has list values and current swaps."""
-    current = {"doc.md": ["script_b.py"]}
-    base = {"doc.md": ["script_a.py"]}
+    current: dict[str, list[str]] = {"doc.md": ["script_b.py"]}
+    base: dict[str, list[str] | int] = {"doc.md": ["script_a.py"]}
     regressions, improvements = diff_against_baseline(current, base)
     assert regressions, "swap must produce a regression"
     assert "script_b.py" in regressions[0]


### PR DESCRIPTION
## Summary

Fixes a blind spot in `check_doc_interpreter_portability.py`: the ratchet
compared per-file offense COUNTS, so removing one bare-`python3` invocation
and adding a different one in the same file left the count unchanged and the
new unportable invocation shipped undetected.

## Specification References

| Issue | Coverage |
|---|---|
| #4292 | Doc interpreter portability ratchet identity baseline |

## Type of Change

- [x] Bug fix
- [x] Tests updated

## Root cause

`scan()` returned `dict[str, int]` (a count per file). `diff_against_baseline()`
compared `cur > limit` per file. A swap (remove script A, add script B, same file)
left `cur == limit`, so `1 > 1` was False and no regression fired.

## Fix

`scan()` now returns `dict[str, list[str]]`: each value is a sorted list of
the normalized script paths found in that file.

`diff_against_baseline()` uses set-difference for list-valued baselines:
new entries in the current scan that are not in the baseline are regressions.
A swap (A removed, B added) produces one new entry; the ratchet fires.

`load_baseline()` accepts both the new list format and the legacy int format
via `_BaselineValue = list[str] | int`. Legacy int baselines continue to use
count comparison, so existing baseline files load without migration.

## Baseline "may only fall" property

For list-valued baselines, adding a new script is always a regression; removing
one is an improvement. The property holds: the baseline can only fall (improve),
never rise. For legacy int baselines, count comparison is unchanged.

## Mutation proof

The reproducer from #4292:

**Before this fix:** Remove `script_a.py` from a doc, add `script_b.py` at equal
count. `check_doc_interpreter_portability --baseline` exits 0. New offense ships.

**After this fix:** `test_same_count_swap_is_detected_with_identity_baseline`
(in `tests/test_check_doc_interpreter_portability_identity.py`) performs exactly
this swap against an identity baseline and asserts exit 1. The test passes.

## Changes

- `scripts/validation/check_doc_interpreter_portability.py`: changed `scan()`
  return type, added `_BaselineValue`, rewrote `load_baseline()` and
  `diff_against_baseline()`.
- `tests/test_check_doc_interpreter_portability.py`: updated `write_baseline()`
  signature to accept `dict[str, int | list[str]]`; updated 8 `scan()` assertions
  from int to list format.
- `tests/test_check_doc_interpreter_portability_identity.py` (new): 5 tests
  covering the mutation proof, negative control, legacy int baseline acceptance,
  legacy int count-rise detection, and unit-level `diff_against_baseline` swap.

Refs #4292

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- closing-claim-audit-2026-08-03 -->
## Closing claim audit

These references do not close their linked items:

- Refs #4292. Issue #4292 is already closed; this diff adds defense-in-depth identity tracking.
