### PR TITLE
docs(rules): record that always-on membership lives in the mirror, not the source

### DIFF
--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -91,6 +91,8 @@ The question is whether a rule loads on every agent turn. A rule is always-on wh
 
 `governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
 
+That the generator inverts scope this way is a tracked defect, issue #4317: the narrower the source scope, the more likely the plugin consumer loads the rule on every file. This section describes the behaviour as it stands; do not read it as an endorsement. If #4317 closes, re-measure before quoting any number here.
+
 `build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
 
 1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -78,6 +78,57 @@ The function's own docstring stated the real behavior accurately. Reading it wou
 
 This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
+## The one place the mirror outranks the source: always-on membership
+
+Everything above says the canonical source is authoritative and a generated mirror is not. For one question that is backwards, and the inversion is easy to miss because it contradicts the rest of this file.
+
+The question is whether a rule loads on every agent turn. A rule is always-on when its **generated** `applyTo` resolves to `**`, so the answer lives in the generated tree. It is also not a single answer: the two destination trees disagree, measured at `0c75045d6`.
+
+| Tree | Consumer | Always-on |
+|---|---|---|
+| `.github/instructions` | Copilot working in this repository | 8 rules, 72,291 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 11 rules, 79,823 bytes |
+
+`governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
+
+`build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
+
+1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.
+2. **The source declares `alwaysApply: true` and no path scope.** Line 25 drops `alwaysApply:`, leaving no scope, so situation 3 applies. `_has_path_scope` at line 209 reads only the path-scope keys, so `alwaysApply` never counts as a scope.
+3. **The source declares no scope at all.** Situations 2 and 3 share one branch, `build/scripts/generate_rules.py:338-341`:
+
+   ```python
+   if not had_scope and "applyTo" not in result:
+       # Universal-scope default for unscoped rules. Insert at the top
+       # of the output frontmatter for consistent placement.
+       result = {"applyTo": _UNIVERSAL_SCOPE, **result}
+   ```
+
+4. **The source declares a scope whose globs are all filtered as internal-only.** `build/scripts/generate_rules.py:335-337` falls back to `**` rather than shipping an empty scope:
+
+   ```python
+   applyto_value = result.get("applyTo")
+   if had_scope and isinstance(applyto_value, str) and not applyto_value.strip():
+       result["applyTo"] = _UNIVERSAL_SCOPE
+   ```
+
+   This one is **destination-dependent**, and it is the whole reason the two trees disagree. `templates/platforms/copilot-cli.yaml:39-40` lists `.github/instructions` under `keepInternalGlobsFor`, which disables the filter for that tree, so situation 4 cannot fire there. It fires only for `src/copilot-cli/instructions`.
+
+Situations 3 and 4 leave no source line to grep for. Situation 4 also inverts intent: narrowing a rule to `.claude/**` reads like a reduction in scope and silently widens it to every turn in the shipped plugin. The generator prints `WARNING: dropped internal-only glob from applyTo` to stderr when it fires, and nobody reads stderr during a build.
+
+So a measurement taken from `.claude/rules/` is not conservative, it is wrong in both directions. And a measurement taken from one generated tree does not answer for the other. Name the tree with the number.
+
+## Read frontmatter with a YAML parser, never a line regex
+
+A scope key can be an inline string or a block list. `.claude/rules/knowledge-persistence.md` uses the block form:
+
+```yaml
+paths:
+  - "**"
+```
+
+A pattern like `^applyTo:\s*(.+)$` returns nothing for that file and reports the rule as unscoped, which is the opposite of the truth: the rule is universally scoped. Use `yaml.safe_load` on the frontmatter block. This is not hypothetical; it produced a wrong always-on count during the audit that added this section, and the count looked plausible enough to act on.
+
 ## Reference: the M4 episode
 
 `scripts/validate_session_json.py:CONTRADICTION_PATTERNS` is a single compiled regex:

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -71,6 +71,57 @@ The function's own docstring stated the real behavior accurately. Reading it wou
 
 This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
