### PR TITLE
fix(ci): stop gate diagnostics asserting what the gate never measured

### DIFF
--- a/.claude/rules/ci-scripts.md
+++ b/.claude/rules/ci-scripts.md
@@ -81,10 +81,12 @@ Decide by the check's input, not by which paths look related:
 | The diff | Correct | May skip |
 | The whole tree | Wrong on the mainline | MUST run |
 
-Force the mainline run in Python, not in a YAML `if:` (ADR-006).
-`scripts/workflows/determine_should_run_from_filters.py` reads
-`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
-determine step and leaves the job conditions alone.
+Delete the filter, do not force one event past it. `instruction-budget.yml`
+now runs one unconditional job. Forcing only `push` leaves every PR
+unmeasured, so two PRs each green against their own base still merge to a
+breaching union. `determine_should_run_from_filters.py` still reads
+`FORCE_RUN_EVENTS` for a diff-shaped check that wants a mainline run; no
+workflow uses it today.
 
 Do not reach for the concurrency group instead. Within one group GitHub keeps
 one run in flight and one queued, and a newly queued run cancels the previously

--- a/.github/instructions/ci-scripts.instructions.md
+++ b/.github/instructions/ci-scripts.instructions.md
@@ -71,10 +71,12 @@ Decide by the check's input, not by which paths look related:
 | The diff | Correct | May skip |
 | The whole tree | Wrong on the mainline | MUST run |
 
-Force the mainline run in Python, not in a YAML `if:` (ADR-006).
-`scripts/workflows/determine_should_run_from_filters.py` reads
-`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
-determine step and leaves the job conditions alone.
+Delete the filter, do not force one event past it. `instruction-budget.yml`
+now runs one unconditional job. Forcing only `push` leaves every PR
+unmeasured, so two PRs each green against their own base still merge to a
+breaching union. `determine_should_run_from_filters.py` still reads
+`FORCE_RUN_EVENTS` for a diff-shaped check that wants a mainline run; no
+workflow uses it today.
 
 Do not reach for the concurrency group instead. Within one group GitHub keeps
 one run in flight and one queued, and a newly queued run cancels the previously

--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -7,10 +7,13 @@
 #
 # Exit codes: 0 = pass, 1 = budget exceeded, 2 = config error (ADR-035).
 #
-# IMPORTANT: This workflow runs on ALL PRs to satisfy required status checks,
-# but skips actual validation when no relevant files are changed. A push to
-# main always validates, because the budget scores the whole corpus and the
-# skip path reports a fresh green tick without measuring the tree.
+# IMPORTANT: no required status check depends on this workflow. Ruleset
+# 11104075 names 17 contexts and none of them is a job here, so there is
+# nothing for a skip-announcer job to satisfy. Every trigger measures the whole
+# corpus instead: the budget is a sum over the always-on tree, so a path filter
+# on the diff cannot decide it, and a skipped measurement reporting success is
+# the failure that let main sit 201 bytes over ceiling with a green tick
+# (issue #4345). The validator reads the whole tree in well under a second.
 
 name: Instruction Budget
 
@@ -30,50 +33,8 @@ permissions:
   contents: read
 
 jobs:
-  check-paths:
-    name: Detect changes
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 5
-    outputs:
-      should-run-budget: ${{ steps.determine.outputs.should-run-budget }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Check path filters
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        if: github.event_name != 'workflow_dispatch'
-        with:
-          filters: |
-            rules:
-              - '.claude/rules/**'
-              - '.github/instructions/**'
-            validator:
-              - 'scripts/validation/instruction_budget*.py'
-              - 'scripts/validation/token_budget.py'
-              - 'tests/validation/test_instruction_budget*.py'
-              - '.github/workflows/instruction-budget.yml'
-
-      - name: Determine if budget validation should run
-        id: determine
-        env:
-          GH_EVENT_NAME: ${{ github.event_name }}
-          FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
-          FILTER_KEYS: rules,validator
-          OUTPUT_NAME: should-run-budget
-          # The budget scores the whole .github/instructions corpus, not the
-          # diff, so a push to main must always measure it. When the filter
-          # misses, Validate budget is skipped and Skip budget reports success
-          # in its place, which is a green tick that asserts nothing about the
-          # tree. See the should_run docstring for the measured case.
-          FORCE_RUN_EVENTS: push
-        run: python3 scripts/workflows/determine_should_run_from_filters.py
-
   validate-budget:
     name: Validate budget
-    needs: check-paths
-    if: needs.check-paths.outputs.should-run-budget == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
@@ -86,17 +47,3 @@ jobs:
       - name: Run budget validator
         run: |
           uv run --frozen python3 -m scripts.validation.instruction_budget --ci
-
-  skip-budget:
-    name: Skip budget (no changes)
-    needs: check-paths
-    if: needs.check-paths.outputs.should-run-budget != 'true'
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 1
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Skip message
-        run: |
-          echo "No instruction budget changes detected - skipping validation"

--- a/.serena/memories/decision-a-whole-corpus-gate-cannot-be-path-filtered.md
+++ b/.serena/memories/decision-a-whole-corpus-gate-cannot-be-path-filtered.md
@@ -114,14 +114,16 @@ Measured at `160d1670a`:
 That is **8 bytes** of headroom. Any rule edit adding a single short sentence
 re-breaches.
 
-`PR #4361` (`06299410b`) later added `FORCE_RUN_EVENTS: push` to
-`instruction-budget.yml`, with the comment "a push to main always validates,
-because the budget scores the whole corpus and the skip path reports a fresh
-green tick without measuring the tree." That closes mechanism two on push to
-main. It does **not** close mechanism three below: a run cancelled while pending
-never reaches the job, so forcing the job to run inside it changes nothing.
-Verify such a fix against run **jobs** across a burst of merges, never against
-the workflow source.
+`PR #4361` (`06299410b`) first added `FORCE_RUN_EVENTS: push` to
+`instruction-budget.yml`, which closed mechanism two on push to main and left
+`pull_request` filtered. Issue #4345 then deleted the filter, the `check-paths`
+job and the `skip-budget` job outright, so that env var, that header comment,
+and the whole filter are gone from the file. Do not go looking for them: the
+workflow now holds one unconditional `validate-budget` job. Neither shape
+closes mechanism three below, because a run cancelled while pending never
+reaches the job, so forcing or unconditioning the job inside it changes
+nothing. Verify such a fix against run **jobs** across a burst of merges, never
+against the workflow source.
 
 Running an absolute ceiling at 100.0 percent utilization under
 `strict_required_status_checks_policy: false` guarantees recurrence, because

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -643,11 +643,17 @@ def validate_evidence_agrees_with_session(data: dict[str, Any], result: Validati
 
         problem = commit_reachability_problem(ending, _PROJECT_ROOT)
         if problem is not None:
+            # State the observation and list the candidates. The reachability
+            # check knows the SHA is unreachable and nothing else, so naming
+            # one cause sends readers after a mistake they did not make: this
+            # repository merges by squash, which orphans every branch SHA a
+            # session log records (issue #4347).
             result.errors.append(
-                f"endingCommit {ending!r} {problem}; the SHA was most likely "
-                "orphaned by amending or rebasing the commit that carried it. "
-                "Record the SHA in a follow-up commit instead of amending "
-                "afterwards (issue #3618)"
+                f"endingCommit {ending!r} {problem}. Candidate causes, most "
+                "likely first: the PR was squash merged, which orphans the "
+                "branch SHA; the commit was amended or rebased after the log "
+                "named it; the SHA was never pushed. Record the SHA in a "
+                "follow-up commit (issue #3618)"
             )
 
     if "nextSteps" not in data:

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -639,21 +639,29 @@ def validate_evidence_agrees_with_session(data: dict[str, Any], result: Validati
         # in this file sits below a sys.path insert and so needs an E402
         # suppression, and a new suppression is exactly what the push gate
         # refuses. Function scope needs none, and the module is already loaded.
-        from scripts.validation.session_scope import commit_reachability_problem
+        from scripts.validation.session_scope import (
+            NOT_AN_ANCESTOR,
+            commit_reachability_problem,
+        )
 
         problem = commit_reachability_problem(ending, _PROJECT_ROOT)
         if problem is not None:
-            # State the observation and list the candidates. The reachability
-            # check knows the SHA is unreachable and nothing else, so naming
-            # one cause sends readers after a mistake they did not make: this
-            # repository merges by squash, which orphans every branch SHA a
-            # session log records (issue #4347).
+            # State the observation and list only the candidates the check did
+            # not already rule out. Naming one cause sends readers after a
+            # mistake they did not make: this repository merges by squash,
+            # which orphans every branch SHA a session log records. And when
+            # the object is present but unreachable, `git cat-file -e` already
+            # found it here, so it was pushed (issue #4347).
+            causes = (
+                "the PR was squash merged, which orphans the branch SHA; the "
+                "commit was amended or rebased after the log named it"
+            )
+            if problem != NOT_AN_ANCESTOR:
+                causes += "; the SHA was never pushed"
             result.errors.append(
                 f"endingCommit {ending!r} {problem}. Candidate causes, most "
-                "likely first: the PR was squash merged, which orphans the "
-                "branch SHA; the commit was amended or rebased after the log "
-                "named it; the SHA was never pushed. Record the SHA in a "
-                "follow-up commit (issue #3618)"
+                f"likely first: {causes}. Record the SHA in a follow-up "
+                "commit (issue #3618)"
             )
 
     if "nextSteps" not in data:

--- a/scripts/validation/checks_coverage.py
+++ b/scripts/validation/checks_coverage.py
@@ -21,6 +21,24 @@ if str(_SCRIPT_DIR) not in sys.path:
 
 from checks_common import _run_subprocess  # noqa: E402
 
+_FAIL_TOKEN = "[FAIL]"
+_WARN_TOKEN = "[WARN]"
+
+
+def _as_advisory(line: str) -> str:
+    """Rewrite a leading ``[FAIL]`` token to ``[WARN]``.
+
+    ``validate_review_marker.py`` writes ``[FAIL]`` because it blocks under
+    ``/ship``. Forwarding that token from a caller that goes on to return True
+    prints a blocking severity on a passing check, so the reader reconciles it
+    against the ``RESULT:`` count at the bottom of the log (issue #4315).
+    """
+    stripped = line.lstrip()
+    if not stripped.startswith(_FAIL_TOKEN):
+        return line
+    indent = line[: len(line) - len(stripped)]
+    return indent + _WARN_TOKEN + stripped[len(_FAIL_TOKEN) :]
+
 
 def validate_review_marker(repo_root: Path) -> bool:
     """Advisory check for a SHA-bound ``Reviewed-By: /review@...`` marker on HEAD.
@@ -50,8 +68,12 @@ def validate_review_marker(repo_root: Path) -> bool:
     )
     output = (stdout or "") + (stderr or "")
     if output.strip():
+        # Decide the severity before forwarding, not after. Under
+        # REVIEW_MARKER_ENFORCED the wrapped script's [FAIL] is accurate and
+        # travels verbatim; otherwise this call returns True and the token
+        # would describe a failure that is not one.
         for line in output.strip().splitlines()[:20]:
-            print(line)
+            print(line if enforced else _as_advisory(line))
 
     if exit_code == 0:
         return True

--- a/scripts/validation/session_scope.py
+++ b/scripts/validation/session_scope.py
@@ -24,6 +24,13 @@ from pathlib import Path
 _GIT_TIMEOUT_SECONDS = 30
 _COMMIT_SHA = re.compile(r"^[0-9a-f]{7,40}$")
 
+# The fragments ``commit_reachability_problem`` returns. Named so a caller can
+# tell which question failed without matching on prose: the object being absent
+# and the object being present but unreachable have different causes.
+NOT_A_COMMIT_SHA = "is not a commit SHA"
+NO_SUCH_COMMIT = "names no commit in this repository"
+NOT_AN_ANCESTOR = "names a commit that is not an ancestor of HEAD"
+
 
 def _git(args: list[str], repo_root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -61,7 +68,7 @@ def commit_reachability_problem(sha: str, repo_root: Path) -> str | None:
         A sentence fragment naming the problem, or None when there is none.
     """
     if not _COMMIT_SHA.match(sha):
-        return "is not a commit SHA"
+        return NOT_A_COMMIT_SHA
     try:
         if _git(["rev-parse", "--is-inside-work-tree"], repo_root).returncode != 0:
             return None
@@ -69,9 +76,9 @@ def commit_reachability_problem(sha: str, repo_root: Path) -> str | None:
         if shallow.returncode != 0 or shallow.stdout.strip() == "true":
             return None
         if _git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root).returncode != 0:
-            return "names no commit in this repository"
+            return NO_SUCH_COMMIT
         if _git(["merge-base", "--is-ancestor", sha, "HEAD"], repo_root).returncode != 0:
-            return "names a commit that is not an ancestor of HEAD"
+            return NOT_AN_ANCESTOR
     except (OSError, subprocess.SubprocessError):
         return None
     return None

--- a/scripts/workflows/determine_should_run_from_filters.py
+++ b/scripts/workflows/determine_should_run_from_filters.py
@@ -36,9 +36,12 @@ def should_run(
     changes)`` passed in its place. The commit that caused the breach had its own
     run cancelled in a merge burst, so no run ever measured the breach.
 
-    List ``push`` here for a whole-tree check so the mainline is always measured.
-    Leave it empty for a diff-scoped check, where re-running on an unrelated push
-    buys nothing.
+    A whole-tree check should drop its filter instead of listing ``push`` here.
+    Forcing one event measures the mainline and leaves every pull request
+    unmeasured, so two of them each green against their own base still merge to
+    a breaching union. ``instruction-budget.yml`` took the filter out for that
+    reason and no workflow lists ``push`` today. Leave this empty for a
+    diff-scoped check, where re-running on an unrelated push buys nothing.
     """
     if event_name == "workflow_dispatch" or event_name in force_run_events:
         return True

--- a/src/copilot-cli/instructions/ci-scripts.instructions.md
+++ b/src/copilot-cli/instructions/ci-scripts.instructions.md
@@ -71,10 +71,12 @@ Decide by the check's input, not by which paths look related:
 | The diff | Correct | May skip |
 | The whole tree | Wrong on the mainline | MUST run |
 
-Force the mainline run in Python, not in a YAML `if:` (ADR-006).
-`scripts/workflows/determine_should_run_from_filters.py` reads
-`FORCE_RUN_EVENTS`, so a whole-tree check sets `FORCE_RUN_EVENTS: push` on its
-determine step and leaves the job conditions alone.
+Delete the filter, do not force one event past it. `instruction-budget.yml`
+now runs one unconditional job. Forcing only `push` leaves every PR
+unmeasured, so two PRs each green against their own base still merge to a
+breaching union. `determine_should_run_from_filters.py` still reads
+`FORCE_RUN_EVENTS` for a diff-shaped check that wants a mainline run; no
+workflow uses it today.
 
 Do not reach for the concurrency group instead. Within one group GitHub keeps
 one run in flight and one queued, and a newly queued run cancels the previously

--- a/tests/ci/test_whole_tree_budget_workflow.py
+++ b/tests/ci/test_whole_tree_budget_workflow.py
@@ -1,0 +1,127 @@
+"""No job in the instruction budget workflow may pass without measuring.
+
+Issue #4345. The budget is a sum over the whole always-on corpus, so a path
+filter over the diff cannot decide it. When the filter missed, ``Validate
+budget`` was skipped and a companion ``Skip budget (no changes)`` job reported
+success in its place. That is a fresh green tick asserting only that the diff
+was uninteresting, and it is how ``main`` sat 201 bytes over ceiling with a
+green Instruction Budget run at ``a72ee868c``.
+
+No required status check depends on this workflow (ruleset 11104075 names 17
+contexts, none of them a job here), so the skip-announcer satisfied nothing.
+The invariant this pins: every job in this workflow runs the validator, and no
+job is gated on a condition.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "instruction-budget.yml"
+
+VALIDATOR_MODULE = "scripts.validation.instruction_budget"
+
+
+def _load(path: Path) -> dict[Any, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict), f"{path.name} is not a workflow mapping"
+    return loaded
+
+
+def _job_runs_validator(job: dict[Any, Any]) -> bool:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return False
+    for step in steps:
+        run = step.get("run") if isinstance(step, dict) else None
+        if isinstance(run, str) and VALIDATOR_MODULE in run:
+            return True
+    return False
+
+
+def _unmeasured_success_errors(workflow: dict[Any, Any]) -> list[str]:
+    """Report jobs that can report success without measuring the corpus."""
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return ["workflow declares no jobs"]
+
+    errors: list[str] = []
+    for name, job in jobs.items():
+        if not isinstance(job, dict):
+            errors.append(f"{name}: job is not a mapping")
+            continue
+        if "if" in job:
+            errors.append(
+                f"{name}: gated on a condition. A whole-tree sum cannot be "
+                "decided from the diff, and a skipped measurement reports "
+                "success in its place."
+            )
+        if not _job_runs_validator(job):
+            errors.append(
+                f"{name}: never runs {VALIDATOR_MODULE}, so a green result "
+                "from it asserts nothing about the tree."
+            )
+    return errors
+
+
+def test_every_job_measures_the_corpus() -> None:
+    assert _unmeasured_success_errors(_load(WORKFLOW)) == []
+
+
+def test_pull_requests_and_main_pushes_both_reach_the_validator() -> None:
+    workflow = _load(WORKFLOW)
+    triggers = workflow.get(True, workflow.get("on"))
+
+    assert isinstance(triggers, dict)
+    assert "pull_request" in triggers
+    assert triggers["push"]["branches"] == ["main"]
+    assert _unmeasured_success_errors(workflow) == []
+
+
+def test_detector_flags_a_skip_announcer_job() -> None:
+    workflow = {
+        "jobs": {
+            "validate-budget": {
+                "steps": [{"run": f"python -m {VALIDATOR_MODULE} --ci"}],
+            },
+            "skip-budget": {
+                "if": "needs.check-paths.outputs.should-run-budget != 'true'",
+                "steps": [{"run": "echo 'no changes detected'"}],
+            },
+        }
+    }
+
+    errors = _unmeasured_success_errors(workflow)
+
+    assert any("skip-budget" in error for error in errors)
+    assert not any("validate-budget" in error for error in errors)
+
+
+def test_detector_flags_a_gated_validator_job() -> None:
+    workflow = {
+        "jobs": {
+            "validate-budget": {
+                "if": "needs.check-paths.outputs.should-run-budget == 'true'",
+                "steps": [{"run": f"python -m {VALIDATOR_MODULE} --ci"}],
+            }
+        }
+    }
+
+    errors = _unmeasured_success_errors(workflow)
+
+    assert len(errors) == 1
+    assert errors[0].startswith("validate-budget: gated on a condition")
+
+
+def test_detector_accepts_an_ungated_measuring_job() -> None:
+    workflow = {
+        "jobs": {
+            "validate-budget": {"steps": [{"run": f"uv run python -m {VALIDATOR_MODULE} --ci"}]}
+        }
+    }
+
+    assert _unmeasured_success_errors(workflow) == []

--- a/tests/test_session_ending_commit_diagnostic.py
+++ b/tests/test_session_ending_commit_diagnostic.py
@@ -87,6 +87,9 @@ def test_squash_merged_sha_is_reported_without_blaming_an_amend(
     assert "squash merged" in message
     assert "most likely orphaned by amending" not in message
     assert "instead of amending" not in message
+    # `git cat-file -e` found the object before the ancestor test ran, so the
+    # object is present here and "never pushed" is a cause the check ruled out.
+    assert "never pushed" not in message
 
 
 def test_reachable_sha_produces_no_error(

--- a/tests/test_session_ending_commit_diagnostic.py
+++ b/tests/test_session_ending_commit_diagnostic.py
@@ -1,0 +1,116 @@
+"""The unreachable-endingCommit error must not assert a cause it never checked.
+
+Issue #4347, instance 2. ``commit_reachability_problem`` learns one thing: the
+SHA is not an ancestor of HEAD. The diagnostic then told the reader the SHA was
+"most likely orphaned by amending or rebasing" and to stop amending. This
+repository merges by squash (ruleset 11104075 allows only the squash method),
+so a squash merge orphans every branch SHA a session log records, and the
+remedy named does not apply to the reader who hit it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import scripts.validate_session_json as vsj
+from scripts.validation.models import ValidationResult
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _repo_with_squash_merged_branch(tmp_path: Path) -> tuple[Path, str]:
+    """Return a repo and a branch SHA orphaned by a squash merge.
+
+    The branch commit still exists as an object and is still named by
+    ``refs/heads/feature``. What it is not is an ancestor of HEAD, which is the
+    only thing the reachability check measures.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Tester")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    (repo / "a.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "chore: base")
+
+    _git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "b.txt").write_text("work\n", encoding="utf-8")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "-q", "-m", "feat: work")
+    branch_sha = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "--squash", "feature")
+    _git(repo, "commit", "-q", "-m", "feat: work (#1)")
+
+    return repo, branch_sha
+
+
+def _errors_for_ending_commit(repo: Path, sha: str, monkeypatch: Any) -> list[str]:  # noqa: ANN401
+    monkeypatch.setattr(vsj, "_PROJECT_ROOT", repo)
+    data = {
+        "session": {"branch": "feature"},
+        "protocolCompliance": {
+            "sessionEnd": {"changesCommitted": {"complete": True, "evidence": "pushed"}}
+        },
+        "endingCommit": sha,
+    }
+    result = ValidationResult()
+    vsj.validate_evidence_agrees_with_session(data, result)
+    return result.errors
+
+
+def test_squash_merged_sha_is_reported_without_blaming_an_amend(
+    tmp_path: Path,
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo, branch_sha = _repo_with_squash_merged_branch(tmp_path)
+
+    errors = _errors_for_ending_commit(repo, branch_sha, monkeypatch)
+
+    assert len(errors) == 1
+    message = errors[0]
+    assert "not an ancestor of HEAD" in message
+    assert "squash merged" in message
+    assert "most likely orphaned by amending" not in message
+    assert "instead of amending" not in message
+
+
+def test_reachable_sha_produces_no_error(
+    tmp_path: Path,
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo, _ = _repo_with_squash_merged_branch(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD~1")
+
+    assert _errors_for_ending_commit(repo, head, monkeypatch) == []
+
+
+def test_unknown_sha_still_names_every_candidate_cause(
+    tmp_path: Path,
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo, _ = _repo_with_squash_merged_branch(tmp_path)
+    absent = "0" * 40
+
+    errors = _errors_for_ending_commit(repo, absent, monkeypatch)
+
+    assert len(errors) == 1
+    message = errors[0]
+    assert "names no commit in this repository" in message
+    assert "squash merged" in message
+    assert "amended or rebased" in message
+    assert "never pushed" in message

--- a/tests/validation/test_checks_coverage_severity.py
+++ b/tests/validation/test_checks_coverage_severity.py
@@ -1,0 +1,123 @@
+"""Severity tokens the review-marker gate forwards must match its verdict.
+
+Issue #4315: ``validate_review_marker`` is advisory by default and returns
+True on a missing or stale marker, but it forwarded the wrapped script's
+``[FAIL]`` line verbatim first. A passing check therefore printed a line
+byte-identical in shape to a blocking failure, and the reader had to reconcile
+it against the ``RESULT:`` count at the bottom of a long pre-push log.
+
+These tests drive the real wrapped script against a real git repository rather
+than a mocked subprocess, so they observe the token a contributor actually
+sees.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.validation.checks_coverage import _as_advisory, validate_review_marker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _repo(tmp_path: Path, *, with_script: bool) -> Path:
+    """Build a repository whose HEAD changes files and carries no marker."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    if with_script:
+        dest = repo / "scripts" / "validation"
+        dest.mkdir(parents=True)
+        source = _REPO_ROOT / "scripts" / "validation" / "validate_review_marker.py"
+        (dest / "validate_review_marker.py").write_text(
+            source.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Tester")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "a.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "feat: one")
+    (repo / "b.txt").write_text("y\n", encoding="utf-8")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "-q", "-m", "feat: two")
+    return repo
+
+
+def test_advisory_failure_prints_warn_and_never_fail(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo = _repo(tmp_path, with_script=True)
+    monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
+
+    passed = validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert passed is True
+    assert "[FAIL]" not in captured
+    assert "[WARN]" in captured
+    assert "a review marker must be an empty commit" in captured
+
+
+def test_enforced_failure_keeps_the_fail_token(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo = _repo(tmp_path, with_script=True)
+    monkeypatch.setenv("REVIEW_MARKER_ENFORCED", "1")
+
+    passed = validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert passed is False
+    assert "[FAIL]" in captured
+
+
+def test_missing_script_advisory_still_warns(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,  # noqa: ANN401
+) -> None:
+    repo = _repo(tmp_path, with_script=False)
+    monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
+
+    passed = validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert passed is True
+    assert "[WARN] validate_review_marker.py not found (advisory skip)" in captured
+    assert "[FAIL]" not in captured
+
+
+def test_as_advisory_downgrades_a_leading_token_and_keeps_indent() -> None:
+    assert _as_advisory("[FAIL] no marker") == "[WARN] no marker"
+    assert _as_advisory("  [FAIL] no marker") == "  [WARN] no marker"
+
+
+def test_as_advisory_leaves_a_non_leading_token_alone() -> None:
+    line = "grep for [FAIL] in the log"
+
+    assert _as_advisory(line) == line
+
+
+def test_as_advisory_leaves_unrelated_lines_alone() -> None:
+    assert _as_advisory("[OK] marker binds HEAD") == "[OK] marker binds HEAD"
+    assert _as_advisory("") == ""


### PR DESCRIPTION
## Summary

Three gates told a reader something the gate never measured, and one whole-corpus gate could skip itself. This branch fixes the diagnostics and deletes the skip.

1. `validate_review_marker` is advisory by default and returns `True`, but it forwarded the wrapped script's `[FAIL]` line verbatim. A passing check printed a line byte-identical in shape to a blocking failure, so the reader had to reconcile it against the `RESULT:` count at the bottom of a long pre-push log. The wrapper now downgrades a leading `[FAIL]` to `[WARN]` on the advisory path only. Under `REVIEW_MARKER_ENFORCED=1` the token travels verbatim because there it is accurate.

2. The unreachable-`endingCommit` error asserted the SHA was "most likely orphaned by amending or rebasing" and told the reader to stop amending. This repository merges by squash only (ruleset 11104075 allows one merge method), so a squash merge orphans every branch SHA a session log records, and the remedy did not apply to the reader who hit it. The message now states the observation and lists candidate causes, most likely first. On the not-an-ancestor branch it omits "the SHA was never pushed", because `git cat-file -e` already proved the object is present before that branch is reached.

3. The instruction budget is a sum over the whole always-on tree, so a `dorny/paths-filter` over the diff cannot decide it. When the filter missed, `Validate budget` was skipped and `Skip budget (no changes)` reported success in its place. That is how `main` sat 201 bytes over ceiling with a green Instruction Budget run at `a72ee868c`. The old header comment justified the skip job by claiming the workflow "runs on ALL PRs to satisfy required status checks". No such contract exists: ruleset 11104075 names 17 required contexts and none of them is a job in this workflow, and `repos/rjmurillo/ai-agents/branches/main/protection` returns 404. The filter, the `check-paths` job, and the `skip-budget` job are deleted. One job remains and it always measures.

The always-on rule and the helper docstring both prescribed `FORCE_RUN_EVENTS: push` as the whole-tree remedy. This diff removes its last production consumer, so both now say to delete the filter instead, and both record that `FORCE_RUN_EVENTS` still exists for a diff-shaped check with no workflow using it today. The Serena memory that quoted the deleted header comment is corrected the same way.

## Acceptance criteria

- [x] Advisory review-marker failure prints `[WARN]` and never `[FAIL]`, and still returns `True`.
- [x] Enforced review-marker failure keeps `[FAIL]` and returns `False`.
- [x] The missing-script advisory path keeps its existing `[WARN]`.
- [x] A squash-merged `endingCommit` is reported without blaming an amend, and without naming "never pushed" on the branch where the object was found.
- [x] An absent `endingCommit` still names every candidate cause.
- [x] Every job in `instruction-budget.yml` runs the validator, and no job is gated on a condition. Pinned by a test on the invariant, not on the file text.
- [x] Both instruction mirrors regenerate from `.claude/rules/ci-scripts.md` with no diff.

## Verification

Run on the branch, not inherited from the author.

Gate against the full corpus, per `.claude/rules/ci-scripts.md` MUST 13:

```
$ uv run --frozen python3 -m scripts.validation.instruction_budget --ci
Ext     Files     Bytes   Ceiling   Tokens~    Usage  Status
.cs        11     94998     99000     25106    96.0%    PASS
.md         9     82002     83000     21636    98.8%    PASS
.ps1       11     94830     99000     25139    95.8%    PASS
.py        11     95121     99000     25202    96.1%    PASS
PASS: All languages within the always-on instruction ceiling.
```

The now-unconditional job therefore does not red `main`.

Live behavior of the review-marker wrapper on this branch, advisory then enforced:

```
[WARN] HEAD (bee6c9a0791e) changes files; a review marker must be an empty commit ...
  Note: advisory only (default). ...
RET= True

[FAIL] HEAD (bee6c9a0791e) changes files; a review marker must be an empty commit ...
RET= False
```

Negative controls, each reverted by hand with `__pycache__` cleared and `-p no:cacheprovider`:

| Reverted | Result |
| --- | --- |
| `print(line if enforced else _as_advisory(line))` back to `print(line)` | 1 failed, 5 passed |
| `scripts/validate_session_json.py` and `session_scope.py` to `origin/main` | 2 failed, 1 passed |
| the `problem != NOT_AN_ANCESTOR` guard removed | 1 failed, 2 passed |
| `.github/workflows/instruction-budget.yml` to `origin/main` | 2 failed, 3 passed |

Each revert leaves at least one test in the same file green, so the controls are inverted rather than blanket.

External claims checked against the live API rather than taken from prose: `gh api repos/rjmurillo/ai-agents/rulesets` returns one ruleset (11104075) with 17 required contexts and none of them a job in this workflow; `gh api repos/rjmurillo/ai-agents/branches/main/protection` returns 404 Branch not protected.

Suite and ratchets: `uv run --frozen python -m pytest -q -x` gives 22310 passed, 31 skipped in 816s. `ruff_count_ratchet.py` OK at baseline 311. `taste_count_ratchet.py` OK at baseline 598. Neither baseline was raised. `actionlint` clean on the changed workflow, `ruff check` clean on every changed Python file, `build/scripts/generate_rules.py` produces no diff, and `memory_index.py --ci` passes.

## Scope

`Fixes #4315` only.

`Refs #4345`, deliberately not `Fixes`. This closes the workflow half. Acceptance criterion 3 of that issue (record how an always-on addition earns its bytes) is untouched, and root cause 2 stands: no job in this workflow is a required context, so a green run cannot block a merge, and two pull requests each measured against their own base can still merge to a union that breaches. This is detection, not prevention.

`Refs #4347`. Two of the three gates that issue names are fixed here.

Not fixed, named so the next reader does not inherit a wrong safety argument: `.github/workflows/skill-passive-compliance.yml` line 91 runs `skill_description_budget.py --max-total-chars 40000`, which sums every skill description and is the same whole-corpus-sum-behind-a-path-filter shape. It cannot red the job only because the step carries `continue-on-error: true`. Enforcing it is not available today. Measured on this branch the corpus is 41061 chars against the 40000 ceiling, so removing `continue-on-error` would red `main` and breach `ci-scripts.md` MUST 13. That is a separate change with a separate owner.

`.serena/memories/decision-a-whole-corpus-gate-cannot-be-path-filtered.md` has no row in `memory-index.md`. Pre-existing since #4342, not introduced here, and `memory_index.py --ci` passes because it only checks that index rows resolve to files.
