### PR TITLE
docs: record that a push in flight owns its working tree

### DIFF
--- a/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
+++ b/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
@@ -97,9 +97,10 @@ That error is not real. `lefthook.yml` is byte identical across worktrees
 rejects duplicate mapping keys. So does the shared checkout's different copy.
 No production script writes `lefthook.yml`, it is absent from
 `GENERATOR-FILES.md`, and the tests that do write one are all scoped to
-`tmp_path`. The concrete writer behind the torn read stays unidentified; what
-is established is that the failure only appears when a second lefthook run
-overlaps a first, and that the config it complains about is valid.
+`tmp_path`. What is established is that the failure only appears when a second
+lefthook run overlaps a first, and that the config it complains about is valid.
+The writer class behind the torn read was later identified; see the next
+section.
 
 The first push then completed normally, `* [new branch] 191a73dd13e... ->
 docs/stale-checkout-tooling`, `PUSH_EXIT=0`. Roughly eight tool calls went into
@@ -117,6 +118,38 @@ git ls-remote origin refs/heads/"$BR"
 
 Never start a second push of a ref while the first is unresolved. Overlapping
 lefthook runs produce failures that describe the wrong subsystem.
+
+## A push in flight owns the working tree
+
+The pre-push chain runs for roughly eleven minutes against the **live working
+tree**, not against the pushed commit. Measured on one run: `pre-pr-validation`
+59s, `python-tests` 654s, plus generators and ratchets. Any file edited in that
+worktree during the window is read by the running chain.
+
+Two things follow, both observed in the same run:
+
+1. **The push fails.** A file mutated mid-flight for an unrelated experiment
+   left `python-tests (654.08 seconds)` then `PUSH_EXIT=1`. Eleven minutes
+   spent, nothing pushed, and the failure named a test rather than the edit.
+2. **Generated mirrors silently absorb the edit.**
+   `build/scripts/generate_skills.py` copies `.claude/skills/**` into
+   `src/copilot-cli/skills/**` (97 skills, 620 files written) straight from the
+   working tree. A mutation to `.claude/skills/github/scripts/pr/new_pr.py`
+   reappeared in `src/copilot-cli/skills/github/scripts/pr/new_pr.py` with no
+   command of mine having touched the mirror. Restoring only the source leaves
+   the mirror dirty, which then reads as unexplained drift.
+
+Ruled out individually as the writer, each with the mutation live and no push
+running: a scoped `pytest` of one file, `tests/build_scripts` (1555 passed),
+`scripts/validation/pre_pr.py`, and `build/scripts/build_all.py --check`. None
+touched the mirror. The generator does exactly this transformation on demand,
+so the class is proven even though the specific job inside the chain is not
+named.
+
+Rule: treat a worktree with a push in flight as read only. Mutation experiments
+belong in a different worktree, or after `PUSH_EXIT` is known. When a mirror
+turns up modified and no command of yours wrote it, check for a push in flight
+before hunting a generator bug.
 
 ## Generalization
 