+## The one place the mirror outranks the source: always-on membership
+
+Everything above says the canonical source is authoritative and a generated mirror is not. For one question that is backwards, and the inversion is easy to miss because it contradicts the rest of this file.
+
+The question is whether a rule loads on every agent turn. A rule is always-on when its **generated** `applyTo` resolves to `**`, so the answer lives in the generated tree. It is also not a single answer: the two destination trees disagree, measured at `0c75045d6`.
+
+| Tree | Consumer | Always-on |
+|---|---|---|
+| `.github/instructions` | Copilot working in this repository | 8 rules, 72,291 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 11 rules, 79,823 bytes |
+
+`governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
+
+`build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
+
+1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.
+2. **The source declares `alwaysApply: true` and no path scope.** Line 25 drops `alwaysApply:`, leaving no scope, so situation 3 applies. `_has_path_scope` at line 209 reads only the path-scope keys, so `alwaysApply` never counts as a scope.
+3. **The source declares no scope at all.** Situations 2 and 3 share one branch, `build/scripts/generate_rules.py:338-341`:
+
+   ```python
+   if not had_scope and "applyTo" not in result:
+       # Universal-scope default for unscoped rules. Insert at the top
+       # of the output frontmatter for consistent placement.
+       result = {"applyTo": _UNIVERSAL_SCOPE, **result}
+   ```
+
+4. **The source declares a scope whose globs are all filtered as internal-only.** `build/scripts/generate_rules.py:335-337` falls back to `**` rather than shipping an empty scope:
+
+   ```python
+   applyto_value = result.get("applyTo")
+   if had_scope and isinstance(applyto_value, str) and not applyto_value.strip():
+       result["applyTo"] = _UNIVERSAL_SCOPE
+   ```
+
+   This one is **destination-dependent**, and it is the whole reason the two trees disagree. `templates/platforms/copilot-cli.yaml:39-40` lists `.github/instructions` under `keepInternalGlobsFor`, which disables the filter for that tree, so situation 4 cannot fire there. It fires only for `src/copilot-cli/instructions`.
+
+Situations 3 and 4 leave no source line to grep for. Situation 4 also inverts intent: narrowing a rule to `.claude/**` reads like a reduction in scope and silently widens it to every turn in the shipped plugin. The generator prints `WARNING: dropped internal-only glob from applyTo` to stderr when it fires, and nobody reads stderr during a build.
+
+So a measurement taken from `.claude/rules/` is not conservative, it is wrong in both directions. And a measurement taken from one generated tree does not answer for the other. Name the tree with the number.
+
+## Read frontmatter with a YAML parser, never a line regex
+
+A scope key can be an inline string or a block list. `.claude/rules/knowledge-persistence.md` uses the block form:
+
+```yaml
+paths:
+  - "**"
+```
+
+A pattern like `^applyTo:\s*(.+)$` returns nothing for that file and reports the rule as unscoped, which is the opposite of the truth: the rule is universally scoped. Use `yaml.safe_load` on the frontmatter block. This is not hypothetical; it produced a wrong always-on count during the audit that added this section, and the count looked plausible enough to act on.
+
 ## Reference: the M4 episode
 
 `scripts/validate_session_json.py:CONTRADICTION_PATTERNS` is a single compiled regex:

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -84,6 +84,8 @@ The question is whether a rule loads on every agent turn. A rule is always-on wh
 
 `governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
 
+That the generator inverts scope this way is a tracked defect, issue #4317: the narrower the source scope, the more likely the plugin consumer loads the rule on every file. This section describes the behaviour as it stands; do not read it as an endorsement. If #4317 closes, re-measure before quoting any number here.
+
 `build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
 
 1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -1,0 +1,124 @@
