### PR TITLE
fix(validation): name the shallow pin SHA from inside a worktree

### DIFF
--- a/.serena/memories/git/git-shallow-is-shared-across-every-worktree.md
+++ b/.serena/memories/git/git-shallow-is-shared-across-every-worktree.md
@@ -1,0 +1,99 @@
+# A shallow graft is repository-global, so one `--depth` fetch blocks every push
+
+## The trap
+
+`git fetch --depth=<n>` writes a `shallow` file into the **common** git
+directory. Linked worktrees do not get their own. Every worktree of this
+repository then reports `rev-parse --is-shallow-repository` as `true`, and
+`push-ref-policy` refuses the push with exit 2 in all of them at once.
+
+The fetch that caused it is usually not in the worktree you are standing in.
+Reproducing a CI step locally is the common source, because several jobs
+historically fetched with `--depth=1`.
+
+## What it looks like when it bites
+
+Observed 2026-08-04. A push from `wt-shallowfix` was refused:
+
+```
+ERROR: push validation requires complete Git history.
+  A `git fetch --depth=<n>` made this clone shallow, most likely while
+  reproducing a CI step locally.
+  Fix: git fetch --unshallow origin
+```
+
+Nothing in that worktree had run a depth-limited fetch. The graft lived in the
+primary clone's `.git/shallow`, pinned at `81a2a7469`, and had already blocked
+every other worktree silently, since none of them had tried to push yet.
+
+Confirm the shape rather than guessing:
+
+```bash
+git rev-parse --git-dir          # .git/worktrees/<name>  in a linked worktree
+git rev-parse --git-common-dir   # .git                   shared by all of them
+cat "$(git rev-parse --git-common-dir)/shallow"
+```
+
+## Do this instead
+
+Repair once, from any worktree:
+
+```bash
+git fetch --unshallow origin
+```
+
+Verified 2026-08-04: a single `--unshallow` from the primary clone flipped four
+worktrees (`ai-agents`, `wt-covgap`, `wt-doctrinefix`, `wt-e2eauth`) to
+`is-shallow=false` simultaneously and removed the shared `shallow` file. The
+sharing runs in both directions: one graft blocks the fleet, one repair clears
+it.
+
+Never hand-delete `shallow`. The file is what tells git which commits have
+truncated parents; removing it leaves the object store still missing those
+parents and produces corruption reports instead of a clean history.
+
+An ordinary undepthed `git fetch` does **not** clear an existing graft. Only
+`--unshallow` (or `--depth` large enough to reach the roots) does.
+
+## Why the diagnostic used to go missing
+
+Until issue #4576, the guard looked for `repo_root / ".git" / "shallow"`. In a
+linked worktree `<root>/.git` is a pointer file, so that path named a child of a
+file, never existed, and the line naming the pinning SHA was dropped. The guard
+still blocked; it just stopped saying where the graft was, in exactly the
+multi-worktree layout where that is hardest to work out by hand.
+
+The fix asks git for the path (`rev-parse --git-path shallow`) rather than
+building it. Git already knows which files are shared across worktrees and which
+are per-worktree, so it routes `shallow` to the common directory on its own:
+
+```
+$ cd <a linked worktree> && git rev-parse --git-path shallow
+/home/you/src/primary/.git/shallow
+```
+
+That is also the idiom `_check_no_grafts` uses 30 lines above, with
+`--git-path info/grafts`. Parsing the pointer file by hand would have needed
+shape-specific logic, since a submodule's `.git` points at `.git/modules/<name>`
+and that path *is* its common directory, not its grandparent.
+
+The sharing is contractual, not an accident of one git build.
+`gitrepository-layout(5)` says of `shallow`: "This file is ignored if
+`$GIT_COMMON_DIR` is set and `$GIT_COMMON_DIR/shallow` will be used instead."
+It also names `info/grafts` as the sibling mechanism, which is why the same
+idiom fits both. `git-worktree(5)` gives the matching directive: "To access
+refs, it's best not to look inside `$GIT_DIR` directly. Instead use commands
+such as git-rev-parse(1)." So the rule generalizes past `shallow`: when you
+need a path under the git directory, ask `rev-parse --git-path` for it instead
+of joining `.git` yourself, and the worktree, submodule, and
+`$GIT_OBJECT_DIRECTORY` cases all resolve without shape-specific code.
+
+## Related
+
+`.serena/memories/git/git-stash-is-shared-across-every-worktree.md` is the same
+family: the stash stack also lives in the common directory, so a concurrent
+agent's `stash push` and your `stash pop` share one stack.
+
+`.serena/memories/decision-shallow-fetch-kills-merge-base-in-ci.md` covers the
+CI-side consequence: a graft makes `git merge-base` return nothing for the rest
+of the job, which fails one ratchet closed and another open.

