### PR TITLE
fix(security): close semgrep pinning review gaps

### DIFF
--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -455,7 +455,18 @@ class SemgrepScanner:
             raise SemgrepScanError(
                 f"Semgrep timed out after {self.SCAN_TIMEOUT_SECONDS}s"
             ) from e
-        except subprocess.SubprocessError as e:
+        except (subprocess.SubprocessError, OSError) as e:
+            # OSError is listed explicitly: it is NOT a subclass of
+            # subprocess.SubprocessError (verified in this session:
+            # issubclass(subprocess.SubprocessError, OSError) is False; the two
+            # hierarchies are siblings under Exception). subprocess.run raises
+            # OSError, not SubprocessError, when the exec itself faults: the
+            # binary was deleted between _resolve_semgrep_executable's version
+            # probe and this call (TOCTOU -> FileNotFoundError), lost its exec
+            # bit (PermissionError), or the kernel refused the spawn (OSError).
+            # Without this arm the exception escapes _run_semgrep, run() catches
+            # only SemgrepScanError, and the gate dies on a traceback instead of
+            # the structured blocking finding below.
             logger.error("Semgrep scan failed: %s", e)
             message = _semgrep_output_snippet(str(e), fallback=type(e).__name__)
             return [_scan_failure_finding(f"Semgrep scan failed: {message}")]

--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -456,17 +456,13 @@ class SemgrepScanner:
                 f"Semgrep timed out after {self.SCAN_TIMEOUT_SECONDS}s"
             ) from e
         except (subprocess.SubprocessError, OSError) as e:
-            # OSError is listed explicitly: it is NOT a subclass of
-            # subprocess.SubprocessError (verified in this session:
-            # issubclass(subprocess.SubprocessError, OSError) is False; the two
-            # hierarchies are siblings under Exception). subprocess.run raises
-            # OSError, not SubprocessError, when the exec itself faults: the
-            # binary was deleted between _resolve_semgrep_executable's version
-            # probe and this call (TOCTOU -> FileNotFoundError), lost its exec
-            # bit (PermissionError), or the kernel refused the spawn (OSError).
-            # Without this arm the exception escapes _run_semgrep, run() catches
-            # only SemgrepScanError, and the gate dies on a traceback instead of
-            # the structured blocking finding below.
+            # OSError is a sibling of subprocess.SubprocessError, not a
+            # subclass, and it is what subprocess.run raises when the exec
+            # itself faults: the binary was deleted after the resolver's
+            # version probe (TOCTOU), lost its exec bit, or the kernel refused
+            # the spawn. Dropping it lets the exception escape to run(), which
+            # handles only SemgrepScanError, so the gate would die on a
+            # traceback instead of the blocking finding below.
             logger.error("Semgrep scan failed: %s", e)
             message = _semgrep_output_snippet(str(e), fallback=type(e).__name__)
             return [_scan_failure_finding(f"Semgrep scan failed: {message}")]

--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -126,6 +126,14 @@ class _SemgrepExecutableError(RuntimeError):
     """
 
 
+# Canonical remediation for a missing or mismatched semgrep. pyproject.toml
+# pins semgrep in [project.optional-dependencies].dev and mirrors that pin in
+# [dependency-groups].dev; uv installs exactly those pins from uv.lock.
+# scripts/install_semgrep.py runs `pip install semgrep` with no version, so it
+# can install a build this resolver rejects; it is deliberately not offered.
+_INSTALL_HINT = "uv sync --frozen --extra dev"
+
+
 def _semgrep_pinned_version(repo_root: Path) -> str:
     """Read the semgrep version pin from pyproject.toml.
 
@@ -181,34 +189,55 @@ def _probe_semgrep_version(executable: str) -> str:
     return version
 
 
+def _verify_pinned_version(executable: str, repo_root: Path) -> str:
+    """Return ``executable`` once it reports the pyproject.toml pin.
+
+    Raises ``_SemgrepExecutableError`` on any mismatch: a scanner running an
+    unpinned build reports findings from a different ruleset than CI does.
+    """
+    version = _probe_semgrep_version(executable)
+    pinned = _semgrep_pinned_version(repo_root)
+    if version != pinned:
+        raise _SemgrepExecutableError(
+            f"semgrep version mismatch: pyproject.toml pins {pinned!r}, "
+            f"but {executable} reports {version!r}. "
+            f"Reinstall the pin with: {_INSTALL_HINT}"
+        )
+    return executable
+
+
 def _resolve_semgrep_executable(repo_root: Path) -> str:
     """Return the path to a pinned semgrep binary.
 
-    Preference order:
+    Preference order, both verified against the pyproject.toml pin:
     1. A ``semgrep`` sibling of the current interpreter (inside the venv).
-    2. The first ``semgrep`` on PATH, verified against the pyproject.toml pin.
+    2. The first ``semgrep`` on PATH.
 
     Raises ``_SemgrepExecutableError`` if no matching binary is found, and
     ``FileNotFoundError`` if semgrep is not on PATH at all.  Both map to a
     loud failure rather than a silent fallback.
+
+    Stricter/looser/different than canonical: the sibling branch of
+    ``scripts/validation/git_hook_policy.py::_resolve_semgrep_executable``
+    returns the venv sibling with no version probe (its
+    ``test_semgrep_uses_sibling_binary_without_version_probe`` in
+    ``tests/test_lefthook_integration.py`` asserts ``args[1] != "--version"``).
+    This resolver is stricter: it probes the sibling too, because a venv built
+    by anything other than ``uv sync`` (a manual ``pip install semgrep``, or a
+    venv left over from an older pin) puts an unpinned binary in that exact
+    slot and the scan then passes against the wrong ruleset. The extra probe
+    costs one ``semgrep --version`` call per resolution.
     """
     sibling_name = "semgrep.exe" if os.name == "nt" else "semgrep"
     sibling = Path(sys.executable).parent / sibling_name
     if sibling.is_file() and os.access(sibling, os.X_OK):
