### PR TITLE
fix(scripts): repoint new_validated_pr at the surviving PR script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,15 +104,18 @@ Creates a PR with all guardrails enforced.
 
 **Usage**:
 
+Titles must follow conventional commit format. That check runs before
+`--skip-validation` is considered, so the flag does not bypass it.
+
 ```bash
 # Normal PR (runs validations)
 uv run --frozen python -m scripts.new_validated_pr --title "feat: Add feature" --body "Description"
 
 # Draft PR
-uv run --frozen python -m scripts.new_validated_pr --title "WIP: Feature" --draft
+uv run --frozen python -m scripts.new_validated_pr --title "feat: Add feature" --draft
 
 # Force mode (creates audit trail)
-uv run --frozen python -m scripts.new_validated_pr --title "hotfix" --skip-validation --audit-reason "hotfix"
+uv run --frozen python -m scripts.new_validated_pr --title "fix: Restore login" --skip-validation --audit-reason "hotfix"
 
 # Interactive mode
 uv run --frozen python -m scripts.new_validated_pr --web

--- a/scripts/new_validated_pr.py
+++ b/scripts/new_validated_pr.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Create a validated PR with all guardrails enforced.
 
-Wrapper around the New-PR skill that provides a convenient interface for
-creating PRs with validation. Delegates to the skill for better cohesion.
+Wrapper around the `new_pr` skill script that provides a convenient interface
+for creating PRs with validation. Delegates to the skill for better cohesion.
 
 EXIT CODES:
   0  - Success
@@ -19,11 +19,19 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from scripts.github_core.repo import get_repo_root
 
+SKILL_RELPATH = Path(".claude/skills/github/scripts/pr/new_pr.py")
+"""Dispatch target, relative to the repo root.
 
-def main(argv: list[str] | None = None) -> int:
+Exported so tests can assert the wrapper points at a script that exists rather
+than restating the path and drifting from it.
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Create a validated PR with guardrails")
     parser.add_argument("--title", default="", help="PR title in conventional commit format")
     parser.add_argument("--body", default="", help="PR description body")
@@ -36,7 +44,49 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--skip-validation", action="store_true", help="Skip validation checks")
     parser.add_argument("--audit-reason", default="", help="Reason for skipping validation")
-    args = parser.parse_args(argv)
+    return parser
+
+
+def _run_web_mode(base: str) -> int:
+    """Hand off to `gh pr create --web`, which needs a browser and so refuses in CI."""
+    is_ci = os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")
+    if is_ci or not os.environ.get("DISPLAY"):
+        print("ERROR: Web mode not available in CI or headless environments", file=sys.stderr)
+        return 2
+
+    gh_args = ["gh", "pr", "create", "--web"]
+    if base:
+        gh_args.extend(["--base", base])
+
+    sys.stdout.flush()
+    return subprocess.run(gh_args).returncode
+
+
+def _build_skill_args(skill_script: Path, args: argparse.Namespace) -> list[str]:
+    """Translate this wrapper's flags into the target script's command line."""
+    skill_args = [
+        sys.executable, str(skill_script),
+        "--title", args.title, "--base", args.base,
+    ]
+
+    if args.head:
+        skill_args.extend(["--head", args.head])
+    if args.body:
+        skill_args.extend(["--body", args.body])
+    if args.body_file:
+        skill_args.extend(["--body-file", args.body_file])
+    if args.draft:
+        skill_args.append("--draft")
+    if args.skip_validation:
+        skill_args.append("--skip-validation")
+        if args.audit_reason:
+            skill_args.extend(["--audit-reason", args.audit_reason])
+
+    return skill_args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
 
     repo_root = get_repo_root()
     if not repo_root:
@@ -48,47 +98,19 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.web:
-        is_ci = os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")
-        if is_ci or not os.environ.get("DISPLAY"):
-            print("ERROR: Web mode not available in CI or headless environments", file=sys.stderr)
-            return 2
-        gh_args = ["gh", "pr", "create", "--web"]
-        if args.base:
-            gh_args.extend(["--base", args.base])
-        sys.stdout.flush()
-        result = subprocess.run(gh_args)
-        return result.returncode
+        return _run_web_mode(args.base)
 
     if not args.title:
         print("ERROR: Title required (use --title or --web)", file=sys.stderr)
         return 2
 
-    skill_script = repo_root / ".claude" / "skills" / "github" / "scripts" / "pr" / "New-PR.ps1"
+    skill_script = repo_root / SKILL_RELPATH
     if not skill_script.exists():
         print(f"ERROR: PR creation skill not found: {skill_script}", file=sys.stderr)
         return 2
 
-    skill_args = [
-        "pwsh", "-NoProfile", "-File", str(skill_script),
-        "-Title", args.title, "-Base", args.base,
-    ]
-
-    if args.head:
-        skill_args.extend(["-Head", args.head])
-    if args.body:
-        skill_args.extend(["-Body", args.body])
-    if args.body_file:
-        skill_args.extend(["-BodyFile", args.body_file])
-    if args.draft:
-        skill_args.append("-Draft")
-    if args.skip_validation:
-        skill_args.append("-SkipValidation")
-        if args.audit_reason:
-            skill_args.extend(["-AuditReason", args.audit_reason])
-
     sys.stdout.flush()
-    result = subprocess.run(skill_args)
-    return result.returncode
+    return subprocess.run(_build_skill_args(skill_script, args)).returncode
 
 
 if __name__ == "__main__":

--- a/tests/test_new_validated_pr.py
+++ b/tests/test_new_validated_pr.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import argparse
-import importlib.util
 import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -252,25 +252,41 @@ class TestFlagContractWithRealTarget:
     """
 
     @staticmethod
-    def _real_target_parser() -> argparse.ArgumentParser:
-        """Load the actual dispatch target and return its real parser.
+    def _target_accepted_flags(cwd: Path) -> frozenset[str]:
+        """Return the options the real target accepts, read from its own --help.
 
-        new_pr.py inserts its own directory onto sys.path at import time to
-        reach a sibling module. That mutation would outlive this test and make
-        those siblings importable everywhere else in the suite, so sys.path is
-        snapshotted and restored.
+        Deliberately a subprocess. Importing new_pr.py in this process would run
+        its top level, which inserts its own directory onto sys.path and imports
+        `validate_pr_description` under that bare name. Two different modules
+        carry that name, `.claude/skills/github/scripts/pr/` and
+        `src/copilot-cli/skills/github/scripts/pr/`, so the import would pin one
+        of them in sys.modules for the rest of the session and hand any later
+        importer the wrong tree's copy. Restoring sys.path does not undo that.
+        In a repo whose premise is those two trees staying in sync, a leak that
+        silently substitutes one for the other is worse than the drift this
+        class exists to catch.
+
+        Reading --help rather than calling build_parser() also pins the parser
+        the script actually runs. A build_parser() left behind as dead code
+        after main() starts building its own would still answer an in-process
+        call, and the contract would break at runtime with the suite green.
+
+        argparse answers --help and exits before the script does any work, so
+        this cannot reach `gh pr create` or touch the repository.
         """
         target = REPO_ROOT / SKILL_RELPATH
-        spec = importlib.util.spec_from_file_location("_flag_contract_new_pr", target)
-        assert spec is not None
-        assert spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        saved_path = list(sys.path)
-        try:
-            spec.loader.exec_module(module)
-        finally:
-            sys.path[:] = saved_path
-        return module.build_parser()
+        result = subprocess.run(
+            [sys.executable, str(target), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+        )
+        assert result.returncode == 0, (
+            f"{SKILL_RELPATH} could not answer --help "
+            f"(exit {result.returncode}): {result.stderr}"
+        )
+        return frozenset(re.findall(r"--[a-z][a-z0-9-]*", result.stdout))
 
     @staticmethod
     def _emitted_flags(argv: list[str]) -> list[str]:
@@ -278,17 +294,20 @@ class TestFlagContractWithRealTarget:
         args = _build_parser().parse_args(argv)
         return _build_skill_args(Path("unused.py"), args)[2:]
 
-    def test_target_still_exposes_a_parser_to_check_against(self) -> None:
+    def test_help_extraction_finds_the_targets_flags(self, tmp_path: Path) -> None:
         """Guards the check itself.
 
-        The two contract tests below are only meaningful while the target keeps
-        a parser they can interrogate. If build_parser is renamed or removed,
-        _real_target_parser raises AttributeError and this fails loudly, rather
-        than the contract silently degrading into an assertion about nothing.
+        The two contract tests below compare against whatever this extraction
+        returns. If --help stopped listing options, or the pattern stopped
+        matching, they would report every emitted flag as unknown rather than
+        passing on an empty set, so the failure is loud either way. This test
+        exists to say which of the two broke.
         """
-        assert isinstance(self._real_target_parser(), argparse.ArgumentParser)
+        accepted = self._target_accepted_flags(tmp_path)
+        assert "--help" in accepted
+        assert "--title" in accepted
 
-    def test_target_accepts_the_maximal_flag_set(self) -> None:
+    def test_target_accepts_the_maximal_flag_set(self, tmp_path: Path) -> None:
         emitted = self._emitted_flags(
             [
                 "--title", "fix: t", "--base", "release", "--head", "topic",
@@ -296,18 +315,23 @@ class TestFlagContractWithRealTarget:
                 "--skip-validation", "--audit-reason", "hotfix",
             ],
         )
-        parsed = self._real_target_parser().parse_args(emitted)
-        assert parsed.title == "fix: t"
-        assert parsed.base == "release"
-        assert parsed.head == "topic"
-        assert parsed.body == "text"
-        assert parsed.body_file == "b.md"
-        assert parsed.draft is True
-        assert parsed.skip_validation is True
-        assert parsed.audit_reason == "hotfix"
+        self._assert_all_accepted(emitted, self._target_accepted_flags(tmp_path))
 
-    def test_target_accepts_the_minimal_flag_set(self) -> None:
+    def test_target_accepts_the_minimal_flag_set(self, tmp_path: Path) -> None:
         emitted = self._emitted_flags(["--title", "fix: t"])
-        parsed = self._real_target_parser().parse_args(emitted)
-        assert parsed.title == "fix: t"
-        assert parsed.base == "main"
+        self._assert_all_accepted(emitted, self._target_accepted_flags(tmp_path))
+
+    @staticmethod
+    def _assert_all_accepted(emitted: list[str], accepted: frozenset[str]) -> None:
+        """Compare by set membership, never by substring.
+
+        `--body` is a substring of `--body-file`. A containment check against
+        the raw help text would keep passing after `--body` was removed, which
+        is the same silent pass this class exists to prevent.
+        """
+        unknown = [a for a in emitted if a.startswith("--") and a not in accepted]
+        assert not unknown, (
+            f"wrapper emits {unknown}, which {SKILL_RELPATH} does not accept; "
+            f"it accepts {sorted(accepted)}"
+        )
+

--- a/tests/test_new_validated_pr.py
+++ b/tests/test_new_validated_pr.py
@@ -43,12 +43,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # staying in sync, a leak that substitutes one for the other is worse than the
 # drift this test exists to catch.
 _PARSER_PROBE = r"""
-import argparse, json, runpy, subprocess, sys
+import argparse, json, os, runpy, subprocess, sys
 
-target = sys.argv[1]
+target = os.path.realpath(sys.argv[1])
+_real_parse_args = argparse.ArgumentParser.parse_args
 
 
 def _capture(self, args=None, namespace=None):
+    # Only the target's own parser counts. Patching parse_args globally would
+    # otherwise capture a parser built by an imported dependency and report its
+    # flags as the target's. Nothing in the current import chain parses at
+    # import time, but a future one might, and it would fail silently.
+    caller = sys._getframe(1).f_globals.get("__file__", "")
+    if not caller or os.path.realpath(caller) != target:
+        return _real_parse_args(self, args, namespace)
     flags = sorted({s for action in self._actions for s in action.option_strings})
     sys.stdout.write("FLAGS_JSON:" + json.dumps(flags) + "\n")
     raise SystemExit(0)
@@ -58,7 +66,7 @@ def _blocked(*args, **kwargs):
     raise SystemExit(f"probe blocked a subprocess call before parse_args: {args[:1]!r}")
 
 
-# main() parses before it does anything else, so the capture below fires first.
+# main() parses before it does anything else, so the capture above fires first.
 # If that ever stops being true, fail loudly here instead of running `gh pr
 # create` from a test.
 subprocess.run = _blocked

