### PR TITLE
test(validation): cover the review-marker success path

### DIFF
--- a/tests/validation/test_checks_coverage_severity.py
+++ b/tests/validation/test_checks_coverage_severity.py
@@ -214,27 +214,38 @@ def test_success_forwards_each_line_once(
     assert _pass_line_count(captured) == 1
 
 
-def test_success_keeps_the_pass_token_unrewritten(
+@pytest.mark.parametrize("enforced", [False, True], ids=["advisory", "enforced"])
+def test_success_severity_token_stays_pass_in_both_modes(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: Any,
+    enforced: bool,
 ) -> None:
-    """A passing run must not be downgraded, in either mode.
+    """A passing run prints ``[PASS]`` and never a lower verdict, in either mode.
 
-    The advisory branch rewrites ``[FAIL]`` to ``[WARN]``. Routing the success
-    path through that same rewrite would be silent, since a success line
-    carries neither token, so assert the forwarded text is untouched.
+    Kills two mutations: emitting the success line under a ``[WARN]`` or
+    ``[FAIL]`` token, and dropping the success print entirely. It deliberately
+    does not claim to catch the success path being routed through
+    ``_as_advisory``. That rewrite only touches a leading ``[FAIL]``, so a
+    ``[PASS]`` line survives it unchanged and no assertion here could tell.
+    ``test_print_output_downgrade_spares_a_non_leading_token`` covers the
+    forwarder's use of that rewrite instead.
     """
     repo = _repo(tmp_path, with_script=True)
-    _add_valid_marker(repo)
-    monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
+    reviewed = _add_valid_marker(repo)
+    if enforced:
+        monkeypatch.setenv("REVIEW_MARKER_ENFORCED", "1")
+    else:
+        monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
 
-    validate_review_marker(repo)
+    passed = validate_review_marker(repo)
 
     captured = capsys.readouterr().out
+    assert passed is True
     assert "[PASS]" in captured
     assert "[WARN]" not in captured
     assert "[FAIL]" not in captured
+    assert reviewed[:12] in captured
 
 
 def test_success_forwards_each_line_once_when_enforced(

--- a/tests/validation/test_checks_coverage_severity.py
+++ b/tests/validation/test_checks_coverage_severity.py
@@ -134,6 +134,30 @@ def _marker_line_count(captured: str) -> int:
     )
 
 
+def _pass_line_count(captured: str) -> int:
+    """Count how many times the wrapped script's success verdict was forwarded."""
+    return sum(1 for line in captured.splitlines() if "reviewed: /review@" in line)
+
+
+def _add_valid_marker(repo: Path) -> str:
+    """Append an empty review-marker commit binding the current HEAD.
+
+    The marker contract in ``validate_review_marker`` binds a commit's parent,
+    so the marker must be an empty commit whose trailer names the SHA it sits
+    on top of. Returns the reviewed SHA.
+    """
+    reviewed = _git(repo, "rev-parse", "HEAD")
+    _git(
+        repo,
+        "commit",
+        "-q",
+        "--allow-empty",
+        "-m",
+        f"chore: review marker\n\nReviewed-By: /review@correctness on {reviewed}",
+    )
+    return reviewed
+
+
 def test_advisory_failure_forwards_each_line_once(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -165,6 +189,75 @@ def test_enforced_failure_forwards_each_line_once(
     validate_review_marker(repo)
 
     assert _marker_line_count(capsys.readouterr().out) == 1
+
+
+def test_success_forwards_each_line_once(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,
+) -> None:
+    """The success path forwards its verdict once, same as both failure paths.
+
+    Both failure paths carry a forwards-once test; the exit-zero path did not,
+    so duplicating its ``_print_output`` call survived the whole suite. The
+    duplicate is invisible to a severity assertion because both copies read
+    ``[PASS]``.
+    """
+    repo = _repo(tmp_path, with_script=True)
+    _add_valid_marker(repo)
+    monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
+
+    passed = validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert passed is True
+    assert _pass_line_count(captured) == 1
+
+
+def test_success_keeps_the_pass_token_unrewritten(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,
+) -> None:
+    """A passing run must not be downgraded, in either mode.
+
+    The advisory branch rewrites ``[FAIL]`` to ``[WARN]``. Routing the success
+    path through that same rewrite would be silent, since a success line
+    carries neither token, so assert the forwarded text is untouched.
+    """
+    repo = _repo(tmp_path, with_script=True)
+    _add_valid_marker(repo)
+    monkeypatch.delenv("REVIEW_MARKER_ENFORCED", raising=False)
+
+    validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert "[PASS]" in captured
+    assert "[WARN]" not in captured
+    assert "[FAIL]" not in captured
+
+
+def test_success_forwards_each_line_once_when_enforced(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: Any,
+) -> None:
+    """Enforcement changes the failure verdict, never the success one."""
+    repo = _repo(tmp_path, with_script=True)
+    _add_valid_marker(repo)
+    monkeypatch.setenv("REVIEW_MARKER_ENFORCED", "1")
+
+    passed = validate_review_marker(repo)
+
+    captured = capsys.readouterr().out
+    assert passed is True
+    assert _pass_line_count(captured) == 1
+
+
+def test_pass_line_counter_is_not_vacuous() -> None:
+    """A counter that matched nothing would make the forwards-once tests green."""
+    assert _pass_line_count("[PASS] reviewed: /review@correctness binds abc123 (1 axis/axes)") == 1
+    assert _pass_line_count("[PASS] something else entirely") == 0
 
 
 def test_print_output_downgrade_spares_a_non_leading_token(


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds coverage for the success path of the review-marker severity check, and retargets one existing assertion at a mutation it actually kills.

### Why

The severity check had tests for every failure branch and none for the branch that passes. A success path with no test is a path that can be silently rewritten, and that is the same vacuous-coverage shape the second commit here fixes in one of the new tests.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4315 | Review marker severity behavior |

Test-only change. No spec required.

## Changes

**First commit: cover the success path.** The severity check distinguishes advisory mode from enforced mode, and every existing test drove it through a failure. Nothing asserted what the check does when the marker is valid. The new cases drive a valid marker through both modes and assert the exit status, the severity token, and that the reviewed commit is the one reported.

**Second commit: retarget an assertion that claimed a kill it did not have.** One of the new tests carried a docstring saying it would catch the success path being routed through the advisory rewriter. An adversarial review on a different model family ran that mutation and the test stayed green. The reason is that the advisory rewriter only rewrites a leading failure token, so a passing line survives it unchanged. The test was alive against other mutations while advertising one it could not detect.

The fix does not delete the test. It renames it to describe the mutation it does kill, parametrizes it across both modes, adds an assertion on the boolean result and on the reviewed commit prefix, and states in the docstring which mutation it explicitly does not claim.

That distinction is the point worth carrying forward. Non-vacuity is a property of a claim, not of a test. A test can kill real mutations and still be vacuous for the specific thing its name promises.

Files changed:

- `tests/validation/test_checks_coverage_severity.py`

## Type of Change

- [x] Test coverage

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether the retargeted docstring now matches the mutations proven below, and whether the disclaimed mutation is worth a separate test.

## Testing

Deliverables in this PR:

- [x] Unit tests added
- [x] All tests pass locally

Fifteen tests in the file, all passing. Both claimed kills were proven by running the mutation rather than by reading the code:

| Mutation applied to the checker | Expected | Observed |
|---|---|---|
| Drop the success print entirely | Both parametrized cases red | Both red |
| Rewrite the success token to a warning token | Exactly the two parametrized cases red | Exactly those two, nothing else in the file |
| Route the success path through the advisory rewriter | Explicitly not claimed | Stays green, and the docstring now says so |

The second row matters more than the first. A mutation that reds the whole file proves the file runs, not that this test discriminates. Reding exactly the two cases is what makes the claim specific.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

Adversarial review ran on a model family other than the one that authored the change, with explicit instructions to run the mutations itself rather than trust the author's report. It confirmed the core coverage claim and filed one finding at Medium severity, which is the subject of the second commit. The finding was verified independently before being accepted.

## Author Pre-flight

- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] No new warnings introduced

## Notes for Reviewers

One test in this PR was written, reviewed, found vacuous for its stated claim, and fixed inside the same branch. That is the honest version of the story and it is why the second commit exists as its own commit rather than being squashed into the first.

The disclaimed mutation is left uncovered on purpose. Catching it would need a test that asserts the rewriter is not called at all, which is an implementation-coupled assertion rather than a behavioral one. Naming it in the docstring costs nothing and keeps the next reader from assuming coverage that is not there.

## Related Issues

Refs #4315
