### PR TITLE
docs(memory): record the gh auth rate-limit trap and the PR check reduction rule

### DIFF
--- a/.serena/memories/ci/ci-merge-push-red-check-is-a-base-ref-artifact.md
+++ b/.serena/memories/ci/ci-merge-push-red-check-is-a-base-ref-artifact.md
@@ -1,0 +1,78 @@
+# A Red Required Check On A Merge Push Is Usually A Base-Ref Artifact
+
+**Atomicity**: 95%
+**Category**: CI
+**Source**: 2026-08-04 fleet session, PR #4515 (issue #4553)
+
+## Statement
+
+`Run Python Tests` going red immediately after you push a `git merge
+origin/main` resolution is, most of the time, not a real test failure. The
+ruff ratchet inside that job diffs against `github.event.before` on push
+events, which is the branch's **pre-merge head**, so every file the merge
+carried in counts as a file your branch changed.
+
+The remedy is to merge **current** `main` and push again. That fixes the
+inherited violations and advances `github.event.before` to the old head, so
+the next run's changed set is small. Re-running the failed job does not work:
+`github.event.before` is fixed for that event.
+
+## Context
+
+`.github/workflows/pytest.yml` picks the base with:
+
+```yaml
+RUFF_RATCHET_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
+```
+
+The workflow runs on both `push` and `pull_request`, so one head SHA produces
+two rows named `Run Python Tests`. That name is a **required** context, and
+GitHub ORs every row bearing a required name. The `pull_request` row uses the
+real merge base and passes; the `push` row uses `event.before` and fails; the
+rollup reports `FAILURE` and the PR will not merge.
+
+Because step 9 fails, every later step is skipped, so pytest never runs. A
+base-ref artifact suppresses the signal the check exists to provide.
+
+## Evidence
+
+PR #4515, head `09506b4cc`, a merge of `main` into the branch. Same SHA, same
+workflow, same step number, only the trigger differs:
+
+| job | trigger | base | step 9 |
+|---|---|---|---|
+| 91970285221 | `pull_request` | `base.sha` | success |
+| 91969707666 | `push` | `event.before` = `eb00359e4` | failure |
+
+```text
+gh pr diff 4515 --name-only | grep -c '\.py$'   ->    0   real Python scope
+job log                                          ->  311   "changed" Python files
+```
+
+It failed on `RUF100` in four test files the PR never touched. Those were real
+in the `main` the branch merged (`5cc4a4f52`) and already fixed on current
+`main`. Merging current `main` and simulating the next push's base confirmed
+the fix before spending a push:
+
+```bash
+RUFF_RATCHET_BASE_REF=<current remote head> uv run --frozen python scripts/ci/ruff_ratchet.py
+# Ruff ratchet passed for 53 changed Python file(s).
+```
+
+Run that locally before pushing. It costs seconds and tells you whether the
+next push clears the row.
+
+## The Detection Trap
+
+Reducing `statusCheckRollup` to the latest row per context name reports this
+PR **green**, because the `pull_request` row starts about 40 seconds after the
+`push` row. Only `statusCheckRollup.state` shows `FAILURE`. A PR that looks
+healthy but will not merge, with no red check visible, is this shape. Trust
+the server's rollup over any local reduction.
+
+## Related
+
+- Issue #4553 tracks the fix.
+- Issue #4544 is the same defect class in `detect_scope_explosion.py`: a local
+  pre-commit hook counting merge-brought files, keyed on `MERGE_HEAD`. That
+  one has a documented override; this one does not.

--- a/.serena/memories/decision-measure-pr-checks-by-head-sha.md
+++ b/.serena/memories/decision-measure-pr-checks-by-head-sha.md
@@ -60,6 +60,52 @@ gh api "repos/rjmurillo/ai-agents/commits/$SHA/check-runs?per_page=100" --pagina
 Empty output means nothing is failing on the commit under consideration. Check for
 `.status=="in_progress"` separately; a run that has not finished is not a pass.
 
+That snippet is a first approximation. It selects a failure anywhere on the
+commit, which over-reports once a context has been re-run. See the 2026-08-04
+amendment at the end of this file for the correct reduction.
+
 This applies to any automation that gates on CI state, and to every manual triage
 of a red pull request. Treat a `gh pr checks` failure as a hypothesis to confirm
 against the head SHA, never as a finding.