--- a/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
+++ b/.serena/memories/git/git-empty-hook-run-means-an-empty-push.md
@@ -69,10 +69,73 @@ the wrongly pushed commit is an ancestor of the real one, a plain
 git merge-base --is-ancestor "$WRONG_SHA" HEAD && echo fast-forward-safe
 ```
 
+## The converse: absence from the remote is not failure
+
+The trap above is a push that finished carrying nothing. The mirror image is a
+push that is carrying something and has not finished yet.
+
+Because every pre-push step runs against the full suite, a real push here takes
+minutes, not seconds. The 660 second figure above is the reference point. So
+for the first ten-plus minutes of any genuine push, the branch is absent from
+the remote, and that absence looks exactly like a failure.
+
+Measured 2026-08-05. An async push of a two file memory branch was still
+running. `git ls-remote origin refs/heads/docs/stale-checkout-tooling` returned
+empty. Reading that as failure, a second push of the same ref was launched from
+the same worktree while the first was still in flight. The second one died on:
+
+```text
+Error: yaml: unmarshal errors:
+  line 424: mapping key "timeout" already defined at line 417
+  line 425: mapping key "run" already defined at line 418
+  line 426: mapping key "glob" already defined at line 421
+error: failed to push some refs
+```
+
+That error is not real. `lefthook.yml` is byte identical across worktrees
+(`md5 ddf7726679a84c0c09d3de3c39504b99`) and parses clean under a loader that
+rejects duplicate mapping keys. So does the shared checkout's different copy.
+No production script writes `lefthook.yml`, it is absent from
+`GENERATOR-FILES.md`, and the tests that do write one are all scoped to
+`tmp_path`. The concrete writer behind the torn read stays unidentified; what
+is established is that the failure only appears when a second lefthook run
+overlaps a first, and that the config it complains about is valid.
+
+The first push then completed normally, `* [new branch] 191a73dd13e... ->
+docs/stale-checkout-tooling`, `PUSH_EXIT=0`. Roughly eight tool calls went into
+investigating a config bug that did not exist.
+
+The check is the shell's own exit status, not the remote:
+
+```bash
+# right: ask the process that is doing the work
+read_bash <shellId>          # wait for PUSH_EXIT
+
+# wrong while a push is in flight: absence here proves nothing
+git ls-remote origin refs/heads/"$BR"
+```
+
+Never start a second push of a ref while the first is unresolved. Overlapping
+lefthook runs produce failures that describe the wrong subsystem.
+
 ## Generalization
+
+Three different measurements get confused for one another, and the workflow
+supplies them in the least useful order.
+
+| Question | Signal that answers it | Signal that does not |
+|---|---|---|
+| Has the push finished? | the shell's exit status | the remote ref, absent until it lands |
+| Did the push succeed? | `PUSH_EXIT=0` | elapsed time |
+| What did the push carry? | the hook summary, `rev-list --count` | `PUSH_EXIT=0` |
 
 `REAL_EXIT=0` answers whether the push finished, never what it carried.
 Completion and content are different measurements, and the push workflow
 supplies only the first. The hook summary is the cheapest content signal
 available for free: a run where nothing matched is a run where nothing was
 sent.
+
+Symmetrically, the remote answers what landed, never whether the work is still
+running. Polling a side channel for a result the primary channel has not
+produced yet invents failures, and acting on those invented failures creates
+real ones.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -92,7 +92,7 @@
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |agent steering system prompt renders from live checkout stale behind main detached superseded rule no gate catches: [git/git-checkout-drift-feeds-stale-agent-steering](git/git-checkout-drift-feeds-stale-agent-steering.md) (943)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
-|push skips every hook empty range detached HEAD no commits between ls-remote absence not failure slow push still running concurrent lefthook bogus yaml duplicate key exit status not remote: [git/git-empty-hook-run-means-an-empty-push](git/git-empty-hook-run-means-an-empty-push.md) (1544)
+|push skips every hook empty range detached HEAD no commits between ls-remote absence not failure slow push still running concurrent lefthook bogus yaml duplicate key exit status not remote: [git/git-empty-hook-run-means-an-empty-push](git/git-empty-hook-run-means-an-empty-push.md) (1972)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)
 |cva refactoring variant consolidation template generate: [utilities/utilities-cva-refactoring](utilities/utilities-cva-refactoring.md) (1251)
 

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -92,6 +92,7 @@
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |agent steering system prompt renders from live checkout stale behind main detached superseded rule no gate catches: [git/git-checkout-drift-feeds-stale-agent-steering](git/git-checkout-drift-feeds-stale-agent-steering.md) (943)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
+|push skips every hook empty range detached HEAD no commits between ls-remote absence not failure slow push still running concurrent lefthook bogus yaml duplicate key exit status not remote: [git/git-empty-hook-run-means-an-empty-push](git/git-empty-hook-run-means-an-empty-push.md) (1544)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)
 |cva refactoring variant consolidation template generate: [utilities/utilities-cva-refactoring](utilities/utilities-cva-refactoring.md) (1251)
 


### PR DESCRIPTION
## Summary

Extends the existing `git-empty-hook-run-means-an-empty-push` memory with the converse trap and the mechanism behind it, and adds the memory to the root index, which had never listed it.

Files:

- `.serena/memories/git/git-empty-hook-run-means-an-empty-push.md`
- `.serena/memories/memory-index.md`

The memory already covered a push that finished carrying nothing. This adds the mirror image: a push that is carrying something and has not finished yet.

## The converse: absence from the remote is not failure

Every pre-push step runs the full suite, so a real push here takes minutes. For the first ten-plus minutes the branch is absent from the remote, and that absence looks exactly like a failure.

Measured 2026-08-05. An async push was still running. `git ls-remote origin refs/heads/docs/stale-checkout-tooling` returned empty. Reading that as failure, a second push of the same ref went out from the same worktree while the first was in flight. The second died on:

```text
Error: yaml: unmarshal errors:
  line 424: mapping key "timeout" already defined at line 417
