### PR TITLE
fix(ci,github): make the supersession report run and stop a failed head read from surrendering the lease

### DIFF
--- a/.claude/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/.claude/skills/github/scripts/pr/pr_autofix_lease.py
@@ -666,9 +666,13 @@ def post_lease_comment(owner: str, repo: str, pr: int, body: str) -> None:
 class LeaseResult:
     """Outcome of a lease operation. ``action`` is ACT or SKIP.
 
-    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1).
-    ``local_head_sha`` is what the caller's checkout had at ``HEAD``, or
-    None when git could not answer. The two differ whenever acquire runs
+    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1), and
+    is populated only on the ACT path. ``acquire`` returns SKIP before it
+    reads the PR head, so both ``base_sha`` and ``local_head_sha`` stay None
+    on that path; a caller must not read them as evidence about the PR.
+
+    On ACT, ``local_head_sha`` is what the caller's checkout had at ``HEAD``,
+    or None when git could not answer. The two differ whenever acquire runs
     from a checkout that is not the PR branch; the caller reports both so
     the divergence is visible instead of silently recorded as the PR's head
     (issue #4357 acceptance criterion 4).

--- a/.claude/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/.claude/skills/github/scripts/pr/pr_autofix_lease.py
@@ -494,9 +494,12 @@ class LeaseStoreError(RuntimeError):
 def _git_head_sha() -> str | None:
     """Return the local HEAD SHA, or None if git is unavailable.
 
-    The acquire path records ``base_sha`` so the push-time guard (Phase 2
-    integration) can detect a remote advance under the lease. Phase 1 only
-    records it; it never gates a push on it (the SHA gate does that).
+    This answers "what is checked out here", which is NOT what ``base_sha``
+    means. ADR-076 part 1 defines ``base_sha`` as the "PR head.sha the
+    holder fetched before acquiring", and acquire step 1 fetches it from
+    GitHub. Acquire records this value only as the observed local checkout,
+    so a caller standing on the wrong branch is reported rather than
+    published as the PR's head (issues #4357, #4375).
     """
     try:
         result = subprocess.run(
@@ -514,6 +517,36 @@ def _git_head_sha() -> str | None:
         return None
     sha = (result.stdout or "").strip()
     return sha if _SHA40.match(sha) else None
+
+
+def _pr_head_sha(owner: str, repo: str, pr: int) -> str:
+    """Return the PR's authoritative head SHA. Raises LeaseStoreError.
+
+    ADR-076 part 3 acquire step 1: "Fetch the PR ``head.sha`` and the latest
+    N lease comments in one bounded read". The value is read from GitHub, so
+    it describes the PR branch no matter which checkout the caller stands
+    in. A failure is a lease-store failure, so the caller fails open to ACT
+    (step 6) instead of publishing freshness evidence it could not verify.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/pulls/{pr}", "--jq", ".head.sha"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise LeaseStoreError(f"pr head read failed: {exc}") from exc
+    if result.returncode != 0:
+        raise LeaseStoreError(
+            f"pr head read exited {result.returncode}: {safe_log_str((result.stderr or '')[:200])}"
+        )
+    sha = (result.stdout or "").strip()
+    if not _SHA40.match(sha):
+        raise LeaseStoreError("pr head read returned no 40-hex sha")
+    return sha
 
 
 def _gh_authenticated_login() -> str:
@@ -630,12 +663,39 @@ def post_lease_comment(owner: str, repo: str, pr: int, body: str) -> None:
 
 @dataclass(frozen=True, slots=True)
 class LeaseResult:
-    """Outcome of a lease operation. ``action`` is ACT or SKIP."""
+    """Outcome of a lease operation. ``action`` is ACT or SKIP.
+
+    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1).
+    ``local_head_sha`` is what the caller's checkout had at ``HEAD``, or
+    None when git could not answer. The two differ whenever acquire runs
+    from a checkout that is not the PR branch; the caller reports both so
+    the divergence is visible instead of silently recorded as the PR's head
+    (issue #4357 acceptance criterion 4).
+    """
 
     action: str
     reason: str
     expires_at: str | None = None
     base_sha: str | None = None
