### PR TITLE
fix(memory): re-exec memory hooks under the project venv again

### DIFF
--- a/scripts/memory_enhancement/interpreter.py
+++ b/scripts/memory_enhancement/interpreter.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 REQUIRED_MODULE = "frontmatter"
 REENTRY_GUARD = "MEMORY_HOOK_VENV_REEXEC"
+VENV_DIRNAME = ".venv"
 
 _INTERPRETER_NAMES = ("bin/python3", "bin/python", "Scripts/python.exe")
 
@@ -45,12 +46,32 @@ def dependency_available(module_name: str = REQUIRED_MODULE) -> bool:
 
 def find_venv_interpreter(project_dir: Path) -> Path | None:
     """Interpreter inside ``project_dir/.venv``, or None when there is none."""
-    venv_dir = project_dir / ".venv"
+    venv_dir = project_dir / VENV_DIRNAME
     for relative in _INTERPRETER_NAMES:
         candidate = venv_dir / relative
         if candidate.is_file():
             return candidate
     return None
+
+
+def running_under_venv(venv_dir: Path) -> bool:
+    """True when the interpreter executing this call belongs to venv_dir.
+
+    ``sys.prefix`` is the virtualenv root while a virtualenv is active and the
+    base installation otherwise, so it separates the two cases directly.
+
+    Comparing interpreter paths does not, which is what issue #4468 reports.
+    A virtualenv's ``bin/python3`` is a symlink to the interpreter it was built
+    from, so ``os.path.realpath`` collapses the virtualenv path and the running
+    interpreter to the same file whenever both descend from that base install.
+    That holds for the system ``python3`` the hooks actually run under, so the
+    path comparison reported "already running here" for every invocation and
+    the re-exec never happened.
+    """
+    try:
+        return Path(sys.prefix).resolve() == venv_dir.resolve()
+    except OSError:
+        return False
 
 
 def reexec_under_project_venv(
@@ -60,9 +81,9 @@ def reexec_under_project_venv(
 
     Returns without doing anything when the dependency already imports, when
     the guard variable marks this process as the re-exec, when the project has
-    no virtualenv, or when the virtualenv interpreter is the running one. The
-    guard is set in ``os.environ`` before the exec so the child inherits it and
-    a broken virtualenv cannot loop.
+    no virtualenv, or when this process is already running under that
+    virtualenv. The guard is set in ``os.environ`` before the exec so the child
+    inherits it and a broken virtualenv cannot loop.
     """
     if os.environ.get(REENTRY_GUARD) == "1":
         return
@@ -72,7 +93,7 @@ def reexec_under_project_venv(
     interpreter = find_venv_interpreter(project_dir)
     if interpreter is None:
         return
-    if os.path.realpath(interpreter) == os.path.realpath(sys.executable):
+    if running_under_venv(project_dir / VENV_DIRNAME):
         return
 
     os.environ[REENTRY_GUARD] = "1"

--- a/tests/test_memory_hook_interpreter.py
+++ b/tests/test_memory_hook_interpreter.py
@@ -8,6 +8,7 @@ changing the registration.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from memory_enhancement.interpreter import (
     dependency_available,
     find_venv_interpreter,
     reexec_under_project_venv,
+    running_under_venv,
 )
 
 
@@ -25,6 +27,19 @@ def _make_venv(project_dir: Path, name: str = "bin/python3") -> Path:
     interpreter = project_dir / ".venv" / name
     interpreter.parent.mkdir(parents=True, exist_ok=True)
     interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    return interpreter
+
+
+def _make_symlinked_venv(project_dir: Path) -> Path:
+    """A fixture interpreter shaped like a real one: a symlink, not a file.
+
+    Every virtualenv built by ``python -m venv`` or ``uv`` on POSIX links
+    ``bin/python3`` back to the interpreter it was created from. Reproducing
+    that is what makes the issue #4468 regression test meaningful.
+    """
+    interpreter = project_dir / ".venv" / "bin" / "python3"
+    interpreter.parent.mkdir(parents=True, exist_ok=True)
+    interpreter.symlink_to(sys.executable)
     return interpreter
 
 
@@ -110,8 +125,6 @@ class TestReexecUnderProjectVenv:
 
         reexec_under_project_venv(tmp_path, ["hook.py"])
 
-        import os
-
         assert os.environ[REENTRY_GUARD] == "1"
 
     @pytest.mark.unit
@@ -153,18 +166,99 @@ class TestReexecUnderProjectVenv:
         assert calls == []
 
     @pytest.mark.unit
-    def test_does_nothing_when_the_venv_interpreter_is_already_running(
+    def test_does_nothing_when_already_running_under_that_venv(
         self, tmp_path, monkeypatch
     ):
-        interpreter = tmp_path / ".venv" / "bin" / "python3"
-        interpreter.parent.mkdir(parents=True)
-        interpreter.symlink_to(sys.executable)
+        """The intended skip: this process belongs to the virtualenv found.
+
+        Establishing that means setting ``sys.prefix``, which is what actually
+        changes when a virtualenv is active. An earlier version of this test
+        symlinked the fixture interpreter at ``sys.executable`` instead, which
+        proves only that two paths resolve alike and is true of every
+        virtualenv on the machine whether or not it is active (issue #4468).
+        """
+        _make_venv(tmp_path)
         monkeypatch.setenv(REENTRY_GUARD, "0")
         monkeypatch.setattr(
             "memory_enhancement.interpreter.dependency_available", lambda: False
+        )
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.sys.prefix", str(tmp_path / ".venv")
         )
         calls = self._record_execv(monkeypatch)
 
         reexec_under_project_venv(tmp_path, ["hook.py"])
 
         assert calls == []
+
+    @pytest.mark.unit
+    def test_execs_when_the_venv_interpreter_symlinks_to_the_running_one(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for issue #4468: the shape every real virtualenv has.
+
+        ``bin/python3`` is a symlink to the interpreter the virtualenv was
+        built from, so it resolves to the same file as any other interpreter
+        from that base install, including the system ``python3`` the hooks run
+        under. The old guard compared resolved paths and skipped the re-exec
+        here, which disabled the feature everywhere it was needed.
+        """
+        interpreter = _make_symlinked_venv(tmp_path)
+        monkeypatch.setenv(REENTRY_GUARD, "0")
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.dependency_available", lambda: False
+        )
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.sys.prefix", str(tmp_path / "elsewhere")
+        )
+        calls = self._record_execv(monkeypatch)
+
+        reexec_under_project_venv(tmp_path, ["hook.py"])
+
+        assert calls == [(str(interpreter), [str(interpreter), "-u", "hook.py"])]
+
+    @pytest.mark.unit
+    def test_the_symlinked_fixture_really_does_collide_under_realpath(self, tmp_path):
+        """Negative control for the regression above.
+
+        If the symlink stopped resolving to the running interpreter, that test
+        would pass without exercising the condition it exists to cover. This
+        asserts the fixture still reproduces the collision the old guard saw.
+        """
+        interpreter = _make_symlinked_venv(tmp_path)
+
+        assert os.path.realpath(interpreter) == os.path.realpath(sys.executable)
+
+
+class TestRunningUnderVenv:
+    """sys.prefix is the discriminator; resolved interpreter paths are not."""
+
+    @pytest.mark.unit
+    def test_true_when_the_prefix_is_the_venv(self, tmp_path, monkeypatch):
+        venv_dir = tmp_path / ".venv"
+        venv_dir.mkdir()
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.sys.prefix", str(venv_dir)
+        )
+
+        assert running_under_venv(venv_dir) is True
+
+    @pytest.mark.unit
+    def test_false_when_the_prefix_is_the_base_installation(
+        self, tmp_path, monkeypatch
+    ):
+        venv_dir = tmp_path / ".venv"
+        venv_dir.mkdir()
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.sys.prefix", str(tmp_path / "usr")
+        )
+
+        assert running_under_venv(venv_dir) is False
+
+    @pytest.mark.unit
+    def test_false_for_a_venv_that_does_not_exist(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "memory_enhancement.interpreter.sys.prefix", str(tmp_path / "usr")
+        )
+
+        assert running_under_venv(tmp_path / "absent" / ".venv") is False