-        return str(sibling)
+        return _verify_pinned_version(str(sibling), repo_root)
 
     resolved = shutil.which("semgrep")
     if resolved is None:
         raise FileNotFoundError("semgrep not found on PATH")
 
-    version = _probe_semgrep_version(resolved)
-    pinned = _semgrep_pinned_version(repo_root)
-    if version != pinned:
-        raise _SemgrepExecutableError(
-            f"semgrep version mismatch: pyproject.toml pins {pinned!r}, "
-            f"but {resolved} reports {version!r}"
-        )
-    return resolved
+    return _verify_pinned_version(resolved, repo_root)
 
 
 class SemgrepScanner:
@@ -268,10 +297,8 @@ class SemgrepScanner:
         except FileNotFoundError:
             logger.error("ERROR: semgrep not found on PATH")
             logger.error("")
-            logger.error("Install with:")
-            logger.error("  pip install semgrep")
-            logger.error("  OR")
-            logger.error("  python3 scripts/Install-Semgrep.py")
+            logger.error("Install the pinned version with:")
+            logger.error("  %s", _INSTALL_HINT)
             return False
         except _SemgrepExecutableError as exc:
             logger.error("ERROR: semgrep resolution failed: %s", exc)

--- a/scripts/validation/check_python3_entrypoints.py
+++ b/scripts/validation/check_python3_entrypoints.py
@@ -94,6 +94,11 @@ def check_docs(
 
     Returns a list of (doc_path, line_number, script_rel_path, bad_imports).
     An empty list means no violations.
+
+    Raises OSError when a listed doc exists but cannot be read (a directory
+    passed as a doc, a permission denial). ``main`` maps that to exit code 2
+    per the module contract; the scanner itself does not swallow it, because a
+    doc that was never scanned is not a doc that passed.
     """
     violations: list[tuple[Path, int, str, set[str]]] = []
 
@@ -136,7 +141,11 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = Path(args.repo_root).resolve()
     doc_paths = [repo_root / d for d in args.docs]
 
-    violations = check_docs(doc_paths, repo_root)
+    try:
+        violations = check_docs(doc_paths, repo_root)
+    except OSError as exc:
+        print(f"ERROR: cannot read documentation file: {exc}", file=sys.stderr)
+        return 2
 
     if not violations:
         print("OK: no bare-python3 invocations of dependency-importing scripts found")

--- a/tests/mutation/mutation_harness_4190.py
+++ b/tests/mutation/mutation_harness_4190.py
@@ -22,6 +22,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TARGET = _REPO_ROOT / "scripts" / "security" / "run_semgrep.py"
 _TESTS = [
     "tests/test_run_semgrep_pinning.py",
+    # Covers the exec-fault handler in _run_semgrep, whose mutant below is
+    # invisible to the pinning tests.
+    "tests/test_run_semgrep.py",
 ]
 
 
@@ -81,6 +84,17 @@ def run_mutants() -> None:
             "weaken version regex to match any semgrep line",
             b'        r\'^\\s*"semgrep==([^"]+)",\\s*$\',',
             b'        r\'"semgrep==([^"]+)",\',  # MUTANT-DELETED-4190',
+        ),
+        (
+            "flip the platform mapping for the venv sibling filename",
+            b'sibling_name = "semgrep.exe" if os.name == "nt" else "semgrep"',
+            b'sibling_name = "semgrep" if os.name == "nt" else "semgrep.exe"'
+            b"  # MUTANT-DELETED-4190",
+        ),
+        (
+            "drop OSError from the scan spawn failure handler",
+            b"        except (subprocess.SubprocessError, OSError) as e:",
+            b"        except subprocess.SubprocessError as e:  # MUTANT-DELETED-4190",
         ),
         (
             "suppress _SemgrepExecutableError on no PATH semgrep",

--- a/tests/mutation/mutation_harness_4190.py
+++ b/tests/mutation/mutation_harness_4190.py
@@ -57,22 +57,24 @@ def run_mutants() -> None:
             "remove venv sibling semgrep check",
             b"    sibling = Path(sys.executable).parent / sibling_name\n"
             b"    if sibling.is_file() and os.access(sibling, os.X_OK):\n"
-            b"        return str(sibling)",
+            b"        return _verify_pinned_version(str(sibling), repo_root)",
             b"    sibling = Path(sys.executable).parent / sibling_name\n"
             b"    if False:  # MUTANT-DELETED-4190\n"
-            b"        return str(sibling)",
+            b"        return _verify_pinned_version(str(sibling), repo_root)",
         ),
         (
-            "remove version mismatch check in _resolve_semgrep_executable",
+            "remove version mismatch check in _verify_pinned_version",
             b"    if version != pinned:\n"
             b"        raise _SemgrepExecutableError(\n"
             b"            f\"semgrep version mismatch: pyproject.toml pins {pinned!r}, \"\n"
-            b"            f\"but {resolved} reports {version!r}\"\n"
+            b"            f\"but {executable} reports {version!r}. \"\n"
+            b"            f\"Reinstall the pin with: {_INSTALL_HINT}\"\n"
             b"        )",
             b"    if False:  # MUTANT-DELETED-4190\n"
             b"        raise _SemgrepExecutableError(\n"
             b"            f\"semgrep version mismatch: pyproject.toml pins {pinned!r}, \"\n"
-            b"            f\"but {resolved} reports {version!r}\"\n"
+            b"            f\"but {executable} reports {version!r}. \"\n"
+            b"            f\"Reinstall the pin with: {_INSTALL_HINT}\"\n"
             b"        )",
         ),
         (

--- a/tests/test_check_python3_entrypoints.py
+++ b/tests/test_check_python3_entrypoints.py
@@ -36,6 +36,14 @@ from scripts.validation.check_python3_entrypoints import (
 _REPO_ROOT = Path(__file__).parent.parent
 _VALIDATOR = _REPO_ROOT / "scripts/validation/check_python3_entrypoints.py"
 
+# Subprocess captures below pass encoding="utf-8", errors="replace". The
+# repo-wide guard tests/test_subprocess_text_encoding.py enforces the encoding
+# and states verbatim: "It checks ``encoding`` only. ``errors`` is deliberately
+# left to each call site". These sites set it because the child echoes a
+# tmp_path that carries whatever bytes the OS gave it, and these assertions
+# read the exit code, never the text: a strict decoder could only turn a
+# passing run into an unrelated UnicodeDecodeError.
+
 
 def _write_script(tmp_path: Path, name: str, source: str) -> Path:
     p = tmp_path / name
@@ -199,6 +207,7 @@ class TestMain:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
 
         assert result.returncode == 1
@@ -213,6 +222,7 @@ class TestMain:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
 
         assert result.returncode == 0
@@ -220,3 +230,34 @@ class TestMain:
     def test_returns_0_when_doc_missing(self, tmp_path: Path) -> None:
         result = main(["--docs", "nonexistent.md", "--repo-root", str(tmp_path)])
         assert result == 0
+
+    def test_returns_2_when_doc_is_unreadable(self, tmp_path: Path) -> None:
+        """A doc that exists but cannot be read is a file access error (exit 2).
+
+        A directory is the portable unreadable-but-existing path: read_text
+        raises IsADirectoryError on POSIX and PermissionError on Windows, both
+        OSError. Without the mapping the exception escapes main() and the
+        process dies with a traceback and exit 1, which the module contract
+        reserves for "mismatches detected".
+        """
+        (tmp_path / "README.md").mkdir()
+
+        result = main(["--docs", "README.md", "--repo-root", str(tmp_path)])
+
+        assert result == 2
+
+    def test_exits_2_as_subprocess_when_doc_is_unreadable(self, tmp_path: Path) -> None:
+        """Process exit code for a file access error is 2, with no traceback."""
+        (tmp_path / "README.md").mkdir()
+
+        result = subprocess.run(
+            [sys.executable, str(_VALIDATOR), "--docs", "README.md", "--repo-root", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+        assert result.returncode == 2, result.stderr
+        assert "Traceback" not in result.stderr
+        assert "cannot read documentation file" in result.stderr

--- a/tests/test_run_semgrep.py
+++ b/tests/test_run_semgrep.py
@@ -203,12 +203,9 @@ class TestRunSemgrepFailClosed:
     ) -> None:
         """An exec-time OSError must fail closed, not escape _run_semgrep.
 
-        OSError is not a subclass of subprocess.SubprocessError
-        (``issubclass(subprocess.SubprocessError, OSError)`` is False), so the
-        SubprocessError arm alone does not cover it. subprocess.run raises
-        OSError when the spawn itself faults. Uncaught, it escapes
-        _run_semgrep; run() catches only SemgrepScanError, so the gate would
-        die on a traceback with no structured finding.
+        Discriminating input: OSError is not a subclass of
+        subprocess.SubprocessError, so the SubprocessError arm alone lets every
+        case here escape uncaught instead of returning a blocking finding.
         """
         with patch(
             "scripts.security.run_semgrep.subprocess.run",
@@ -223,10 +220,9 @@ class TestRunSemgrepFailClosed:
     def test_os_error_makes_run_exit_1(self, scanner: SemgrepScanner) -> None:
         """End to end: an exec-time OSError blocks the push, never passes it.
 
-        Discriminating input: with the OSError uncaught, run() propagates it
-        and the process dies on a traceback; were _run_semgrep to swallow it
-        and return [], run() would log "PASS: No security findings" and exit 0.
-        Exit 1 is the only fail-closed answer.
+        Discriminating input: uncaught, the OSError escapes run() entirely;
+        swallowed and returned as [], run() would exit 0 on a scan that never
+        ran. Exit 1 is the only fail-closed answer.
         """
         with (
             patch.object(

--- a/tests/test_run_semgrep.py
+++ b/tests/test_run_semgrep.py
@@ -32,6 +32,24 @@ def scanner() -> SemgrepScanner:
         return SemgrepScanner()
 
 
+@pytest.fixture(autouse=True)
+def _stub_pinned_executable():
+    """Stub semgrep executable resolution for every test in this module.
+
+    ``_resolve_semgrep_executable`` verifies the resolved binary against the
+    pyproject.toml pin, which costs a ``semgrep --version`` subprocess. The
+    tests below mock ``subprocess.run`` to script the *scan* call, so an
+    unstubbed probe consumes that mock and the scan never runs. Resolution has
+    its own coverage in ``tests/test_run_semgrep_pinning.py``; here it is an
+    external boundary and is stubbed like one.
+    """
+    with patch(
+        "scripts.security.run_semgrep._resolve_semgrep_executable",
+        return_value="/pinned/semgrep",
+    ):
+        yield
+
+
 def _completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
     result = MagicMock()
     result.returncode = returncode

--- a/tests/test_run_semgrep.py
+++ b/tests/test_run_semgrep.py
@@ -182,6 +182,63 @@ class TestRunSemgrepFailClosed:
         assert findings[0].severity == "ERROR"
         assert "generic failure" in findings[0].message
 
+    @pytest.mark.parametrize(
+        ("error", "expected_fragment"),
+        [
+            # Binary passed the resolver's version probe, then vanished before
+            # the scan spawn (TOCTOU).
+            (FileNotFoundError(2, "No such file or directory"), "No such file"),
+            # Exec bit dropped, or the binary sits on a noexec mount.
+            (PermissionError(13, "Permission denied"), "Permission denied"),
+            # Any other kernel-level spawn refusal (ENOMEM, ETXTBSY, ...).
+            (OSError("spawn refused"), "spawn refused"),
+        ],
+        ids=["file-not-found", "permission-denied", "generic-oserror"],
+    )
+    def test_os_error_returns_scan_failure(
+        self,
+        scanner: SemgrepScanner,
+        error: OSError,
+        expected_fragment: str,
+    ) -> None:
+        """An exec-time OSError must fail closed, not escape _run_semgrep.
+
+        OSError is not a subclass of subprocess.SubprocessError
+        (``issubclass(subprocess.SubprocessError, OSError)`` is False), so the
+        SubprocessError arm alone does not cover it. subprocess.run raises
+        OSError when the spawn itself faults. Uncaught, it escapes
+        _run_semgrep; run() catches only SemgrepScanError, so the gate would
+        die on a traceback with no structured finding.
+        """
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            side_effect=error,
+        ):
+            findings = scanner._run_semgrep([Path("/repo/a.py")])
+        assert len(findings) == 1
+        assert findings[0].check_id == "semgrep-scan-failure"
+        assert findings[0].severity == "ERROR"
+        assert expected_fragment in findings[0].message
+
+    def test_os_error_makes_run_exit_1(self, scanner: SemgrepScanner) -> None:
+        """End to end: an exec-time OSError blocks the push, never passes it.
+
+        Discriminating input: with the OSError uncaught, run() propagates it
+        and the process dies on a traceback; were _run_semgrep to swallow it
+        and return [], run() would log "PASS: No security findings" and exit 0.
+        Exit 1 is the only fail-closed answer.
+        """
+        with (
+            patch.object(
+                scanner, "_get_changed_files", return_value=[Path("/repo/a.py")]
+            ),
+            patch(
+                "scripts.security.run_semgrep.subprocess.run",
+                side_effect=PermissionError(13, "Permission denied"),
+            ),
+        ):
+            assert scanner.run() == 1
+
     def test_invalid_json_returns_scan_failure(self, scanner: SemgrepScanner) -> None:
         with patch(
             "scripts.security.run_semgrep.subprocess.run",

--- a/tests/test_run_semgrep_pinning.py
+++ b/tests/test_run_semgrep_pinning.py
@@ -12,6 +12,7 @@ No real semgrep binary is used; subprocess is mocked throughout.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -20,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.security.run_semgrep import (
+    _INSTALL_HINT,
     SemgrepScanner,
     _probe_semgrep_version,
     _resolve_semgrep_executable,
@@ -39,6 +41,88 @@ def _make_scanner(repo_root: Path) -> SemgrepScanner:
 
 def _pyproject(tmp_path: Path, content: str) -> None:
     (tmp_path / "pyproject.toml").write_text(content, encoding="utf-8")
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts/security/run_semgrep.py"
+
+#: Pin written into the fixture repo. Independent of this repo's real pin so
+#: the test does not move when renovate bumps semgrep.
+_FIXTURE_PIN = "1.171.0"
+#: Version the fake binary reports. Never equal to _FIXTURE_PIN.
+_FAKE_VERSION = "9.9.9"
+
+_posix_shim_only = pytest.mark.skipif(
+    os.name == "nt",
+    reason="the fake semgrep is a POSIX shell shim",
+)
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    """Create a real git repo carrying a semgrep pin.
+
+    A real repo is required: SemgrepScanner.__init__ resolves the repo root via
+    git and raises before any semgrep code runs when the cwd is not a work
+    tree, which exits 1 on a traceback and proves nothing about pinning.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    _pyproject(repo, f'[project]\ndependencies = [\n    "semgrep=={_FIXTURE_PIN}",\n]\n')
+    return repo
+
+
+def _fresh_venv_python(tmp_path: Path) -> Path:
+    """Create a venv with no semgrep sibling and return its interpreter."""
+    venv = tmp_path / "venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(venv)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return venv / "bin" / "python"
+
+
+def _write_fake_semgrep(directory: Path) -> Path:
+    """Write an executable semgrep shim that reports _FAKE_VERSION."""
+    directory.mkdir(parents=True, exist_ok=True)
+    shim = directory / "semgrep"
+    shim.write_text(f"#!/bin/sh\necho {_FAKE_VERSION}\n", encoding="utf-8")
+    shim.chmod(0o755)
+    return shim
+
+
+def _run_scanner(
+    interpreter: Path,
+    repo: Path,
+    path_prefix: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the scanner as a process from inside the fixture repo."""
+    env = dict(os.environ)
+    # The scanner imports scripts.github_core.repo; a bare venv has no
+    # editable install of this project, so hand it the source tree.
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    if path_prefix is not None:
+        env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
+    return subprocess.run(
+        [str(interpreter), str(_SCRIPT), "--dry-run"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        timeout=60,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -128,18 +212,51 @@ class TestProbeSemgrepVersion:
 
 
 class TestResolveSemgrepExecutable:
-    def test_uses_sibling_if_present(self, tmp_path: Path) -> None:
+    def test_uses_sibling_when_version_matches(self, tmp_path: Path) -> None:
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
         sibling = tmp_path / "bin" / "semgrep"
         sibling.parent.mkdir(parents=True)
         sibling.write_text("#!/bin/sh\n")
         sibling.chmod(0o755)
 
-        with patch("scripts.security.run_semgrep.sys") as mock_sys:
+        with (
+            patch("scripts.security.run_semgrep.sys") as mock_sys,
+            patch(
+                "scripts.security.run_semgrep._probe_semgrep_version",
+                return_value="1.171.0",
+            ),
+        ):
             mock_sys.executable = str(tmp_path / "bin" / "python")
             result = _resolve_semgrep_executable(tmp_path)
 
         assert result == str(sibling)
+
+    def test_raises_when_sibling_version_mismatches(self, tmp_path: Path) -> None:
+        """A stale venv sibling must fail, not shortcut the pin check.
+
+        The sibling slot is exactly where a manual `pip install semgrep` or a
+        venv left over from an older pin lands. Returning it unverified lets
+        the scan pass against a different ruleset than CI runs.
+        """
+        _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
+        sibling = tmp_path / "bin" / "semgrep"
+        sibling.parent.mkdir(parents=True)
+        sibling.write_text("#!/bin/sh\n")
+        sibling.chmod(0o755)
+
+        with (
+            patch("scripts.security.run_semgrep.sys") as mock_sys,
+            patch(
+                "scripts.security.run_semgrep._probe_semgrep_version",
+                return_value="9.9.9",
+            ),
+            patch("scripts.security.run_semgrep.shutil.which") as mock_which,
+        ):
+            mock_sys.executable = str(tmp_path / "bin" / "python")
+            with pytest.raises(_SemgrepExecutableError, match="version mismatch"):
+                _resolve_semgrep_executable(tmp_path)
+
+        assert mock_which.call_count == 0, "a mismatched sibling must not fall back to PATH"
 
     def test_raises_file_not_found_when_not_on_path(self, tmp_path: Path) -> None:
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
@@ -218,39 +335,46 @@ class TestRunExitCode:
         with patch.object(scanner, "_check_semgrep_installed", return_value=False):
             assert scanner.run() == 2
 
-    def test_run_exits_2_as_subprocess_when_semgrep_wrong_version(
+    @_posix_shim_only
+    def test_run_exits_2_as_subprocess_when_path_semgrep_mismatches(
         self, tmp_path: Path
     ) -> None:
-        """Process exit code must be nonzero when semgrep is missing.
+        """A PATH semgrep off the pin exits 2 from a real process.
 
-        This tests the exit-code contract at the process boundary, not just
-        the helper return value.
+        Hermetic: a throwaway git repo carrying its own pin, a fresh venv with
+        no semgrep sibling, and a fake semgrep first on PATH. Nothing here
+        reads the developer's installed semgrep or this repo's pin.
         """
-        _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
-        script = Path(__file__).parent.parent / "scripts/security/run_semgrep.py"
+        repo = _fixture_repo(tmp_path)
+        interpreter = _fresh_venv_python(tmp_path)
+        fake_bin = tmp_path / "fakebin"
+        _write_fake_semgrep(fake_bin)
 
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(script),
-                "--dry-run",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            env={
-                **__import__("os").environ,
-                # Point git to a tmp dir that is not a real repo so _find_repo_root
-                # raises -- but we only care about the semgrep resolution path.
-            },
-            cwd=str(tmp_path),
-        )
+        result = _run_scanner(interpreter, repo, path_prefix=fake_bin)
 
-        # semgrep is not installed in this venv or PATH differs -- either way,
-        # the scanner must exit nonzero (2) when resolution fails.
-        assert result.returncode in (0, 1, 2), (
-            f"unexpected exit code {result.returncode}: {result.stderr}"
-        )
+        assert result.returncode == 2, f"stdout={result.stdout} stderr={result.stderr}"
+        assert "version mismatch" in result.stderr
+        assert _INSTALL_HINT in result.stderr
+
+    @_posix_shim_only
+    def test_run_exits_2_as_subprocess_when_venv_sibling_mismatches(
+        self, tmp_path: Path
+    ) -> None:
+        """A stale venv sibling exits 2 instead of reporting a clean pass.
+
+        Discriminating input: with the sibling returned unverified, the scan
+        gets past the install check, finds no tracked files in the fixture
+        repo, logs "PASS: No files to scan" and exits 0. The wrong semgrep
+        reads as green.
+        """
+        repo = _fixture_repo(tmp_path)
+        interpreter = _fresh_venv_python(tmp_path)
+        _write_fake_semgrep(interpreter.parent)
+
+        result = _run_scanner(interpreter, repo)
+
+        assert result.returncode == 2, f"stdout={result.stdout} stderr={result.stderr}"
+        assert "version mismatch" in result.stderr
 
     def test_run_uses_pinned_executable_in_run_semgrep(self, tmp_path: Path) -> None:
         """_run_semgrep must call the pinned executable, not bare 'semgrep'."""

--- a/tests/test_run_semgrep_pinning.py
+++ b/tests/test_run_semgrep_pinning.py
@@ -57,13 +57,10 @@ _posix_shim_only = pytest.mark.skipif(
     reason="the fake semgrep is a POSIX shell shim",
 )
 
-#: Filename production looks for beside the interpreter. Mirrors
-#: scripts/security/run_semgrep.py::_resolve_semgrep_executable verbatim:
-#:     sibling_name = "semgrep.exe" if os.name == "nt" else "semgrep"
-#: Duplicated rather than imported on purpose: an independent oracle fails when
-#: production flips the mapping, while an imported constant would follow it.
-#: A fixture hardcoded to "semgrep" left the sibling branch unreachable on
-#: Windows, where resolution fell through to the PATH branch instead.
+#: Filename production looks for beside the interpreter, mirroring
+#: _resolve_semgrep_executable. Duplicated rather than imported on purpose: an
+#: independent oracle fails when production flips the mapping, while an imported
+#: constant would follow it.
 _SIBLING_NAME = "semgrep.exe" if os.name == "nt" else "semgrep"
 #: The other platform's filename. Production must never resolve it on this host.
 _DECOY_SIBLING_NAME = "semgrep" if os.name == "nt" else "semgrep.exe"
@@ -235,13 +232,12 @@ class TestResolveSemgrepExecutable:
     def test_uses_sibling_when_version_matches(self, tmp_path: Path) -> None:
         """The platform-correct sibling wins over the other platform's name.
 
-        Discriminating input: both names exist in the interpreter directory,
-        so a flipped platform mapping in production returns the decoy path and
-        fails this assertion instead of quietly resolving something.
+        Discriminating input: both names exist in the interpreter directory, so
+        a flipped platform mapping resolves the decoy and fails the assertion.
         """
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
         sibling = _write_sibling(tmp_path / "bin", _SIBLING_NAME)
-        decoy = _write_sibling(tmp_path / "bin", _DECOY_SIBLING_NAME)
+        _write_sibling(tmp_path / "bin", _DECOY_SIBLING_NAME)
 
         with (
             patch("scripts.security.run_semgrep.sys") as mock_sys,
@@ -254,15 +250,12 @@ class TestResolveSemgrepExecutable:
             result = _resolve_semgrep_executable(tmp_path)
 
         assert result == str(sibling)
-        assert result != str(decoy), "resolver used the other platform's filename"
 
     def test_ignores_sibling_named_for_the_other_platform(self, tmp_path: Path) -> None:
         """A sibling carrying the other platform's name must not be used.
 
-        On Windows production resolves ``semgrep.exe``; on POSIX, ``semgrep``.
-        Reaching PATH (FileNotFoundError here, since which() returns None)
-        proves the sibling branch did not fire on the wrong filename. Without
-        this check a resolver that ignored os.name would look correct.
+        Reaching PATH (FileNotFoundError, since which() returns None) proves the
+        sibling branch did not fire; a resolver ignoring os.name would return it.
         """
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
         _write_sibling(tmp_path / "bin", _DECOY_SIBLING_NAME)

--- a/tests/test_run_semgrep_pinning.py
+++ b/tests/test_run_semgrep_pinning.py
@@ -57,6 +57,26 @@ _posix_shim_only = pytest.mark.skipif(
     reason="the fake semgrep is a POSIX shell shim",
 )
 
+#: Filename production looks for beside the interpreter. Mirrors
+#: scripts/security/run_semgrep.py::_resolve_semgrep_executable verbatim:
+#:     sibling_name = "semgrep.exe" if os.name == "nt" else "semgrep"
+#: Duplicated rather than imported on purpose: an independent oracle fails when
+#: production flips the mapping, while an imported constant would follow it.
+#: A fixture hardcoded to "semgrep" left the sibling branch unreachable on
+#: Windows, where resolution fell through to the PATH branch instead.
+_SIBLING_NAME = "semgrep.exe" if os.name == "nt" else "semgrep"
+#: The other platform's filename. Production must never resolve it on this host.
+_DECOY_SIBLING_NAME = "semgrep" if os.name == "nt" else "semgrep.exe"
+
+
+def _write_sibling(bin_dir: Path, name: str) -> Path:
+    """Create an executable file called ``name`` inside ``bin_dir``."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    sibling = bin_dir / name
+    sibling.write_text("#!/bin/sh\n", encoding="utf-8")
+    sibling.chmod(0o755)
+    return sibling
+
 
 def _fixture_repo(tmp_path: Path) -> Path:
     """Create a real git repo carrying a semgrep pin.
@@ -213,11 +233,15 @@ class TestProbeSemgrepVersion:
 
 class TestResolveSemgrepExecutable:
     def test_uses_sibling_when_version_matches(self, tmp_path: Path) -> None:
+        """The platform-correct sibling wins over the other platform's name.
+
+        Discriminating input: both names exist in the interpreter directory,
+        so a flipped platform mapping in production returns the decoy path and
+        fails this assertion instead of quietly resolving something.
+        """
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
-        sibling = tmp_path / "bin" / "semgrep"
-        sibling.parent.mkdir(parents=True)
-        sibling.write_text("#!/bin/sh\n")
-        sibling.chmod(0o755)
+        sibling = _write_sibling(tmp_path / "bin", _SIBLING_NAME)
+        decoy = _write_sibling(tmp_path / "bin", _DECOY_SIBLING_NAME)
 
         with (
             patch("scripts.security.run_semgrep.sys") as mock_sys,
@@ -230,6 +254,32 @@ class TestResolveSemgrepExecutable:
             result = _resolve_semgrep_executable(tmp_path)
 
         assert result == str(sibling)
+        assert result != str(decoy), "resolver used the other platform's filename"
+
+    def test_ignores_sibling_named_for_the_other_platform(self, tmp_path: Path) -> None:
+        """A sibling carrying the other platform's name must not be used.
+
+        On Windows production resolves ``semgrep.exe``; on POSIX, ``semgrep``.
+        Reaching PATH (FileNotFoundError here, since which() returns None)
+        proves the sibling branch did not fire on the wrong filename. Without
+        this check a resolver that ignored os.name would look correct.
+        """
+        _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
+        _write_sibling(tmp_path / "bin", _DECOY_SIBLING_NAME)
+
+        with (
+            patch("scripts.security.run_semgrep.sys") as mock_sys,
+            patch("scripts.security.run_semgrep.shutil.which", return_value=None) as mock_which,
+            patch(
+                "scripts.security.run_semgrep._probe_semgrep_version",
+                return_value="1.171.0",
+            ),
+        ):
+            mock_sys.executable = str(tmp_path / "bin" / "python")
+            with pytest.raises(FileNotFoundError, match="semgrep not found on PATH"):
+                _resolve_semgrep_executable(tmp_path)
+
+        assert mock_which.call_count == 1, "resolver must fall through to PATH"
 
     def test_raises_when_sibling_version_mismatches(self, tmp_path: Path) -> None:
         """A stale venv sibling must fail, not shortcut the pin check.
@@ -239,10 +289,7 @@ class TestResolveSemgrepExecutable:
         the scan pass against a different ruleset than CI runs.
         """
         _pyproject(tmp_path, '[project]\ndependencies = [\n    "semgrep==1.171.0",\n]\n')
-        sibling = tmp_path / "bin" / "semgrep"
-        sibling.parent.mkdir(parents=True)
-        sibling.write_text("#!/bin/sh\n")
-        sibling.chmod(0o755)
+        _write_sibling(tmp_path / "bin", _SIBLING_NAME)
 
         with (
             patch("scripts.security.run_semgrep.sys") as mock_sys,

--- a/tests/test_security_gate_timeouts_2810.py
+++ b/tests/test_security_gate_timeouts_2810.py
@@ -29,6 +29,24 @@ def _detached_mcp_client(timeout: float) -> McpClient:
     return client
 
 
+@pytest.fixture(autouse=True)
+def _stub_pinned_executable():
+    """Stub semgrep executable resolution for every test in this module.
+
+    ``_resolve_semgrep_executable`` verifies the resolved binary against the
+    pyproject.toml pin, which costs a ``semgrep --version`` subprocess. The
+    tests below mock ``subprocess.run`` to script the *scan* call, so an
+    unstubbed probe consumes that mock and the scan never runs. Resolution has
+    its own coverage in ``tests/test_run_semgrep_pinning.py``; here it is an
+    external boundary and is stubbed like one.
+    """
+    with patch(
+        "scripts.security.run_semgrep._resolve_semgrep_executable",
+        return_value="/pinned/semgrep",
+    ):
+        yield
+
+
 def test_ensure_psscriptanalyzer_timeout_returns_false() -> None:
     # Construct before patching so the ctor's git repo-root lookup is real.
     check = PreCommitSecurityCheck(skip_codeql=True)


### PR DESCRIPTION
## Summary

### What

Closes six unresolved review findings left on merged PR #4260. The validator now maps unreadable documentation to exit 2, and the legacy Semgrep scanner verifies both virtual-environment and PATH binaries against the pinned version before scanning.

### Why

PR #4260 merged with valid follow-up findings still open. The highest-risk gap allowed a stale virtual-environment Semgrep sibling to scan with an unpinned ruleset and report green.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4260 | Follow-up for unresolved review findings on the merged script-correctness change |

## Changes

- Verify virtual-environment and PATH Semgrep executables against the `pyproject.toml` pin.
- Fail closed with structured findings when Semgrep execution raises an operating-system error.
- Replace invalid free-floating install guidance with the locked `uv sync --frozen --extra dev` path.
- Map unreadable documentation inputs to the validator contract exit code 2.
- Add hermetic process tests, Windows-aware sibling fixtures, and mutation controls.

## Acceptance criteria

- [x] Both Semgrep resolution branches reject versions that differ from the project pin.
- [x] Semgrep spawn faults return a blocking finding instead of escaping on a traceback.
- [x] Unreadable documentation returns exit code 2 without a traceback.
- [x] All six unresolved PR #4260 review findings have regression coverage.
- [x] Full required test and validation gates pass without bypass.
- [x] Independent GPT-5.6 Sol review is clean and security review passes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted security and correctness review, high scrutiny, follow-up to a merged PR.

**Focus areas**: Semgrep pin verification, fail-closed subprocess handling, validator exit codes, and the hermetic regression tests.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Validation evidence:

- `uv run python scripts/validation/pre_pr.py`: 44 PASS, 0 FAIL, 4 SKIP.
- Canonical full test gate: 22,439 passed, 32 skipped, 50 deselected.
- Targeted tests: 862 passed.
- Mutation harnesses: #3791 4/4 mutants dead; #4190 6/6 mutants dead.
- Ruff, mypy, syntax-floor, Semgrep push, and changed-path ratchets: pass.

## Agent Review

### Security Review

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `scripts/security/run_semgrep.py`
- `tests/test_run_semgrep.py`
- `tests/test_run_semgrep_pinning.py`
- `tests/mutation/mutation_harness_4190.py`

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

Independent GPT-5.6 Sol review: CLEAN. Security review: PASS.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

The original PR is already merged. This follow-up contains only confirmed findings that still reproduced on current `main`; speculative summary-mode warnings and pre-existing advisory items were excluded.

## Related Issues

Refs #4260
