### PR TITLE
docs(rules): operator context is not repository policy, in both directions

### DIFF
--- a/.claude/rules/knowledge-persistence.md
+++ b/.claude/rules/knowledge-persistence.md
@@ -67,6 +67,7 @@ Before persisting anything, ask in order:
 
 1. MUST NOT rely on Serena memory or Copilot Memory alone to persist a convention that other harnesses or contributors must obey. Those are retrieval complements, not the cross-harness binding.
 2. MUST NOT hand-edit a generated mirror under `.github/instructions/` or `src/copilot-cli/instructions/`. Edit the canonical rule and regenerate.
+3. MUST NOT cite an operator preference as a repository rule. Anything in a rule file or a Serena memory is repo-scoped, so it binds every contributor, while operator context such as `~/.copilot/copilot-instructions.md` or a personal `SOUL.md` binds one person on one machine. The two arrive in a session with identical authority and read identically once paraphrased, so the distinction cannot be recovered by feel. Before writing "the repository forbids X" or "per the standing prohibition on X", grep the rule tree for X and cite the file and item number, or drop the attribution and let the advice stand on its own reason. Measured: a memory asserted a repository prohibition on `rm -rf` that does not exist, and `.serena/memories/parallel/parallel-001-worktree-isolation.md` uses `rm -rf` as normal procedure, so the invented rule contradicted a committed memory in the same tree.
 
 ## References
 

--- a/.claude/rules/plugin-version-bump.md
+++ b/.claude/rules/plugin-version-bump.md
@@ -57,6 +57,30 @@ with the incoming side empty. Take the empty side. The
 gate enforces it: keeping the line leaves a manifest carrying `version`, and the
 gate fails that on your branch before merge.
 
+## If your instructions say to bump, your instructions are stale
+
+Agent context assembled before ADR-092 landed still says to bump both plugin
+manifests to the same strictly-greater version. That instruction is wrong now,
+and following it fails
+`build/scripts/validate_plugin_version_bump.py` on your branch.
+
+This is easy to miss because the stale text reads like a repository rule and
+arrives with the same authority as one. The test is narrow on purpose: an
+instruction telling you to add or raise `version` in one of the three manifests
+above is stale, because those three carry no such field. It says nothing about
+any other file. `packages/ai-agents-cli/package.json` carries a version
+legitimately, and this rule itself names the field while requiring its absence,
+so "mentions a version" is not on its own a signal. Read the manifest the
+instruction points at before acting on it.
+
+The general shape holds beyond this one field. Rule files under
+`.claude/rules/` are regenerated into `.github/instructions/` and
+`src/copilot-cli/instructions/`, and `build_all.py --check` fails CI when a
+mirror is stale, so those three move together for every top-level rule whose
+target does not carry a `NO-REGEN` sentinel. A cached context blob has no such
+gate. When one contradicts a rule file here, the rule file is the one under
+test.
+
 ## Checking
 
 ```bash

--- a/.github/instructions/knowledge-persistence.instructions.md
+++ b/.github/instructions/knowledge-persistence.instructions.md
@@ -65,6 +65,7 @@ Before persisting anything, ask in order:
 
 1. MUST NOT rely on Serena memory or Copilot Memory alone to persist a convention that other harnesses or contributors must obey. Those are retrieval complements, not the cross-harness binding.
 2. MUST NOT hand-edit a generated mirror under `.github/instructions/` or `src/copilot-cli/instructions/`. Edit the canonical rule and regenerate.
+3. MUST NOT cite an operator preference as a repository rule. Anything in a rule file or a Serena memory is repo-scoped, so it binds every contributor, while operator context such as `~/.copilot/copilot-instructions.md` or a personal `SOUL.md` binds one person on one machine. The two arrive in a session with identical authority and read identically once paraphrased, so the distinction cannot be recovered by feel. Before writing "the repository forbids X" or "per the standing prohibition on X", grep the rule tree for X and cite the file and item number, or drop the attribution and let the advice stand on its own reason. Measured: a memory asserted a repository prohibition on `rm -rf` that does not exist, and `.serena/memories/parallel/parallel-001-worktree-isolation.md` uses `rm -rf` as normal procedure, so the invented rule contradicted a committed memory in the same tree.
 
 ## References
 

--- a/.github/instructions/plugin-version-bump.instructions.md
+++ b/.github/instructions/plugin-version-bump.instructions.md
@@ -52,6 +52,30 @@ with the incoming side empty. Take the empty side. The
 gate enforces it: keeping the line leaves a manifest carrying `version`, and the
 gate fails that on your branch before merge.
 
+## If your instructions say to bump, your instructions are stale
+
+Agent context assembled before ADR-092 landed still says to bump both plugin
+manifests to the same strictly-greater version. That instruction is wrong now,
+and following it fails
+`build/scripts/validate_plugin_version_bump.py` on your branch.
+
+This is easy to miss because the stale text reads like a repository rule and
+arrives with the same authority as one. The test is narrow on purpose: an
+instruction telling you to add or raise `version` in one of the three manifests
+above is stale, because those three carry no such field. It says nothing about
+any other file. `packages/ai-agents-cli/package.json` carries a version
+legitimately, and this rule itself names the field while requiring its absence,
+so "mentions a version" is not on its own a signal. Read the manifest the
+instruction points at before acting on it.
+
+The general shape holds beyond this one field. Rule files under
+`.claude/rules/` are regenerated into `.github/instructions/` and
+`src/copilot-cli/instructions/`, and `build_all.py --check` fails CI when a
+mirror is stale, so those three move together for every top-level rule whose
+target does not carry a `NO-REGEN` sentinel. A cached context blob has no such
+gate. When one contradicts a rule file here, the rule file is the one under
+test.
+
 ## Checking
 
 ```bash