### PR DESCRIPTION
## Summary

The virtualenv re-exec added for #4011 never fired. The memory hooks kept running
under the ambient interpreter, so they died on `No module named frontmatter` and
silently contributed nothing.

Fixes #4468. Refs #4011.

## Root cause

The final guard compared `os.path.realpath` of the virtualenv interpreter against
`os.path.realpath` of the running one, intending to skip the exec when the
process is already the virtualenv interpreter.

A virtualenv's `bin/python3` is a symlink to the interpreter it was built from,
so `realpath` collapses both sides to the same base install whenever both descend
from it. That is exactly the case for the system `python3` that `settings.json`
registers the hooks under. The guard therefore reported "already running here" on
every invocation, and the re-exec was dead code from the day it landed.

## Fix

Compare `sys.prefix` to the virtualenv directory. That is the value which
actually changes when a virtualenv is active, so it separates the two cases the
path comparison could not. The reentry guard still prevents a loop, and a broken
virtualenv still costs at most one wasted exec.

## Evidence

Measured against the real hook with the ambient interpreter and
`PYTHONNOUSERSITE=1`:

| | exit | stdout | stderr |
|---|---|---|---|
| Before | 0 | empty | `No module named frontmatter` |
| After | 0 | 1093 bytes of recalled memory context | empty |

`PYTHONNOUSERSITE=1` matters for reproduction. A `python-frontmatter==1.3.0` in
`~/.local/lib/python3.14/site-packages` masks the defect locally, so the hook
appears to work on a machine that has it.

## The existing test asserted the defect

It symlinked a throwaway venv interpreter at `sys.executable` and required no
exec. That fixture establishes only that two paths resolve alike, which is true
of every virtualenv on the machine whether or not it is active. The test name
claimed an intent the fixture never set up, so it passed both before and after
the bug existed.

Rewritten to set `sys.prefix`, which does establish the intent, and kept
alongside a regression test that uses the symlink shape and now requires the
exec.

## Test rigor

- Both behavioural tests were mutation checked: restoring the old comparison
  fails both and leaves the rest of the file green.
- A negative control asserts the symlinked fixture still collides under
  `realpath`, so the regression cannot start passing because the fixture drifted.