```

That error is not real. `lefthook.yml` is byte identical across worktrees (`md5 ddf7726679a84c0c09d3de3c39504b99`) and parses clean under a loader that rejects duplicate mapping keys. No production script writes it, it is absent from `GENERATOR-FILES.md`, and every test that writes one is scoped to `tmp_path`. The first push then completed normally with `PUSH_EXIT=0`.

Roughly eight tool calls went into investigating a config bug that did not exist.

## A push in flight owns the working tree

The finding that explains the torn read above, and the reason it is worth a memory rather than a note.

The pre-push chain runs for roughly eleven minutes against the **live working tree**, not the pushed commit. Any file edited during that window is read by the running chain.

A clean A/B on one commit:

| Tree state during push | Result |
|---|---|
| a file mutated mid-flight | `python-tests (654.08s)`, `PUSH_EXIT=1` |
| clean | `python-tests (663.76s)`, `PUSH_EXIT=0` |

Same commit, same branch, same remote. Eleven minutes spent for nothing, and the failure named a test rather than the edit.

Second consequence, observed in the same run: `build/scripts/generate_skills.py` copies `.claude/skills/**` into `src/copilot-cli/skills/**` (97 skills, 620 files written) straight from the working tree. A mutation to `.claude/skills/github/scripts/pr/new_pr.py` reappeared in the Copilot mirror with no command of mine having touched it. Restoring only the source leaves the mirror dirty, which then reads as unexplained drift.

Ruled out individually as the writer, each with the mutation live and no push running:

| Candidate | Result |
|---|---|
| scoped `pytest` of the one file | mirror clean |
| `tests/build_scripts` (1555 passed) | mirror clean |
| `scripts/validation/pre_pr.py` | mirror clean |
| `build/scripts/build_all.py --check` | mirror clean |

Also ruled out: hardlinks (different inodes, link count 1) and conftest sync. The generator does exactly this transformation on demand, so the writer class is established. The specific job inside the chain is not named, and the memory says so rather than guessing.

This is the same root cause class as the bogus lefthook YAML error above: a concurrent hook chain reading and writing the live tree.

## Three measurements, supplied in the least useful order

| Question | Signal that answers it | Signal that does not |
|---|---|---|
| Has the push finished? | the shell's exit status | the remote ref, absent until it lands |
| Did the push succeed? | `PUSH_EXIT=0` | elapsed time |
| What did the push carry? | the hook summary, `rev-list --count` | `PUSH_EXIT=0` |

## The index entry

The memory has existed on disk without a root index entry. `scripts/validation/memory_index.py` validates index to disk only, so an entry missing in the other direction passes silently: 313 files indexed, 0 missing, PASSED, while this file was unreachable by index lookup.

Worth a separate issue; not fixed here to keep the change atomic.

## Validation

- `memory_index.py`: 33 domains passed, 313 files indexed, 0 missing, PASSED
- token count auto-staged by the hook, not hand-edited
- dash scan: 0 en dashes, 0 em dashes
- push: `e75575e34..282e92b44`, `PUSH_EXIT=0`

Refs #4506
