### PR TITLE
test(portability): make the check_skill_portability wiring controls falsifiable

### DIFF
--- a/tests/validation/test_portability_scan_coverage_refusal.py
+++ b/tests/validation/test_portability_scan_coverage_refusal.py
@@ -31,7 +31,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from scripts.validation import check_skill_md_exec_portability as cep  # noqa: E402
 from scripts.validation import check_skill_md_portability as cmp  # noqa: E402
-from scripts.validation import check_skill_portability as csp  # noqa: E402
 from scripts.validation.portability_common import (  # noqa: E402
     refuse_uncovered_scan,
     tracked_coverage_by_root,
@@ -385,66 +384,3 @@ class TestWorktreeGapCoverage:
         argv = ["--repo-root", str(tmp_path), "--baseline", "baseline.json", "--update-baseline"]
         assert module.main(argv) == 2
         assert baseline.read_bytes() == before
-
-
-class TestScriptCheckerSymlinkRefusal:
-    """Per-consumer wiring test for check_skill_portability.py (Issue #4252).
-
-    This class is the test that would have caught an unwired security guard
-    on the day it shipped. It drives the consumer's real entry point (main())
-    twice over the same skills tree, differing only in whether the baseline is
-    a symlink, which is the condition the guard rejects.
-
-    The positive control (real file) confirms the consumer calls the guard and
-    the guard permits the write. The negative control (symlinked baseline)
-    confirms the consumer calls the guard and the guard refuses. If
-    check_skill_portability.py were ever unwired from write_baseline_json,
-    the symlink check would be skipped and the negative control would return 0,
-    failing this test.
-
-    Exemplar for SHOULD-6 in .claude/rules/testing.md.
-    """
-
-    def _populate(self, root: Path) -> None:
-        skills = root / ".claude" / "skills"
-        skills.mkdir(parents=True)
-        (skills / "my-skill").mkdir()
-        (skills / "my-skill" / "run.py").write_text(
-            "# no upstream paths\nprint('hello')\n", encoding="utf-8"
-        )
-        _git(root, "init", "-q", "-b", "main")
-        _git(root, "add", "-A")
-        _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed")
-
-    def test_positive_real_baseline_file_permits_write(
-        self, tmp_path: Path
-    ) -> None:
-        """Positive control: normal baseline file, guard permits the write."""
-        self._populate(tmp_path)
-        baseline = tmp_path / "skill_portability_baseline.json"
-        argv = ["--repo-root", str(tmp_path), "--baseline", str(baseline), "--update-baseline"]
-        assert csp.main(argv) == 0
-        assert baseline.is_file()
-        import json
-        data = json.loads(baseline.read_text(encoding="utf-8"))
-        assert "files" in data
-
-    def test_negative_symlinked_baseline_refuses_write(
-        self, tmp_path: Path
-    ) -> None:
-        """Negative control: symlinked baseline, guard refuses the write.
-
-        If check_skill_portability.py stops calling write_baseline_json (the
-        function that contains the symlink check), this test returns 0 instead
-        of 2 and fails. That is the wiring test catching the unwired consumer.
-        """
-        if __import__("os").name == "nt":
-            import pytest as _pytest
-            _pytest.skip("Symlink creation requires elevated Windows privileges")
-        self._populate(tmp_path)
-        real_target = tmp_path / "real_baseline.json"
-        real_target.write_text("{}", encoding="utf-8")
-        baseline = tmp_path / "skill_portability_baseline.json"
-        baseline.symlink_to(real_target)
-        argv = ["--repo-root", str(tmp_path), "--baseline", str(baseline), "--update-baseline"]
-        assert csp.main(argv) == 2

--- a/tests/validation/test_portability_script_checker_wiring.py
+++ b/tests/validation/test_portability_script_checker_wiring.py
@@ -1,0 +1,198 @@
+"""Per-consumer wiring tests for `check_skill_portability.py` (#4252, #4454).
+
+`main()` reaches the baseline guards down two independent paths, and each one
+needs its own control. Every line number below is as of base `db5aab393`; the
+function names are what actually anchor the claims. Verbatim from
+`scripts/validation/check_skill_portability.py`::
+
+    344:    baseline_path = _resolve_baseline_path(root, args.baseline)
+    345:    if baseline_path is None:
+    346:        return 2
+    ...
+    354:    if args.update_baseline:
+    355:        return write_baseline(
+
+`_resolve_baseline_path` delegates to `resolve_checked_baseline`, which runs
+`if refuse_symlinked_baseline(root, resolved):` at
+`scripts/validation/portability_common.py:190`. `write_baseline` reaches
+`write_baseline_json` at `portability_common.py:217`, which runs
+`if refuse_symlinked_baseline(repo_root, baseline_path):` again at
+`scripts/validation/portability_baseline.py:428` and
+`if refuse_dropped_entries(previous, counted, unit, allow_shrink, problem):` at
+`:435`.
+
+So the symlink condition is refused by *both* paths, and the resolver runs
+first. A single symlinked-baseline control therefore observes neither: unwire
+the writer and the resolver still returns 2, unwire the resolver and the writer
+still returns 2. Each guard masks the other's removal. #4281 shipped exactly
+that one control, and #4454 recorded the surviving mutant. Measured here on
+`db5aab393`, both directions survived it::
+
+    #4281 control with resolver unwired: rc=2 -> SURVIVED (test asserts ==2)
+    #4281 control with writer unwired:   rc=2 -> SURVIVED (test asserts ==2)
+
+Each path consequently gets a condition only that path can refuse, plus the
+mutation that must kill it, asserted as a test rather than left in a commit
+message. Exit code 2 alone is not evidence, because `main()` returns 2 from
+several branches, so every control also asserts the refusing guard's own stderr
+text and that the bytes it protects did not move.
+
+The symlink refusal on the write path is not dropped, only tested where it can
+be seen: `test_portability_baseline_destination.py::TestSymlinkedBaseline::
+test_a_symlinked_parent_does_not_get_written_through` calls `write_baseline_json`
+directly and asserts the victim still reads `DO NOT OVERWRITE`.
+
+Exemplar for SHOULD-6 in `.claude/rules/testing.md`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validation import check_skill_portability as csp  # noqa: E402
+
+SYMLINK_REFUSAL = "Refusing a baseline reached through a symlink"
+SHRINK_REFUSAL = "Refusing to write a baseline that reduces"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+class TestScriptCheckerBaselineGuardWiring:
+    """Drive `csp.main()` over conditions each guard alone can refuse."""
+
+    def _populate(self, root: Path) -> None:
+        skills = root / ".claude" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "my-skill").mkdir()
+        (skills / "my-skill" / "run.py").write_text(
+            "# no upstream paths\nprint('hello')\n", encoding="utf-8"
+        )
+        _git(root, "init", "-q", "-b", "main")
+        _git(root, "add", "-A")
+        _git(root, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed")
+
+    def _argv(self, root: Path, baseline: Path, *, update: bool) -> list[str]:
+        argv = ["--repo-root", str(root), "--baseline", str(baseline)]
+        return [*argv, "--update-baseline"] if update else argv
+
+    def _symlinked_baseline(self, root: Path) -> tuple[Path, Path]:
+        """Return `(link, target)`, skipping only when the platform refuses.
+
+        Attempted rather than assumed: Windows creates symlinks under Developer
+        Mode or an elevated shell, so skipping every `nt` run unconditionally
+        gives up the coverage on the machines that do hold the privilege.
+        """
+        target = root / "real_baseline.json"
+        target.write_text(json.dumps({"files": {}}), encoding="utf-8")
+        link = root / "skill_portability_baseline.json"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+        return link, target
+
+    def _shrinking_baseline(self, root: Path) -> Path:
+        """A real baseline recording debt the fresh scan cannot find.
+
+        The fixture skill holds no upstream refs, so the replacement would drop
+        `ghost/run.py` entirely. `read_previous_sections` reads the working-tree
+        copy, so the entry does not need to be committed to be protected.
+        """
+        baseline = root / "skill_portability_baseline.json"
+        baseline.write_text(
+            json.dumps({"_comment": "seed", "files": {"ghost/run.py": 3}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return baseline
+
+    def test_positive_real_baseline_file_permits_write(self, tmp_path: Path) -> None:
+        """Positive control: an ordinary baseline, both guards permit the write."""
+        self._populate(tmp_path)
+        baseline = tmp_path / "skill_portability_baseline.json"
+
+        assert csp.main(self._argv(tmp_path, baseline, update=True)) == 0
+
+        assert baseline.is_file()
+        assert "files" in json.loads(baseline.read_text(encoding="utf-8"))
+
+    def test_symlinked_baseline_is_refused_before_the_write_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Resolver wiring: the writer is unreachable, so only the resolver can refuse."""
+        self._populate(tmp_path)
+        link, target = self._symlinked_baseline(tmp_path)
+        before = target.read_bytes()
+
+        assert csp.main(self._argv(tmp_path, link, update=False)) == 2
+
+        assert SYMLINK_REFUSAL in capsys.readouterr().err
+        assert target.read_bytes() == before
+        assert link.is_symlink()
+
+    def test_unwiring_the_resolver_lets_the_symlinked_baseline_through(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Recorded mutation that must kill the control above.
+
+        Replaces the consumer's resolver with one that hands the path back
+        unvetted, which is what `check_skill_portability.py` no longer calling
+        `resolve_checked_baseline` looks like. Measured on `db5aab393`: exit 0
+        and no refusal on stderr. Without this the control is unfalsifiable,
+        which is the defect #4454 records.
+        """
+        self._populate(tmp_path)
+        link, _target = self._symlinked_baseline(tmp_path)
+        monkeypatch.setattr(csp, "_resolve_baseline_path", lambda root, baseline: baseline)
+
+        assert csp.main(self._argv(tmp_path, link, update=False)) == 0
+
+        assert SYMLINK_REFUSAL not in capsys.readouterr().err
+
+    def test_shrinking_baseline_is_refused_inside_the_writer(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Writer wiring: the resolver permits, so only the writer can refuse."""
+        self._populate(tmp_path)
+        baseline = self._shrinking_baseline(tmp_path)
+        before = baseline.read_bytes()
+
+        assert csp.main(self._argv(tmp_path, baseline, update=True)) == 2
+
+        assert SHRINK_REFUSAL in capsys.readouterr().err
+        assert baseline.read_bytes() == before
+
+    def test_unwiring_the_writer_lets_the_shrinking_baseline_through(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Recorded mutation that must kill the control above.
+
+        This is the exact mutation #4454 recorded as SURVIVING against the
+        #4281 exemplar: `csp.write_baseline` replaced by a stub returning 0.
+        Against a symlinked baseline it survived, because the resolver had
+        already refused. Against this control, measured on `db5aab393`, it
+        exits 0 and the guard's message is gone.
+        """
+        self._populate(tmp_path)
+        baseline = self._shrinking_baseline(tmp_path)
+        monkeypatch.setattr(csp, "write_baseline", lambda *args, **kwargs: 0)
+
+        assert csp.main(self._argv(tmp_path, baseline, update=True)) == 0
+
+        assert SHRINK_REFUSAL not in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

### What

Replaces the single symlinked-baseline control that PR #4281 shipped for the
`check_skill_portability` ratchet with one control per guarded path, each
paired with the mutation that must kill it. Test-only change, no production
code touched.

### Why

The #4281 control was unfalsifiable. The `check_skill_portability` ratchet
refuses a symlinked baseline twice, so each refusal masked the other's removal.
Measured on merged base `db5aab393`:

```
#4281 control with resolver unwired (csp._resolve_baseline_path -> identity): rc=2 -> SURVIVED
#4281 control with writer   unwired (csp.write_baseline        -> stub 0):    rc=2 -> SURVIVED
```

A per-consumer wiring test that survives the removal of the wiring it names is
worse than no test: it reports coverage of a claim it never checks.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | #4454 | Per-consumer wiring exemplar from #4281 is unfalsifiable |
| **Rule** | `.claude/rules/testing.md` SHOULD-6 | Prove the wiring, not only the guard |
| **Rule** | `.claude/rules/testing.md` MUST-7, MUST-11 | Mutation harness reports three outcomes; inverted control required |

## Root cause

`main()` reaches `refuse_symlinked_baseline` down two independent paths. Line
numbers as of `db5aab393`:

```text
check_skill_portability.py:344  _resolve_baseline_path -> resolve_checked_baseline
portability_common.py:190           if refuse_symlinked_baseline(root, resolved):
check_skill_portability.py:346  main() returns 2

check_skill_portability.py:355  write_baseline -> write_baseline_json
portability_common.py:217           write_baseline_json(...)
portability_baseline.py:428             if refuse_symlinked_baseline(repo_root, baseline_path):
```

The resolver runs first, so the write path was never reached. Removing the
resolver did not fail the control either, because the writer then refused the
same symlink. `main()` also returns 2 from several unrelated branches, so
asserting only `== 2` cannot say which branch produced it.

## Changes

- Each guarded path gets a condition only that path can refuse:
  - **Resolver**: symlinked `--baseline` *without* `--update-baseline`. Line 355
    sits behind `if args.update_baseline`, so the writer is unreachable by
    construction and the refusal can only be the resolver's.
  - **Writer**: a real, in-tree, diffable `--baseline` recording debt the fresh
    scan drops, *with* `--update-baseline`. The resolver has nothing to object
    to, leaving `refuse_dropped_entries` inside `write_baseline_json` as the only
    objector.
- Each control is paired with the mutation that must kill it, asserted as a test
  rather than recorded in a commit message.
- Every control asserts the refusing guard's own stderr text, so exit code 2
  alone is never the evidence.
- Target integrity asserted on both refusal paths: the symlink target bytes are
  snapshotted and re-checked, the link is asserted to still be a link, and the
  writer control asserts the baseline bytes did not move.
- Windows now attempts the symlink and skips only when creation actually fails,
  instead of skipping every `nt` run. Developer Mode and elevated shells keep the
  coverage.
- Duplicate local `import json` and `import pytest` removed (they shadowed the
  module-scope imports). Cleanup, not correctness.
- Moved into `tests/validation/test_portability_script_checker_wiring.py` rather
  than growing the scan-coverage module past the 500-line taste-lint ceiling.
  The name carries the `_wiring` suffix the two SHOULD-6 exemplars already use.

## Files Changed

- `tests/validation/test_portability_script_checker_wiring.py` (new)
- `tests/validation/test_portability_scan_coverage_refusal.py` (class removed, unused import dropped)

## Evidence

Source-level mutation sweep, three outcomes with occurrence counting, `cmp`
verification of both patch and restore, run on `db5aab393`:

```
[baseline] unmutated run: rc=0 -> 5 passed
[DEAD]     M1 resolver unwired (consumer stops vetting the baseline)       (expected DEAD)
[DEAD]     M2 writer unwired (consumer stops calling write_baseline)       (expected DEAD)
[DEAD]     M3 writer guard neutered (refuse_dropped_entries never fires)   (expected DEAD)
[SURVIVED] M4 INVERTED CONTROL: cosmetic print reworded (must survive)     (expected SURVIVED)

Summary: 4 mutants, 4 as expected, 0 unexpected
```

M4 is the inverted control MUST-11 requires: without it, a harness that fails
unconditionally reads as a clean sweep.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny, no rush.

**Focus areas**:

1. Is each control genuinely unmaskable? The resolver control depends on line
   355 sitting behind `if args.update_baseline`; the writer control depends on
   `refuse_dropped_entries` living only inside `write_baseline_json`. Both are
   quoted in the module docstring. If either premise is wrong, the control is as
   vacuous as the one it replaces.
2. The two mutation tests monkeypatch `csp._resolve_baseline_path` and
   `csp.write_baseline`. That asserts the consumer's wiring, not the guards'
   internals. Say so if you would rather see the guard itself neutered.
3. Coverage moved, not dropped: the writer's symlink refusal is still asserted
   by `test_portability_baseline_destination.py::
   TestTheWriteCannotBeRedirectedOffThePathGitTracks::
   test_a_symlinked_parent_does_not_get_written_through`, which calls
   `write_baseline_json` directly and checks the victim still reads
   `DO NOT OVERWRITE`.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Commands run on `db5aab393`:

| Command | Result |
|---|---|
| `uv run pytest tests/validation -q` | 2014 passed, 1 skipped |
| `uv run pytest tests/validation/test_portability_script_checker_wiring.py -q` | 5 passed |
| `uv run ruff check tests/validation/test_portability_script_checker_wiring.py` | All checks passed |
| `uv run ruff format --check` on both changed files | new module already formatted |
| `uv run ruff check .` | 306 errors, all pre-existing, delta 0 from the changed files |
| `uv run python scripts/validation/pre_pr.py` | RESULT: All validations passed |
| `uv run python build/scripts/build_all.py --check` | exit 0, no drift |
| Mutation sweep (4 mutants) | 4 as expected, 0 unexpected |

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Test-only change. No production code, workflow, hook, or auth surface touched.

**Files requiring security review:** none.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

Issue #4454 was corrected before this PR was opened. Three claims in its original
filing did not survive verification and are withdrawn in the issue body:

1. "Re-scope the test to the resolver" was offered as a sufficient fix. It is
   not: under `--update-baseline` the writer still refuses a symlinked baseline,
   so a relabelled control still passes with the resolver removed.
2. PR #4281 was said to have introduced the mutation-harness MUST. It did not.
   MUST-7 landed in PR #4264 (commit `af27638a6`) and SHOULD-6 landed in PR #4265
   (commit `639cc5c0b`); #4281's concurrent variant was merged into #4265's
   wording. SHOULD-6 names `test_pre_pr_model_pin_wiring.py` and
   `test_rule_activation_coverage_wiring.py` as exemplars, not this class.
3. The duplicate imports were listed as a correctness follow-up. They change no
   behavior and are carried here only as cleanup.

PR #4281 is merged and was left untouched: `check_pr_live_state.py --pull-request
4281` returned `action: SKIP, reason: PR is already merged` before every
PR-related decision in this session.

## Post-review corrections

Final QA on this branch found one defect in the change itself and one inherited
CI failure. Both are resolved here.

1. **Bad citation (fixed in `f8bc4b20d`).** The new module docstring
   originally cited a nonexistent class. The actual class is
   `TestTheWriteCannotBeRedirectedOffThePathGitTracks`, and the method name was
   already right. The citation is load-bearing because it proves the write-path
   symlink refusal moved rather than disappeared. Verified by node id:

   ```
   $ uv run pytest "...::TestTheWriteCannotBeRedirectedOffThePathGitTracks::test_a_symlinked_parent_does_not_get_written_through" -q
   1 passed
   ```

   The same bad citation was in issue #4454's body and in this description; both
   are corrected.

2. **Required `Run Python Tests` failure (inherited, fixed by updating from
   `main`).** `tests/test_check_doc_interpreter_portability_identity.py:42` runs
   `git commit` in a fixture repo built by `make_repo`, which called `git init`
   and never set an author identity. It passed locally off `~/.gitconfig` and
   exited 128 on a runner. Reproduced on the old base:

   ```
   $ GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null uv run pytest tests/test_check_doc_interpreter_portability_identity.py -q
   fatal: unable to auto-detect email address
   1 failed
   ```

   The file is identical on `main` and on this branch, so it is not this change's
   defect. It is tracked as #4464, which argues the fix belongs in the shared
   `make_repo` helper rather than at the one call site that commits. That fix
   landed on `main` in `0c75045d6`. This branch was merged up to `main`, and the
   same scrubbed-environment run now passes:

   ```
   $ GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null uv run pytest tests/test_check_doc_interpreter_portability_identity.py tests/test_check_doc_interpreter_portability.py -q
   53 passed
   ```

   No call-site override was added: it would duplicate the helper fix and
   contradict #4464's stated design.

The branch was brought up to date with a normal merge commit, not a rebase or a
force-push.

## Related Issues

Fixes #4454
Refs #4281, #4252, #4264, #4265

