### PR TITLE
fix(deps): pin cryptography 50.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,12 @@ eval = [
 ]
 
 [tool.uv]
-# Semgrep 1.170.0 pins vulnerable versions of these optional MCP server
-# dependencies. The scan and MCP command paths both work with the fixed releases.
+# Semgrep pins vulnerable optional MCP server dependencies; both command paths
+# work with the fixed releases and reviewed exact overrides below.
 exclude-newer = "7 days"
 override-dependencies = [
-    "click==8.3.3", "cryptography==50.0.0",
+    "click==8.3.3",
+    "cryptography==50.0.0",
     "mcp==1.28.1",
 ]
 
@@ -47,9 +48,8 @@ override-dependencies = [
 anthropic = false
 click = false
 # CVE-2026-69247 affects cryptography 49.0.0 and is fixed in 50.0.0. The
-# 7-day exclude-newer window held the resolver on the vulnerable release, so
-# pip-audit failed the security job. Opt this package out of the window so a
-# security fix is reachable the day it ships.
+# 7-day cooldown held the vulnerable release, so opt this package out to make
+# security fixes reachable immediately.
 cryptography = false
 lefthook = false
 mcp = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ eval = [
 # dependencies. The scan and MCP command paths both work with the fixed releases.
 exclude-newer = "7 days"
 override-dependencies = [
-    "click==8.3.3",
+    "click==8.3.3", "cryptography==50.0.0",
     "mcp==1.28.1",
 ]
 

--- a/tests/test_pyproject_dev_deps_parity.py
+++ b/tests/test_pyproject_dev_deps_parity.py
@@ -49,7 +49,7 @@ REQUIRED_DEV_TOOLS = frozenset(
         "semgrep",
     }
 )
-SAFE_SEMGREP_OVERRIDES = frozenset({"click==8.3.3", "mcp==1.28.1"})
+SAFE_SEMGREP_OVERRIDES = frozenset({"click==8.3.3", "cryptography==50.0.0", "mcp==1.28.1"})
 COOLDOWN_EXEMPT_PACKAGES = frozenset(
     {"anthropic", "click", "cryptography", "lefthook", "mcp", "semgrep"}
 )

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ semgrep = false
 [manifest]
 overrides = [
     { name = "click", specifier = "==8.3.3" },
+    { name = "cryptography", specifier = "==50.0.0" },
     { name = "mcp", specifier = "==1.28.1" },
 ]
 


### PR DESCRIPTION
## Summary

### What

Pin the transitive CI-only `cryptography` dependency to `50.0.0` and record the exact security override in the uv lock and dependency-policy regression test.

### Why

CVE-2026-69247 affects `cryptography` `>=44,<50`. Main now permits `cryptography` to bypass the seven-day freshness cooldown so the fix can resolve immediately; this follow-up prevents that permanent exception from floating to an unreviewed future release.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4535 | pip-audit: cryptography 49.0.0 carries CVE-2026-69247 |
| **Advisory** | [GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5) | High severity; vulnerable `>=44,<50`, first patched `50.0.0` |

## Changes

- Add `cryptography==50.0.0` to reviewed uv overrides.
- Persist the override in `uv.lock` without changing any resolved package version beyond main's existing `50.0.0` lock.
- Extend the exact dependency-policy invariant so the pin cannot silently disappear.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted security/dependency review, high scrutiny, blocks green CI reliability

**Focus areas**: exact pin versus the permanent `[tool.uv.exclude-newer-package]` exception; lockfile minimality; downgrade/future-floating prevention

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed

Validation evidence:

- Baseline reproduction: `cryptography 49.0.0  CVE-2026-69247 50.0.0`; `pip-audit` exit 1.
- Fixed audit: no known vulnerabilities; exit 0 (existing unrelated ignored advisory policy unchanged).
- Negative control: requirements audit of `cryptography==49.0.0` still reports CVE-2026-69247 and exits 1.
- Compatibility: PyJWT 2.13.0 declares `cryptography>=3.4.0`; imports and Semgrep 1.171.0 CLI pass with 50.0.0.
- `uv run --frozen pytest`: 23,128 passed, 36 skipped.
- `uv build`: wheel and sdist produced successfully.
- `uv run --frozen python scripts/validation/pre_pr.py`: 46 passed, 4 skipped, 0 failed.
- Normal `git push` pre-push gate: passed, including 23,035 tests, security scans, count ratchets, build check, and pre-PR validation.

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes
- [x] Security patterns applied

**Files requiring security review:**

- `pyproject.toml`
- `uv.lock`
- `tests/test_pyproject_dev_deps_parity.py`

Independent security verdict: **APPROVED**, no findings.

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally
- [x] Pre-PR validation passed
- [x] Lint and formatting clean
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (N/A beyond dependency rationale)
- [x] No new warnings introduced

## Related Issues

Fixes #4535