--- a/.serena/memories/git/git-shallow-is-shared-across-every-worktree.md
+++ b/.serena/memories/git/git-shallow-is-shared-across-every-worktree.md
@@ -94,6 +94,7 @@ of joining `.git` yourself, and the worktree, submodule, and
 family: the stash stack also lives in the common directory, so a concurrent
 agent's `stash push` and your `stash pop` share one stack.
 
-`.serena/memories/decision-shallow-fetch-kills-merge-base-in-ci.md` covers the
-CI-side consequence: a graft makes `git merge-base` return nothing for the rest
-of the job, which fails one ratchet closed and another open.
+A graft has a CI-side consequence too: it makes `git merge-base` return nothing
+for the rest of the job, which fails one ratchet closed and another open. That
+is documented in `decision-shallow-fetch-kills-merge-base-in-ci.md`, which ships
+with PR #4572 and is not on `main` until that lands.

--- a/.serena/memories/git/git-stash-is-shared-across-every-worktree.md
+++ b/.serena/memories/git/git-stash-is-shared-across-every-worktree.md
@@ -47,8 +47,23 @@ To measure another ref without moving your tree, read it directly rather than
 checking it out:
 
 ```bash
-git show main:path/to/file > /tmp/scratch/file.main
+git show main:path/to/file > ~/src/scratch/file.main
 ```
+
+The same applies to the most tempting case, checking whether a lint or test
+failure predates your change. `git stash` to get a clean tree, run the tool, pop
+back is the obvious move and it is the one that loses work. Extract the base
+version and run the tool on that instead:
+
+```bash
+git show origin/main:path/to/file > ~/src/scratch/file.base
+uv run --frozen python <the linter> ~/src/scratch/file.base
+```
+
+Observed 2026-08-04: the author of this memory reached for `git stash` to check
+a taste-lints baseline within an hour of writing it. Three other agents' stashes
+were on the stack at the time. The pop happened to return the right entry, which
+is luck, not safety.
 
 Most gates in this repository accept a ref argument for exactly this reason, for
 example `scripts/ci/taste_count_ratchet.py --base-ref FETCH_HEAD`.
@@ -69,6 +84,10 @@ Verify your own commits were not contaminated before continuing, with
 unaffected by the pop but a `git add -A` would not be.
 
 ## Related