+# To Learn Which Rules Are Always-On, Parse the Mirror, Not the Source
+
+## The contradiction
+
+This repository's dominant convention is that the canonical source wins and a
+generated mirror is never authoritative. `.claude/rules/canonical-source-mirror.md`
+is a whole rule file devoted to it, and `.claude/rules/generated-artifacts.md`
+forbids hand-editing a mirror at all.
+
+For exactly one question that convention is backwards.
+
+The question is which rules load on every agent turn. A rule is always-on when
+its **generated** `applyTo` resolves to `**`, so the answer lives in the
+generated tree. Parsing `.claude/rules/*.md` gives a wrong answer, wrong in both
+directions.
+
+There is also no single answer. The two destination trees disagree, measured at
+`0c75045d6`:
+
+| Tree | Consumer | Always-on |
+|---|---|---|
+| `.github/instructions` | Copilot in this repository | 8 rules, 72,291 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 11 rules, 79,823 bytes |
+
+`governance`, `secret-redaction`, and `session-logs` are narrowly scoped here and
+always-on in the plugin. A vendor install pays 7,532 bytes every turn that this
+repository never measures, on three rules that point at `.agents/` paths the
+installing repository does not have. Always name the tree with the number.
+
+## Why the source cannot answer it
+
+`build/scripts/generate_rules.py` reaches `applyTo: "**"` four ways. Only the
+first leaves a line in the source file that a grep can find.
+
+1. The source declares `paths: ["**"]` or `applyTo: '**'`. Renamed verbatim
+   (`build/scripts/generate_rules.py:24`).
+2. The source declares `alwaysApply: true` and no path scope. Line 25 drops
+   `alwaysApply:`, which leaves no scope, so case 3 fires.
+3. The source declares no scope at all. Lines 338-341 synthesize `**`:
+
+   ```python
+   if not had_scope and "applyTo" not in result:
+       result = {"applyTo": _UNIVERSAL_SCOPE, **result}
+   ```
+
+4. The source declares a scope whose globs are **all** filtered as internal-only.
+   Lines 335-337 fall back to `**` rather than shipping an empty scope:
+
+   ```python
+   applyto_value = result.get("applyTo")
+   if had_scope and isinstance(applyto_value, str) and not applyto_value.strip():
+       result["applyTo"] = _UNIVERSAL_SCOPE
+   ```
+
+   This case is **destination-dependent** and is why the two trees disagree.
+   `templates/platforms/copilot-cli.yaml:39-40` lists `.github/instructions`
+   under `keepInternalGlobsFor`, disabling the filter there, so case 4 cannot
+   fire for that tree. It fires only for `src/copilot-cli/instructions`.
+
+Cases 2 and 3 are one branch, not two. `_has_path_scope` (line 209) reads only
+the path-scope keys, so `alwaysApply` never sets `had_scope`.
+
+## The footgun
+
+Case 4 inverts intent. Narrowing a rule to `.claude/**` reads like a reduction in
+scope and silently widens it to every turn in the shipped plugin. The generator
+prints `WARNING: dropped internal-only glob from applyTo` to stderr, and nobody
+reads stderr during a build.
+
+Cases 3 and 4 are why a source-tree measurement is not merely conservative. It
+misses synthesized members, and it can count a rule whose globs were filtered
+out from under it.
+
+## Second trap: do not regex the frontmatter
+
+A scope key may be an inline string or a YAML block list.
+`.claude/rules/knowledge-persistence.md` uses the block form:
+
+```yaml
+paths:
+  - "**"
+```
+
+`^applyTo:\s*(.+)$` returns nothing for that file and reports it as unscoped,
+which is the exact opposite of the truth. Use `yaml.safe_load` on the
+frontmatter block. This produced a wrong always-on count during the audit that
+wrote this memory, and the wrong count looked plausible enough to act on.
+
+## How to measure it
+
+```python
+import yaml
+from pathlib import Path
+
+# Pass the tree you actually mean. They do not agree.
+TREE = ".github/instructions"  # or "src/copilot-cli/instructions"
+
+always_on = []
+for p in sorted(Path(TREE).glob("*.instructions.md")):
+    text = p.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        continue
+    fm = yaml.safe_load(text.split("---", 2)[1]) or {}
+    scope = fm.get("applyTo")
+    globs = [scope] if isinstance(scope, str) else list(scope or [])
+    if "**" in globs:
+        always_on.append(p.stem.removesuffix(".instructions"))
+```
+
+## Where this is enforced
+
+`tests/validation/test_always_on_corpus_claims.py` measures the corpus this way
+and fails when a shipped document drifts from it. Added because PR #4424
+narrowed `pragmatic-programmer` out of the always-on set and left two documents
+quoting the old composition.
+
+## Related
+
+- `.claude/rules/canonical-source-mirror.md`, section "The one place the mirror
+  outranks the source: always-on membership".
+- `.claude/skills/context-optimizer/references/model-context-doctrine.md`, which
+  carries the measured corpus figures.
+- `.agents/architecture/ADR-088-progressive-disclosure-book-rules.md`. Its
+  always-on list is stale as of #4424 and needs a human decision to correct.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -27,6 +27,9 @@ always-on in the plugin. A vendor install pays 7,532 bytes every turn that this
 repository never measures, on three rules that point at `.agents/` paths the
 installing repository does not have. Always name the tree with the number.
 
