### PR TITLE
fix(ci): fetch base at full depth for the merge-tree ratchet

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -322,9 +322,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          # CI-only: --depth=1 keeps this disposable checkout shallow.
-          # See taste-lint ratchet step above for the caveat on working clones.
-          git fetch --depth=1 origin "$BASE_REF"
+          # Issue #4518: this fetch MUST NOT be shallow. The two count ratchets
+          # above read a single baseline file at the base ref, so --depth=1 is
+          # enough for them. merge-tree needs a merge base, and a --depth=1
+          # fetch writes .git/shallow and cuts traversal at the fetched commit.
+          # git then aborts with "refusing to merge unrelated histories" (rc 128)
+          # on any branch behind the base, which is the only case this gate
+          # exists to evaluate. Measured: behind+shallow rc=128, behind+full
+          # rc=0, up-to-date+shallow rc=0.
+          git fetch origin "$BASE_REF"
           uv run --frozen --extra dev python3 scripts/ci/merge_tree_ratchet_check.py --base-ref FETCH_HEAD
       # Issue #3770: `conflict-marker-policy` runs only at pre-commit over the
       # index. Every route that skips local hooks reached the remote unchecked:

--- a/scripts/ci/merge_tree_ratchet_check.py
+++ b/scripts/ci/merge_tree_ratchet_check.py
@@ -80,16 +80,24 @@ def _git(cwd: Path, *argv: str) -> subprocess.CompletedProcess[str]:
 
 
 def _merge_tree_oid(repo_root: Path, base_ref: str) -> tuple[str | None, bool]:
-    """Return (tree-oid, conflicts). oid is None on git failure."""
+    """Return (tree-oid, conflicts). oid is None on git failure.
+
+    Every None return writes its own explanation to stderr, so callers must not
+    add a second generic one. Two messages for one failure make the specific
+    diagnosis read like a guess (PR #4567 review).
+    """
     proc = _git(repo_root, "merge-tree", "--write-tree", base_ref, "HEAD")
-    if proc.returncode == 0:
-        oid = proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else None
-        return oid, False
-    if proc.returncode == 1:
+    if proc.returncode in (0, 1):
         # exit 1 means conflicts; stdout still has the partial tree oid on line 1
         lines = proc.stdout.strip().splitlines()