+
+`.serena/memories/git/git-shallow-is-shared-across-every-worktree.md` is the
+same family: `shallow` also lives in the common directory, so one depth-limited
+fetch in any worktree blocks the push in all of them.
 
 `git commit` in a compound command is the sibling trap: `git switch X && git
 commit` looks safe, but a `switch` that aborts (an untracked file would be

--- a/.serena/memories/memory-index-validator-checks-one-direction-only.md
+++ b/.serena/memories/memory-index-validator-checks-one-direction-only.md
@@ -1,0 +1,69 @@
+# The memory index validator only checks index to file, never file to index
+
+## The trap
+
+`scripts/validation/memory_index.py` walks entries and asserts each target
+exists. It never walks the filesystem and asks whether a memory got indexed.
+Add a memory file, forget the `memory-index.md` entry, and the validator prints
+`Result: PASSED`. The memory is then invisible to keyword search, which is the
+only way anything finds it.
+
+Verified 2026-08-04 by probe. Two unindexed files were dropped in, one at
+`.serena/memories/zz-probe-unindexed.md` and one at
+`.serena/memories/git/zz-probe-subdir.md`, and the default run still reported:
+
+```
+Domains: 33 total, 33 passed, 0 failed
+Files: 305 indexed, 0 missing
+Keyword Issues: 0
+
+Result: PASSED
+```
+
+## The orphan check does not close the gap
+
+There is a `--fix-orphans` flag, and it is not the safety net it looks like:
+
+- **Opt-in.** Nothing in the default run or the push gates passes it.
+- **Warn only.** It prints `[P1 WARN]` and leaves the exit code alone.
+- **Non-recursive.** `find_orphaned_files` uses `memory_path.glob("*.md")`, so
+  anything under `git/`, `patterns/`, `session/`, or any other subdirectory is
+  unreachable by it. Neither probe above was reported, including the top-level
+  one.
+- **Prefix-scoped.** It only considers files matching a domain prefix against
+  the 33 `skills-*-index.md` domain indices, so a plain descriptive filename is
+  out of scope even at the top level.
+
+## Read the counts correctly
+
+`Files: 305 indexed` counts entries parsed from the 33 `skills-*-index.md`
+domain indices. It is not the filesystem count, which is 948, and it is not the
+`memory-index.md` entry count, which is 121. Adding a row to `memory-index.md`
+does not move it. A stable 305 across an edit is expected and says nothing about
+whether your entry landed.
+
+## Do this instead
+
+After adding any memory file, confirm your own entry by name rather than
+trusting the summary line:
+
+```bash
+grep -n "your-memory-file-name" .serena/memories/memory-index.md
+uv run --frozen python scripts/update_memory_index_tokens.py
+```
+
+The token-count script is the second half of the step. A new row written by hand
+carries a placeholder count until it runs.
+
+## What it cost
+
+Commit `478d3a906` shipped `decision-shallow-fetch-kills-merge-base-in-ci.md`
+with no index row. Every validator was green. It was caught by reading the diff,
+not by any gate, and needed a follow-up commit.
+
+## Related
+
+`.serena/memories/find-coverage-by-mutation-not-by-name.md` is the same shape
+one level up: a name-based check answers whether a spelling exists, not whether
+the guarantee does. Here the validator checks that every named entry resolves to
+a file, which says nothing about whether every file has an entry.

--- a/.serena/memories/memory-index-validator-checks-one-direction-only.md
+++ b/.serena/memories/memory-index-validator-checks-one-direction-only.md
@@ -57,9 +57,10 @@ carries a placeholder count until it runs.
 
 ## What it cost
 
-Commit `478d3a906` shipped `decision-shallow-fetch-kills-merge-base-in-ci.md`
-with no index row. Every validator was green. It was caught by reading the diff,
-not by any gate, and needed a follow-up commit.
+Commit `478d3a906` shipped a memory file with no index row. Every validator was
+green. It was caught by reading the diff, not by any gate, and needed a
+follow-up commit. (That file, `decision-shallow-fetch-kills-merge-base-in-ci.md`,
+ships with PR #4572 and is not on `main` until that lands.)
 
 ## Related
 

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -81,7 +81,8 @@
 |edit file read search replace text operation: [patterns/edit-001-read-before-edit-pattern](patterns/edit-001-read-before-edit-pattern.md) (464), [patterns/edit-002-unique-context-for-edit-matching](patterns/edit-002-unique-context-for-edit-matching.md) (368)
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (287)
-|git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (738)
+|git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
+|git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1113)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)
 |cva refactoring variant consolidation template generate: [utilities/utilities-cva-refactoring](utilities/utilities-cva-refactoring.md) (1251)