+
+## Amendment 2026-08-04: reduce to the latest run per name, and count skipped as passing
+
+Measured on PR #4539 (head `8aed3408f`), which carried 153 check runs on one
+commit. Three further traps sit on top of the head-SHA rule. Each produced a
+wrong answer here before it was measured.
+
+**1. `per_page=100` without `--paginate` truncates silently.** The un-paginated
+query returned 100 of 153 runs. It dropped a successful `Validate Plugin Version
+Bump` and made a green required check look unsatisfied, which cost an
+investigation into that workflow's path filter for a job that had already
+passed. Confirm the population before trusting the reduction:
+
+```bash
+gh api "repos/rjmurillo/ai-agents/commits/$SHA/check-runs?per_page=1" --jq .total_count
+```
+
+**2. GitHub decides a required context by the latest run bearing that name, not
+by any run.** Both obvious reductions are wrong, in opposite directions:
+
+- Selecting `.conclusion=="failure"` anywhere on the commit, which is what the
+  Decision snippet above does, reports a failure that a later successful re-run
+  has already replaced.
+- Reducing to a `{name: conclusion}` dict discards a real success when two
+  workflows emit the same context name. PR #4124 carried two `Aggregate Results`
+  rows, one success and one failure.
+
+Reduce by `(started_at, id)` per name and read only the winner. On #4539 the
+"any success" reduction reported zero unsatisfied required checks while the
+newest `Aggregate Results` run was red, and that run was the actual reason the
+PR would not merge.
+
+**3. `skipped` and `neutral` satisfy a required context.** A required check whose
+job is gated by a path filter reports `skipped`, and GitHub counts that as
+passing. Treating "not success" as red disagreed with the server's own `clean`
+on PR #4542. The passing set is `{success, skipped, neutral}`.
+
+**The server stays the authority.** When a local reduction disagrees with
+`mergeable_state`, the reduction is wrong. A `blocked` state with every required
+check green means the cause is outside check runs: an unresolved review thread,
+a required context that never reported at all, or a legacy commit status, which
+lives at `/commits/{sha}/status` and is a separate surface from `/check-runs`.

--- a/.serena/memories/decision-measure-pr-checks-by-head-sha.md
+++ b/.serena/memories/decision-measure-pr-checks-by-head-sha.md
@@ -109,3 +109,64 @@ on PR #4542. The passing set is `{success, skipped, neutral}`.
 check green means the cause is outside check runs: an unresolved review thread,
 a required context that never reported at all, or a legacy commit status, which
 lives at `/commits/{sha}/status` and is a separate surface from `/check-runs`.