+The scope inversion behind this is tracked as issue #4317. Re-measure before
+quoting any number here if that issue closes.
+
 ## Why the source cannot answer it
 
 `build/scripts/generate_rules.py` reaches `applyTo: "**"` four ways. Only the

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -6,8 +6,8 @@
 |protocol blocking gate RFC MUST verification template legacy: [skills-protocol-index](skills-protocol-index.md) (245)
 
 [GitHub and PR Operations]
-|self-assessment ready-to-push refuted independent review negative control inert fix guard does not bite: [decision-agent-self-assessment-does-not-survive-review](decision-agent-self-assessment-does-not-survive-review.md) (0)
-|merge invalidates open PRs stale baseline ratchet strict status checks merge queue thread non-monotonic: [decision-every-merge-invalidates-every-open-pr](decision-every-merge-invalidates-every-open-pr.md) (0)
+|self-assessment ready-to-push refuted independent review negative control inert fix guard does not bite: [decision-agent-self-assessment-does-not-survive-review](decision-agent-self-assessment-does-not-survive-review.md) (1149)
+|merge invalidates open PRs stale baseline ratchet strict status checks merge queue thread non-monotonic: [decision-every-merge-invalidates-every-open-pr](decision-every-merge-invalidates-every-open-pr.md) (932)
 |gh graphql rest rate limit budget separate exhaustion pr list api repos: [process/process-gh-graphql-and-rest-budgets-are-separate](process/process-gh-graphql-and-rest-budgets-are-separate.md) (902)
 |new_pr create stale main ref session end validation failed opaque diff: [new-pr-stale-main-ref-trap](new-pr-stale-main-ref-trap.md) (1827)
 |close_issue comment-file must stay under repo root git scratch verify-claims unmerged reason quoting: [github-skill/issue-comment-file-must-live-inside-the-repo](github-skill/issue-comment-file-must-live-inside-the-repo.md) (891)
@@ -36,6 +36,7 @@
 |adr decision record active proposed superseded rationale artifact amendment: [adr-reference-index](adr-reference-index.md) (673), [adr/adr-artifact-count-verification](adr/adr-artifact-count-verification.md) (401), [adr/adr-retroactive-amendment-criteria](adr/adr-retroactive-amendment-criteria.md) (824), [adr/adr-review-observations](adr/adr-review-observations.md) (749)
 |cache invalidation TTL session-local cloudmcp stale refresh: [adr-reference-index](adr-reference-index.md) (673)
 |design agent specialization entry-criteria limitation composability: [skills-design-index](skills-design-index.md) (206)
+|always-on corpus membership applyTo mirror generated synthesized internal-only glob yaml block list frontmatter regex: [architecture/always-on-membership-lives-in-the-mirror](architecture/always-on-membership-lives-in-the-mirror.md) (1255)
 
 [Implementation and Quality]
 |implementation code feature bug fix test TDD additive: [skills-implementation-index](skills-implementation-index.md) (304)
@@ -70,7 +71,7 @@
 |edit file read search replace text operation: [patterns/edit-001-read-before-edit-pattern](patterns/edit-001-read-before-edit-pattern.md) (464), [patterns/edit-002-unique-context-for-edit-matching](patterns/edit-002-unique-context-for-edit-matching.md) (368)
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (287)
-|git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (0)
+|git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (738)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)
 |cva refactoring variant consolidation template generate: [utilities/utilities-cva-refactoring](utilities/utilities-cva-refactoring.md) (1251)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -36,7 +36,7 @@
 |adr decision record active proposed superseded rationale artifact amendment: [adr-reference-index](adr-reference-index.md) (673), [adr/adr-artifact-count-verification](adr/adr-artifact-count-verification.md) (401), [adr/adr-retroactive-amendment-criteria](adr/adr-retroactive-amendment-criteria.md) (824), [adr/adr-review-observations](adr/adr-review-observations.md) (749)
 |cache invalidation TTL session-local cloudmcp stale refresh: [adr-reference-index](adr-reference-index.md) (673)
 |design agent specialization entry-criteria limitation composability: [skills-design-index](skills-design-index.md) (206)
-|always-on corpus membership applyTo mirror generated synthesized internal-only glob yaml block list frontmatter regex: [architecture/always-on-membership-lives-in-the-mirror](architecture/always-on-membership-lives-in-the-mirror.md) (1255)
+|always-on corpus membership applyTo mirror generated synthesized internal-only glob yaml block list frontmatter regex: [architecture/always-on-membership-lives-in-the-mirror](architecture/always-on-membership-lives-in-the-mirror.md) (1283)
 
 [Implementation and Quality]
 |implementation code feature bug fix test TDD additive: [skills-implementation-index](skills-implementation-index.md) (304)

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -71,6 +71,57 @@ The function's own docstring stated the real behavior accurately. Reading it wou
 
 This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
