### PR TITLE
fix(ci): un-shallow the bot-skip checkout so merge-tree works on bot PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -235,6 +235,21 @@ jobs:
       - name: Checkout repository for workflow validation
         if: steps.should-run.outputs.skip == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Issue #4518 follow-up: this checkout must match the `fetch-depth: 0`
+          # on the primary checkout above. It is the only checkout a bot PR ever
+          # gets, and the `Run merge-tree ratchet` step later in this same job
+          # needs a merge base. A default checkout writes .git/shallow, and a
+          # plain `git fetch origin "$BASE_REF"` does not remove it, so
+          # merge-tree aborts with "refusing to merge unrelated histories"
+          # (rc 128) on every Renovate and Dependabot PR.
+          #
+          # Measured 2026-08-04 on #4552 (run 30944714371) and #4569
+          # (run 30939418867), both after the full-depth fetch landed: the
+          # fetch line was already `git fetch origin "$BASE_REF"` and both
+          # still failed rc 128. Human PRs take the fetch-depth: 0 checkout
+          # above and pass, which is why the failure looked bot-specific.
+          fetch-depth: 0
 
       - name: Setup uv for workflow validation
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -1039,3 +1039,70 @@ def test_merge_tree_ratchet_fetches_base_at_full_depth() -> None:
                 f"step {step.get('name')!r} fetches the base shallowly ({line!r}); "
                 "merge-tree needs a merge base. See issue #4518."
             )
+
+
+def _merge_tree_job() -> dict:
+    """Return the job that runs the merge-tree ratchet step."""
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []) or []:
+            if "merge_tree_ratchet_check.py" in (step.get("run") or ""):
+                return job
+    raise AssertionError(
+        "no job in pr-validation.yml runs merge_tree_ratchet_check.py"
+    )
+
+
+def _checkout_steps(job: dict) -> list[dict]:
+    return [
+        s
+        for s in (job.get("steps", []) or [])
+        if "actions/checkout" in (s.get("uses") or "")
+    ]
+
+
+def test_every_checkout_in_the_merge_tree_job_is_unshallow() -> None:
+    """Issue #4518 follow-up: the bot-skip checkout was shallow.
+
+    The job carries two checkouts. The first sets ``fetch-depth: 0``. The second
+    is guarded by ``if: steps.should-run.outputs.skip == 'true'`` and fires only
+    when the bot-skip guard suppressed the first one, which is exactly what
+    happens on a Renovate or Dependabot PR. It originally carried no ``with:``
+    block at all, so a bot PR got a depth-1 checkout.
+
+    A shallow *checkout* is not repaired by a full *fetch*. ``.git/shallow``
+    survives ``git fetch origin <base>``, so merge-tree still aborts rc 128.
+    Measured on #4552 (run 30944714371) and #4569 (run 30939418867): both ran
+    the already-fixed full-depth fetch line and both still failed.
+
+    Asserting on the fetch line alone cannot catch this, which is why the
+    sibling test above passed while bot PRs stayed red.
+    """
+    job = _merge_tree_job()
+    checkouts = _checkout_steps(job)
+    assert checkouts, "the merge-tree job must check out the repository"
+    for step in checkouts:
+        depth = (step.get("with") or {}).get("fetch-depth")
+        assert depth == 0, (
+            f"checkout step {step.get('name') or '<unnamed>'!r} in the merge-tree "
+            f"job has fetch-depth={depth!r}; merge-tree needs full history on "
+            "every path into this job, including the bot-skip path. "
+            "See issue #4518."
+        )
+
+
+def test_the_merge_tree_job_has_a_conditional_second_checkout() -> None:
+    """Negative control for the guard above.
+
+    If the bot-skip checkout is ever deleted, the assertion above starts passing
+    vacuously: one checkout, already correct, nothing to catch. This test fails
+    in that case so the deletion is a deliberate decision rather than a silent
+    weakening of the guard.
+    """
+    job = _merge_tree_job()
+    conditional = [s for s in _checkout_steps(job) if s.get("if")]
+    assert conditional, (
+        "the merge-tree job no longer has a conditional checkout. If the "
+        "bot-skip path was removed on purpose, delete this test and "
+        "test_every_checkout_in_the_merge_tree_job_is_unshallow together."
+    )


### PR DESCRIPTION
# Pull Request

## Summary

### What

The merge-tree ratchet job aborts `rc 128` on Renovate and Dependabot PRs even after the full-depth fetch added by PR #4567 landed on main. This adds `fetch-depth: 0` to the second, conditional checkout in that job, plus a guard that walks every checkout step rather than only the fetch line.

### Why

`pr-validation.yml` has two `actions/checkout` steps in the same job. The primary one already carried `fetch-depth: 0`. The second is guarded by `if: steps.should-run.outputs.skip == 'true'` and had no `with:` block at all, so it took the action default of `fetch-depth: 1`.

That guard fires only when the bot-skip path suppressed the first checkout, which in practice means only Renovate and Dependabot PRs. Those are exactly the PRs still failing.

A shallow clone is not repaired by fetching one ref. `.git/shallow` survives `git fetch origin <base>`, the graft points stay, and `git merge-tree` still aborts on the truncated graph. The fetch fixed *missing base ref*; it did not fix *shallow*.

## Changes

- `.github/workflows/pr-validation.yml`: add `fetch-depth: 0` to the conditional bot-skip checkout, with the measured run IDs in the comment.
- `tests/ci/test_pr_validation_workflow.py`: add `test_every_checkout_in_the_merge_tree_job_is_unshallow`, which walks every checkout step in the job, and `test_the_merge_tree_job_has_a_conditional_second_checkout` as a negative control so the guard cannot pass vacuously if the bot-skip path is ever deleted.

## Evidence

Measured failures after PR #4567 merged to main:

| PR | Result |
|---|---|
| 4552 | merge-tree ratchet `rc 128` |
| 4569 | merge-tree ratchet `rc 128` |

**The guard fails against the unfixed workflow and passes with the fix.** Reverting only the workflow change and running the new guard:

```
AssertionError: checkout step 'Checkout repository for workflow validation' in the
merge-tree job has fetch-depth=None; merge-tree needs full history on every path
into this job, including the bot-skip path.
1 failed, 53 deselected
```

Restoring the fix: `54 passed`.

Why the pre-existing test could not catch this: `test_merge_tree_ratchet_fetches_base_at_full_depth` asserts on the fetch line, which was correct both before and after. It had no way to observe the second checkout.

**Required validation, all exit code 0:**

| Command | Result |
|---|---|
| `pytest tests/ci/test_pr_validation_workflow.py` | 54 passed |
| `pytest tests/ci/test_merge_tree_ratchet_check.py` | 17 passed |
| `validate_workflows.py` | All validations passed |

## Checklist

- [x] Tests added for the change
- [x] Guard proven to fail without the fix
- [x] No new warnings introduced

Refs #4518