--- a/tests/test_new_validated_pr.py
+++ b/tests/test_new_validated_pr.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +19,59 @@ from scripts.new_validated_pr import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Runs the dispatch target far enough to reach its parser, captures the flags
+# argparse itself agreed to accept, and exits before the target does any work.
+#
+# Asking argparse rather than reading --help text is the whole point. Help
+# output interleaves option declarations with prose, so any pattern over it
+# counts a flag named inside a description ("replaces the deprecated
+# --body-file") as accepted, and the contract test passes after that flag is
+# gone. `_actions[].option_strings` is argparse's own registry of what parses.
+#
+# Intercepting parse_args rather than importing build_parser() pins the parser
+# main() actually runs. A build_parser() left behind as dead code after main()
+# started building its own would still answer a direct call, and the contract
+# would break at runtime with the suite green.
+#
+# A subprocess rather than an in-process import: new_pr.py's top level inserts
+# its own directory onto sys.path and imports `validate_pr_description` under
+# that bare name. Two modules carry that name, one under .claude/ and one under
+# src/copilot-cli/, so an in-process import pins one in sys.modules for the
+# rest of the session and hands any later importer the wrong tree's copy.
+# Restoring sys.path does not undo that. In a repo whose premise is those trees
+# staying in sync, a leak that substitutes one for the other is worse than the
+# drift this test exists to catch.
+_PARSER_PROBE = r"""
+import argparse, json, runpy, subprocess, sys
+
+target = sys.argv[1]
+
+
+def _capture(self, args=None, namespace=None):
+    flags = sorted({s for action in self._actions for s in action.option_strings})
+    sys.stdout.write("FLAGS_JSON:" + json.dumps(flags) + "\n")
+    raise SystemExit(0)
+
+
+def _blocked(*args, **kwargs):
+    raise SystemExit(f"probe blocked a subprocess call before parse_args: {args[:1]!r}")
+
+
+# main() parses before it does anything else, so the capture below fires first.
+# If that ever stops being true, fail loudly here instead of running `gh pr
+# create` from a test.
+subprocess.run = _blocked
+subprocess.Popen = _blocked
+subprocess.check_output = _blocked
+subprocess.check_call = _blocked
+argparse.ArgumentParser.parse_args = _capture
+
+sys.argv = [target]
+runpy.run_path(target, run_name="__main__")
+raise SystemExit("target finished without calling parse_args")
+"""
+_FLAGS_SENTINEL = "FLAGS_JSON:"
 
 
 def _fake_repo_with_skill(root: Path) -> Path:
@@ -253,40 +306,35 @@ class TestFlagContractWithRealTarget:
 
     @staticmethod
     def _target_accepted_flags(cwd: Path) -> frozenset[str]:
-        """Return the options the real target accepts, read from its own --help.
+        """Return the options the real target's parser accepts.
 
-        Deliberately a subprocess. Importing new_pr.py in this process would run
-        its top level, which inserts its own directory onto sys.path and imports
-        `validate_pr_description` under that bare name. Two different modules
-        carry that name, `.claude/skills/github/scripts/pr/` and
-        `src/copilot-cli/skills/github/scripts/pr/`, so the import would pin one
-        of them in sys.modules for the rest of the session and hand any later
-        importer the wrong tree's copy. Restoring sys.path does not undo that.
-        In a repo whose premise is those two trees staying in sync, a leak that
-        silently substitutes one for the other is worse than the drift this
-        class exists to catch.
-
-        Reading --help rather than calling build_parser() also pins the parser
-        the script actually runs. A build_parser() left behind as dead code
-        after main() starts building its own would still answer an in-process
-        call, and the contract would break at runtime with the suite green.
-
-        argparse answers --help and exits before the script does any work, so
-        this cannot reach `gh pr create` or touch the repository.
+        Reads argparse's own action registry through _PARSER_PROBE rather than
+        parsing --help text; see that constant for why each of those three
+        choices (argparse over text, interception over build_parser, subprocess
+        over import) is load-bearing.
         """
         target = REPO_ROOT / SKILL_RELPATH
         result = subprocess.run(
-            [sys.executable, str(target), "--help"],
+            [sys.executable, "-c", _PARSER_PROBE, str(target)],
             capture_output=True,
             text=True,
             check=False,
             cwd=cwd,
         )
-        assert result.returncode == 0, (
-            f"{SKILL_RELPATH} could not answer --help "
-            f"(exit {result.returncode}): {result.stderr}"
+        line = next(
+            (
+                one
+                for one in result.stdout.splitlines()
+                if one.startswith(_FLAGS_SENTINEL)
+            ),
+            None,
         )
-        return frozenset(re.findall(r"--[a-z][a-z0-9-]*", result.stdout))
+        assert line is not None, (
+            f"parser probe did not reach {SKILL_RELPATH}'s parse_args "
+            f"(exit {result.returncode}). stdout: {result.stdout!r} "
+            f"stderr: {result.stderr!r}"
+        )
+        return frozenset(json.loads(line[len(_FLAGS_SENTINEL) :]))
 
     @staticmethod
     def _emitted_flags(argv: list[str]) -> list[str]:
@@ -294,14 +342,14 @@ class TestFlagContractWithRealTarget:
         args = _build_parser().parse_args(argv)
         return _build_skill_args(Path("unused.py"), args)[2:]
 
-    def test_help_extraction_finds_the_targets_flags(self, tmp_path: Path) -> None:
+    def test_probe_reaches_the_targets_real_parser(self, tmp_path: Path) -> None:
         """Guards the check itself.
 