+## The one place the mirror outranks the source: always-on membership
+
+Everything above says the canonical source is authoritative and a generated mirror is not. For one question that is backwards, and the inversion is easy to miss because it contradicts the rest of this file.
+
+The question is whether a rule loads on every agent turn. A rule is always-on when its **generated** `applyTo` resolves to `**`, so the answer lives in the generated tree. It is also not a single answer: the two destination trees disagree, measured at `0c75045d6`.
+
+| Tree | Consumer | Always-on |
+|---|---|---|
+| `.github/instructions` | Copilot working in this repository | 8 rules, 72,291 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 11 rules, 79,823 bytes |
+
+`governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
+
+`build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
+
+1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.
+2. **The source declares `alwaysApply: true` and no path scope.** Line 25 drops `alwaysApply:`, leaving no scope, so situation 3 applies. `_has_path_scope` at line 209 reads only the path-scope keys, so `alwaysApply` never counts as a scope.
+3. **The source declares no scope at all.** Situations 2 and 3 share one branch, `build/scripts/generate_rules.py:338-341`:
+
+   ```python
+   if not had_scope and "applyTo" not in result:
+       # Universal-scope default for unscoped rules. Insert at the top
+       # of the output frontmatter for consistent placement.
+       result = {"applyTo": _UNIVERSAL_SCOPE, **result}
+   ```
+
+4. **The source declares a scope whose globs are all filtered as internal-only.** `build/scripts/generate_rules.py:335-337` falls back to `**` rather than shipping an empty scope:
+
+   ```python
+   applyto_value = result.get("applyTo")
+   if had_scope and isinstance(applyto_value, str) and not applyto_value.strip():
+       result["applyTo"] = _UNIVERSAL_SCOPE
+   ```
+
+   This one is **destination-dependent**, and it is the whole reason the two trees disagree. `templates/platforms/copilot-cli.yaml:39-40` lists `.github/instructions` under `keepInternalGlobsFor`, which disables the filter for that tree, so situation 4 cannot fire there. It fires only for `src/copilot-cli/instructions`.
+
+Situations 3 and 4 leave no source line to grep for. Situation 4 also inverts intent: narrowing a rule to `.claude/**` reads like a reduction in scope and silently widens it to every turn in the shipped plugin. The generator prints `WARNING: dropped internal-only glob from applyTo` to stderr when it fires, and nobody reads stderr during a build.
+
+So a measurement taken from `.claude/rules/` is not conservative, it is wrong in both directions. And a measurement taken from one generated tree does not answer for the other. Name the tree with the number.
+
+## Read frontmatter with a YAML parser, never a line regex
+
+A scope key can be an inline string or a block list. `.claude/rules/knowledge-persistence.md` uses the block form:
+
+```yaml
+paths:
+  - "**"
+```
+
+A pattern like `^applyTo:\s*(.+)$` returns nothing for that file and reports the rule as unscoped, which is the opposite of the truth: the rule is universally scoped. Use `yaml.safe_load` on the frontmatter block. This is not hypothetical; it produced a wrong always-on count during the audit that added this section, and the count looked plausible enough to act on.
+
 ## Reference: the M4 episode
 
 `scripts/validate_session_json.py:CONTRADICTION_PATTERNS` is a single compiled regex:

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -84,6 +84,8 @@ The question is whether a rule loads on every agent turn. A rule is always-on wh
 
 `governance`, `secret-redaction`, and `session-logs` are narrowly scoped rules here and always-on in the plugin. A vendor install carries 7,532 bytes on every turn that this repository never measures, and those three rules point at `.agents/` paths that do not exist in the installing repository.
 
