### PR TITLE
fix(ci): extract copilot-context-synthesis Summary step, close ADR-006 burn-down

### DIFF
--- a/.github/workflows/copilot-context-synthesis.yml
+++ b/.github/workflows/copilot-context-synthesis.yml
@@ -110,18 +110,7 @@ jobs:
         if: success()
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
-        run: |
-          echo "## Copilot Context Synthesis Complete :robot:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Issue**: #${ISSUE_NUMBER}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Actions Taken" >> $GITHUB_STEP_SUMMARY
-          echo "- Synthesized context from trusted sources" >> $GITHUB_STEP_SUMMARY
-          echo "- Posted/updated synthesis comment with @copilot mention" >> $GITHUB_STEP_SUMMARY
-          echo "- Assigned copilot-swe-agent to the issue" >> $GITHUB_STEP_SUMMARY
-          echo "- Removed copilot-ready label (processing complete)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Copilot will now create a PR based on the synthesized context." >> $GITHUB_STEP_SUMMARY
+        run: python3 scripts/ci/write_copilot_synthesis_summary.py
 
   # ===========================================================================
   # Job 2: Sweep for Missed Issues (scheduled or manual without issue number)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -249,7 +249,7 @@ jobs:
       # the actors who author workflow changes is weaker than the hook it
       # backstops, not equal to it.
       - name: Run ADR-006 run-block ratchet
-        run: python3 scripts/ci/adr006_run_block_scanner.py --max 58
+        run: python3 scripts/ci/adr006_run_block_scanner.py --max 0
 
       # Issue #3779: taste-lints emits severity="error" and nothing could fail
       # because of one. The linter itself is correct (it exits 10 on an error),