@@ -106,6 +107,7 @@
 |context engineering token optimization progressive disclosure just-in-time: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)
 |passive context AGENTS.md skills decision-point retrieval-led compression: [memory/passive-context-vs-skills-vercel-research](memory/passive-context-vs-skills-vercel-research.md) (447), [claude/claude-md-anthropic-best-practices](claude/claude-md-anthropic-best-practices.md) (683), [claude/claude-code-skills-official-guidance](claude/claude-code-skills-official-guidance.md) (623)
 |instruction budget always-on ceiling applyTo scope headroom rule authoring: [decision-the-instruction-budget-gate-already-exists](decision-the-instruction-budget-gate-already-exists.md) (1856)
+|memory index validator one direction unindexed orphan check non-recursive opt-in warn only passes clean: [memory-index-validator-checks-one-direction-only](memory-index-validator-checks-one-direction-only.md) (693)
 
 [Root Cause Patterns (PR #908)]
 |governance enforcement ADR limits commits files programmatic gate: [root-cause-governance-enforcement](root-cause-governance-enforcement.md) (603)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -82,7 +82,7 @@
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (287)
 |git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
-|git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1113)
+|git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)
 |cva refactoring variant consolidation template generate: [utilities/utilities-cva-refactoring](utilities/utilities-cva-refactoring.md) (1251)
@@ -107,7 +107,7 @@
 |context engineering token optimization progressive disclosure just-in-time: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)
 |passive context AGENTS.md skills decision-point retrieval-led compression: [memory/passive-context-vs-skills-vercel-research](memory/passive-context-vs-skills-vercel-research.md) (447), [claude/claude-md-anthropic-best-practices](claude/claude-md-anthropic-best-practices.md) (683), [claude/claude-code-skills-official-guidance](claude/claude-code-skills-official-guidance.md) (623)
 |instruction budget always-on ceiling applyTo scope headroom rule authoring: [decision-the-instruction-budget-gate-already-exists](decision-the-instruction-budget-gate-already-exists.md) (1856)