+That the generator inverts scope this way is a tracked defect, issue #4317: the narrower the source scope, the more likely the plugin consumer loads the rule on every file. This section describes the behaviour as it stands; do not read it as an endorsement. If #4317 closes, re-measure before quoting any number here.
+
 `build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different source situations. Only the first is visible in the source file:
 
 1. **The source declares it.** `paths: ["**"]` or `applyTo: '**'`, renamed verbatim per the generator's contract at `build/scripts/generate_rules.py:24`.


### PR DESCRIPTION
## Summary

`.claude/rules/canonical-source-mirror.md` exists to stop people from treating a
generated mirror as authoritative. Its premise is that `.claude/rules/` is the
source and `.github/instructions/` and `src/copilot-cli/instructions/` are
derived copies, so a claim should cite and quote the source.

There is exactly one question where that is backwards, and getting it wrong
costs an afternoon. This PR records it, in the rule that owns the premise.

## The finding

**Which rules load on every turn is not answerable from `.claude/rules/`.**

`build/scripts/generate_rules.py` reaches `applyTo: "**"` from four different
source situations, and two of them leave nothing in the source to grep for:

| Situation | Source | Generator |
|---|---|---|
| Source declares `**` | `paths: ["**"]` | renamed verbatim, line 24 |
| `alwaysApply: true`, no path scope | `alwaysApply: true` | line 25 drops the key, then falls through |
| No scope declared at all | nothing | lines 338-341, shared with the above |
| Scope declared but every glob is internal-only | a real, narrow scope | lines 335-337 |

Situation 2 is the trap. The key that says "always" is deleted before the scope
check runs, because `_has_path_scope` (line 209) reads only path-scope keys.
Situation 4 is worse: the source declares a narrow scope and the rule still
lands always-on.

So a grep for `applyTo: "**"` over `.claude/rules/` under-reports. The mirror is
the only place membership is observable, and it is the only artifact the
consuming model actually reads.

**And membership differs per destination tree.** Situation 4 is destination
dependent. `templates/platforms/copilot-cli.yaml:39-40` lists
`.github/instructions` under `keepInternalGlobsFor`, disabling the internal-glob
filter there, so the fallback fires only for the plugin tree:

| Tree | Consumer | Always-on |
|---|---|---|
| `.github/instructions` | Copilot in this repository | 8 rules, 72,291 bytes |
| `src/copilot-cli/instructions` | the shipped plugin | 11 rules, 79,823 bytes |

`governance`, `secret-redaction`, and `session-logs` are narrowly scoped here
and always-on in the plugin. A vendored install pays 7,532 bytes a turn on three
rules whose globs point at `.agents/` paths the installing repository does not
have. That is the plugin self-containment problem arriving through a path
nothing was watching.

## Change

1. `.claude/rules/canonical-source-mirror.md` gains two sections, plus both
   generated mirrors regenerated from it:
   - **"The one place the mirror outranks the source"**, the carve-out above,
     with the two-tree table and the measurement recipe.
   - **"Read frontmatter with a YAML parser, never a line regex"**, because
     `.claude/rules/knowledge-persistence.md` writes its scope as a YAML block
     list. A regex like `^applyTo:\s*(.+)$` reports it as unscoped, which is the
     exact inverse of the truth.
2. `.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md`,
   the individually recallable form, with a runnable recipe.
3. `.serena/memories/memory-index.md` entry and token counts, via
   `scripts/update_memory_index_tokens.py`.

The rule was chosen over an always-on surface deliberately: it is path scoped to
`.claude/rules/**` and `build/scripts/**`, so it costs nothing per turn and
fires exactly where someone would be about to get this wrong.

## Verification

- Every generator line number cited was confirmed with `sed -n "${n}p"` rather
  than read by eye. Two of my own citations were off by one and one by two
  before that check; both are corrected.
- The memory's measurement recipe was run before it was written down. It
  returns exactly the eight members named.
- `scripts/validation/pre_pr.py`: all validations pass.

## Notes for the reviewer

This is the rule's own discipline applied to itself: it demands that a "mirrors"
claim cite and quote the source, so every claim here quotes
`build/scripts/generate_rules.py` at a verified line.

Related: #4485 corrects the same two-tree error in the context-optimizer
doctrine and adds tests that pin the figures. This PR records the general rule;
that one fixes the specific document.

Refs #4017

## Related tracked defect

The two-tree section documents that `governance`, `secret-redaction`, and
`session-logs` are narrowly scoped here and always-on in the shipped plugin.
Issue #4317 already tracks that scope inversion as a defect and cites the same
generator path, reached independently.

This PR documents and guards the behaviour as it currently stands. It does not
endorse it. If #4317 closes, the plugin-tree figures here need re-measuring,
and the guard in `test_always_on_corpus_claims.py` will fail loudly rather than
drift, which is the point of pinning them.

Refs #4317

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