-        oid = lines[0] if lines else None
-        return oid, True
+        conflicts = proc.returncode == 1
+        if not lines:
+            sys.stderr.write(
+                f"merge-tree-ratchet: git merge-tree exited {proc.returncode} but wrote\n"
+                "no tree OID, so there is no merged tree to evaluate.\n"
+            )
+            return None, conflicts
+        return lines[0], conflicts
     sys.stderr.write(f"git merge-tree failed (rc {proc.returncode}):\n{proc.stderr}\n")
     if "unrelated histories" in proc.stderr:
         sys.stderr.write(
@@ -237,7 +245,8 @@ def _evaluate_merged_tree(repo_root: Path, base_ref: str) -> int:
     """Extract merged tree, run counters, compare. Returns an EXIT_* code."""
     tree_oid, conflicts = _merge_tree_oid(repo_root, base_ref)
     if tree_oid is None:
-        sys.stderr.write("merge-tree-ratchet: git merge-tree did not produce a tree OID.\n")
+        # _merge_tree_oid already named the specific reason on stderr. A generic
+        # line here would contradict it (PR #4567 review).
         return EXIT_EXTERNAL
     if conflicts:
         print(

--- a/scripts/ci/merge_tree_ratchet_check.py
+++ b/scripts/ci/merge_tree_ratchet_check.py
@@ -91,6 +91,13 @@ def _merge_tree_oid(repo_root: Path, base_ref: str) -> tuple[str | None, bool]:
         oid = lines[0] if lines else None
         return oid, True
     sys.stderr.write(f"git merge-tree failed (rc {proc.returncode}):\n{proc.stderr}\n")
+    if "unrelated histories" in proc.stderr:
+        sys.stderr.write(
+            "merge-tree-ratchet: no merge base was reachable. This is a shallow-fetch\n"
+            "regression, not a ratchet breach: a `git fetch --depth=1` writes\n"
+            ".git/shallow and cuts history traversal, so any branch behind the base\n"
+            "aborts here. Fetch the base ref at full depth (issue #4518).\n"
+        )
     return None, False
 
 

--- a/tests/ci/test_merge_tree_ratchet_check.py
+++ b/tests/ci/test_merge_tree_ratchet_check.py
@@ -313,3 +313,55 @@ class TestMergeTreeRatchetCheck:
         ):
             rc = _m.main(["--repo-root", str(repo), "--base-ref", "HEAD"])
         assert rc == _m.EXIT_OK
+
+    def _behind_base_clone(self, tmp_path: Path, *, shallow: bool) -> Path:
+        """A clone whose branch is behind base, with base fetched shallow or full.
+
+        Reproduces issue #4518: the gate exists to judge branches that are behind
+        their base, and a shallow base fetch made exactly that case error out.
+        """
+        origin = _make_repo_with_baselines(tmp_path, ruff=10, taste=10, ignore=10)
+        behind_point = _git(origin, "rev-parse", "HEAD").stdout.strip()
+        (origin / "later.py").write_text("y = 2\n", encoding="utf-8")
+        _commit_all(origin, "main moves ahead")
+
+        work = tmp_path / "work"
+        subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+        subprocess.run(["git", "-C", str(work), "config", "user.email", "t@e.com"], check=True)
+        subprocess.run(["git", "-C", str(work), "config", "user.name", "t"], check=True)
+        _git(work, "checkout", "-q", "-b", "feature", behind_point)
+        (work / "feature.py").write_text("z = 3\n", encoding="utf-8")
+        _commit_all(work, "feature work")
+
+        depth = ["--depth=1"] if shallow else []
+        subprocess.run(
+            ["git", "-C", str(work), "fetch", "-q", *depth, "origin", "main"], check=True
+        )
+        return work
+
+    def test_branch_behind_base_renders_a_verdict(self, tmp_path: Path) -> None:
+        """Issue #4518: a branch behind its base must get a real verdict.
+
+        This is the gate's target case. With the base fetched at full depth a
+        merge base is reachable, so the check evaluates the merged tree instead
+        of erroring out.
+        """
+        work = self._behind_base_clone(tmp_path, shallow=False)
+        rc = _run(work, "FETCH_HEAD")
+        assert rc == _m.EXIT_OK, "behind-base branch must be judged, not errored"
+
+    def test_shallow_base_fetch_reports_the_fetch_not_a_ratchet_breach(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Issue #4518: if the shallow fetch ever returns, say so by name.
+
+        Negative control for the test above: same repository shape, only the
+        fetch depth differs. Without this pair a regression to `--depth=1` is
+        indistinguishable from a real ratchet breach.
+        """
+        work = self._behind_base_clone(tmp_path, shallow=True)
+        rc = _run(work, "FETCH_HEAD")
+        assert rc == _m.EXIT_EXTERNAL
+        err = capsys.readouterr().err
+        assert "shallow-fetch" in err, err
+        assert "#4518" in err, err

--- a/tests/ci/test_merge_tree_ratchet_check.py
+++ b/tests/ci/test_merge_tree_ratchet_check.py
@@ -365,3 +365,47 @@ class TestMergeTreeRatchetCheck:
         err = capsys.readouterr().err
         assert "shallow-fetch" in err, err
         assert "#4518" in err, err
+
+    def test_shallow_diagnostic_is_not_followed_by_a_generic_oid_message(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """PR #4567 review: one failure must produce exactly one explanation.
+
+        The caller used to append "git merge-tree did not produce a tree OID"
+        after the shallow-fetch diagnosis. Two messages for one failure make the
+        specific one read like a guess and send the reader back to the ratchet.
+        """
+        work = self._behind_base_clone(tmp_path, shallow=True)
+        _run(work, "FETCH_HEAD")
+        err = capsys.readouterr().err
+        assert "shallow-fetch" in err, err
+        assert "did not produce a tree OID" not in err, err
+
+    def test_empty_merge_tree_output_still_explains_itself(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Edge case: git succeeds but prints no OID, so nothing else explains it.
+
+        Moving the message out of the caller must not turn this path silent.
+        A bare EXIT_EXTERNAL with no stderr is the failure mode to avoid.
+        """
+        repo = _make_repo_with_baselines(tmp_path, ruff=10, taste=10, ignore=10)
+        empty = subprocess.CompletedProcess(args=["git"], returncode=0, stdout="", stderr="")
+        with patch.object(_m, "_git", return_value=empty):
+            oid, conflicts = _m._merge_tree_oid(repo, "HEAD")
+        assert oid is None
+        assert conflicts is False
+        err = capsys.readouterr().err
+        assert "no tree OID" in err, err
+
+    def test_successful_run_prints_no_failure_diagnostic(self, tmp_path: Path) -> None:
+        """Negative control: the diagnostics must not fire on a clean evaluation.
+
+        Without this the two assertions above would pass against a build that
+        never writes to stderr at all.
+        """
+        work = self._behind_base_clone(tmp_path, shallow=False)
+        with patch.object(_m.sys.stderr, "write") as writes:
+            rc = _run(work, "FETCH_HEAD")
+        assert rc == _m.EXIT_OK
+        assert writes.call_args_list == []

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -998,3 +998,44 @@ class TestBotSkipGuardClassification:
                 f"_ALLOWED_BEHIND_GUARD contains {name!r} but no step with that name "
                 "exists in the workflow. Remove the stale entry."
             )
+
+
+def _pr_validation_steps() -> list[dict]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps: list[dict] = []
+    for job in data.get("jobs", {}).values():
+        steps.extend(job.get("steps", []) or [])
+    return steps
+
+
+def test_merge_tree_ratchet_fetches_base_at_full_depth() -> None:
+    """Issue #4518: the merge-tree step's base fetch must not be shallow.
+
+    A `--depth=1` fetch writes .git/shallow and severs history traversal, so
+    `git merge-tree` aborts with "refusing to merge unrelated histories" on any
+    branch behind the base. That is the only case this gate exists to judge, so
+    a shallow fetch silences the gate instead of failing loudly.
+
+    The sibling behaviour test in tests/ci/test_merge_tree_ratchet_check.py runs
+    its own fetch, so it cannot see a regression here. This assertion is the one
+    that catches a revert of the workflow line.
+    """
+    matching = [
+        s
+        for s in _pr_validation_steps()
+        if "merge_tree_ratchet_check.py" in (s.get("run") or "")
+    ]
+    assert matching, "the merge-tree ratchet step is missing from pr-validation.yml"
+    for step in matching:
+        run = step["run"]
+        fetch_lines = [
+            ln.strip()
+            for ln in run.splitlines()
+            if ln.strip().startswith("git fetch") and not ln.strip().startswith("#")
+        ]
+        assert fetch_lines, f"step {step.get('name')!r} must fetch the base ref"
+        for line in fetch_lines:
+            assert "--depth" not in line, (
+                f"step {step.get('name')!r} fetches the base shallowly ({line!r}); "
+                "merge-tree needs a merge base. See issue #4518."
+            )


### PR DESCRIPTION
fix(ci): fetch the base at full depth so merge-tree can find a merge base

The merge-tree ratchet fetched its base with `git fetch --depth=1`. That
writes .git/shallow and cuts history traversal, so `git merge-tree` aborts
with "refusing to merge unrelated histories" (rc 128) on any branch behind
its base. A branch behind its base is the only case this gate exists to
judge, so the gate errored in its target case and passed trivially
otherwise. It never rendered its verdict in either direction.

Measured control matrix, synthetic two-commit repository:

  behind base + --depth=1   rc=128, refusing to merge unrelated histories
  behind base + full fetch  rc=0
  up to date  + --depth=1   rc=0

Both conditions are required, which is why the two sibling count ratchets
are unaffected: they read one baseline file at the base ref and never walk
history. Their --depth=1 fetches are left alone.

Three changes:

1. The merge-tree step fetches the base at full depth.
2. rc 128 with "unrelated histories" now names the shallow fetch as the
   cause instead of reporting a missing tree OID, which pointed the reader
   at the script rather than at the fetch above it.
3. Two regression tests plus a workflow guard. The behaviour test runs its
   own fetch, so it cannot see a revert of the workflow line; the guard
   asserts the step's fetch carries no --depth. Verified both fail against
   the pre-fix tree.

Refs #4518
Refs #3755, #4398

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Closing claim audit correction

- `Refs #4518`: A second shallow checkout remained after this merge, and the issue was reopened with that reproduction.