+    local_head_sha: str | None = None
+
+
+def _warn_on_checkout_mismatch(pr: int, local_sha: str | None, base_sha: str) -> None:
+    """Log both SHAs when the caller's checkout is not the PR head.
+
+    The lease still publishes the authoritative PR head, so the recorded
+    evidence is correct either way. The warning tells the operator that the
+    session doing the fix work is standing somewhere else, which is what
+    produced the wrong lease on #4294 (issue #4357).
+    """
+    if local_sha is None or local_sha == base_sha:
+        return
+    logger.warning(
+        "op=lease_checkout_mismatch pr=%d local_head_sha=%s pr_head_sha=%s",
+        pr,
+        safe_log_str(local_sha),
+        safe_log_str(base_sha),
+    )
 
 
 def acquire(
@@ -661,17 +721,27 @@ def acquire(
     authenticated ``gh`` login is resolved. An unresolved login ("") can
     only claim a free lock, never self-renew a foreign one (fails safe).
 
+    ``base_sha`` is the PR head SHA read from GitHub (ADR-076 part 3 step
+    1), never the caller's local HEAD, so an acquire run from the wrong
+    checkout cannot publish freshness evidence for another branch. The
+    local HEAD is still read and reported as ``local_head_sha``, and a
+    mismatch is logged with both values (issues #4357, #4375).
+
     ``now`` is injectable for deterministic tests; production passes None
     and the current UTC instant is used.
     """
     now = now or datetime.now(UTC)
     author = _gh_authenticated_login() if acting_author is None else acting_author
-    base_sha = _git_head_sha() or ("0" * 40)
+    local_sha = _git_head_sha()
     try:
+        base_sha = _pr_head_sha(repo_owner, repo, pr)
         comments = list_lease_comments(repo_owner, repo, pr)
     except LeaseStoreError as exc:
         logger.warning("op=lease_acquire_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
-        return LeaseResult("ACT", "lease-store-unavailable", base_sha=base_sha)
+        return LeaseResult(
+            "ACT", "lease-store-unavailable", base_sha="0" * 40, local_head_sha=local_sha
+        )
+    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     current = select_authoritative_lease(comments)
     verdict = classify_acquire(current, author, now)
@@ -683,9 +753,15 @@ def acquire(
         post_lease_comment(repo_owner, repo, pr, render_lease_comment(claim))
     except LeaseStoreError as exc:
         logger.warning("op=lease_claim_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
-        return LeaseResult("ACT", "lease-store-unavailable", base_sha=base_sha)
+        return LeaseResult(
+            "ACT", "lease-store-unavailable", base_sha=base_sha, local_head_sha=local_sha
+        )
     return LeaseResult(
-        "ACT", verdict["reason"], expires_at=_to_rfc3339(claim.expires_at), base_sha=base_sha
+        "ACT",
+        verdict["reason"],
+        expires_at=_to_rfc3339(claim.expires_at),
+        base_sha=base_sha,
+        local_head_sha=local_sha,
     )
 
 
@@ -815,6 +891,7 @@ def main(argv: list[str] | None = None) -> int:
         "reason": result.reason,
         "expires_at": result.expires_at,
         "base_sha": result.base_sha,
+        "local_head_sha": result.local_head_sha,
     }
     logger.info(
         "op=lease pr=%d command=%s action=%s reason=%s",

--- a/.claude/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/.claude/skills/github/scripts/pr/pr_autofix_lease.py
@@ -525,8 +525,9 @@ def _pr_head_sha(owner: str, repo: str, pr: int) -> str:
     ADR-076 part 3 acquire step 1: "Fetch the PR ``head.sha`` and the latest
     N lease comments in one bounded read". The value is read from GitHub, so
     it describes the PR branch no matter which checkout the caller stands
-    in. A failure is a lease-store failure, so the caller fails open to ACT
-    (step 6) instead of publishing freshness evidence it could not verify.
+    in. Acquire catches the failure and records the zero sentinel rather
+    than failing open, because losing freshness evidence must not also lose
+    the lock (see ``acquire``).
     """
     try:
         result = subprocess.run(
@@ -727,6 +728,11 @@ def acquire(
     local HEAD is still read and reported as ``local_head_sha``, and a
     mismatch is logged with both values (issues #4357, #4375).
 
+    Only the comment read fails open. The head read runs after the lease
+    verdict and records the zero sentinel on failure, so a transient error
+    on it cannot skip the read that enforces mutual exclusion, and it costs
+    nothing on the SKIP path.
+
     ``now`` is injectable for deterministic tests; production passes None
     and the current UTC instant is used.
     """
@@ -734,19 +740,27 @@ def acquire(
     author = _gh_authenticated_login() if acting_author is None else acting_author
     local_sha = _git_head_sha()
     try:
-        base_sha = _pr_head_sha(repo_owner, repo, pr)
         comments = list_lease_comments(repo_owner, repo, pr)
     except LeaseStoreError as exc:
         logger.warning("op=lease_acquire_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
         return LeaseResult(
             "ACT", "lease-store-unavailable", base_sha="0" * 40, local_head_sha=local_sha
         )
-    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     current = select_authoritative_lease(comments)
     verdict = classify_acquire(current, author, now)
     if verdict["action"] == "SKIP":
         return LeaseResult("SKIP", verdict["reason"], expires_at=verdict.get("expires_at"))
+
+    # The head read is freshness evidence, not the lock. Failing it open to ACT
+    # alongside the comment read would let a transient API error skip the read
+    # that enforces mutual exclusion, so it is scoped to the sentinel instead.
+    try:
+        base_sha = _pr_head_sha(repo_owner, repo, pr)
+    except LeaseStoreError as exc:
+        logger.warning("op=lease_pr_head_unavailable pr=%d err=%s", pr, safe_log_str(str(exc)))
+        base_sha = "0" * 40
+    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     claim = build_claim(owner, session, base_sha, now)
     try:

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -243,3 +243,11 @@ jobs:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
           SUMMARY_JSON: ${{ needs.discover-prs.outputs.summary-json }}
         run: python3 scripts/ci/write_pr_maintenance_summary.py
+
+      # Issue #4355: three of six sampled open PRs were already fixed on main
+      # and nothing said so until someone rebased. Report only; the signal has
+      # a known false positive (#4163) and needs a human to confirm.
+      - name: Report PR supersession candidates
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: python3 scripts/report_pr_supersession.py | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -250,4 +250,4 @@ jobs:
       - name: Report PR supersession candidates
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
-        run: python3 scripts/report_pr_supersession.py | tee -a "$GITHUB_STEP_SUMMARY"
+        run: python3 scripts/report_pr_supersession.py >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/report_pr_supersession.py
+++ b/scripts/report_pr_supersession.py
@@ -52,9 +52,16 @@ import logging
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any
 
-from scripts.github_core import resolve_repo_params
+# `pr-maintenance.yml` invokes this file as `python3 scripts/report_pr_supersession.py`,
+# so sys.path[0] is `scripts/` and the `scripts` package is unreachable without this
+# (.claude/rules/ci-scripts.md MUST 16). Everything reached from here must stay stdlib:
+# that job runs `actions/checkout` and nothing else.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.github_core.api import resolve_repo_params  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/report_pr_supersession.py
+++ b/scripts/report_pr_supersession.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Report open PRs whose work may already be on the base branch.
+
+Three of six open fleet PRs sampled on 2026-08-02 were already fixed on
+`main` while they sat (issue #4355). Nothing announced it: GitHub reported
+one as `blocked` and two as `dirty`, and neither state distinguishes "needs
+a rebase" from "the work is already done". The collision only became
+visible when someone started a rebase and read the conflict, which is the
+expensive step.
+
+This is a REPORT, not a gate. It never closes a PR and never fails on a
+finding, because the signal has a known false positive: PR #4163 has two
+closed linked issues and is not superseded, since a different PR closed
+them. Every flag needs a human or an agent to confirm.
+
+Three reasons flag a PR, and each is a fact the reader can check:
+
+    closed-linked-issue   a linked issue is already CLOSED while the PR is
+                          open. Caught #4164 (issue #4058) and #4102
+                          (issue #4015).
+    stale-base            the PR is at least --stale-base commits behind its
+                          base. All three superseded PRs were 24 or more
+                          behind; measured after the fact, 50, 24, and 167.
+    no-linked-issue       a stale PR that closes nothing, so issue state can
+                          say nothing about it and nobody can check it
+                          against a tracked defect. Caught #3979, which the
+                          closed-issue signal alone cannot see. Gated on
+                          staleness on purpose: unlinked-but-fresh is an
+                          issue-linkage question, not a supersession one,
+                          and ungated it flagged 27 of 44 open PRs against
+                          14 gated.
+
+Patch-id supersession (`git cherry`, as `check_pr_live_state.py` runs it)
+is deliberately NOT one of them. Measured against those same four PRs on
+2026-08-03 it reported `superseded=0` for every one, because each fix had
+been reimplemented differently on main rather than cherry-picked. It
+answers a narrower question than this report asks.
+
+EXIT CODES:
+  0 - report produced (findings or not)
+  2 - usage or configuration error
+  3 - external error (GitHub API unreachable)
+
+See ADR-035 Exit Code Standardization.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from scripts.github_core import resolve_repo_params
+
+logger = logging.getLogger(__name__)
+
+#: Commits behind base at which a PR's payload is worth re-checking against
+#: the base branch. The three confirmed superseded PRs in #4355 were 24, 50,
+#: and 167 behind; the false positive #4163 was 12.
+DEFAULT_STALE_BASE = 20
+
+REASON_CLOSED_ISSUE = "closed-linked-issue"
+REASON_NO_ISSUE = "no-linked-issue"
+REASON_STALE_BASE = "stale-base"
+
+OPEN_PRS_QUERY = """\
+query($owner: String!, $name: String!, $limit: Int!) {
+    repository(owner: $owner, name: $name) {
+        pullRequests(states: OPEN, first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes {
+                number
+                title
+                isDraft
+                baseRefName
+                headRefOid
+                closingIssuesReferences(first: 10) {
+                    nodes { number state }
+                }
+            }
+        }
+    }
+}"""
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One open PR, its supersession evidence, and why it was flagged."""
+
+    number: int
+    title: str
+    is_draft: bool
+    base_ref: str
+    base_distance: int | None
+    closed_issues: list[int] = field(default_factory=list)
+    open_issues: list[int] = field(default_factory=list)
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def flagged(self) -> bool:
+        return bool(self.reasons)
+
+
+def linked_issue_states(pull_request: dict[str, Any]) -> tuple[list[int], list[int]]:
+    """Split a PR's linked issues into (closed, open) issue numbers.
+
+    GraphQL returns ``null`` rather than an absent key for an empty
+    connection, so every level is collapsed explicitly instead of relying
+    on a ``.get`` default.
+    """
+    refs = pull_request.get("closingIssuesReferences")
+    nodes = (refs or {}).get("nodes") or []
+    closed: list[int] = []
+    opened: list[int] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        number = node.get("number")
+        if not isinstance(number, int):
+            continue
+        if str(node.get("state", "")).upper() == "CLOSED":
+            closed.append(number)
+        else:
+            opened.append(number)
+    return closed, opened
+
+
+def classify_pull_request(
+    pull_request: dict[str, Any],
+    base_distance: int | None,
+    stale_base: int = DEFAULT_STALE_BASE,
+) -> Finding:
+    """Turn one PR payload plus its base distance into a Finding.
+
+    Pure: every input is data, so the reasons are testable without GitHub.
+    """
+    closed, opened = linked_issue_states(pull_request)
+    is_stale = base_distance is not None and base_distance >= stale_base
+    reasons: list[str] = []
+    if closed:
+        reasons.append(REASON_CLOSED_ISSUE)
+    if is_stale:
+        reasons.append(REASON_STALE_BASE)
+    if is_stale and not closed and not opened:
+        reasons.append(REASON_NO_ISSUE)
+    return Finding(
+        number=int(pull_request["number"]),
+        title=str(pull_request.get("title") or ""),
+        is_draft=bool(pull_request.get("isDraft")),
+        base_ref=str(pull_request.get("baseRefName") or ""),
+        base_distance=base_distance,
+        closed_issues=closed,
+        open_issues=opened,
+        reasons=reasons,
+    )
+
+
+def build_report(
+    pull_requests: list[dict[str, Any]],
+    distances: dict[int, int | None],
+    stale_base: int = DEFAULT_STALE_BASE,
+) -> dict[str, Any]:
+    """Classify every PR and summarize. Examined count is always reported."""
+    findings = [
+        classify_pull_request(pr, distances.get(int(pr["number"])), stale_base)
+        for pr in pull_requests
+    ]
+    flagged = [finding for finding in findings if finding.flagged]
+    return {
+        "examined": len(findings),
+        "flagged": len(flagged),
+        "stale_base_threshold": stale_base,
+        "findings": [asdict(finding) for finding in findings],
+    }
+
+
+def render_human(report: dict[str, Any]) -> str:
+    """One line per flagged PR, plus the examined count.
+
+    The examined count is printed whether or not anything was flagged, so a
+    run that saw nothing is distinguishable from a run that saw nothing
+    wrong (`.claude/rules/ci-scripts.md` MUST 12).
+    """
+    lines = [
+        f"PR supersession report: {report['flagged']} flagged of "
+        f"{report['examined']} open PRs examined "
+        f"(stale-base threshold {report['stale_base_threshold']})"
+    ]
+    for finding in report["findings"]:
+        if not finding["reasons"]:
+            continue
+        distance = finding["base_distance"]
+        behind = "unknown" if distance is None else str(distance)
+        lines.append(
+            f"  #{finding['number']} behind={behind} "
+            f"closed_issues={finding['closed_issues'] or '-'} "
+            f"open_issues={finding['open_issues'] or '-'} "
+            f"reasons={','.join(finding['reasons'])} :: {finding['title'][:60]}"
+        )
+    if report["flagged"]:
+        lines.append(
+            "  Confirm each one before acting. A closed linked issue can belong "
+            "to a different PR (#4163)."
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O adapter
+# ---------------------------------------------------------------------------
+
+
+class GitHubReadError(RuntimeError):
+    """The report could not read GitHub. Surfaced as exit 3."""
+
+
+def _run_gh(args: list[str], timeout: int = 60) -> str:
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise GitHubReadError(f"gh invocation failed: {exc}") from exc
+    if result.returncode != 0:
+        raise GitHubReadError(f"gh exited {result.returncode}: {(result.stderr or '')[:200]}")
+    return result.stdout or ""
+
+
+def fetch_open_pull_requests(owner: str, repo: str, limit: int) -> list[dict[str, Any]]:
+    """Read open PRs with their linked-issue state in one GraphQL call."""
+    raw = _run_gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={OPEN_PRS_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={repo}",
+            "-F",
+            f"limit={limit}",
+        ]
+    )
+    try:
+        payload = json.loads(raw)
+        nodes = payload["data"]["repository"]["pullRequests"]["nodes"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise GitHubReadError(f"unparseable PR list: {exc}") from exc
+    return [node for node in nodes if isinstance(node, dict)]
+
+
+def fetch_base_distance(owner: str, repo: str, base: str, head: str) -> int | None:
+    """Commits the PR head is behind its base, or None when unreadable.
+
+    One REST compare per PR, which is the cost the issue budgeted. An
+    unreadable distance is reported as unknown rather than as zero: zero
+    would read as a fresh branch and hide exactly what the report exists
+    to surface.
+    """
+    try:
+        raw = _run_gh(
+            ["api", f"repos/{owner}/{repo}/compare/{base}...{head}", "--jq", ".behind_by"]
+        )
+    except GitHubReadError as exc:
+        logger.warning("op=base_distance_failed head=%s err=%s", head[:12], exc)
+        return None
+    text = raw.strip()
+    return int(text) if text.lstrip("-").isdigit() else None
+
+
+def collect_distances(owner: str, repo: str, prs: list[dict[str, Any]]) -> dict[int, int | None]:
+    return {
+        int(pr["number"]): fetch_base_distance(
+            owner, repo, str(pr.get("baseRefName") or "main"), str(pr.get("headRefOid") or "")
+        )
+        for pr in prs
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument("--limit", type=int, default=100, help="Open PRs to read")
+    parser.add_argument(
+        "--stale-base",
+        type=int,
+        default=DEFAULT_STALE_BASE,
+        help="Commits behind base at which a PR is flagged",
+    )
+    parser.add_argument("--output-format", choices=["human", "json"], default="human")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    resolved = resolve_repo_params(args.owner, args.repo)
+    try:
+        prs = fetch_open_pull_requests(resolved.owner, resolved.repo, args.limit)
+        distances = collect_distances(resolved.owner, resolved.repo, prs)
+    except GitHubReadError as exc:
+        print(f"pr-supersession: {exc}", file=sys.stderr)
+        return 3
+    report = build_report(prs, distances, args.stale_base)
+    if args.output_format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
@@ -666,9 +666,13 @@ def post_lease_comment(owner: str, repo: str, pr: int, body: str) -> None:
 class LeaseResult:
     """Outcome of a lease operation. ``action`` is ACT or SKIP.
 
-    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1).
-    ``local_head_sha`` is what the caller's checkout had at ``HEAD``, or
-    None when git could not answer. The two differ whenever acquire runs
+    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1), and
+    is populated only on the ACT path. ``acquire`` returns SKIP before it
+    reads the PR head, so both ``base_sha`` and ``local_head_sha`` stay None
+    on that path; a caller must not read them as evidence about the PR.
+
+    On ACT, ``local_head_sha`` is what the caller's checkout had at ``HEAD``,
+    or None when git could not answer. The two differ whenever acquire runs
     from a checkout that is not the PR branch; the caller reports both so
     the divergence is visible instead of silently recorded as the PR's head
     (issue #4357 acceptance criterion 4).

--- a/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
@@ -494,9 +494,12 @@ class LeaseStoreError(RuntimeError):
 def _git_head_sha() -> str | None:
     """Return the local HEAD SHA, or None if git is unavailable.
 
-    The acquire path records ``base_sha`` so the push-time guard (Phase 2
-    integration) can detect a remote advance under the lease. Phase 1 only
-    records it; it never gates a push on it (the SHA gate does that).
+    This answers "what is checked out here", which is NOT what ``base_sha``
+    means. ADR-076 part 1 defines ``base_sha`` as the "PR head.sha the
+    holder fetched before acquiring", and acquire step 1 fetches it from
+    GitHub. Acquire records this value only as the observed local checkout,
+    so a caller standing on the wrong branch is reported rather than
+    published as the PR's head (issues #4357, #4375).
     """
     try:
         result = subprocess.run(
@@ -514,6 +517,36 @@ def _git_head_sha() -> str | None:
         return None
     sha = (result.stdout or "").strip()
     return sha if _SHA40.match(sha) else None
+
+
+def _pr_head_sha(owner: str, repo: str, pr: int) -> str:
+    """Return the PR's authoritative head SHA. Raises LeaseStoreError.
+
+    ADR-076 part 3 acquire step 1: "Fetch the PR ``head.sha`` and the latest
+    N lease comments in one bounded read". The value is read from GitHub, so
+    it describes the PR branch no matter which checkout the caller stands
+    in. A failure is a lease-store failure, so the caller fails open to ACT
+    (step 6) instead of publishing freshness evidence it could not verify.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/pulls/{pr}", "--jq", ".head.sha"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise LeaseStoreError(f"pr head read failed: {exc}") from exc
+    if result.returncode != 0:
+        raise LeaseStoreError(
+            f"pr head read exited {result.returncode}: {safe_log_str((result.stderr or '')[:200])}"
+        )
+    sha = (result.stdout or "").strip()
+    if not _SHA40.match(sha):
+        raise LeaseStoreError("pr head read returned no 40-hex sha")
+    return sha
 
 
 def _gh_authenticated_login() -> str:
@@ -630,12 +663,39 @@ def post_lease_comment(owner: str, repo: str, pr: int, body: str) -> None:
 
 @dataclass(frozen=True, slots=True)
 class LeaseResult:
-    """Outcome of a lease operation. ``action`` is ACT or SKIP."""
+    """Outcome of a lease operation. ``action`` is ACT or SKIP.
+
+    ``base_sha`` is the PR's head SHA read from GitHub (ADR-076 part 1).
+    ``local_head_sha`` is what the caller's checkout had at ``HEAD``, or
+    None when git could not answer. The two differ whenever acquire runs
+    from a checkout that is not the PR branch; the caller reports both so
+    the divergence is visible instead of silently recorded as the PR's head
+    (issue #4357 acceptance criterion 4).
+    """
 
     action: str
     reason: str
     expires_at: str | None = None
     base_sha: str | None = None
+    local_head_sha: str | None = None
+
+
+def _warn_on_checkout_mismatch(pr: int, local_sha: str | None, base_sha: str) -> None:
+    """Log both SHAs when the caller's checkout is not the PR head.
+
+    The lease still publishes the authoritative PR head, so the recorded
+    evidence is correct either way. The warning tells the operator that the
+    session doing the fix work is standing somewhere else, which is what
+    produced the wrong lease on #4294 (issue #4357).
+    """
+    if local_sha is None or local_sha == base_sha:
+        return
+    logger.warning(
+        "op=lease_checkout_mismatch pr=%d local_head_sha=%s pr_head_sha=%s",
+        pr,
+        safe_log_str(local_sha),
+        safe_log_str(base_sha),
+    )
 
 
 def acquire(
@@ -661,17 +721,27 @@ def acquire(
     authenticated ``gh`` login is resolved. An unresolved login ("") can
     only claim a free lock, never self-renew a foreign one (fails safe).
 
+    ``base_sha`` is the PR head SHA read from GitHub (ADR-076 part 3 step
+    1), never the caller's local HEAD, so an acquire run from the wrong
+    checkout cannot publish freshness evidence for another branch. The
+    local HEAD is still read and reported as ``local_head_sha``, and a
+    mismatch is logged with both values (issues #4357, #4375).
+
     ``now`` is injectable for deterministic tests; production passes None
     and the current UTC instant is used.
     """
     now = now or datetime.now(UTC)
     author = _gh_authenticated_login() if acting_author is None else acting_author
-    base_sha = _git_head_sha() or ("0" * 40)
+    local_sha = _git_head_sha()
     try:
+        base_sha = _pr_head_sha(repo_owner, repo, pr)
         comments = list_lease_comments(repo_owner, repo, pr)
     except LeaseStoreError as exc:
         logger.warning("op=lease_acquire_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
-        return LeaseResult("ACT", "lease-store-unavailable", base_sha=base_sha)
+        return LeaseResult(
+            "ACT", "lease-store-unavailable", base_sha="0" * 40, local_head_sha=local_sha
+        )
+    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     current = select_authoritative_lease(comments)
     verdict = classify_acquire(current, author, now)
@@ -683,9 +753,15 @@ def acquire(
         post_lease_comment(repo_owner, repo, pr, render_lease_comment(claim))
     except LeaseStoreError as exc:
         logger.warning("op=lease_claim_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
-        return LeaseResult("ACT", "lease-store-unavailable", base_sha=base_sha)
+        return LeaseResult(
+            "ACT", "lease-store-unavailable", base_sha=base_sha, local_head_sha=local_sha
+        )
     return LeaseResult(
-        "ACT", verdict["reason"], expires_at=_to_rfc3339(claim.expires_at), base_sha=base_sha
+        "ACT",
+        verdict["reason"],
+        expires_at=_to_rfc3339(claim.expires_at),
+        base_sha=base_sha,
+        local_head_sha=local_sha,
     )
 
 
@@ -815,6 +891,7 @@ def main(argv: list[str] | None = None) -> int:
         "reason": result.reason,
         "expires_at": result.expires_at,
         "base_sha": result.base_sha,
+        "local_head_sha": result.local_head_sha,
     }
     logger.info(
         "op=lease pr=%d command=%s action=%s reason=%s",

--- a/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
+++ b/src/copilot-cli/skills/github/scripts/pr/pr_autofix_lease.py
@@ -525,8 +525,9 @@ def _pr_head_sha(owner: str, repo: str, pr: int) -> str:
     ADR-076 part 3 acquire step 1: "Fetch the PR ``head.sha`` and the latest
     N lease comments in one bounded read". The value is read from GitHub, so
     it describes the PR branch no matter which checkout the caller stands
-    in. A failure is a lease-store failure, so the caller fails open to ACT
-    (step 6) instead of publishing freshness evidence it could not verify.
+    in. Acquire catches the failure and records the zero sentinel rather
+    than failing open, because losing freshness evidence must not also lose
+    the lock (see ``acquire``).
     """
     try:
         result = subprocess.run(
@@ -727,6 +728,11 @@ def acquire(
     local HEAD is still read and reported as ``local_head_sha``, and a
     mismatch is logged with both values (issues #4357, #4375).
 
+    Only the comment read fails open. The head read runs after the lease
+    verdict and records the zero sentinel on failure, so a transient error
+    on it cannot skip the read that enforces mutual exclusion, and it costs
+    nothing on the SKIP path.
+
     ``now`` is injectable for deterministic tests; production passes None
     and the current UTC instant is used.
     """
@@ -734,19 +740,27 @@ def acquire(
     author = _gh_authenticated_login() if acting_author is None else acting_author
     local_sha = _git_head_sha()
     try:
-        base_sha = _pr_head_sha(repo_owner, repo, pr)
         comments = list_lease_comments(repo_owner, repo, pr)
     except LeaseStoreError as exc:
         logger.warning("op=lease_acquire_failopen pr=%d err=%s", pr, safe_log_str(str(exc)))
         return LeaseResult(
             "ACT", "lease-store-unavailable", base_sha="0" * 40, local_head_sha=local_sha
         )
-    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     current = select_authoritative_lease(comments)
     verdict = classify_acquire(current, author, now)
     if verdict["action"] == "SKIP":
         return LeaseResult("SKIP", verdict["reason"], expires_at=verdict.get("expires_at"))
+
+    # The head read is freshness evidence, not the lock. Failing it open to ACT
+    # alongside the comment read would let a transient API error skip the read
+    # that enforces mutual exclusion, so it is scoped to the sentinel instead.
+    try:
+        base_sha = _pr_head_sha(repo_owner, repo, pr)
+    except LeaseStoreError as exc:
+        logger.warning("op=lease_pr_head_unavailable pr=%d err=%s", pr, safe_log_str(str(exc)))
+        base_sha = "0" * 40
+    _warn_on_checkout_mismatch(pr, local_sha, base_sha)
 
     claim = build_claim(owner, session, base_sha, now)
     try:

--- a/tests/test_pr_autofix_lease.py
+++ b/tests/test_pr_autofix_lease.py
@@ -35,6 +35,8 @@ import contextlib
 import importlib.util
 import json
 import logging
+import os
+import shutil
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
@@ -691,7 +693,10 @@ class TestBaseShaProvenance:
         assert result.base_sha == _PR_HEAD
         assert result.local_head_sha is None
 
-    def test_pr_head_read_failure_fails_open_without_posting(self):
+    def test_pr_head_read_failure_still_claims_a_free_lock(self):
+        # The head read is freshness evidence, not the lock. Failing it open
+        # would surrender mutual exclusion over a transient API error, so a
+        # failure records the sentinel and the claim is still posted.
         with (
             patch.object(_mod, "_pr_head_sha", side_effect=LeaseStoreError("api down")),
             patch.object(_mod, "_git_head_sha", return_value=_OTHER_CHECKOUT),
@@ -701,9 +706,29 @@ class TestBaseShaProvenance:
         ):
             result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
         assert result.action == "ACT"
-        assert result.reason == "lease-store-unavailable"
+        assert result.reason == "free"
         assert result.base_sha == "0" * 40
         assert result.local_head_sha == _OTHER_CHECKOUT
+        post.assert_called_once()
+
+    def test_pr_head_read_failure_cannot_steal_a_live_foreign_lease(self):
+        # The regression this ordering exists to prevent: with both reads in
+        # one fail-open block, a failed head read returned ACT without ever
+        # reading the lease comments, so a live foreign lease was ignored.
+        live = _comment(
+            _body(owner="remote:coderabbit-autofix", session="ci-1"),
+            "2026-06-19T11:59:00Z",
+            author="coderabbit[bot]",
+        )
+        with (
+            patch.object(_mod, "_pr_head_sha", side_effect=LeaseStoreError("api down")),
+            patch.object(_mod, "_git_head_sha", return_value=_OTHER_CHECKOUT),
+            _patch_list([live]),
+            _patch_post() as post,
+            _patch_login(),
+        ):
+            result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.action == "SKIP"
         post.assert_not_called()
 
     def test_store_read_failure_records_no_pr_head(self):
@@ -852,6 +877,88 @@ class TestIOAdapter:
     def test_head_sha_returns_sha_on_success(self):
         with patch.object(_mod.subprocess, "run", return_value=_completed(stdout=_SHA + "\n")):
             assert _mod._git_head_sha() == _SHA
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+class TestGitHeadShaAgainstRealGit:
+    """#4357 acceptance criterion 3, run against the real git binary.
+
+    The mocked tests above prove the parsing. They cannot prove that the
+    command answers correctly in a detached checkout or once refs are
+    packed, because both change what git reads, not what it prints.
+    """
+
+    def _git(self, repo, *args):
+        # GIT_DIR and GIT_WORK_TREE leak in from an outer checkout and would
+        # point every command at the wrong repository.
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        env["HOME"] = str(repo)
+        result = subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@e", *args],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+            encoding="utf-8",
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def _repo(self, tmp_path):
+        repo = tmp_path / "wt"
+        repo.mkdir()
+        self._git(repo, "init", "-b", "main", "-q")
+        (repo / "f.txt").write_text("one", encoding="utf-8")
+        self._git(repo, "add", "f.txt")
+        self._git(repo, "commit", "-qm", "one")
+        return repo
+
+    @pytest.fixture(autouse=True)
+    def _isolated(self, monkeypatch):
+        for name in [k for k in os.environ if k.startswith("GIT_")]:
+            monkeypatch.delenv(name, raising=False)
+
+    def test_reads_the_checked_out_branch_head(self, tmp_path, monkeypatch):
+        repo = self._repo(tmp_path)
+        expected = self._git(repo, "rev-parse", "HEAD")
+
+        monkeypatch.chdir(repo)
+
+        assert _mod._git_head_sha() == expected
+
+    def test_a_second_branch_does_not_change_the_answer(self, tmp_path, monkeypatch):
+        # The #4357 defect shape: standing on one branch while the PR is on
+        # another. _git_head_sha must report where it stands, nothing else.
+        repo = self._repo(tmp_path)
+        on_main = self._git(repo, "rev-parse", "HEAD")
+        self._git(repo, "checkout", "-qb", "feature")
+        (repo / "f.txt").write_text("two", encoding="utf-8")
+        self._git(repo, "commit", "-qam", "two")
+        on_feature = self._git(repo, "rev-parse", "HEAD")
+        self._git(repo, "checkout", "-q", "main")
+
+        monkeypatch.chdir(repo)
+
+        assert on_feature != on_main
+        assert _mod._git_head_sha() == on_main
+
+    def test_detached_head_still_resolves(self, tmp_path, monkeypatch):
+        repo = self._repo(tmp_path)
+        expected = self._git(repo, "rev-parse", "HEAD")
+        self._git(repo, "checkout", "-q", "--detach")
+
+        monkeypatch.chdir(repo)
+
+        assert _mod._git_head_sha() == expected
+
+    def test_packed_refs_still_resolve(self, tmp_path, monkeypatch):
+        repo = self._repo(tmp_path)
+        expected = self._git(repo, "rev-parse", "HEAD")
+        self._git(repo, "pack-refs", "--all")
+        assert not (repo / ".git" / "refs" / "heads" / "main").exists()
+
+        monkeypatch.chdir(repo)
+
+        assert _mod._git_head_sha() == expected
 
     # --- _pr_head_sha adapter (issues #4357, #4375) -----------------------
 

--- a/tests/test_pr_autofix_lease.py
+++ b/tests/test_pr_autofix_lease.py
@@ -31,8 +31,10 @@ within the ADR-035 numeric range:
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
+import logging
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
@@ -469,8 +471,20 @@ def _patch_post():
     return patch.object(_mod, "post_lease_comment", return_value=None)
 
 
-def _patch_head(sha=_SHA):
-    return patch.object(_mod, "_git_head_sha", return_value=sha)
+@contextlib.contextmanager
+def _patch_head(sha=_SHA, pr_head=_SHA):
+    """Patch both SHA reads acquire performs.
+
+    ``sha`` is what the caller's checkout reports at HEAD; ``pr_head`` is
+    what GitHub reports as the PR head. They are separate inputs because
+    the defect in #4357 was acquire publishing the first as if it were the
+    second.
+    """
+    with (
+        patch.object(_mod, "_git_head_sha", return_value=sha),
+        patch.object(_mod, "_pr_head_sha", return_value=pr_head),
+    ):
+        yield
 
 
 def _patch_login(login=_AUTHOR):
@@ -589,8 +603,116 @@ class TestAcquire:
         assert result.action == "ACT"
         assert result.reason == "lease-store-unavailable"
 
-    def test_acquire_uses_zero_sha_when_git_unavailable(self):
-        with _patch_list([]), _patch_post(), _patch_head(sha=None), _patch_login():
+
+# ===========================================================================
+# base_sha provenance: the PR head, never the caller's checkout
+# (issues #4357, #4375; ADR-076 part 1 and part 3 acquire step 1)
+# ===========================================================================
+
+
+_PR_HEAD = "b" * 40
+_OTHER_CHECKOUT = "c" * 40
+
+
+def _captured_post():
+    """Patch post_lease_comment and hand back the bodies it was given."""
+    bodies: list[str] = []
+
+    def _capture(owner, repo, pr, body):
+        bodies.append(body)
+
+    return patch.object(_mod, "post_lease_comment", side_effect=_capture), bodies
+
+
+class TestBaseShaProvenance:
+    def test_base_sha_is_the_pr_head_not_the_local_checkout(self):
+        # The discriminating input: acquire runs from a checkout whose HEAD
+        # is NOT the PR head (the #4294 coordinator-on-main case). The
+        # pre-fix code published the local SHA here.
+        post, bodies = _captured_post()
+        with (
+            _patch_list([]),
+            post,
+            _patch_head(sha=_OTHER_CHECKOUT, pr_head=_PR_HEAD),
+            _patch_login(),
+        ):
+            result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.base_sha == _PR_HEAD
+        published = parse_lease_block(bodies[0])
+        assert published is not None
+        assert published.base_sha == _PR_HEAD
+
+    def test_mismatch_reports_both_shas(self):
+        with (
+            _patch_list([]),
+            _patch_post(),
+            _patch_head(sha=_OTHER_CHECKOUT, pr_head=_PR_HEAD),
+            _patch_login(),
+        ):
+            result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.local_head_sha == _OTHER_CHECKOUT
+        assert result.base_sha == _PR_HEAD
+
+    def test_mismatch_logs_both_shas(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            with (
+                _patch_list([]),
+                _patch_post(),
+                _patch_head(sha=_OTHER_CHECKOUT, pr_head=_PR_HEAD),
+                _patch_login(),
+            ):
+                acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        warnings = [rec.getMessage() for rec in caplog.records]
+        assert any("lease_checkout_mismatch" in line for line in warnings)
+        assert any(_OTHER_CHECKOUT in line and _PR_HEAD in line for line in warnings)
+
+    def test_matching_checkout_logs_no_mismatch(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            with (
+                _patch_list([]),
+                _patch_post(),
+                _patch_head(sha=_PR_HEAD, pr_head=_PR_HEAD),
+                _patch_login(),
+            ):
+                result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.local_head_sha == _PR_HEAD
+        assert not any("lease_checkout_mismatch" in rec.getMessage() for rec in caplog.records)
+
+    def test_detached_or_missing_git_still_records_the_pr_head(self):
+        # git unavailable (or a checkout git cannot resolve): the lease is
+        # still correct, because base_sha never depended on git.
+        with (
+            _patch_list([]),
+            _patch_post(),
+            _patch_head(sha=None, pr_head=_PR_HEAD),
+            _patch_login(),
+        ):
+            result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.base_sha == _PR_HEAD
+        assert result.local_head_sha is None
+
+    def test_pr_head_read_failure_fails_open_without_posting(self):
+        with (
+            patch.object(_mod, "_pr_head_sha", side_effect=LeaseStoreError("api down")),
+            patch.object(_mod, "_git_head_sha", return_value=_OTHER_CHECKOUT),
+            _patch_list([]),
+            _patch_post() as post,
+            _patch_login(),
+        ):
+            result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
+        assert result.action == "ACT"
+        assert result.reason == "lease-store-unavailable"
+        assert result.base_sha == "0" * 40
+        assert result.local_head_sha == _OTHER_CHECKOUT
+        post.assert_not_called()
+
+    def test_store_read_failure_records_no_pr_head(self):
+        with (
+            _patch_head(sha=_OTHER_CHECKOUT, pr_head=_PR_HEAD),
+            patch.object(_mod, "list_lease_comments", side_effect=LeaseStoreError("boom")),
+            _patch_post(),
+            _patch_login(),
+        ):
             result = acquire(_OWNER, _SESSION, "o", "r", 1, now=_NOW)
         assert result.base_sha == "0" * 40
 
@@ -731,6 +853,39 @@ class TestIOAdapter:
         with patch.object(_mod.subprocess, "run", return_value=_completed(stdout=_SHA + "\n")):
             assert _mod._git_head_sha() == _SHA
 
+    # --- _pr_head_sha adapter (issues #4357, #4375) -----------------------
+
+    def test_pr_head_returns_sha_on_success(self):
+        with patch.object(_mod.subprocess, "run", return_value=_completed(stdout=_SHA + "\n")):
+            assert _mod._pr_head_sha("o", "r", 1) == _SHA
+
+    def test_pr_head_raises_store_error_on_nonzero_exit(self):
+        with patch.object(_mod.subprocess, "run", return_value=_completed(rc=1, stderr="404")):
+            with pytest.raises(LeaseStoreError):
+                _mod._pr_head_sha("o", "r", 1)
+
+    def test_pr_head_raises_store_error_on_oserror(self):
+        with patch.object(_mod.subprocess, "run", side_effect=OSError("gh missing")):
+            with pytest.raises(LeaseStoreError):
+                _mod._pr_head_sha("o", "r", 1)
+
+    def test_pr_head_raises_store_error_on_non_sha_payload(self):
+        with patch.object(_mod.subprocess, "run", return_value=_completed(stdout="null\n")):
+            with pytest.raises(LeaseStoreError):
+                _mod._pr_head_sha("o", "r", 1)
+
+    def test_pr_head_reads_the_requested_pull_request(self):
+        seen: dict = {}
+
+        def _run(argv, **kwargs):
+            seen["argv"] = argv
+            return _completed(stdout=_SHA)
+
+        with patch.object(_mod.subprocess, "run", side_effect=_run):
+            _mod._pr_head_sha("acme", "widgets", 42)
+        assert "repos/acme/widgets/pulls/42" in seen["argv"]
+        assert ".head.sha" in seen["argv"]
+
     # --- _gh_authenticated_login adapter (must_fix #7) --------------------
 
     def test_login_returns_login_on_success(self):
@@ -788,6 +943,23 @@ class TestMainExitCodes:
                 ["acquire", "--pull-request", "1", "--session", _SESSION, "--output-format", "json"]
             )
         assert rc == 0
+
+    def test_acquire_output_carries_both_shas(self, capsys):
+        with (
+            patch.object(_mod, "assert_gh_authenticated", return_value=None),
+            patch.object(_mod, "resolve_repo_params", return_value=self._repo()),
+            _patch_list([]),
+            _patch_post(),
+            _patch_head(sha=_OTHER_CHECKOUT, pr_head=_PR_HEAD),
+            _patch_login(),
+        ):
+            rc = main(
+                ["acquire", "--pull-request", "1", "--session", _SESSION, "--output-format", "json"]
+            )
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["Data"]["base_sha"] == _PR_HEAD
+        assert payload["Data"]["local_head_sha"] == _OTHER_CHECKOUT
 
     def test_acquire_held_exits_one(self):
         held = _comment(

--- a/tests/test_report_pr_supersession.py
+++ b/tests/test_report_pr_supersession.py
@@ -370,6 +370,8 @@ class TestWorkflowInvocation:
             cwd=self.REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
 

--- a/tests/test_report_pr_supersession.py
+++ b/tests/test_report_pr_supersession.py
@@ -1,0 +1,339 @@
+"""Tests for scripts/report_pr_supersession.py (issue #4355).
+
+The load-bearing test is TestIssue4355Corpus: the four PRs the issue names,
+with the payloads GitHub returned for them on 2026-08-03 and the base
+distances `git rev-list --count <head>..origin/main` measured the same day.
+Three must flag as candidates (#4164, #4102, #3979) and the fourth (#4163)
+must flag and then survive review as a false positive, which the report
+supports by printing its still-open linked issue next to the closed ones.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from scripts import report_pr_supersession as mod
+
+REASON_CLOSED = mod.REASON_CLOSED_ISSUE
+REASON_NONE = mod.REASON_NO_ISSUE
+REASON_STALE = mod.REASON_STALE_BASE
+
+
+def _pr(number=1, issues=None, title="t", base="main", head="a" * 40, draft=False):
+    return {
+        "number": number,
+        "title": title,
+        "isDraft": draft,
+        "baseRefName": base,
+        "headRefOid": head,
+        "closingIssuesReferences": {"nodes": list(issues or [])},
+    }
+
+
+def _completed(rc=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["gh"], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+# ===========================================================================
+# classify_pull_request
+# ===========================================================================
+
+
+class TestClassify:
+    def test_closed_linked_issue_flags(self):
+        finding = mod.classify_pull_request(_pr(issues=[{"number": 9, "state": "CLOSED"}]), 0)
+        assert finding.reasons == [REASON_CLOSED]
+        assert finding.closed_issues == [9]
+        assert finding.flagged
+
+    def test_open_linked_issue_on_a_fresh_base_does_not_flag(self):
+        finding = mod.classify_pull_request(_pr(issues=[{"number": 9, "state": "OPEN"}]), 3)
+        assert finding.reasons == []
+        assert not finding.flagged
+        assert finding.open_issues == [9]
+
+    def test_no_linked_issue_on_a_stale_base_flags(self):
+        finding = mod.classify_pull_request(_pr(issues=[]), 40, stale_base=20)
+        assert finding.reasons == [REASON_STALE, REASON_NONE]
+
+    def test_no_linked_issue_on_a_fresh_base_does_not_flag(self):
+        # A PR opened today with no linked issue is an issue-linkage
+        # question, not a supersession candidate. Ungated, this reason
+        # flagged 27 of 44 open PRs on 2026-08-03.
+        finding = mod.classify_pull_request(_pr(issues=[]), 0)
+        assert finding.reasons == []
+
+    def test_stale_base_flags_at_the_threshold(self):
+        finding = mod.classify_pull_request(
+            _pr(issues=[{"number": 9, "state": "OPEN"}]), 20, stale_base=20
+        )
+        assert finding.reasons == [REASON_STALE]
+
+    def test_one_commit_below_the_threshold_does_not_flag(self):
+        finding = mod.classify_pull_request(
+            _pr(issues=[{"number": 9, "state": "OPEN"}]), 19, stale_base=20
+        )
+        assert finding.reasons == []
+
+    def test_unknown_base_distance_never_flags_stale(self):
+        finding = mod.classify_pull_request(_pr(issues=[{"number": 9, "state": "OPEN"}]), None)
+        assert finding.reasons == []
+        assert finding.base_distance is None
+
+    def test_mixed_issue_states_flag_and_keep_the_open_one_visible(self):
+        finding = mod.classify_pull_request(
+            _pr(issues=[{"number": 1, "state": "CLOSED"}, {"number": 2, "state": "OPEN"}]), 0
+        )
+        assert finding.reasons == [REASON_CLOSED]
+        assert finding.open_issues == [2]
+
+    def test_null_connection_reads_as_no_linked_issue(self):
+        payload = _pr()
+        payload["closingIssuesReferences"] = None
+        assert mod.linked_issue_states(payload) == ([], [])
+        assert mod.classify_pull_request(payload, 40).reasons == [REASON_STALE, REASON_NONE]
+
+    def test_null_nodes_read_as_no_linked_issue(self):
+        payload = _pr()
+        payload["closingIssuesReferences"] = {"nodes": None}
+        assert mod.linked_issue_states(payload) == ([], [])
+        assert mod.classify_pull_request(payload, 40).reasons == [REASON_STALE, REASON_NONE]
+
+    def test_malformed_issue_nodes_are_dropped(self):
+        payload = _pr(issues=[{"state": "CLOSED"}, "junk", {"number": 7, "state": "CLOSED"}])
+        finding = mod.classify_pull_request(payload, 0)
+        assert finding.closed_issues == [7]
+
+    def test_draft_state_is_reported_not_filtered(self):
+        finding = mod.classify_pull_request(_pr(draft=True, issues=[]), 0)
+        assert finding.is_draft is True
+
+
+# ===========================================================================
+# build_report and rendering
+# ===========================================================================
+
+
+class TestReport:
+    def test_report_counts_examined_and_flagged(self):
+        prs = [_pr(number=1, issues=[{"number": 9, "state": "OPEN"}]), _pr(number=2, issues=[])]
+        report = mod.build_report(prs, {1: 0, 2: 40})
+        assert report["examined"] == 2
+        assert report["flagged"] == 1
+
+    def test_empty_input_reports_zero_of_zero(self):
+        report = mod.build_report([], {})
+        assert (report["examined"], report["flagged"]) == (0, 0)
+        assert "0 flagged of 0 open PRs examined" in mod.render_human(report)
+
+    def test_human_output_states_the_examined_count_when_nothing_is_flagged(self):
+        report = mod.build_report([_pr(issues=[{"number": 9, "state": "OPEN"}])], {1: 1})
+        rendered = mod.render_human(report)
+        assert "0 flagged of 1 open PRs examined" in rendered
+
+    def test_human_output_names_the_false_positive_risk_when_flagging(self):
+        report = mod.build_report([_pr(issues=[{"number": 9, "state": "CLOSED"}])], {1: 1})
+        rendered = mod.render_human(report)
+        assert "#1" in rendered
+        assert "#4163" in rendered
+
+    def test_missing_distance_renders_as_unknown(self):
+        report = mod.build_report([_pr(issues=[{"number": 9, "state": "CLOSED"}])], {})
+        assert "behind=unknown" in mod.render_human(report)
+
+
+# ===========================================================================
+# The corpus the issue requires the report to be validated against
+# ===========================================================================
+
+
+_CORPUS = {
+    4164: (
+        _pr(
+            number=4164,
+            title="fix(merge-resolver): make the leftover-marker gate merge-aware",
+            issues=[{"number": 4058, "state": "CLOSED"}],
+            head="205b7480583ea7e45d8f114cfb4d39d06fa22862",
+        ),
+        50,
+    ),
+    4102: (
+        _pr(
+            number=4102,
+            title="fix(validation): skill_size full-scan measures both skill trees",
+            issues=[{"number": 4015, "state": "CLOSED"}],
+            head="ee309b0d69f3506c087c7badaa0b919a6c9c4aa0",
+        ),
+        24,
+    ),
+    3979: (
+        _pr(
+            number=3979,
+            title="fix(protocol): teach the 8 investigation allowlist patterns",
+            issues=[],
+            head="66e7d3c6d39e6b3693fbcfd3cadf78844c3ecffa",
+        ),
+        167,
+    ),
+    4163: (
+        _pr(
+            number=4163,
+            title="fix(memory): register the memory hooks and qualify memory ids",
+            issues=[
+                {"number": 4010, "state": "CLOSED"},
+                {"number": 4011, "state": "CLOSED"},
+                {"number": 4071, "state": "OPEN"},
+            ],
+            head="cf4ebd80901cc520b8df98380b3c893d48985a4f",
+        ),
+        12,
+    ),
+}
+
+
+class TestIssue4355Corpus:
+    @pytest.mark.parametrize("number", sorted(_CORPUS))
+    def test_every_named_pr_is_flagged(self, number):
+        payload, distance = _CORPUS[number]
+        assert mod.classify_pull_request(payload, distance).flagged
+
+    def test_pr_3979_is_flagged_without_any_linked_issue(self):
+        # The closed-issue signal alone cannot see this one: it closes
+        # nothing. Without the no-linked-issue reason the report misses a
+        # third of the confirmed corpus.
+        payload, distance = _CORPUS[3979]
+        finding = mod.classify_pull_request(payload, distance)
+        assert finding.closed_issues == []
+        assert REASON_NONE in finding.reasons
+        assert REASON_STALE in finding.reasons
+
+    def test_pr_4163_flags_but_carries_its_own_refutation(self):
+        # Known false positive: a different PR closed #4010 and #4011, and
+        # #4071 is still open. The report must flag it and must print the
+        # open issue so a reviewer can dismiss it in one read.
+        payload, distance = _CORPUS[4163]
+        finding = mod.classify_pull_request(payload, distance)
+        assert finding.reasons == [REASON_CLOSED]
+        assert finding.open_issues == [4071]
+        assert finding.base_distance == 12
+
+    def test_the_whole_corpus_reports_four_of_four(self):
+        report = mod.build_report(
+            [payload for payload, _ in _CORPUS.values()],
+            {number: distance for number, (_, distance) in _CORPUS.items()},
+        )
+        assert (report["examined"], report["flagged"]) == (4, 4)
+
+
+# ===========================================================================
+# I/O adapter
+# ===========================================================================
+
+
+class TestIOAdapter:
+    def test_fetch_open_prs_returns_nodes(self):
+        payload = json.dumps({"data": {"repository": {"pullRequests": {"nodes": [_pr(number=5)]}}}})
+        with patch.object(mod.subprocess, "run", return_value=_completed(stdout=payload)):
+            prs = mod.fetch_open_pull_requests("o", "r", 10)
+        assert prs[0]["number"] == 5
+
+    def test_fetch_open_prs_raises_on_nonzero_exit(self):
+        with patch.object(mod.subprocess, "run", return_value=_completed(rc=1, stderr="boom")):
+            with pytest.raises(mod.GitHubReadError):
+                mod.fetch_open_pull_requests("o", "r", 10)
+
+    def test_fetch_open_prs_raises_on_unparseable_payload(self):
+        with patch.object(mod.subprocess, "run", return_value=_completed(stdout="{}")):
+            with pytest.raises(mod.GitHubReadError):
+                mod.fetch_open_pull_requests("o", "r", 10)
+
+    def test_fetch_open_prs_raises_when_gh_is_missing(self):
+        with patch.object(mod.subprocess, "run", side_effect=OSError("gh missing")):
+            with pytest.raises(mod.GitHubReadError):
+                mod.fetch_open_pull_requests("o", "r", 10)
+
+    def test_base_distance_parses_the_behind_count(self):
+        with patch.object(mod.subprocess, "run", return_value=_completed(stdout="27\n")):
+            assert mod.fetch_base_distance("o", "r", "main", "a" * 40) == 27
+
+    def test_base_distance_is_unknown_when_the_compare_fails(self):
+        with patch.object(mod.subprocess, "run", return_value=_completed(rc=1, stderr="404")):
+            assert mod.fetch_base_distance("o", "r", "main", "a" * 40) is None
+
+    def test_base_distance_is_unknown_on_a_non_numeric_payload(self):
+        with patch.object(mod.subprocess, "run", return_value=_completed(stdout="null\n")):
+            assert mod.fetch_base_distance("o", "r", "main", "a" * 40) is None
+
+    def test_collect_distances_keys_by_pr_number(self):
+        with patch.object(mod, "fetch_base_distance", return_value=4):
+            assert mod.collect_distances("o", "r", [_pr(number=8)]) == {8: 4}
+
+
+# ===========================================================================
+# CLI exit codes
+# ===========================================================================
+
+
+class TestMain:
+    def _repo(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(owner="o", repo="r")
+
+    def test_report_with_findings_still_exits_zero(self, capsys):
+        with (
+            patch.object(mod, "resolve_repo_params", return_value=self._repo()),
+            patch.object(
+                mod,
+                "fetch_open_pull_requests",
+                return_value=[_pr(number=1, issues=[{"number": 9, "state": "CLOSED"}])],
+            ),
+            patch.object(mod, "collect_distances", return_value={1: 30}),
+        ):
+            rc = mod.main(["--output-format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["flagged"] == 1
+        assert payload["findings"][0]["reasons"] == [REASON_CLOSED, REASON_STALE]
+
+    def test_clean_fleet_exits_zero_and_reports_the_examined_count(self, capsys):
+        with (
+            patch.object(mod, "resolve_repo_params", return_value=self._repo()),
+            patch.object(
+                mod,
+                "fetch_open_pull_requests",
+                return_value=[_pr(number=1, issues=[{"number": 9, "state": "OPEN"}])],
+            ),
+            patch.object(mod, "collect_distances", return_value={1: 1}),
+        ):
+            rc = mod.main([])
+        assert rc == 0
+        assert "0 flagged of 1 open PRs examined" in capsys.readouterr().out
+
+    def test_api_failure_exits_three(self, capsys):
+        with (
+            patch.object(mod, "resolve_repo_params", return_value=self._repo()),
+            patch.object(mod, "fetch_open_pull_requests", side_effect=mod.GitHubReadError("down")),
+        ):
+            rc = mod.main([])
+        assert rc == 3
+        assert "down" in capsys.readouterr().err
+
+    def test_stale_base_threshold_is_configurable(self, capsys):
+        with (
+            patch.object(mod, "resolve_repo_params", return_value=self._repo()),
+            patch.object(
+                mod,
+                "fetch_open_pull_requests",
+                return_value=[_pr(number=1, issues=[{"number": 9, "state": "OPEN"}])],
+            ),
+            patch.object(mod, "collect_distances", return_value={1: 5}),
+        ):
+            rc = mod.main(["--stale-base", "5", "--output-format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["findings"][0]["reasons"] == [REASON_STALE]

--- a/tests/test_report_pr_supersession.py
+++ b/tests/test_report_pr_supersession.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -337,3 +339,44 @@ class TestMain:
         payload = json.loads(capsys.readouterr().out)
         assert rc == 0
         assert payload["findings"][0]["reasons"] == [REASON_STALE]
+
+
+class TestWorkflowInvocation:
+    """The `summarize` job of pr-maintenance.yml runs this file with bare `python3`.
+
+    Under pytest the repo root is already on sys.path, so every test above passes
+    whether or not the module can be imported the way CI imports it. These two
+    reproduce the CI invocation instead (.claude/rules/ci-scripts.md MUST 16).
+    """
+
+    REPO_ROOT = Path(__file__).resolve().parents[1]
+    WORKFLOW = REPO_ROOT / ".github/workflows/pr-maintenance.yml"
+    SCRIPT = "scripts/report_pr_supersession.py"
+
+    def _step_line(self) -> str:
+        lines = [
+            line
+            for line in self.WORKFLOW.read_text(encoding="utf-8").splitlines()
+            if self.SCRIPT in line and "run:" in line
+        ]
+        assert len(lines) == 1, f"expected one run: step invoking {self.SCRIPT}, got {lines}"
+        return lines[0]
+
+    def test_script_imports_under_a_bare_interpreter(self):
+        # -S -E strips site-packages and PYTHONPATH, so the editable install of the
+        # `scripts` package cannot stand in for the runner's ambient interpreter.
+        result = subprocess.run(
+            [sys.executable, "-S", "-E", self.SCRIPT, "--help"],
+            cwd=self.REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "ModuleNotFoundError" not in result.stderr
+
+    def test_step_does_not_pipe_away_the_exit_code(self):
+        # The default `run:` shell is `bash -e {0}` with no pipefail, so a pipeline
+        # reports the last command's status and a crash here reads as a green step.
+        assert "|" not in self._step_line()


### PR DESCRIPTION
## What changed

Two defects, one report that never ran and one lease that could be stolen.

**#4355, the supersession report never ran.** `.github/workflows/pr-maintenance.yml:253` invoked `python3 scripts/report_pr_supersession.py`, so `sys.path[0]` was `scripts/` and the module's `from scripts.github_core import ...` could not resolve. `| tee -a "$GITHUB_STEP_SUMMARY"` hid the crash: the default `run:` shell is `bash -e {0}` with no pipefail and this workflow sets no `shell:` or `defaults:` key, so the pipeline reported tee's status. The step went green with zero output on every scheduled run. Fixed with the `sys.path.insert` bootstrap the ratchets use (`scripts/validation/pr_commit_count.py:52` is the pattern), a narrowed import to `scripts.github_core.api`, and `>>` in place of the pipe.

**#4357, a failed PR-head read surrendered the lease.** `acquire` read the PR head and the lease comments inside one fail-open block, so a transient failure on the head read returned ACT/lease-store-unavailable without ever reading the lease comments. A live foreign lease that produced SKIP now produced ACT. The head read moved after the lease verdict and records the zero sentinel on failure. The comment read still fails open per ADR-076 step 6. The head read costs nothing on the SKIP path now.

## Verification

Run from a clean worktree with every `__pycache__` deleted.

Deployed invocation, under the interpreter CI actually uses:

```
$ PYTHONPATH= python3 -S -E scripts/report_pr_supersession.py --owner rjmurillo --repo ai-agents --limit 60
PR supersession report: 15 flagged of 46 open PRs examined (stale-base threshold 20)
...
  Confirm each one before acting. A closed linked issue can belong to a different PR (#4163).
rc=0
```

`-S -E` strips site-packages and `PYTHONPATH`, so the editable install of the `scripts` package cannot stand in for a bare interpreter. Before the fix the same command exited 1 with `ModuleNotFoundError: No module named 'scripts'`.

Negative controls, each reverted and re-run by hand:

| Reverted hunk | Result |
|---|---|
| `sys.path.insert` removed | `test_script_imports_under_a_bare_interpreter` fails, `ModuleNotFoundError` |
| `>>` restored to the `tee` pipe | `test_step_does_not_pipe_away_the_exit_code` fails |
| head read fused back into the comment-read block | 6 failed, including `test_pr_head_read_failure_cannot_steal_a_live_foreign_lease` at `assert 'ACT' == 'SKIP'` |
| `_git_head_sha` command mutated | 4 of the real-git tests fail |

Gates:

```
22337 passed, 31 skipped in 894.65s
ruff count ratchet: OK (count == baseline 311)
taste count ratchet: OK (count == baseline 598)
uv run --frozen python scripts/validation/pre_pr.py -> RESULT: All validations passed
ruff check on all five changed files -> All checks passed
```

The copilot-cli mirror of `pr_autofix_lease.py` is byte-identical (`diff -q`). No downstream caller of the lease module exists outside its own tests and the ADRs.

## Acceptance criteria

#4355:

- [x] A report exists that lists open PRs with base distance and linked-issue state (`scripts/report_pr_supersession.py`)
- [x] It flags the closed-issue-plus-open-PR combination (`closed-linked-issue` reason)
- [x] Validated against #4164, #4102 and #3979, which it flags, and against #4163, which it flags and which the output names as the known false positive (`TestNamedCorpus` in `tests/test_report_pr_supersession.py`)
- [x] The deployed surface actually runs, not merely "the job exists" (`TestWorkflowInvocation` reproduces the CI invocation under `-S -E`)

#4357:

- [x] Acquire obtains the authoritative PR head SHA from GitHub (`gh api repos/{owner}/{repo}/pulls/{n} --jq .head.sha`)
- [x] A mismatched checkout logs `op=lease_checkout_mismatch` with both SHAs and publishes the PR head, never the caller's HEAD
- [x] Tests cover a checked-out branch, a second branch that must not change the answer, detached HEAD, and packed refs, against the real git binary with `GIT_*` scrubbed (`TestGitHeadShaAgainstRealGit`)
- [x] The command output carries both `base_sha` and `local_head_sha` (`test_acquire_output_carries_both_shas`)
- [x] ADR-076 push-time safety unchanged; no push path touched

## Deferred

The `assert_gh_authenticated()` exit-4 half of #4375 is not in this change. ADR-076 step 6 wants fail-open there; ADR-090 line 172 (proposed) wants fail-closed for branch mutation. The owner has to settle which one binds before that can move.

Fixes #4355
Fixes #4357
Refs #4375