-        The two contract tests below compare against whatever this extraction
-        returns. If --help stopped listing options, or the pattern stopped
-        matching, they would report every emitted flag as unknown rather than
-        passing on an empty set, so the failure is loud either way. This test
-        exists to say which of the two broke.
+        The two contract tests below compare against whatever this probe
+        returns. If the probe stopped reaching parse_args it would assert on the
+        missing sentinel, and if it reached a parser with no options the two
+        tests would report every emitted flag as unknown, so the failure is loud
+        either way. This test exists to say which of the two broke.
         """
         accepted = self._target_accepted_flags(tmp_path)
         assert "--help" in accepted
@@ -323,11 +371,11 @@ class TestFlagContractWithRealTarget:
 
     @staticmethod
     def _assert_all_accepted(emitted: list[str], accepted: frozenset[str]) -> None:
-        """Compare by set membership, never by substring.
+        """Compare by set membership against argparse's registry, never by text.
 
-        `--body` is a substring of `--body-file`. A containment check against
-        the raw help text would keep passing after `--body` was removed, which
-        is the same silent pass this class exists to prevent.
+        `--body` is a substring of `--body-file`, so a containment check against
+        raw help output would keep passing after `--body` was removed. Set
+        membership over option_strings has no such hole.
         """
         unknown = [a for a in emitted if a.startswith("--") and a not in accepted]
         assert not unknown, (

--- a/tests/test_new_validated_pr.py
+++ b/tests/test_new_validated_pr.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
+import importlib.util
 import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from scripts.github_core.repo import get_repo_root
-from scripts.new_validated_pr import SKILL_RELPATH, _run_web_mode, main
+from scripts.new_validated_pr import (
+    SKILL_RELPATH,
+    _build_parser,
+    _build_skill_args,
+    _run_web_mode,
+    main,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -224,3 +232,82 @@ class TestDispatch:
     ) -> None:
         exit_code, _ = self._run(mock_root, tmp_path, ["--title", "fix: t"], returncode=1)
         assert exit_code == 1
+
+
+class TestFlagContractWithRealTarget:
+    """Every flag this wrapper emits must be one the real target accepts.
+
+    TestDispatchTargetExists pins *which* script runs. This pins that the
+    command line handed to that script actually parses. The two failures are
+    independent: the target can exist, be the right file, and still reject the
+    arguments, which is exactly what happens the moment new_pr.py renames a
+    flag.
+
+    Nothing else in this file can catch that. Every dispatch test mocks
+    subprocess.run, so the argument list is asserted against string literals in
+    this file and never reaches a real parser. A rename in new_pr.py would leave
+    all of them green and fail only at runtime, which is the same class of
+    silent cross-script drift that let the wrapper dispatch to a deleted
+    New-PR.ps1 for months.
+    """
+
+    @staticmethod
+    def _real_target_parser() -> argparse.ArgumentParser:
+        """Load the actual dispatch target and return its real parser.
+
+        new_pr.py inserts its own directory onto sys.path at import time to
+        reach a sibling module. That mutation would outlive this test and make
+        those siblings importable everywhere else in the suite, so sys.path is
+        snapshotted and restored.
+        """
+        target = REPO_ROOT / SKILL_RELPATH
+        spec = importlib.util.spec_from_file_location("_flag_contract_new_pr", target)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        saved_path = list(sys.path)
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.path[:] = saved_path
+        return module.build_parser()
+
+    @staticmethod
+    def _emitted_flags(argv: list[str]) -> list[str]:
+        """Return the args the wrapper would hand the target, without argv[0:2]."""
+        args = _build_parser().parse_args(argv)
+        return _build_skill_args(Path("unused.py"), args)[2:]
+
+    def test_target_still_exposes_a_parser_to_check_against(self) -> None:
+        """Guards the check itself.
+
+        The two contract tests below are only meaningful while the target keeps
+        a parser they can interrogate. If build_parser is renamed or removed,
+        _real_target_parser raises AttributeError and this fails loudly, rather
+        than the contract silently degrading into an assertion about nothing.
+        """
+        assert isinstance(self._real_target_parser(), argparse.ArgumentParser)
+
+    def test_target_accepts_the_maximal_flag_set(self) -> None:
+        emitted = self._emitted_flags(
+            [
+                "--title", "fix: t", "--base", "release", "--head", "topic",
+                "--body", "text", "--body-file", "b.md", "--draft",
+                "--skip-validation", "--audit-reason", "hotfix",
+            ],
+        )
+        parsed = self._real_target_parser().parse_args(emitted)
+        assert parsed.title == "fix: t"
+        assert parsed.base == "release"
+        assert parsed.head == "topic"
+        assert parsed.body == "text"
+        assert parsed.body_file == "b.md"
+        assert parsed.draft is True
+        assert parsed.skip_validation is True
+        assert parsed.audit_reason == "hotfix"
+
+    def test_target_accepts_the_minimal_flag_set(self) -> None:
+        emitted = self._emitted_flags(["--title", "fix: t"])
+        parsed = self._real_target_parser().parse_args(emitted)
+        assert parsed.title == "fix: t"
+        assert parsed.base == "main"

--- a/tests/test_new_validated_pr.py
+++ b/tests/test_new_validated_pr.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from scripts.github_core.repo import get_repo_root
-from scripts.new_validated_pr import main
+from scripts.new_validated_pr import SKILL_RELPATH, _run_web_mode, main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fake_repo_with_skill(root: Path) -> Path:
+    """Create a repo-shaped tree containing the dispatch target."""
+    skill = root / SKILL_RELPATH
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text("")
+    return skill
 
 
 class TestGetRepoRoot:
@@ -20,6 +32,91 @@ class TestGetRepoRoot:
     def test_returns_none_on_failure(self, mock_run: MagicMock) -> None:
         mock_run.return_value = MagicMock(returncode=128, stdout="")
         assert get_repo_root() is None
+
+
+class TestDispatchTargetExists:
+    """Reads the real tree instead of a mocked repo root.
+
+    Every other test in this file points the repo root at an empty tmp_path, so
+    the dispatch target is missing by construction and exit 2 is the expected
+    result. That shape stayed green for the whole time the wrapper pointed at
+    New-PR.ps1, which PR #1144 deleted during the PowerShell to Python
+    migration. Mocking the filesystem cannot detect a dispatch target that
+    stopped existing, so this test does not mock it.
+    """
+
+    def test_dispatch_target_exists_in_this_repo(self) -> None:
+        target = REPO_ROOT / SKILL_RELPATH
+        assert target.is_file(), f"wrapper dispatches to a missing script: {target}"
+
+    def test_dispatch_target_is_the_expected_script(self) -> None:
+        """Pin the identity, not just the existence.
+
+        Existence alone is a weak guard: repointing SKILL_RELPATH at any other
+        real script in the same directory, say close_pr.py, keeps the existence
+        assertion green while the wrapper silently dispatches to the wrong
+        command. Restating the literal here is the point rather than a
+        duplication smell, because the pair catches both failures: this test
+        fails on a wrong target, and the existence test fails on a deleted one.
+        """
+        assert SKILL_RELPATH == Path(".claude/skills/github/scripts/pr/new_pr.py")
+
+    def test_dispatch_target_is_not_powershell(self) -> None:
+        assert SKILL_RELPATH.suffix == ".py", "ADR-042: new scripts are Python"
+
+
+class TestWebMode:
+    """Covers the `--web` branch, which dispatches to gh rather than to a script.
+
+    This path was extracted into _run_web_mode during the complexity refactor
+    and had no coverage at the time, so nothing would have caught a mistake in
+    the extraction.
+    """
+
+    @patch.dict(os.environ, {"CI": "true", "DISPLAY": ":0"}, clear=True)
+    def test_refuses_in_ci(self) -> None:
+        assert _run_web_mode("main") == 2
+
+    @patch.dict(os.environ, {"GITHUB_ACTIONS": "true", "DISPLAY": ":0"}, clear=True)
+    def test_refuses_under_github_actions(self) -> None:
+        assert _run_web_mode("main") == 2
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_refuses_when_headless(self) -> None:
+        assert _run_web_mode("main") == 2
+
+    @patch("scripts.new_validated_pr.subprocess.run")
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_invokes_gh_with_base(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        assert _run_web_mode("develop") == 0
+        assert mock_run.call_args[0][0] == [
+            "gh", "pr", "create", "--web", "--base", "develop",
+        ]
+
+    @patch("scripts.new_validated_pr.subprocess.run")
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_omits_base_when_empty(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        _run_web_mode("")
+        assert mock_run.call_args[0][0] == ["gh", "pr", "create", "--web"]
+
+    @patch("scripts.new_validated_pr.subprocess.run")
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_propagates_gh_exit_code(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=7)
+        assert _run_web_mode("main") == 7
+
+    @patch("scripts.new_validated_pr.subprocess.run")
+    @patch("scripts.new_validated_pr.shutil.which", return_value="/usr/bin/gh")
+    @patch("scripts.new_validated_pr.get_repo_root", return_value=Path("/fake"))
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_main_routes_web_without_requiring_a_title(
+        self, _repo: MagicMock, _which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        assert main(["--web"]) == 0
+        assert mock_run.call_args[0][0][:4] == ["gh", "pr", "create", "--web"]
 
 
 class TestMain:
@@ -45,3 +142,85 @@ class TestMain:
     ) -> None:
         mock_root.return_value = tmp_path
         assert main(["--title", "test: title"]) == 2
+
+
+@patch("scripts.new_validated_pr.shutil.which", return_value="/usr/bin/gh")
+@patch("scripts.new_validated_pr.get_repo_root")
+class TestDispatch:
+    """Success path. None of this was covered before."""
+
+    @staticmethod
+    def _run(
+        mock_root: MagicMock, tmp_path: Path, argv: list[str], returncode: int = 0
+    ) -> tuple[int, list[str]]:
+        skill = _fake_repo_with_skill(tmp_path)
+        mock_root.return_value = tmp_path
+        with patch("scripts.new_validated_pr.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=returncode)
+            exit_code = main(argv)
+            assert mock_run.call_args is not None
+            command = list(mock_run.call_args[0][0])
+        assert command[1] == str(skill)
+        return exit_code, command
+
+    def test_invokes_the_python_skill_with_the_current_interpreter(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        exit_code, command = self._run(mock_root, tmp_path, ["--title", "fix: t"])
+        assert exit_code == 0
+        assert command[0] == sys.executable
+
+    def test_does_not_invoke_powershell(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        _, command = self._run(mock_root, tmp_path, ["--title", "fix: t"])
+        assert "pwsh" not in command
+        assert not any(arg.endswith(".ps1") for arg in command)
+
+    def test_passes_title_and_default_base(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        _, command = self._run(mock_root, tmp_path, ["--title", "fix: t"])
+        assert command[command.index("--title") + 1] == "fix: t"
+        assert command[command.index("--base") + 1] == "main"
+
+    def test_omits_optional_flags_when_unset(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        _, command = self._run(mock_root, tmp_path, ["--title", "fix: t"])
+        for flag in ("--head", "--body", "--body-file", "--draft", "--skip-validation"):
+            assert flag not in command
+
+    def test_forwards_every_optional_flag(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        _, command = self._run(
+            mock_root,
+            tmp_path,
+            [
+                "--title", "fix: t", "--base", "release", "--head", "topic",
+                "--body", "text", "--body-file", "b.md", "--draft",
+                "--skip-validation", "--audit-reason", "hotfix",
+            ],
+        )
+        assert command[command.index("--base") + 1] == "release"
+        assert command[command.index("--head") + 1] == "topic"
+        assert command[command.index("--body") + 1] == "text"
+        assert command[command.index("--body-file") + 1] == "b.md"
+        assert command[command.index("--audit-reason") + 1] == "hotfix"
+        assert "--draft" in command
+        assert "--skip-validation" in command
+
+    def test_audit_reason_is_dropped_without_skip_validation(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        _, command = self._run(
+            mock_root, tmp_path, ["--title", "fix: t", "--audit-reason", "hotfix"]
+        )
+        assert "--audit-reason" not in command
+
+    def test_propagates_a_nonzero_exit_code(
+        self, mock_root: MagicMock, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        exit_code, _ = self._run(mock_root, tmp_path, ["--title", "fix: t"], returncode=1)
+        assert exit_code == 1


### PR DESCRIPTION
## Summary

`scripts/new_validated_pr.py` had been dead since PR #1144. It dispatched to `.claude/skills/github/scripts/pr/New-PR.ps1`, which that PR deleted during the PowerShell to Python migration. Every non-`--web` invocation returned exit 2 with "PR creation skill not found".

This repoints it at the surviving `new_pr.py`, translates the PowerShell-style flags to their Python equivalents, and rebuilds the test suite so the same failure cannot recur silently.

Files:

- `scripts/new_validated_pr.py`
- `tests/test_new_validated_pr.py`
- `scripts/README.md`

## Why no test caught a permanently broken script

All six original tests either mocked `subprocess.run` or pointed `get_repo_root` at an empty `tmp_path`.

The critical one is `test_exits_2_when_skill_not_found`. It asserted exit 2 against a directory that could never contain the script. So it passed, correctly, for the entire time the wrapper was broken. **Mocking the filesystem cannot detect a dispatch target that stopped existing.** A healthy wrapper and a permanently dead one produced identical test output.

The 2026-07-02 safety audit had already flagged this module as "referenced only by its own test" without identifying the cause.

## Tests: 6 to 26

Three new classes, each closing a failure the old suite was structurally blind to.

| Class | Closes |
|---|---|
| `TestDispatchTargetExists` | Resolves the target against the **real tree**, not a mock. Pins the literal path *and* its existence. |
| `TestWebMode` | The `--web` branch, which had zero coverage. |
| `TestFlagContractWithRealTarget` | Runs the real target in a subprocess and reads the flags **argparse itself registered**, then checks the wrapper's emitted flags against that set. |

Two of these came directly from adversarial review, described below.

Existence alone is a weak guard. Repointing at any other real script in the same directory, say `close_pr.py`, keeps an existence-only assertion green while dispatching the wrong command. Identity and existence are separate failures, so the suite asserts both.

The flag contract is the same defect one level down. Every dispatch test mocks `subprocess.run`, so the emitted argument list is only ever compared against string literals in the test file and never reaches a real parser. A flag rename in `new_pr.py` would leave the whole suite green and fail only at runtime, which is the original bug moved from the script path to the flags.

## The contract test's first two designs were both wrong

Worth recording, because both looked correct and one shipped for two rounds of review.

**Design 1, parse the target's `--help` output.** Unsound. argparse interleaves option declarations with prose, so a flag merely *named* in another flag's description counts as accepted. This is live in the shipped help text: `--audit-reason` reads "Required when `--skip-validation` is used". Deleting the `--skip-validation` argument entirely left the help-text check still reporting it accepted. A silent pass on a real deletion.

**Design 2, anchor the regex to line starts.** This was the reviewer's proposed fix. It is worse than plainly wrong, because it is terminal-width dependent: measured False at `COLUMNS` 80, 60, 52, and 48, and **True at 44 and 40**. argparse wraps prose to the terminal, so a wrapped line can begin with a flag. A test that passes locally and fails only where `COLUMNS` is narrow or unset will not reproduce.

The reviewer's own `--body-file` example did not reproduce either. argparse had wrapped it as `--body-` + newline + `file`, so the original regex missed it by luck of the wrap column rather than by design. The mechanism they identified was real; that specific instance was not.

**Design 3, shipped.** A subprocess probe intercepts `ArgumentParser.parse_args`, reads `_actions[].option_strings`, and exits before the target does any work. No prose to misread, so the whole class of defect is gone rather than narrowed.

Three choices in it are load-bearing:

- **Intercepting `parse_args` rather than calling `build_parser()`.** This pins the parser `main()` actually runs. A `build_parser()` left as dead code after `main()` started building its own would still answer a direct call, so the contract would break at runtime with the suite green. That is the original bug again.
- **A subprocess rather than an in-process import.** `new_pr.py` puts its own directory on `sys.path` and imports `validate_pr_description` under a bare name. Two modules in this repo carry that name, so an in-process import pins one in `sys.modules` for the rest of the session. Restoring `sys.path` does not undo it. Verified: `LEAKED MODULES: []`.
- **A calling-frame check.** The probe patches `parse_args` globally, so a dependency that parses at import time would otherwise be captured instead. Proved by making one do so: without the check the probe returned `["--decoy-flag", "--help", "-h"]`.

The probe also blocks `subprocess.run`, `Popen`, `check_output`, and `check_call`. `main()` parses before it does anything else today; if that stops being true the probe dies loudly instead of running `gh pr create` from a test.

Every failure mode fails loudly. Verified by mutating the target to `parse_known_args`: 3 failed, 23 passed, with the target's stderr embedded in the assertion message.

## Verified by mutation, not by assertion count

Each defect was restored and the suite confirmed red.

| Mutation | Result |
|---|---|
| pre-fix wrapper restored | 8 of 15 failed (pre-expansion) |
| repoint at a nonexistent `.py` | 1 failed |
| repoint at `New-PR.ps1` | 3 failed |
| repoint at `close_pr.py`, a real script | 1 failed, the identity pin |
| neutralize the web-mode env guard | 3 failed, the three refusal tests |
| target switched to `parse_known_args` | 3 failed, target stderr surfaced in the message |
| delete the `--skip-validation` argument | probe failed; the help-text design had passed silently |
| wrapper emits `--reviewer`, a flag the target lacks | **2 failed, both contract tests, 24 mocked tests stayed green** |

The last row is the one that matters most. It demonstrates the mocked tests are *incapable* of seeing flag drift and the contract tests are the only thing that can. The failure names the cause and enumerates the truth:

```
wrapper emits ['--reviewer'], which .claude/skills/github/scripts/pr/new_pr.py
does not accept; it accepts ['--audit-reason', '--base', '--body', '--body-file',
'--draft', '--head', '--help', '--skip-validation', '--title', '-h']
```

## Complexity

`main` measured 14 against the taste-lint ceiling of 10. That is pre-existing, measured at 14 both before and after the dispatch fix, but it is the same function this change rewrites, so it is repaired here rather than left behind.

Split along seams it already had: `_build_parser`, `_run_web_mode` (3), `_build_skill_args` (7), `main` (6).

The web-mode tests exist partly because that extraction would otherwise have had no coverage to preserve.

## README correction

`scripts/README.md` carried two unrunnable examples, `--title "WIP: Feature"` and `--title "hotfix" --skip-validation`. Both are rejected: `new_pr.py:639` runs `validate_conventional_commit` unconditionally, *before* the `--skip-validation` branch at line 647. `--skip-validation` does not skip the title check. Examples corrected and the ordering documented.

## Review

Adversarially reviewed across five rounds against `gemini-3.1-pro-preview`, a different model family than the author.

| Round | Verdict | Substance |
|---|---|---|
| 1 | BLOCKED | Importing `SKILL_RELPATH` into its own test buys existence, not identity. `_run_web_mode` had zero coverage, so "behavior preserving, evidenced by passing tests" rested on nothing for that path. |
| 2 to 3 | Iterating | Flag-contract test added, then found to leak `sys.modules` entries into the session. |
| 4 | BLOCKED | The help-text regex counts a flag named in prose as accepted. Correct diagnosis; the proposed fix was defective, see above. |
| 5 | SHIP | "Exceptionally robust." Every failure mode confirmed loud. |

It also caught two factual errors in the original commit messages (the old suite had six tests, not five). Both were verified against `git show` before correcting, and the history was squashed to remove the inaccurate messages.

Both fixes the reviewer proposed contained real defects, so each was tested rather than applied. The round 4 verdict was correct and the round 4 remedy was not; that gap is why design 3 exists.

## Validation

- 26 passed
- ruff clean, mypy clean
- every function under the complexity ceiling
- live dispatch confirmed end to end: the wrapper reaches `new_pr.py`, and `new_pr.py`'s own conventional-commit check fires on a bad title

Fixes #4594
Refs #2815