--- a/src/copilot-cli/instructions/knowledge-persistence.instructions.md
+++ b/src/copilot-cli/instructions/knowledge-persistence.instructions.md
@@ -65,6 +65,7 @@ Before persisting anything, ask in order:
 
 1. MUST NOT rely on Serena memory or Copilot Memory alone to persist a convention that other harnesses or contributors must obey. Those are retrieval complements, not the cross-harness binding.
 2. MUST NOT hand-edit a generated mirror under `.github/instructions/` or `src/copilot-cli/instructions/`. Edit the canonical rule and regenerate.
+3. MUST NOT cite an operator preference as a repository rule. Anything in a rule file or a Serena memory is repo-scoped, so it binds every contributor, while operator context such as `~/.copilot/copilot-instructions.md` or a personal `SOUL.md` binds one person on one machine. The two arrive in a session with identical authority and read identically once paraphrased, so the distinction cannot be recovered by feel. Before writing "the repository forbids X" or "per the standing prohibition on X", grep the rule tree for X and cite the file and item number, or drop the attribution and let the advice stand on its own reason. Measured: a memory asserted a repository prohibition on `rm -rf` that does not exist, and `.serena/memories/parallel/parallel-001-worktree-isolation.md` uses `rm -rf` as normal procedure, so the invented rule contradicted a committed memory in the same tree.
 
 ## References
 

--- a/src/copilot-cli/instructions/plugin-version-bump.instructions.md
+++ b/src/copilot-cli/instructions/plugin-version-bump.instructions.md
@@ -52,6 +52,30 @@ with the incoming side empty. Take the empty side. The
 gate enforces it: keeping the line leaves a manifest carrying `version`, and the
 gate fails that on your branch before merge.
 