-|memory index validator one direction unindexed orphan check non-recursive opt-in warn only passes clean: [memory-index-validator-checks-one-direction-only](memory-index-validator-checks-one-direction-only.md) (693)
+|memory index validator one direction unindexed orphan check non-recursive opt-in warn only passes clean: [memory-index-validator-checks-one-direction-only](memory-index-validator-checks-one-direction-only.md) (719)
 
 [Root Cause Patterns (PR #908)]
 |governance enforcement ADR limits commits files programmatic gate: [root-cause-governance-enforcement](root-cause-governance-enforcement.md) (603)

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -2446,6 +2446,31 @@ def _check_no_grafts(repo_root: Path) -> int:
     return 2
 
 
+def _shallow_file(repo_root: Path) -> Path:
+    """Path to `shallow`, which git keeps in the *common* directory.
+
+    `repo_root / ".git" / "shallow"` only resolves in a primary clone. In a
+    linked worktree `.git` is a pointer file, so that path names a child of a
+    file and never exists; in a submodule it points into `.git/modules/<name>`.
+    Asking git keeps all three shapes correct and leaves the shared-versus
+    per-worktree routing where it belongs, with git.
+
+    It matters here because `shallow` is shared: one depth-limited fetch in any
+    worktree grafts every worktree at once, and this repository routinely runs
+    dozens of them. That sharing is contractual, not incidental:
+    gitrepository-layout(5) states the file "is ignored if $GIT_COMMON_DIR is
+    set and $GIT_COMMON_DIR/shallow will be used instead."
+    """
+    result = _run_git(repo_root, ["rev-parse", "--git-path", "shallow"])
+    lines = result.stdout.splitlines()
+    if result.returncode != 0 or len(lines) != 1 or not lines[0]:
+        return repo_root / ".git" / "shallow"
+    shallow_path = Path(lines[0])
+    if not shallow_path.is_absolute():
+        shallow_path = repo_root / shallow_path
+    return shallow_path
+
+
 def _check_history_integrity(repo_root: Path) -> int:
     shallow_result = _run_git(repo_root, ["rev-parse", "--is-shallow-repository"])
     if shallow_result.returncode != 0:
@@ -2456,17 +2481,18 @@ def _check_history_integrity(repo_root: Path) -> int:
         print(f"ERROR: unexpected shallow repository state: {shallow_state}", file=sys.stderr)
         return 2
     if shallow_state == "true":
-        shallow_file = repo_root / ".git" / "shallow"
+        shallow_file = _shallow_file(repo_root)
         pin_sha = ""
         if shallow_file.is_file():
             first_line = shallow_file.read_text(encoding="utf-8").splitlines()
             pin_sha = first_line[0].strip() if first_line else ""
-        pin_detail = f"  .git/shallow pins history at {pin_sha}." if pin_sha else ""
+        pin_detail = f"{shallow_file} pins history at {pin_sha}." if pin_sha else ""
         print(
             "ERROR: push validation requires complete Git history."
             + (f"\n  {pin_detail}" if pin_detail else "")
             + "\n  A `git fetch --depth=<n>` made this clone shallow,"
             " most likely while reproducing a CI step locally."
+            "\n  Shared across every worktree, so the fetch may have been in another one."
             "\n  Fix: git fetch --unshallow origin",
             file=sys.stderr,
         )

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -7251,19 +7251,26 @@ def test_graft_check_fails_closed_on_git_and_read_errors(
 
 def _git_fake(
     shallow_path: str,
-    shallow: str = "true\n",
+    shallow: subprocess.CompletedProcess[str] | None = None,
 ) -> Callable[..., subprocess.CompletedProcess[str]]:
     """An arg-aware `_run_git` stand-in.
 
     The arg-blind `lambda *_args: _completed(0, "true\\n")` these tests used
     is what let issue #4576 through: it answered every query with the shallow
-    verdict, so a second query could not be observed to be wrong.
+    verdict, so a second query could not be observed to be wrong. Worse, it
+    fed that verdict to the path lookup as well, so `_shallow_file` resolved
+    `repo_root / "true"` and the tests passed only because `is_file()`
+    tolerates a path that does not exist.
+
+    `shallow_path` answers `rev-parse --git-path shallow`; `shallow` answers
+    `rev-parse --is-shallow-repository` and defaults to a shallow verdict.
     """
+    verdict = _completed(0, "true\n") if shallow is None else shallow
 
     def fake(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         if "shallow" in args:
             return _completed(0, f"{shallow_path}\n")
-        return _completed(0, shallow)
+        return verdict
 
     return fake
 
@@ -7283,7 +7290,7 @@ def test_history_integrity_rejects_shallow_or_unknown_state(
     result: subprocess.CompletedProcess[str],
     expected: int,
 ) -> None:
-    monkeypatch.setattr(policy, "_run_git", lambda *_args: result)
+    monkeypatch.setattr(policy, "_run_git", _git_fake(".git/shallow", shallow=result))
     monkeypatch.setattr(policy, "_check_no_grafts", lambda _root: 0)
 
     assert policy._check_history_integrity(tmp_path) == expected
@@ -7295,11 +7302,7 @@ def test_history_integrity_shallow_message_names_remedy(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Shallow clone error must name the fix command (issue #4086)."""
-    monkeypatch.setattr(
-        policy,
-        "_run_git",
-        lambda *_args: _completed(0, "true\n"),
-    )
+    monkeypatch.setattr(policy, "_run_git", _git_fake(".git/shallow"))
 
     assert policy._check_history_integrity(tmp_path) == 2
 

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from datetime import UTC, datetime, tzinfo
 from pathlib import Path
 from typing import Any, NoReturn, Self, cast
@@ -7249,6 +7249,25 @@ def test_graft_check_fails_closed_on_git_and_read_errors(
     assert policy._check_no_grafts(tmp_path) == 2
 
 
+def _git_fake(
+    shallow_path: str,
+    shallow: str = "true\n",
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """An arg-aware `_run_git` stand-in.
+
+    The arg-blind `lambda *_args: _completed(0, "true\\n")` these tests used
+    is what let issue #4576 through: it answered every query with the shallow
+    verdict, so a second query could not be observed to be wrong.
+    """
+
+    def fake(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if "shallow" in args:
+            return _completed(0, f"{shallow_path}\n")
+        return _completed(0, shallow)
+
+    return fake
+
+
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
@@ -7299,17 +7318,145 @@ def test_history_integrity_shallow_message_names_pin_sha(
     shallow_file.parent.mkdir(parents=True, exist_ok=True)
     shallow_file.write_text(f"{pin}\n", encoding="utf-8")
 
-    monkeypatch.setattr(
-        policy,
-        "_run_git",
-        lambda *_args: _completed(0, "true\n"),
-    )
+    monkeypatch.setattr(policy, "_run_git", _git_fake(".git/shallow"))
 
     assert policy._check_history_integrity(tmp_path) == 2
 
     err = capsys.readouterr().err
     assert pin in err
     assert "git fetch --unshallow origin" in err
+
+
+def test_history_integrity_names_pin_sha_from_a_linked_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The pin SHA must survive the worktree shape (issue #4576).
+
+    In a linked worktree `<root>/.git` is a pointer file, not a directory, so
+    the old `repo_root / ".git" / "shallow"` named a child of a file and never
+    existed. The guard still blocked, but silently dropped the one line that
+    says where the graft is, in exactly the layout this repository runs dozens
+    of. `shallow` lives in the common directory, which is shared, so the graft
+    is usually not even from the worktree you are standing in.
+
+    Built on a real worktree with real git rather than a hand-made pointer
+    file, so the path resolution itself is under test. A hardcoded fake would
+    pass with the wrong `rev-parse` flag; this does not.
+    """
+    repo = tmp_path / "repo"
+    linked = tmp_path / "linked"
+    _init_repo(repo)
+    _commit_file(repo, "source.py", "value = 1\n")
+    _git(repo, "worktree", "add", "-q", "-b", "feature/linked", str(linked))
+    assert (linked / ".git").is_file(), "fixture must reproduce the pointer-file shape"
+
+    common_dir = Path(_git(linked, "rev-parse", "--git-common-dir").stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = (linked / common_dir).resolve()
+    pin = "b" * 40
+    _write_lf(common_dir / "shallow", f"{pin}\n")
+
+    real_run_git = policy._run_git
+
+    def fake(root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if "--is-shallow-repository" in args:
+            return _completed(0, "true\n")
+        return real_run_git(root, args)
+
+    monkeypatch.setattr(policy, "_run_git", fake)
+
+    assert policy._check_history_integrity(linked) == 2
+
+    err = capsys.readouterr().err
+    assert pin in err, "pin SHA dropped in a worktree"
+    assert str(common_dir / "shallow") in err
+    assert "every worktree" in err
+    assert "git fetch --unshallow origin" in err
+
+
+def test_history_integrity_distrusts_stdout_when_the_path_lookup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-zero rc makes stdout untrustworthy, so fall back to the clone shape.
+
+    Written as a discriminating input on purpose. An empty-stdout failure
+    cannot tell the rc guard apart from the malformed-output guard below it,
+    so such a test would pass with either one deleted. Garbage on stdout
+    separates them: without the rc check the guard reads `<root>/junk`, finds
+    nothing, and drops the pin line.
+    """
+    pin = "c" * 40
+    shallow_file = tmp_path / ".git" / "shallow"
+    shallow_file.parent.mkdir(parents=True)
+    shallow_file.write_text(f"{pin}\n", encoding="utf-8")
+
+    def fake(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if "shallow" in args:
+            return _completed(128, "junk\n", "fatal: not a git repository\n")
+        return _completed(0, "true\n")
+
+    monkeypatch.setattr(policy, "_run_git", fake)
+
+    assert policy._check_history_integrity(tmp_path) == 2
+
+    err = capsys.readouterr().err
+    assert pin in err, "fallback dropped the pin when the lookup failed"
+    assert "git fetch --unshallow origin" in err
+
+
+def test_history_integrity_distrusts_malformed_path_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A zero rc with output that is not one path is still untrustworthy.
+
+    Discriminating on the line count specifically: rc is zero here, so only
+    the `len(lines) != 1` clause can produce the fallback that recovers the
+    pin. `_check_no_grafts` guards the same shape 30 lines above.
+    """
+    pin = "d" * 40
+    shallow_file = tmp_path / ".git" / "shallow"
+    shallow_file.parent.mkdir(parents=True)
+    shallow_file.write_text(f"{pin}\n", encoding="utf-8")
+
+    def fake(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if "shallow" in args:
+            return _completed(0, "junk/one\njunk/two\n")
+        return _completed(0, "true\n")
+
+    monkeypatch.setattr(policy, "_run_git", fake)
+
+    assert policy._check_history_integrity(tmp_path) == 2
+
+    err = capsys.readouterr().err
+    assert pin in err, "fallback dropped the pin on malformed output"
+
+
+def test_history_integrity_survives_a_failed_path_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A broken `rev-parse --git-path` must not stop the guard from blocking.
+
+    Degrading to the primary-clone path costs the pin line; swallowing the
+    verdict would let a shallow clone push.
+    """
+
+    def fake(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if "shallow" in args:
+            return _completed(128, "", "fatal: not a git repository\n")
+        return _completed(0, "true\n")
+
+    monkeypatch.setattr(policy, "_run_git", fake)
+
+    assert policy._check_history_integrity(tmp_path) == 2
+    assert "git fetch --unshallow origin" in capsys.readouterr().err
 
 
 def test_push_update_defense_blocks_protected_destination(


### PR DESCRIPTION
Fixes #4576

## The defect

`_check_history_integrity` blocks a push when the clone is shallow, and prints the SHA that pins the truncated history so you know what to repair. It built the path to `shallow` as `repo_root / ".git" / "shallow"`.

That only resolves in a primary clone. In a linked worktree `<root>/.git` is an ~82 byte pointer file, so the expression names a *child of a regular file*, `.is_file()` is False, and the pin line is silently dropped.

The guard still blocks. Only the diagnostic disappears, and it disappears in exactly the layout where the cause is hardest to work out by hand, because `shallow` lives in the common directory shared by every worktree, so the graft is usually not from the worktree you are standing in. Confirmed against a real blocked push from `wt-shallowfix`, where no pin line appeared while the graft sat in the primary clone pinned at `81a2a7469`.

## The fix

Ask git for the path instead of building it. `scripts/validation/git_hook_policy.py` grows a `_shallow_file()` helper, and `_check_history_integrity` prints the full resolved path.

```python
result = _run_git(repo_root, ["rev-parse", "--git-path", "shallow"])
```

This is the idiom `_check_no_grafts` already uses 30 lines above with `--git-path info/grafts`. The first version of this PR used `--git-common-dir`, which also works, but was a bespoke near duplicate of a canonical helper already in the file.

Verified on all three repository shapes on git 2.43.0:

| Shape | `rev-parse --git-path shallow` |
|---|---|
| linked worktree (and from a subdirectory) | absolute, into the shared common dir |
| primary clone | relative `.git/shallow`, resolved against `repo_root` |
| submodule | absolute, into `<main>/.git/modules/<name>/shallow` |

Resolving a relative result against `repo_root` is correct by construction, not by luck: `_run_command` passes `cwd=repo_root`.

The routing is documented, not incidental. `gitrepository-layout(5)` says of `shallow`: "This file is ignored if `$GIT_COMMON_DIR` is set and `$GIT_COMMON_DIR/shallow` will be used instead." It also names `info/grafts` as the sibling mechanism, which is why one idiom fits both. `git-worktree(5)` gives the matching directive: do not look inside `$GIT_DIR` directly, use `git-rev-parse`.

Parsing the pointer file by hand was rejected because it needs shape specific logic. A worktree pointer needs `/worktrees/<name>` stripped to reach the common dir; a submodule pointer names a path that *is* the common dir, with nothing to strip.

The error text now also says the shallow state is shared, since the first instinct on seeing it is to audit the wrong worktree.

## Tests

The existing fakes monkeypatched `_run_git` arg blind:

```python
monkeypatch.setattr(policy, "_run_git", lambda *_args: _completed(0, "true\n"))
```

Every git call got the shallow verdict, so a second call could not be observed to be wrong. That is the shape of fake that let this ship. They are arg aware now.

The worktree test builds a real repository and a real linked worktree with `git worktree add`, writes a real `shallow` into the real common directory, and forces only `--is-shallow-repository`, delegating everything else to the real `_run_git`. The path resolution is therefore under test rather than compared against a hardcoded string. An earlier draft used a hand built pointer file; it could not catch a wrong git flag, and the rewrite can.

Four mutations, each failing a distinct test:

| Mutation | Result |
|---|---|
| revert to `repo_root / ".git" / "shallow"` | worktree test fails |
| swap `--git-path shallow` to `--git-dir` | 3 tests fail |
| drop the `returncode != 0` clause | lookup failure test fails |
| drop the `len(lines) != 1` clause | malformed output test fails |

Two of those clauses were untested speculative code when written. The first draft of the return code test could not discriminate its own mutation, because empty stdout reaches the `or ".git"` default identically; it needed *garbage* on stdout to separate "the guard exists" from "the default exists."

## Deliberate non-changes

`_check_no_grafts` hard fails with exit 2 when its path lookup fails; this helper falls back to the old expression. The asymmetry is the point. There, the lookup decides whether the guard blocks, so failing closed is correct. Here, exit 2 is already decided by `--is-shallow-repository` before the helper is called, so a failed lookup can only cost a diagnostic line, and converting it to a different error would replace a precise message with a vaguer one.

That neighbour also calls `.resolve()` on its relative branch and this does not. `Path.is_file()` already follows symlinks, probed directly, so `.resolve()` could only change the printed string. Adding it without a test that discriminates it would ship exactly the speculative code this PR removed elsewhere.

`ruff format` fails on both changed files, and on `origin/main` for the same files. No gate runs it. Not reformatted.

## Memories

- `git/git-shallow-is-shared-across-every-worktree.md`, new, cross linked to the shared stash sibling as the same family.
- `memory-index-validator-checks-one-direction-only.md`, new. The validator walks index to file only, so an unindexed memory passes clean. Verified by probe, not inferred: two unindexed files, one top level and one in a subdirectory, both produced `Result: PASSED`, and `--fix-orphans` missed both. It is opt in, warn only, non recursive, and prefix scoped. Its `Files: 305 indexed` counts entries in the 33 domain indices, not the 948 files on disk, so a stable count across an edit proves nothing. That gap is what let commit `478d3a906` ship an unindexed memory with every gate green.
- `git/git-stash-is-shared-across-every-worktree.md`, corrected: a `/tmp/scratch` path violating the scratch convention, plus the incident where its own author reached for `git stash` to check a lint baseline within the hour, with three foreign stashes on the shared stack.

## Adversarial review

Reviewed on a different model family. The reviewer independently reached the same `gitrepository-layout(5)` sentence quoted above, and endorsed the soft fallback here against the hard fail in `_check_no_grafts` on the grounds that the graft lookup decides whether the guard blocks while this lookup cannot. Two findings, both fixed in `9618bd04d`:

1. Two memory citations named a file that exists only on this branch. Both now name pull request #4572, which cannot dangle. This mattered more than it first looked: `.github/workflows/memory-validation.yml` treats invalid citations as non blocking, so a dangling reference merges silently and no gate reports it.

2. Two of the four `history_integrity` fakes answered the path query without reading their arguments. Both now route through the arg aware `_git_fake`. Re running the four mutation battery after that change, the wrong flag mutation fails 4 tests where it previously failed 3. The tolerant fake had fed `true` into the path lookup and passed only because `is_file()` tolerates a nonexistent path, hiding a defect in a neighbouring test.

## Verification

807 tests pass, 10 in the `history_integrity` family. `ruff check` clean. Dash gate clean. Memory index PASSED. Taste lints report 3 errors in `tests/test_lefthook_integration.py`, all pre existing on `main` and none added by this change. All 15 pre push gates green, including `python-tests` at 969s.