--- a/scripts/ci/write_copilot_synthesis_summary.py
+++ b/scripts/ci/write_copilot_synthesis_summary.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Write the Copilot context synthesis job summary to GITHUB_STEP_SUMMARY.
+
+Reads ISSUE_NUMBER from the environment and writes a markdown summary
+to $GITHUB_STEP_SUMMARY.
+Replaces the inline "Summary" run step in copilot-context-synthesis.yml
+(issue #2967, ADR-006 burn-down).
+
+EXIT CODES (ADR-035):
+  0  - Summary written to GITHUB_STEP_SUMMARY, or printed to stdout when unset
+  2  - Usage error (ISSUE_NUMBER not set)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+
+
+def _build_summary(issue_number: str) -> str:
+    return (
+        "## Copilot Context Synthesis Complete :robot:\n"
+        "\n"
+        f"**Issue**: #{issue_number}\n"
+        "\n"
+        "### Actions Taken\n"
+        "- Synthesized context from trusted sources\n"
+        "- Posted/updated synthesis comment with @copilot mention\n"
+        "- Assigned copilot-swe-agent to the issue\n"
+        "- Removed copilot-ready label (processing complete)\n"
+        "\n"
+        "Copilot will now create a PR based on the synthesized context.\n"
+    )
+
+
+def main() -> int:
+    issue_number = os.environ.get("ISSUE_NUMBER", "").strip()
+    if not issue_number:
+        print("ERROR: ISSUE_NUMBER is not set", file=sys.stderr)
+        return EXIT_USAGE
+
+    summary = _build_summary(issue_number)
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+    else:
+        print(summary, end="")
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -566,7 +566,7 @@ def test_workflow_delegates_all_pr_validation_blocks():
     assert "python3 scripts/ci/update_needs_split_label.py --mode add" in workflow
     assert "python3 scripts/ci/update_needs_split_label.py --mode remove" in workflow
     assert "python3 scripts/ci/enforce_pr_validation.py" in workflow
-    assert "python3 scripts/ci/adr006_run_block_scanner.py --max 58" in workflow
+    assert "python3 scripts/ci/adr006_run_block_scanner.py --max 0" in workflow
     assert "gh api `\n            -X DELETE" not in workflow
     assert "Write-Error \"PR has $env:COMMIT_COUNT commits" not in workflow
 

--- a/tests/ci/test_write_copilot_synthesis_summary.py
+++ b/tests/ci/test_write_copilot_synthesis_summary.py
@@ -1,0 +1,72 @@
+"""Tests for write_copilot_synthesis_summary.py (ADR-006 burn-down, issue #2967)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path("scripts/ci/write_copilot_synthesis_summary.py")
+
+
+def _run(env: dict[str, str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    import os
+
+    full_env = {**os.environ, **env}
+    return subprocess.run(
+        ["uv", "run", "--frozen", "python", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        cwd=Path(__file__).parents[2],
+    )
+
+
+class TestHappyPath:
+    def test_writes_to_stdout_when_no_summary_file(self) -> None:
+        result = _run({"ISSUE_NUMBER": "42"}, Path())
+        assert result.returncode == 0
+        assert "Copilot Context Synthesis Complete" in result.stdout
+        assert "#42" in result.stdout
+
+    def test_writes_expected_sections(self) -> None:
+        result = _run({"ISSUE_NUMBER": "99"}, Path())
+        assert result.returncode == 0
+        assert "### Actions Taken" in result.stdout
+        assert "#99" in result.stdout
+        assert "Copilot will now create a PR" in result.stdout
+
+    def test_writes_to_summary_file(self, tmp_path: Path) -> None:
+        summary_file = tmp_path / "step_summary.md"
+        result = _run(
+            {"ISSUE_NUMBER": "7", "GITHUB_STEP_SUMMARY": str(summary_file)},
+            tmp_path,
+        )
+        assert result.returncode == 0
+        content = summary_file.read_text()
+        assert "#7" in content
+        assert "Copilot Context Synthesis Complete" in content
+
+
+class TestNegativeControl:
+    def test_exits_2_when_issue_number_missing(self) -> None:
+        result = _run({"ISSUE_NUMBER": ""}, Path())
+        assert result.returncode == 2
+        assert "ISSUE_NUMBER" in result.stderr
+
+    def test_no_output_on_error(self) -> None:
+        result = _run({"ISSUE_NUMBER": ""}, Path())
+        assert result.stdout == ""
+
+
+class TestEdgeCases:
+    def test_appends_to_existing_summary_file(self, tmp_path: Path) -> None:
+        summary_file = tmp_path / "summary.md"
+        summary_file.write_text("# Existing content\n")
+        _run({"ISSUE_NUMBER": "5", "GITHUB_STEP_SUMMARY": str(summary_file)}, tmp_path)
+        content = summary_file.read_text()
+        assert "# Existing content" in content
+        assert "#5" in content
+
+    def test_issue_number_appears_once_in_output(self) -> None:
+        result = _run({"ISSUE_NUMBER": "123"}, Path())
+        assert result.stdout.count("#123") == 1


### PR DESCRIPTION
## Summary

Completes the ADR-006 run-block burn-down (#2967). One violation remained on `main` before this diff
after 92 extractions: an 11-line `echo` block in `copilot-context-synthesis.yml`
writing to `GITHUB_STEP_SUMMARY`. Extracted to
`scripts/ci/write_copilot_synthesis_summary.py`. Scanner now reports 0
violations. Lowers `--max` in `pr-validation.yml` from 58 to 0 so future
additions trip CI immediately.

## Triage

Measured against `origin/main` (`0e75c00b3`):

```
ADR-006 run-block violations (> 10 code lines + logic): 1
  .github/workflows/copilot-context-synthesis.yml:113  (11 code lines)
```

Issue body states 93 violations. **Overturned**: 92 have been extracted in prior
PRs. One remained.

## Changes

- `scripts/ci/write_copilot_synthesis_summary.py`: new script; reads `ISSUE_NUMBER`
  and writes to `GITHUB_STEP_SUMMARY` (or stdout when unset)
- `tests/ci/test_write_copilot_synthesis_summary.py`: 7 tests covering happy path,
  negative control (exit 2 on missing `ISSUE_NUMBER`), and edge cases
- `.github/workflows/copilot-context-synthesis.yml`: replace 11-line echo block with
  `python3 scripts/ci/write_copilot_synthesis_summary.py`
- `.github/workflows/pr-validation.yml`: lower `--max` from 58 to 0

## Testing

7 tests, all passing. Mutation proof:

Mutant (change `return EXIT_USAGE` to `return EXIT_OK` in error path):

```
FAILED tests/ci/test_write_copilot_synthesis_summary.py::TestNegativeControl::test_exits_2_when_issue_number_missing
1 failed, 6 passed
```

Restore: 7 passed.

Fixes #2967

<!-- closing-claim-audit-2026-08-03 -->
## Closing claim audit

This closing claim is supported:

- Fixes #2967. The diff removes the final ADR-006 run block and sets the ratchet maximum to zero.