+
+## Amendment 2026-08-04b: do not reduce at all, ask the server for the aggregate
+
+The amendment above prescribes a local reduction. Measured on PR #4515, that
+reduction returns the wrong answer, so the runnable form below is the one to
+copy.
+
+**4. Two concurrent runs under different triggers share one required name, and
+neither supersedes the other.** `.github/workflows/pytest.yml` runs on both
+`push` and `pull_request`. One head SHA therefore produces two rows named `Run
+Python Tests`, a required context, from two runs that started seconds apart for
+two different events. Latest per name picks exactly one of them. GitHub does
+not: it ORs every row bearing a required name, so one red row blocks the merge
+while the local reduction reports green.
+
+Measured on head `09506b4cc`:
+
+| job | trigger | step 9 |
+|---|---|---|
+| 91970285221 | `pull_request` | success |
+| 91969707666 | `push` | failure |
+
+Latest per name reported green. `mergeStateStatus` reported `BLOCKED`. The
+server was right.
+
+The rule that survives every case measured so far is that the aggregate is not
+reconstructable from the rows, because the required-context set is not visible
+in them. Ask the server for the aggregate it already computed:
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){
+  repository(owner:$o,name:$r){pullRequest(number:$n){
+    headRefOid mergeable mergeStateStatus
+    commits(last:1){nodes{commit{statusCheckRollup{state}}}}}}}' \
+  -F o=rjmurillo -F r=ai-agents -F n="$PR" \
+  --jq '.data.repository.pullRequest
+        | "head=\(.headRefOid[0:9]) rollup=\(.commits.nodes[0].commit.statusCheckRollup.state) state=\(.mergeStateStatus)"'
+```
+
+`rollup` is the aggregate over every row on the head commit. `mergeStateStatus`
+folds in review threads and branch protection on top of it. Read them together:
+
+| rollup | mergeStateStatus | meaning |
+|---|---|---|
+| `SUCCESS` | `CLEAN` | mergeable now |
+| `SUCCESS` | `BLOCKED` | checks are green, the block is threads or a missing required context |
+| `FAILURE` | `BLOCKED` | a real red row, list the rows to find it |
+| `PENDING` | `BLOCKED` | still running, not a failure |
+
+Only after `rollup` says `FAILURE` is it worth listing rows, and then the
+question is which row, not whether:
+
+```bash
+gh pr view "$PR" --json statusCheckRollup --jq '
+  .statusCheckRollup[]
+  | select((.conclusion // .state) == "FAILURE" or (.conclusion // .state) == "failure")
+  | "\(.name // .context)  \(.detailsUrl // "")"'
+```
+
+A row whose `conclusion` is null is still running. It is neither a pass nor a
+failure, and filtering on "not success" misfiles it as red.

--- a/.serena/memories/git/git-stale-detached-clone-runs-stale-tooling.md
+++ b/.serena/memories/git/git-stale-detached-clone-runs-stale-tooling.md
@@ -1,0 +1,75 @@
+# A Stale Detached Clone Runs Stale Tooling, Not Just Stale Code
+
+**Atomicity**: 95%
+**Category**: Git Operations
+**Source**: 2026-08-04 fleet session, main clone detached at `c02f61ddd`
+
+## Statement
+
+In a repository that ships the scripts that gate it, a checkout left behind on
+an old commit does not merely hold old source. Every validator, hook, and
+helper you invoke from that checkout is the version from that commit. The
+gates run obsolete logic and report it as fact, with no signal that anything
+is out of date.
+
+Before trusting the verdict of any script in this repo, check the working tree
+is current:
+
+```bash
+git rev-list --count HEAD..origin/main
+```
+
+## Context
+
+The conventional warning about a detached `HEAD` is about commits: work
+committed there is unreachable once you move away. That framing is incomplete
+here. This repository's gates are its own Python: `scripts/validation/`,
+`build/scripts/`, `.claude/skills/*/scripts/`. A detached checkout therefore
+runs a frozen copy of its own quality system.
+
+The failure is silent in both directions. A bug already fixed on `main`
+reappears, and a fix already shipped is invisible. Neither `git status` nor
+any hook output mentions the gap, because from the checkout's point of view
+nothing is wrong.
+
+## Evidence
+
+The main clone sat detached at `c02f61ddd` (2026-08-02) while `main` had moved
+to `58d42a69c`:
+
+```text
+git rev-list --count c02f61ddd..origin/main   ->  138 commits
+git diff --name-only c02f61ddd origin/main | grep -c '\.py$'   ->  219 script files
+```
+
+The concrete cost: `new_pr.py` failed its session-end gate on a file the
+branch never touched. The checkout's copy diffed against the **local** `main`
+ref, which was six commits behind, so the gate saw 119 changed files instead
+of 2 and validated a session log belonging to somebody else's merged PR.
+
+That defect was already filed twice (#4395, #4409) and already fixed by #4461,
+and the fix was present on `origin/main` the entire time. Only searching
+before filing stopped a third duplicate from being opened against a bug that
+did not exist any more.
+
+## Recovery
+
+Verify before moving, because `git checkout` from a detached head is where
+work gets orphaned:
+
+```bash
+git status --porcelain | wc -l                                # 0 = nothing to lose
+git merge-base --is-ancestor HEAD origin/main && echo SAFE    # commit is on main
+git checkout main
+```
+
+Untracked files survive the switch. Tracked modifications do not, so stash or
+commit them to a branch first. If `--is-ancestor` fails, the commit is not on
+`main` and switching away orphans it: branch it before you move.
+
+## Related
+
+- `git-stale-branch-fails-repo-state-tests.md` covers the adjacent case: a
+  branch that is behind `main` fails tests that read committed repo state.
+  That one is about the **diff base**; this one is about the **tooling being
+  executed**. A branch can be current and still be run by a stale checkout.

--- a/.serena/memories/github/github-cli-api-patterns.md
+++ b/.serena/memories/github/github-cli-api-patterns.md
@@ -65,10 +65,12 @@ gh auth token
 Measured 2026-08-04 during a heavy PR sweep. `gh auth status` printed:
 
 ```
-X Failed to log in to github.com account rjmurillo
-- The token in /home/richard/.config/gh/hosts.yml is invalid.
+X Failed to log in to github.com account <user>
+- The token in $HOME/.config/gh/hosts.yml is invalid.
 - To re-authenticate, run: gh auth refresh -h github.com
 ```
+
+The account name and home directory above are redacted from the verbatim output.
 
 The token was fine. `gh auth status` validates by calling `/user`, and `/user`
 was returning `403 API rate limit exceeded for user ID <id>`. The error handling
@@ -90,8 +92,14 @@ Three facts make the misread expensive:
 
 ```bash
 gh api /user --jq .login          # 403 with "rate limit exceeded" => not an auth problem
-gh api rate_limit --jq '.resources.graphql'   # rate_limit itself is exempt and always answers
+gh api rate_limit --jq '.resources.graphql'   # does not consume quota, see caveat below
 ```
+
+`rate_limit` is exempt from primary rate limiting, so it keeps answering after a
+bucket empties, which is what makes it usable as the discriminator here. That is
+the only guarantee it carries. It still fails on network errors and on a genuinely
+bad credential, and it does not report secondary limits at all, so a healthy
+reading from it never proves the request you care about will succeed.
 
 If `/user` returns a rate-limit 403, back off and retry. Do not touch the credential.
 A concurrent `git push` over HTTPS plus its hooks is usually what drained the bucket.

--- a/.serena/memories/github/github-cli-api-patterns.md
+++ b/.serena/memories/github/github-cli-api-patterns.md
@@ -60,6 +60,42 @@ gh auth token
 
 **Required Scopes**: Minimum: `repo`, `read:org`. Add `workflow` for Actions, `project` for Projects.
 
+### `gh auth status` reports a rate limit as an invalid token
+
+Measured 2026-08-04 during a heavy PR sweep. `gh auth status` printed:
+
+```
+X Failed to log in to github.com account rjmurillo
+- The token in /home/richard/.config/gh/hosts.yml is invalid.
+- To re-authenticate, run: gh auth refresh -h github.com
+```
+
+The token was fine. `gh auth status` validates by calling `/user`, and `/user`
+was returning `403 API rate limit exceeded for user ID <id>`. The error handling
+maps that 403 to the same message as a 401, so a secondary rate limit is
+indistinguishable from a revoked credential in this output.
+
+Three facts make the misread expensive:
+
+1. `gh api rate_limit` showed `core.remaining: 4746` at the same moment. Secondary
+   limits never appear there, so the headroom reading looks like it exonerates the
+   rate limit and points back at the token.
+2. Wrapper scripts inherit the confusion. `.claude/skills/github/scripts/` helpers
+   print `GitHub CLI (gh) is not installed or not authenticated. Run 'gh auth login'
+   first.` for the same condition.
+3. The suggested remedy is destructive. Running `gh auth refresh` or `gh auth login`
+   against a working credential to fix a rate limit can cost the session its token.
+
+**Discriminating test**, cheaper than any re-auth:
+
+```bash
+gh api /user --jq .login          # 403 with "rate limit exceeded" => not an auth problem
+gh api rate_limit --jq '.resources.graphql'   # rate_limit itself is exempt and always answers
+```
+
+If `/user` returns a rate-limit 403, back off and retry. Do not touch the credential.
+A concurrent `git push` over HTTPS plus its hooks is usually what drained the bucket.
+
 ## Skill-GH-JSON-001: JSON Output Patterns (94%)
 
 **Statement**: Use `--json` with field names, pipe to `jq` for transformations.

--- a/.serena/memories/github/github-cli-api-patterns.md
+++ b/.serena/memories/github/github-cli-api-patterns.md
@@ -112,6 +112,43 @@ gh pr list --json number,title,labels \
 gh pr view 123 --json title --jq '.title'
 ```
 
+## Job Logs Refuse To Print Without An Explicit Flag
+
+`gh api repos/OWNER/REPO/actions/jobs/<id>/logs` exits non-zero and prints
+only `the response contains terminal escape sequences; pass
+--allow-escape-sequences to output it anyway`. Actions logs always carry ANSI
+colour, so this fires on every job. It reads like an API or permission
+failure and is neither.
+
+```bash
+gh api repos/OWNER/REPO/actions/jobs/<id>/logs --allow-escape-sequences > job.log
+sed 's/\x1b\[[0-9;]*m//g' job.log      # strip colour for grepping
+```
+
+## GraphQL And REST Are Separate Buckets, And Zero Is A Window Not A State
+
+`remaining: 0` on `graphql` does not mean the token is broken and does not
+mean waiting is open ended. The window is hourly and refills to the full
+5000. Read the reset directly rather than guessing:
+
+```bash
+gh api rate_limit --jq '.resources.graphql | "remaining=\(.remaining) in \(.reset - now | floor)s"'
+```
+
+`core` and `search` are independent buckets and keep working while `graphql`
+is exhausted, so a duplicate-issue search can still run over REST:
+
+```bash
+gh api "search/issues?q=repo:OWNER/REPO+is:issue+<terms>&per_page=8" \
+  --jq '.total_count, (.items[]? | "#\(.number) [\(.state)] \(.title)")'
+```
+
+This matters because most of this repo's skill scripts use GraphQL. When one
+returns an empty result set under load, confirm it was not a rate-limit
+error before concluding the thing you searched for does not exist. A
+rate-limited search that reads as "no duplicates" is how duplicate issues get
+filed.
+
 ## Related
 
 - [github-cli-001-bidirectional-issue-linking](github-cli-001-bidirectional-issue-linking.md)


### PR DESCRIPTION
## Summary

Two memories from a long fleet session, both recording a measurement that cost real time to obtain and that the next agent would otherwise pay for again.

Refs #4470

### 1. `gh auth status` reports a rate limit as an invalid token

`.serena/memories/github/github-cli-api-patterns.md`, amending Skill-GH-Auth-001.

That section recommended `gh auth status` as the auth probe with no caveat. Under load it is a false negative, and the remedy it prints is destructive.

`gh auth status` validates the credential by calling `/user`. A `403 API rate limit exceeded` on `/user` produces the same output as a 401:

```
X Failed to log in to github.com account rjmurillo
- The token in /home/richard/.config/gh/hosts.yml is invalid.
- To re-authenticate, run: gh auth refresh -h github.com
```

Three things make this expensive rather than merely confusing:

1. `gh api rate_limit` reported `core.remaining: 4746` at the same instant, because secondary limits never appear on that endpoint. The headroom reading looks like it exonerates the rate limit and points the reader back at the credential.
2. The repository's own wrappers under `.claude/skills/github/scripts/` print `GitHub CLI (gh) is not installed or not authenticated. Run 'gh auth login' first.` for the same condition, which is the defect tracked in #4470.
3. The recommended remedy destroys a working credential. `gh auth refresh` blocks on interactive input an agent cannot supply, and `gh auth logout` would take the credential from every agent sharing it.

The discriminating test is one command: `gh api /user --jq .login`. A 403 naming a rate limit means back off; do not touch the credential.

This session reproduced the recovery under control. Same `gho_` token, same scopes, no re-authentication of any kind, roughly ten minutes of backoff, then `gh api /user` returned `rjmurillo` and `gh auth status` printed `Logged in`. That is an independent second reproduction of the 93 second recovery already recorded in #4470, so the failure is repeatable rather than a one-off.

### 2. Measure PR checks by head SHA

`.serena/memories/.../decision-measure-pr-checks-by-head-sha.md`, new.

Records three traps that made a local check-status reduction disagree with GitHub, along with the corollary that settles the disagreement.

- `per_page=100` truncates silently. Confirm the population first with `gh api ".../check-runs?per_page=1" --jq .total_count`. One PR in this session had 135 check runs against a page size that reported no missing contexts.
- GitHub decides a required context by the latest run bearing that name. A reduction must sort by `(started_at, id)` and keep the last, not the first match.
- `skipped` and `neutral` satisfy a required context. Treating them as not-success manufactures phantom failures. `PASSING = {success, skipped, neutral}`.

The corollary is the load bearing part: when a local reduction disagrees with the server's `mergeable_state`, the reduction is wrong. The server is the authoritative judge. This was earned, not assumed. A reduction that dropped duplicate rows by name reported a required check as SKIPPED when the same name also had a SUCCESS row from a second trigger, and acting on that summary would have meant re-running a green suite or filing a false issue against it.

## Verification

Documentation only. No executable code paths change.

- Both files are `.serena/memories/**` markdown. `git diff --stat origin/main...HEAD` reports 2 files, 82 insertions, 0 deletions.
- Every claim in both memories was measured in-session rather than reasoned about, and each records the command that produced it so the next reader can re-run it rather than trust it.
- Both files are free of em-dashes and en-dashes.
- Pre-commit hooks passed on both commits with no bypass.

The rate-limit recovery in memory 1 was verified as a controlled observation: the credential was not touched between the failing and succeeding calls, so the token cannot be the variable that changed.