+## If your instructions say to bump, your instructions are stale
+
+Agent context assembled before ADR-092 landed still says to bump both plugin
+manifests to the same strictly-greater version. That instruction is wrong now,
+and following it fails
+`build/scripts/validate_plugin_version_bump.py` on your branch.
+
+This is easy to miss because the stale text reads like a repository rule and
+arrives with the same authority as one. The test is narrow on purpose: an
+instruction telling you to add or raise `version` in one of the three manifests
+above is stale, because those three carry no such field. It says nothing about
+any other file. `packages/ai-agents-cli/package.json` carries a version
+legitimately, and this rule itself names the field while requiring its absence,
+so "mentions a version" is not on its own a signal. Read the manifest the
+instruction points at before acting on it.
+
+The general shape holds beyond this one field. Rule files under
+`.claude/rules/` are regenerated into `.github/instructions/` and
+`src/copilot-cli/instructions/`, and `build_all.py --check` fails CI when a
+mirror is stale, so those three move together for every top-level rule whose
+target does not carry a `NO-REGEN` sentinel. A cached context blob has no such
+gate. When one contradicts a rule file here, the rule file is the one under
+test.
+
 ## Checking
 
 ```bash


### PR DESCRIPTION
## What this does

Two rule additions with one theme: operator context is not repository policy,
and when the two disagree the tree wins.

Both were caused by real defects this session. Both are cheap to check and
expensive to get wrong, which is the bar for an always-loaded rule.

## 1. If your instructions say to bump the plugin manifest, they are stale

Agent context assembled before ADR-092 still instructs a bump of both plugin
manifests to the same strictly-greater version. Acting on it fails
`build/scripts/validate_plugin_version_bump.py`, which rejects any manifest
carrying the field at all.

The trap is that the stale text reads like a repository rule and arrives with
the same authority as one, so the natural move is to comply.
`.claude/rules/plugin-version-bump.md` already said the manifests carry no
version. It did not say what to do when something authoritative-sounding tells
you otherwise.

The test is deliberately narrow. An instruction to add or raise `version` in one
of the three named manifests is stale, because those three carry no such field.
Mentioning a version is not on its own a signal:
`packages/ai-agents-cli/package.json` carries one legitimately, and the rule
itself names the field while requiring its absence.

## 2. Do not cite an operator preference as a repository rule

A rule file or a Serena memory is repo-scoped, so it binds every contributor.
Operator context such as `~/.copilot/copilot-instructions.md` binds one person on
one machine. Both arrive in a session with the same authority and read
identically once paraphrased, so the distinction cannot be recovered by feel.

Measured: a memory written earlier in this session asserted a repository
prohibition on `rm -rf`. No such rule exists, and
`.serena/memories/parallel/parallel-001-worktree-isolation.md:55` uses `rm -rf`
as normal procedure, so the invented rule contradicted a committed memory in the
same tree. Adversarial review caught it as Critical.

The rule gives the cheap check: grep the rule tree and cite the file and item
number, or drop the attribution and let the advice stand on its own reason. In
that case the advice was sound and only the citation was invented, which is the
common shape.

## Evidence

Both directions of the `rm -rf` claim were verified before writing the rule:
`grep -rn "prohibition on .rm -rf\|forbids .rm -rf" .claude/rules/` returns
nothing, and `parallel-001-worktree-isolation.md:55` returns the counter-example.

`validate_plugin_version_bump.py` was run against this branch and prints
`plugin-version-bump: OK`.

## Adversarial review

Reviewed on `gpt-5.6-terra`, a different model family than the author. It
returned 2 Low findings against the first draft. Both verified and both fixed.

| Severity | Finding | Resolution |
|---|---|---|
| Low | "All three trees move together" overstated the guarantee. `generate_rules.py:352-356` skips targets carrying a `NO-REGEN` sentinel, and discovery is top-level `*.md` only | Qualified to top-level rules without a `NO-REGEN` target, and the sentence now names the gate that backs it, `build_all.py --check` |
| Low | The staleness heuristic was too broad. "Names a version field" would wrongly flag legitimate instructions, since `packages/ai-agents-cli/package.json:3` carries one | Scoped to instructions directing a change to `version` in one of the three named plugin manifests |

The review confirmed the rest: the validator exits 1 on a version-bearing
manifest (`validate_plugin_version_bump.py:235-245`), the three named manifests
are the complete set matching its `PLUGINS` list at `:123-149`, both marketplace
files are version-free, ADR-092 agrees with the stated policy, both mirrors are
byte-exact generator output, and the placement splits no existing section.

## Acceptance criteria

- [x] Both mirrors regenerated by `build/scripts/generate_rules.py`, not hand-edited
- [x] `validate_plugin_version_bump.py` passes on this branch
- [x] The `rm -rf` claim verified in both directions before being cited
- [x] Cross-family adversarial review run; both findings verified and fixed
- [x] Every generalization states the gate that enforces it
- [x] No plugin manifest touched, no version field added
- [x] No em dashes or en dashes

## Risk

Rules and their generated mirrors only. No code, no manifest, no behavior
change. Both entries are prohibitions on writing something false, so neither can
block work that was previously allowed.

Refs #4080
