### PR TITLE
perf(test): avoid per-test Git subprocesses

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
 import subprocess
 import tempfile
 import uuid
 import warnings
 from collections.abc import Iterator
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -35,18 +36,20 @@ _REFLOG_EXPIRY_CONTINUATION_PATTERN = re.compile(r"^ \d+: -?\d+$")
 _SETUP_GIT_DIR_PREFIX = "setup: git_dir: "
 _SETUP_CWD_PREFIX = "setup: cwd: "
 
+
 def _git_env() -> dict[str, str]:
     blocked = _GIT_ENV_OVERRIDES | set(_TRACE_ENV_NAMES)
     return {key: value for key, value in os.environ.items() if key not in blocked}
 
 
 def _project_git_dir() -> Path:
+    """Project git dir: `.git/` itself, or the gitdir a worktree's `.git` file points at."""
     dot_git = PROJECT_ROOT / ".git"
-    if dot_git.is_dir():
-        return dot_git.resolve()
     try:
+        if stat.S_ISDIR(dot_git.stat().st_mode):
+            return dot_git.resolve()
         git_dir_line = dot_git.read_text(encoding="utf-8").strip()
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         raise OSError("could not resolve project git directory") from exc
     prefix = "gitdir:"
     if not git_dir_line.startswith(prefix):
@@ -55,6 +58,132 @@ def _project_git_dir() -> Path:
     if not git_dir.is_absolute():
         git_dir = PROJECT_ROOT / git_dir
     return git_dir.resolve()
+
+
+class _HeadFastPathUnresolvedError(Exception):
+    """Fast path cannot prove HEAD; caller falls back to `git rev-parse HEAD`."""
+
+
+_OBJECT_ID_PATTERN = re.compile(r"^[0-9a-f]{40}$|^[0-9a-f]{64}$")  # hex object id, man git-config
+_SYMBOLIC_HEAD_PATTERN = re.compile(r"^ref:\s*(\S+)$")  # e.g. "ref: refs/heads/main"
+
+# CWE-22, git-check-ref-format(1) rules 4 and 10: a ref name never contains ":" or "\"
+# anywhere. Rejecting both closes traversal forms `PurePosixPath` cannot see -- "\" segments
+# and UNC (`\\server\share`) -- plus Windows drive syntax (`C:\Windows`, `C:foo`), which
+# `PureWindowsPath.joinpath` would treat as a new anchor that discards the accumulated path.
+_UNSAFE_REF_NAME_CHARACTERS = frozenset("\\:")
+
+
+def _is_safe_ref_name(ref_name: str) -> bool:
+    """CWE-22 guard: accept only a `refs/heads/` branch target, before it is joined onto a
+    filesystem path. `man gitrepository-layout`'s `refs` entry lists `refs/bisect`,
+    `refs/rewritten`, and `refs/worktree` as per-worktree namespaces outside the shared
+    `common_dir` `_resolve_ref` reads from, so anything else falls back to Git as unproven.
+    """
+    if not ref_name.startswith("refs/heads/"):
+        return False
+    if any(character in ref_name for character in _UNSAFE_REF_NAME_CHARACTERS):
+        return False
+    candidate = PurePosixPath(ref_name)
+    return not candidate.is_absolute() and ".." not in candidate.parts
+
+
+def _fast_path_stat_mode(path: Path, error: str) -> int | None:
+    """`path`'s `stat().st_mode`, or None if absent.
+
+    Only `FileNotFoundError` means absent. `Path.exists()`/`is_dir()`/`is_file()` swallow every
+    `OSError` into False (`genericpath`, Python 3.14 stdlib), so an unreadable path would read
+    as "not there"; here any other `OSError` raises and the caller falls back to Git instead.
+    """
+    try:
+        return path.stat().st_mode
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise _HeadFastPathUnresolvedError(error) from exc
+
+
+def _read_optional_text(path: Path, error: str) -> str | None:
+    """`path`'s UTF-8 text, or None if absent (same absent/unreadable split as
+    `_fast_path_stat_mode`). Non-UTF-8 content (`UnicodeError`, e.g. `UnicodeDecodeError`) is
+    unproven, not absent: it raises rather than misreading foreign-encoded metadata as
+    missing."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError) as exc:
+        raise _HeadFastPathUnresolvedError(error) from exc
+
+
+def _common_git_dir(git_dir: Path) -> Path:
+    """Resolve `git_dir`'s shared ref-storage dir via its `commondir` file (linked worktrees)."""
+    raw = _read_optional_text(git_dir / "commondir", "could not read commondir file")
+    if raw is None:
+        return git_dir
+    if not (target := raw.strip()):
+        raise _HeadFastPathUnresolvedError("commondir file is empty")
+    common_dir = (git_dir / target).resolve()  # an absolute `target` replaces `git_dir`
+    mode = _fast_path_stat_mode(common_dir, "commondir target is not accessible")
+    if mode is None or not stat.S_ISDIR(mode):
+        raise _HeadFastPathUnresolvedError("commondir target does not exist")
+    return common_dir
+
+
+def _resolve_ref(common_dir: Path, ref_name: str) -> str | None:
+    """Object id for `ref_name`'s loose ref file; None only for a genuinely unborn ref.
+
+    Never scans `packed-refs`: this runs in every test's autouse fixture, and parsing it to
+    find one ref costs an O(n) scan of every packed ref per test. A `packed-refs` file
+    existing makes the ref unprovable here, so we raise and fall back to Git; no such file
+    proves the ref absent everywhere at O(1) -- legal unborn HEAD (`man gitrepository-layout`,
+    `HEAD`: "legal if the named branch name does not (yet) exist").
+    """
+    ref_path = common_dir.joinpath(*ref_name.split("/"))
+    content = _read_optional_text(ref_path, "could not read loose ref file")
+    if content is not None:
+        content = content.strip()
+        if not _OBJECT_ID_PATTERN.match(content):
+            raise _HeadFastPathUnresolvedError("loose ref file does not hold a plain object id")
+        return content
+    packed_refs_mode = _fast_path_stat_mode(common_dir / "packed-refs", "packed-refs unreadable")
+    if packed_refs_mode is not None:
+        raise _HeadFastPathUnresolvedError("ref may be packed; not scanning packed-refs")
+    return None
+
+
+def _direct_read_repo_head() -> str | None:
+    """Resolve HEAD via direct filesystem reads: no subprocess for proven cases.
+
+    Raises `_HeadFastPathUnresolvedError` for anything unproven (reftable, malformed data, a
+    packed-only ref, any read failure) so the caller falls back to `git rev-parse HEAD`; `None`
+    means legal unborn HEAD. The reftable check runs first because such repos keep a dummy
+    `refs/heads/.invalid` HEAD (reftable.adoc, git/git) that would otherwise misread as unborn.
+    """
+    try:
+        git_dir = _project_git_dir()
+    except OSError as exc:
+        raise _HeadFastPathUnresolvedError("could not resolve project git directory") from exc
+    common_dir = _common_git_dir(git_dir)
+    if _fast_path_stat_mode(common_dir / "reftable", "reftable directory unreadable") is not None:
+        raise _HeadFastPathUnresolvedError("repository uses reftable ref storage")
+    head_content = _read_optional_text(git_dir / "HEAD", "could not read HEAD file")
+    if head_content is None:
+        raise _HeadFastPathUnresolvedError("could not read HEAD file")
+    head_content = head_content.strip()
+
+    if _OBJECT_ID_PATTERN.match(head_content):
+        return head_content  # detached HEAD
+
+    symbolic_match = _SYMBOLIC_HEAD_PATTERN.match(head_content)
+    if symbolic_match is None:
+        raise _HeadFastPathUnresolvedError("HEAD file content is not a recognized shape")
+
+    ref_name = symbolic_match.group(1)
+    if not _is_safe_ref_name(ref_name):
+        raise _HeadFastPathUnresolvedError("HEAD ref name is not a safe refs/heads/ path")
+
+    return _resolve_ref(common_dir, ref_name)  # None => unborn HEAD
 
 
 def _run_git_capture(*args: str) -> subprocess.CompletedProcess[str] | None:
@@ -74,6 +203,10 @@ def _run_git_capture(*args: str) -> subprocess.CompletedProcess[str] | None:
 
 
 def _real_repo_head() -> str | None:
+    try:
+        return _direct_read_repo_head()
+    except _HeadFastPathUnresolvedError:
+        pass  # unproven case: fail closed to the subprocess, never guess.
     out = _run_git_capture("rev-parse", "HEAD")
     return out.stdout.strip() if out is not None and out.returncode == 0 else None
 
@@ -86,14 +219,7 @@ def _real_repo_head_subject() -> str:
 
 def _reflog_contains_action(action: str) -> bool:
     """Return whether the project HEAD reflog contains this per-test action."""
-    out = _run_git_capture(
-        "reflog",
-        "HEAD",
-        "--format=%gs",
-        f"--grep-reflog={action}",
-        "-n",
-        "1",
-    )
+    out = _run_git_capture("reflog", "HEAD", "--format=%gs", f"--grep-reflog={action}", "-n", "1")
     if out is None or out.returncode != 0:
         raise OSError("could not read project HEAD reflog")
     return bool(out.stdout.strip())
@@ -272,31 +398,24 @@ def _successful_symbolic_ref_updates_head(session: dict[str, object]) -> bool:
     return positionals is not None and len(positionals) == 2 and positionals[0] == "HEAD"
 
 
+def _is_project_git_dir(candidate: str, base: object) -> bool:
+    """Whether `candidate` -- absolute, or relative to `base` -- is the project git dir."""
+    root = Path(base) if isinstance(base, str) else PROJECT_ROOT
+    return (root / candidate).resolve() == _project_git_dir()
+
+
 def _session_targets_project(session: dict[str, object]) -> bool:
     worktree = session.get("worktree")
-    argv = session.get("argv")
-    project_root = PROJECT_ROOT.resolve()
-    if isinstance(worktree, str) and Path(worktree).resolve() == project_root:
+    if isinstance(worktree, str) and Path(worktree).resolve() == PROJECT_ROOT.resolve():
         return True
     setup_git_dir = session.get("git_dir")
-    if isinstance(setup_git_dir, str):
-        git_dir = Path(setup_git_dir)
-        if not git_dir.is_absolute():
-            cwd = session.get("cwd")
-            base = Path(cwd) if isinstance(cwd, str) else PROJECT_ROOT
-            git_dir = base / git_dir
-        if git_dir.resolve() == _project_git_dir():
-            return True
+    if isinstance(setup_git_dir, str) and _is_project_git_dir(setup_git_dir, session.get("cwd")):
+        return True
+    argv = session.get("argv")
     if not isinstance(argv, list):
         return False
     git_dir_argument = _git_dir_argument(argv)
-    if git_dir_argument is None:
-        return False
-    git_dir = Path(git_dir_argument)
-    if not git_dir.is_absolute():
-        base = Path(worktree) if isinstance(worktree, str) else PROJECT_ROOT
-        git_dir = base / git_dir
-    return git_dir.resolve() == _project_git_dir()
+    return git_dir_argument is not None and _is_project_git_dir(git_dir_argument, worktree)
 
 
 def _trace_has_project_head_mutation(trace_path: Path) -> bool:
@@ -376,11 +495,6 @@ def _guard_real_repo_head() -> Iterator[None]:
             else:
                 os.environ[name] = value
     try:
-        _check_head_change(
-            before,
-            _real_repo_head(),
-            reflog_action,
-            trace_path,
-        )
+        _check_head_change(before, _real_repo_head(), reflog_action, trace_path)
     finally:
         trace_path.unlink(missing_ok=True)

--- a/tests/head_guard_test_helpers.py
+++ b/tests/head_guard_test_helpers.py
@@ -1,0 +1,73 @@
+"""Shared fixtures for the pytest HEAD guard suites.
+
+``tests/test_pytest_head_guard.py`` (trace/reflog/attribution behavior) and
+``tests/test_pytest_head_fastpath.py`` (direct-read/path-safety fast path)
+both load the root ``conftest.py`` by path and drive real throwaway git
+repositories, so the loader and repo-builder helpers live here instead of
+being duplicated across the two files.
+
+Kept out of ``conftest.py`` because these helpers are specific to the HEAD
+guard suites; a generic name in the package-wide conftest would be visible
+to every test module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_root_conftest():
+    """Load the root ``conftest.py`` as a fresh, independent module object.
+
+    Each call re-executes the module so a test that monkeypatches it never
+    leaks state into another test's module instance.
+    """
+    path = Path(__file__).resolve().parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("root_conftest_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["root_conftest_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_git(repo: Path, *args: str, env=None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=10,
+    )
+    return result.stdout.strip()
+
+
+def _commit_file(repo: Path, content: str, message: str, env=None) -> str:
+    (repo / "file.txt").write_text(content, encoding="utf-8")
+    _run_git(repo, "add", "file.txt")
+    _run_git(
+        repo,
+        "-c",
+        "user.name=pytest",
+        "-c",
+        "user.email=pytest@example.invalid",
+        "commit",
+        "--quiet",
+        "-m",
+        message,
+        env=env,
+    )
+    return _run_git(repo, "rev-parse", "HEAD")
+
+
+def _init_git_repo(repo: Path) -> str:
+    repo.mkdir()
+    _run_git(repo, "init", "--quiet")
+    return _commit_file(repo, "initial\n", "initial")

--- a/tests/test_pytest_head_fastpath.py
+++ b/tests/test_pytest_head_fastpath.py
@@ -1,0 +1,454 @@
+"""Tests for the pytest HEAD guard's direct-read fast path (conftest.py).
+
+Trace/reflog/attribution behavior (`_check_head_change`,
+`_trace_has_project_head_mutation`, `_reflog_contains_action`, and the
+`_guard_real_repo_head` autouse fixture) lives in
+`tests/test_pytest_head_guard.py`; this file covers `_direct_read_repo_head`
+and its supporting path-safety helpers (`_is_safe_ref_name`, `_common_git_dir`,
+`_resolve_ref`, `_fast_path_stat_mode`, `_read_optional_text`,
+`_project_git_dir`).
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.head_guard_test_helpers import _init_git_repo, _load_root_conftest, _run_git
+
+pytestmark = pytest.mark.windows_path
+
+
+# ---------------------------------------------------------------------------
+# Direct-read fast path (`_direct_read_repo_head`): resolves HEAD from Git metadata with no
+# subprocess for proven cases, and raises `_HeadFastPathUnresolvedError` for anything it
+# cannot prove so the caller falls back to `git rev-parse HEAD`.
+# ---------------------------------------------------------------------------
+
+
+def _refuse_subprocess_run(monkeypatch) -> None:
+    """Fail the test if `subprocess.run` is invoked. Patches the stdlib module (not
+    `module.subprocess`) so the guard holds whichever module object performs the call."""
+
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("git subprocess.run was called; fast path should have handled this")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+
+def test_direct_read_repo_head_resolves_detached_head(tmp_path, monkeypatch):
+    """Positive: HEAD holding a plain object id (detached HEAD) resolves directly."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    head_sha = _init_git_repo(repo)
+    (repo / ".git" / "HEAD").write_text(f"{head_sha}\n", encoding="utf-8")
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+    _refuse_subprocess_run(monkeypatch)
+
+    assert module._direct_read_repo_head() == head_sha
+
+
+def test_direct_read_repo_head_resolves_symbolic_head_with_loose_ref(tmp_path, monkeypatch):
+    """Positive: the ordinary case, a symbolic HEAD backed by a loose ref file."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    head_sha = _init_git_repo(repo)
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+    _refuse_subprocess_run(monkeypatch)
+
+    assert module._direct_read_repo_head() == head_sha
+
+
+def test_direct_read_repo_head_falls_back_for_packed_refs_only_branch(tmp_path, monkeypatch):
+    """Fallback: `git pack-refs --all` removes the loose file. The fast path never scans
+    `packed-refs` (see conftest.py's `_resolve_ref` docstring for why), so it raises here
+    and `_real_repo_head` falls back to the authoritative subprocess, which still
+    resolves."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    head_sha = _init_git_repo(repo)
+    branch = _run_git(repo, "branch", "--show-current")
+    _run_git(repo, "pack-refs", "--all")
+    assert not (repo / ".git" / "refs" / "heads" / branch).exists()  # loose file is gone
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match="may be packed"):
+        module._direct_read_repo_head()
+    assert module._real_repo_head() == head_sha
+
+
+def test_direct_read_repo_head_resolves_linked_worktree_common_dir(tmp_path, monkeypatch):
+    """Positive: a linked worktree's HEAD resolves via its `commondir` to the main git dir."""
+    module = _load_root_conftest()
+    main_repo = tmp_path / "main"
+    _init_git_repo(main_repo)
+    linked = tmp_path / "linked"
+    _run_git(main_repo, "worktree", "add", "--quiet", str(linked), "-b", "feature")
+    feature_sha = _run_git(linked, "rev-parse", "HEAD")
+    assert (linked / ".git").is_file()  # linked worktree uses a gitdir pointer file
+    monkeypatch.setattr(module, "PROJECT_ROOT", linked)
+    _refuse_subprocess_run(monkeypatch)
+
+    assert module._direct_read_repo_head() == feature_sha
+
+
+def test_direct_read_repo_head_returns_none_for_unborn_head(tmp_path, monkeypatch):
+    """Positive: a freshly initialized repo with no commits has a legal unborn HEAD."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init", "--quiet")
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+    _refuse_subprocess_run(monkeypatch)
+
+    assert module._direct_read_repo_head() is None
+
+
+def test_direct_read_repo_head_matches_git_rev_parse_with_zero_subprocess_calls(
+    monkeypatch,
+):
+    """Proves the common path (this real checkout) needs zero subprocess calls."""
+    module = _load_root_conftest()
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=module.PROJECT_ROOT,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+        check=True,
+    ).stdout.strip()
+    _refuse_subprocess_run(monkeypatch)
+
+    assert module._direct_read_repo_head() == expected
+    assert module._real_repo_head() == expected
+
+
+def _make_git_dir(repo: Path, head: str | None = None, **files: str) -> Path:
+    """Build a bare-bones `.git` dir with the given `HEAD` text and extra metadata files."""
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    if head is not None:
+        (git_dir / "HEAD").write_text(head, encoding="utf-8")
+    for name, content in files.items():
+        (git_dir / name).write_text(content, encoding="utf-8")
+    return git_dir
+
+
+def _repo_with_reftable_storage(repo: Path) -> None:
+    """reftable.adoc's dummy `refs/heads/.invalid` HEAD would misread as unborn otherwise."""
+    (_make_git_dir(repo, "ref: refs/heads/.invalid\n") / "reftable").mkdir()
+
+
+def _repo_with_malformed_head(repo: Path) -> None:
+    _make_git_dir(repo, "not-a-recognized-head-shape\n")
+
+
+def _repo_with_packed_only_ref(repo: Path) -> None:
+    """No loose ref for HEAD's branch but a `packed-refs` file exists (e.g. after `git
+    pack-refs --all`): the fast path cannot rule the ref out of it, so it must raise rather
+    than read the ref as absent (see `_resolve_ref`)."""
+    git_dir = _make_git_dir(repo, "ref: refs/heads/main\n")
+    (git_dir / "packed-refs").write_text(
+        f"# pack-refs with: peeled fully-peeled sorted\n{'a' * 40} refs/heads/main\n",
+        encoding="utf-8",
+    )
+
+
+def _repo_with_unsafe_ref_name(repo: Path) -> None:
+    """CWE-22: `..` traversal in the symref target."""
+    _make_git_dir(repo, "ref: refs/heads/../../etc/passwd\n")
+
+
+def _repo_with_windows_style_unsafe_ref_name(repo: Path) -> None:
+    """CWE-22: a Windows drive-letter/backslash symref target (see `_is_safe_ref_name`)."""
+    _make_git_dir(repo, "ref: refs/heads/..\\..\\C:\\Windows\\System32\\config\\SAM\n")
+
+
+def _repo_with_non_heads_ref_name(repo: Path) -> None:
+    """Only `refs/heads/*` is proven here (see `_is_safe_ref_name`): a HEAD symref into any
+    other shared namespace must fall back to Git rather than resolve against `common_dir`."""
+    _make_git_dir(repo, "ref: refs/remotes/origin/main\n")
+
+
+def _repo_with_per_worktree_ref_name(repo: Path) -> None:
+    """`man gitrepository-layout`'s `refs` entry lists `refs/bisect` as a per-worktree
+    namespace not redirected to `$GIT_COMMON_DIR`; resolving it against the shared
+    `common_dir` (as `_resolve_ref` does for `refs/heads/*`) would read the wrong file, so it
+    must fall back to Git instead."""
+    _make_git_dir(repo, "ref: refs/bisect/bad\n")
+
+
+_INVALID_UTF8_BYTES = b"\xff\xfe not valid utf-8"
+
+
+def _repo_with_non_utf8_head(repo: Path) -> None:
+    """HEAD holding a byte sequence that is not valid UTF-8 must fall back to Git instead of
+    raising an uncaught `UnicodeDecodeError` (see `_read_optional_text`)."""
+    (_make_git_dir(repo) / "HEAD").write_bytes(_INVALID_UTF8_BYTES)
+
+
+def _repo_with_non_utf8_commondir(repo: Path) -> None:
+    """A `commondir` file with non-UTF-8 content is unproven, not absent."""
+    (_make_git_dir(repo, "ref: refs/heads/main\n") / "commondir").write_bytes(_INVALID_UTF8_BYTES)
+
+
+def _repo_with_non_utf8_loose_ref(repo: Path) -> None:
+    """A loose ref file with non-UTF-8 content is unproven, not absent."""
+    git_dir = _make_git_dir(repo, "ref: refs/heads/main\n")
+    ref_path = git_dir / "refs" / "heads" / "main"
+    ref_path.parent.mkdir(parents=True)
+    ref_path.write_bytes(_INVALID_UTF8_BYTES)
+
+
+def _repo_with_no_git_dir(repo: Path) -> None:
+    repo.mkdir()
+
+
+def _repo_with_head_as_directory(repo: Path) -> None:
+    (_make_git_dir(repo) / "HEAD").mkdir()
+
+
+def _repo_with_broken_commondir(repo: Path) -> None:
+    _make_git_dir(repo, "ref: refs/heads/main\n", commondir="../missing-main/.git\n")
+
+
+@pytest.mark.parametrize(
+    ("build_repo", "match"),
+    [
+        (_repo_with_reftable_storage, "reftable"),
+        (_repo_with_malformed_head, "not a recognized shape"),
+        (_repo_with_packed_only_ref, "may be packed"),
+        (_repo_with_unsafe_ref_name, "safe refs/heads"),
+        (_repo_with_windows_style_unsafe_ref_name, "safe refs/heads"),
+        (_repo_with_non_heads_ref_name, "safe refs/heads"),
+        (_repo_with_per_worktree_ref_name, "safe refs/heads"),
+        (_repo_with_non_utf8_head, "could not read HEAD file"),
+        (_repo_with_non_utf8_commondir, "could not read commondir file"),
+        (_repo_with_non_utf8_loose_ref, "could not read loose ref file"),
+        (_repo_with_no_git_dir, "resolve project git directory"),
+        (_repo_with_head_as_directory, "could not read HEAD file"),
+        (_repo_with_broken_commondir, "commondir target"),
+    ],
+)
+def test_direct_read_repo_head_raises_for_unproven_state(tmp_path, monkeypatch, build_repo, match):
+    """Negative: anything the fast path cannot prove raises so the caller falls back to
+    `git rev-parse HEAD` instead of guessing."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    build_repo(repo)
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match=match):
+        module._direct_read_repo_head()
+
+
+@pytest.mark.parametrize(
+    ("ref_name", "expected"),
+    [
+        ("refs/heads/main", True),
+        ("refs/heads/feature/x", True),
+        ("notrefs/heads/main", False),
+        ("/refs/heads/main", False),
+        ("refs/heads/../../etc/passwd", False),
+        ("refs/heads/..", False),
+        # Only `refs/heads/*` is proven here (see `_is_safe_ref_name`'s docstring): every
+        # other namespace, whether shared (tags, remotes) or per-worktree (bisect, worktree,
+        # rewritten -- `man gitrepository-layout`'s `refs` entry), is rejected.
+        ("refs/tags/v1.0", False),
+        ("refs/remotes/origin/main", False),
+        ("refs/bisect/bad", False),
+        ("refs/worktree/example", False),
+        ("refs/rewritten/onto", False),
+        # PurePosixPath does not treat "\" as a separator, so backslash traversal and UNC
+        # forms would pass as one opaque component; ":" anchors a `PureWindowsPath` drive
+        # (`C:\Windows`, drive-relative `C:foo`) and is forbidden in a ref name anywhere
+        # (git-check-ref-format rule 4). See `_UNSAFE_REF_NAME_CHARACTERS` in conftest.py.
+        ("refs/heads/..\\..\\Windows\\System32", False),
+        ("refs/heads/C:\\Windows\\System32", False),
+        ("refs/heads/C:foo", False),
+        ("refs/heads/\\\\server\\share\\x", False),
+        ("refs/heads/foo:bar", False),
+    ],
+)
+def test_is_safe_ref_name(ref_name, expected):
+    module = _load_root_conftest()
+
+    assert module._is_safe_ref_name(ref_name) is expected
+
+
+def test_common_git_dir_returns_git_dir_when_no_commondir_file(tmp_path):
+    """Edge: a non-worktree repo has no `commondir` file; common dir is git_dir itself."""
+    module = _load_root_conftest()
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+
+    assert module._common_git_dir(git_dir) == git_dir
+
+
+def test_resolve_ref_returns_none_when_neither_loose_nor_packed_exists(tmp_path):
+    module = _load_root_conftest()
+
+    assert module._resolve_ref(tmp_path, "refs/heads/missing") is None
+
+
+def test_resolve_ref_raises_for_non_object_id_loose_content(tmp_path):
+    """Negative: a legacy chained symref in a loose ref file is not a proven case."""
+    module = _load_root_conftest()
+    ref_path = tmp_path / "refs" / "heads" / "alias"
+    ref_path.parent.mkdir(parents=True)
+    ref_path.write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match="plain object id"):
+        module._resolve_ref(tmp_path, "refs/heads/alias")
+
+
+def test_resolve_ref_prefers_loose_over_packed(tmp_path):
+    """Edge: a loose ref file resolves without ever inspecting a `packed-refs` file that
+    happens to exist alongside it (Git's own read-order precedence: loose wins)."""
+    module = _load_root_conftest()
+    loose_sha = "1" * 40
+    packed_sha = "2" * 40
+    ref_path = tmp_path / "refs" / "heads" / "main"
+    ref_path.parent.mkdir(parents=True)
+    ref_path.write_text(f"{loose_sha}\n", encoding="utf-8")
+    (tmp_path / "packed-refs").write_text(f"{packed_sha} refs/heads/main\n", encoding="utf-8")
+
+    assert module._resolve_ref(tmp_path, "refs/heads/main") == loose_sha
+
+
+# ---------------------------------------------------------------------------
+# OSError-swallowing guards (`_fast_path_stat_mode`, `_read_optional_text`,
+# `_project_git_dir`): `Path.is_file()`/`is_dir()`/`exists()` all catch bare `OSError` -- not
+# just a missing path -- and return False (`genericpath`, Python 3.14 stdlib). These tests
+# prove a non-`FileNotFoundError` failure raises `_HeadFastPathUnresolvedError` (or, for
+# `_project_git_dir`, a plain `OSError`) instead of being silently misread as absence.
+# ---------------------------------------------------------------------------
+
+# (conftest reader, the `Path` method it must not let swallow an OSError)
+_FAST_PATH_READERS = [("_fast_path_stat_mode", "stat"), ("_read_optional_text", "read_text")]
+
+
+def _raise_permission_error(self, *_args, **_kwargs):
+    raise PermissionError("denied")
+
+
+@pytest.mark.parametrize("reader", [reader for reader, _ in _FAST_PATH_READERS])
+def test_fast_path_reader_returns_none_for_missing_path(tmp_path, reader):
+    module = _load_root_conftest()
+
+    assert getattr(module, reader)(tmp_path / "missing", "boom") is None
+
+
+def test_fast_path_readers_return_values_for_existing_paths(tmp_path):
+    module = _load_root_conftest()
+    target = tmp_path / "present"
+    target.write_text("hello", encoding="utf-8")
+
+    assert stat.S_ISREG(module._fast_path_stat_mode(target, "boom"))
+    assert module._read_optional_text(target, "boom") == "hello"
+
+
+@pytest.mark.parametrize(("reader", "path_method"), _FAST_PATH_READERS)
+def test_fast_path_reader_raises_for_permission_error(tmp_path, monkeypatch, reader, path_method):
+    """A failure that is not `FileNotFoundError` must not be read as absence."""
+    module = _load_root_conftest()
+    target = tmp_path / "present"
+    target.write_text("hello", encoding="utf-8")
+    monkeypatch.setattr(Path, path_method, _raise_permission_error)
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match="boom"):
+        getattr(module, reader)(target, "boom")
+
+
+def test_read_optional_text_raises_for_non_utf8_content(tmp_path):
+    """Non-UTF-8 bytes (`UnicodeDecodeError`) are unproven, not absent: `_direct_read_repo_head`
+    (HEAD), `_common_git_dir` (commondir), and `_resolve_ref` (loose ref) all read through
+    `_read_optional_text`, so this one guard covers all three. `_project_git_dir` (`.git`) has
+    its own equivalent guard, tested separately."""
+    module = _load_root_conftest()
+    target = tmp_path / "present"
+    target.write_bytes(b"\xff\xfe not valid utf-8")
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match="boom"):
+        module._read_optional_text(target, "boom")
+
+
+def test_project_git_dir_raises_oserror_for_permission_denied_git_entry(tmp_path, monkeypatch):
+    """Negative: a `.git` entry that cannot be stat'd is unproven, not "not a directory"."""
+    module = _load_root_conftest()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(Path, "stat", _raise_permission_error)
+
+    with pytest.raises(OSError, match="could not resolve project git directory"):
+        module._project_git_dir()
+
+
+def test_project_git_dir_raises_oserror_for_non_utf8_dot_git_file(tmp_path, monkeypatch):
+    """Negative: a `.git` gitdir-pointer file with non-UTF-8 content is unproven, not a
+    missing gitdir entry; `_project_git_dir` has its own `read_text` call, not routed through
+    `_read_optional_text`, so this is covered separately from
+    `test_read_optional_text_raises_for_non_utf8_content`."""
+    module = _load_root_conftest()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    (tmp_path / ".git").write_bytes(b"\xff\xfe not valid utf-8")
+
+    with pytest.raises(OSError, match="could not resolve project git directory"):
+        module._project_git_dir()
+
+
+def test_common_git_dir_raises_for_permission_denied_commondir_target(tmp_path, monkeypatch):
+    """Negative: a `commondir` target that cannot be stat'd is unproven, not "does not
+    exist"."""
+    module = _load_root_conftest()
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "commondir").write_text("../main/.git\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "stat", _raise_permission_error)
+
+    with pytest.raises(module._HeadFastPathUnresolvedError, match="not accessible"):
+        module._common_git_dir(git_dir)
+
+
+def test_real_repo_head_falls_back_to_subprocess_for_unproven_state(tmp_path, monkeypatch):
+    """Fallback: an unprovable on-disk HEAD shape routes through the git subprocess."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("this is not a recognized HEAD shape\n", encoding="utf-8")
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="fedcba9876543210fedcba9876543210fedcba98\n", stderr=""
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module._real_repo_head() == "fedcba9876543210fedcba9876543210fedcba98"
+
+
+def test_real_repo_head_falls_back_to_subprocess_for_non_utf8_head(tmp_path, monkeypatch):
+    """Fallback: a HEAD file holding non-UTF-8 bytes (e.g. a foreign-encoded gitdir line on a
+    misconfigured checkout) routes through `git rev-parse HEAD` instead of propagating an
+    uncaught `UnicodeDecodeError` out of the autouse fixture."""
+    module = _load_root_conftest()
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_bytes(b"\xff\xfe not valid utf-8")
+    monkeypatch.setattr(module, "PROJECT_ROOT", repo)
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="fedcba9876543210fedcba9876543210fedcba98\n", stderr=""
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module._real_repo_head() == "fedcba9876543210fedcba9876543210fedcba98"

--- a/tests/test_pytest_head_guard.py
+++ b/tests/test_pytest_head_guard.py
@@ -1,17 +1,28 @@
-"""Tests for the repository-wide pytest HEAD guard."""
+"""Tests for the repository-wide pytest HEAD guard.
+
+Direct-read/path-safety/fast-path tests for `_direct_read_repo_head` live in
+`tests/test_pytest_head_fastpath.py`; this file covers trace/reflog/attribution
+behavior (`_check_head_change`, `_trace_has_project_head_mutation`,
+`_reflog_contains_action`, and the `_guard_real_repo_head` autouse fixture).
+"""
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import os
 import subprocess
-import sys
 import tempfile
 import warnings
 from pathlib import Path
 
 import pytest
+
+from tests.head_guard_test_helpers import (
+    _commit_file,
+    _init_git_repo,
+    _load_root_conftest,
+    _run_git,
+)
 
 pytestmark = pytest.mark.windows_path
 
@@ -19,19 +30,19 @@ BEFORE_SHA = "a" * 40
 AFTER_SHA = "c" * 40
 
 
-def _load_root_conftest():
-    path = Path(__file__).resolve().parents[1] / "conftest.py"
-    spec = importlib.util.spec_from_file_location("root_conftest_under_test", path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["root_conftest_under_test"] = module
-    spec.loader.exec_module(module)
-    return module
+def _force_fast_path_fallback(module, monkeypatch) -> None:
+    """Make `_direct_read_repo_head` raise so `_real_repo_head` reaches the subprocess path
+    (inside this real checkout the fast path always resolves and never shells out)."""
+
+    def _raise(*_args, **_kwargs):
+        raise module._HeadFastPathUnresolvedError("forced for subprocess-path test")
+
+    monkeypatch.setattr(module, "_direct_read_repo_head", _raise)
 
 
 def test_real_repo_head_unsets_git_environment_overrides(monkeypatch):
     module = _load_root_conftest()
+    _force_fast_path_fallback(module, monkeypatch)
     captured: dict[str, dict[str, object]] = {}
 
     monkeypatch.setenv("GIT_DIR", "wrong")
@@ -90,6 +101,7 @@ def test_real_repo_head_subject_decodes_git_output_as_utf8(monkeypatch):
 
 def test_real_repo_readers_return_fallbacks_on_git_error(monkeypatch):
     module = _load_root_conftest()
+    _force_fast_path_fallback(module, monkeypatch)
 
     def raise_error(*_args, **_kwargs):
         raise OSError("git unavailable")
@@ -102,6 +114,7 @@ def test_real_repo_readers_return_fallbacks_on_git_error(monkeypatch):
 
 def test_real_repo_readers_return_fallbacks_on_nonzero_exit(monkeypatch):
     module = _load_root_conftest()
+    _force_fast_path_fallback(module, monkeypatch)
 
     def fake_run(*_args, **_kwargs):
         return subprocess.CompletedProcess(
@@ -174,44 +187,6 @@ def test_check_head_change_is_silent_when_baseline_is_unreadable(monkeypatch):
         module._check_head_change(None, "bbbbbbbb2222")
 
     assert caught == []
-
-
-def _run_git(repo: Path, *args: str, env=None) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-        env=env,
-        timeout=10,
-    )
-    return result.stdout.strip()
-
-
-def _commit_file(repo: Path, content: str, message: str, env=None) -> str:
-    (repo / "file.txt").write_text(content, encoding="utf-8")
-    _run_git(repo, "add", "file.txt")
-    _run_git(
-        repo,
-        "-c",
-        "user.name=pytest",
-        "-c",
-        "user.email=pytest@example.invalid",
-        "commit",
-        "--quiet",
-        "-m",
-        message,
-        env=env,
-    )
-    return _run_git(repo, "rev-parse", "HEAD")
-
-
-def _init_git_repo(repo: Path) -> str:
-    repo.mkdir()
-    _run_git(repo, "init", "--quiet")
-    return _commit_file(repo, "initial\n", "initial")
 
 
 def _init_repo_with_non_head_commit(repo: Path) -> str:
@@ -376,75 +351,38 @@ def test_guard_fixture_allows_branch_creation_from_recorded_base(tmp_path):
     assert _run_git(repo, "branch", "--show-current") == "local"
 
 
-def test_trace_ignores_read_only_symbolic_ref(tmp_path):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(
-        trace_path,
-        "symbolic-ref",
-        ["git", "symbolic-ref", "HEAD"],
-        module.PROJECT_ROOT,
-    )
-
-    assert not module._trace_has_project_head_mutation(trace_path)
-
-
-def test_trace_detects_symbolic_ref_write(tmp_path):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(
-        trace_path,
-        "symbolic-ref",
-        ["git", "symbolic-ref", "HEAD", "refs/heads/other"],
-        module.PROJECT_ROOT,
-        symref_mutated=True,
-    )
-
-    assert module._trace_has_project_head_mutation(trace_path)
-
-
-def test_trace_detects_successful_symbolic_ref_write_without_ref_transaction(tmp_path):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(
-        trace_path,
-        "symbolic-ref",
-        ["git", "symbolic-ref", "HEAD", "refs/heads/other"],
-        module.PROJECT_ROOT,
-    )
-
-    assert module._trace_has_project_head_mutation(trace_path)
+_SYMREF = ["git", "symbolic-ref"]
+_OTHER_REF = "refs/heads/other"
+# (case id, argv, symref trace line emitted, expected mutation verdict). Git 2.55 can omit
+# the ref-transaction trace lines for symbolic-ref, hence the untraced-write case.
+_SYMBOLIC_REF_TRACE_CASES = [
+    ("read_only", [*_SYMREF, "HEAD"], False, False),
+    ("write_traced", [*_SYMREF, "HEAD", _OTHER_REF], True, True),
+    ("write_untraced", [*_SYMREF, "HEAD", _OTHER_REF], False, True),
+    ("end_of_options", [*_SYMREF, "--end-of-options", "HEAD", _OTHER_REF], False, True),
+    ("unknown_long_option", [*_SYMREF, "--no-delete", "HEAD", _OTHER_REF], False, True),
+    ("long_option_prefix_of_another", [*_SYMREF, "--no-rec", "HEAD", _OTHER_REF], False, True),
+    ("bundled_short_options", [*_SYMREF, "-qmreason", "HEAD", _OTHER_REF], False, True),
+    ("windows_plumbing_executable", ["git-symbolic-ref.exe", "HEAD", _OTHER_REF], False, True),
+    ("unrelated_ref", [*_SYMREF, "refs/meta/current", _OTHER_REF], False, False),
+]
 
 
 @pytest.mark.parametrize(
-    "argv",
-    [
-        ["git", "symbolic-ref", "--end-of-options", "HEAD", "refs/heads/other"],
-        ["git", "symbolic-ref", "--no-delete", "HEAD", "refs/heads/other"],
-        ["git", "symbolic-ref", "--no-rec", "HEAD", "refs/heads/other"],
-        ["git", "symbolic-ref", "-qmreason", "HEAD", "refs/heads/other"],
-        ["git-symbolic-ref.exe", "HEAD", "refs/heads/other"],
-    ],
+    ("argv", "symref_mutated", "expected"),
+    [case[1:] for case in _SYMBOLIC_REF_TRACE_CASES],
+    ids=[case[0] for case in _SYMBOLIC_REF_TRACE_CASES],
 )
-def test_trace_detects_supported_symbolic_ref_write_forms(tmp_path, argv):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(trace_path, "symbolic-ref", argv, module.PROJECT_ROOT)
-
-    assert module._trace_has_project_head_mutation(trace_path)
-
-
-def test_trace_ignores_symbolic_ref_write_to_unrelated_ref(tmp_path):
+def test_trace_verdict_for_symbolic_ref_session(tmp_path, argv, symref_mutated, expected):
+    """A symbolic-ref session counts as a HEAD mutation only when it successfully repoints
+    project HEAD, whether or not Git emitted the ref-transaction trace lines."""
     module = _load_root_conftest()
     trace_path = tmp_path / "git-trace.json"
     _write_trace2(
-        trace_path,
-        "symbolic-ref",
-        ["git", "symbolic-ref", "refs/meta/current", "refs/heads/other"],
-        module.PROJECT_ROOT,
+        trace_path, "symbolic-ref", argv, module.PROJECT_ROOT, symref_mutated=symref_mutated
     )
 
-    assert not module._trace_has_project_head_mutation(trace_path)
+    assert module._trace_has_project_head_mutation(trace_path) is expected
 
 
 def test_trace_parses_actual_symbolic_ref_write(tmp_path, monkeypatch):
@@ -545,52 +483,38 @@ def test_trace_detects_project_git_dir_from_environment(tmp_path, monkeypatch):
     assert module._trace_has_project_head_mutation(trace_path)
 
 
-def test_trace_ignores_failed_plumbing_write(tmp_path):
+_WINDOWS_UPDATE_REF_EXE = r"C:\Program Files\Git\mingw64\libexec\git-core\git-update-ref.exe"
+# (case id, argv, exit code, transaction `finish:` code, expected mutation verdict)
+_UPDATE_REF_TRACE_CASES = [
+    ("update_ref_write", ["git", "update-ref", "HEAD", AFTER_SHA], 0, 0, True),
+    ("windows_plumbing_executable", [_WINDOWS_UPDATE_REF_EXE, "HEAD", AFTER_SHA], 0, 0, True),
+    ("failed_write", ["git", "update-ref", "HEAD", "invalid-object"], 128, -1, False),
+]
+
+
+@pytest.mark.parametrize(
+    ("argv", "exit_code", "transaction_finish", "expected"),
+    [case[1:] for case in _UPDATE_REF_TRACE_CASES],
+    ids=[case[0] for case in _UPDATE_REF_TRACE_CASES],
+)
+def test_trace_verdict_for_update_ref_session(
+    tmp_path, argv, exit_code, transaction_finish, expected
+):
+    """A traced HEAD transaction counts only when the transaction itself finished
+    successfully (`finish: 0`), whatever executable name Git dispatched to."""
     module = _load_root_conftest()
     trace_path = tmp_path / "git-trace.json"
     _write_trace2(
         trace_path,
         "update-ref",
-        ["git", "update-ref", "HEAD", "invalid-object"],
+        argv,
         module.PROJECT_ROOT,
-        exit_code=128,
+        exit_code=exit_code,
         head_mutated=True,
-        transaction_finish=-1,
+        transaction_finish=transaction_finish,
     )
 
-    assert not module._trace_has_project_head_mutation(trace_path)
-
-
-def test_trace_recognizes_windows_plumbing_executable(tmp_path):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(
-        trace_path,
-        "update-ref",
-        [
-            r"C:\Program Files\Git\mingw64\libexec\git-core\git-update-ref.exe",
-            "HEAD",
-            AFTER_SHA,
-        ],
-        module.PROJECT_ROOT,
-        head_mutated=True,
-    )
-
-    assert module._trace_has_project_head_mutation(trace_path)
-
-
-def test_trace_detects_update_ref_write(tmp_path):
-    module = _load_root_conftest()
-    trace_path = tmp_path / "git-trace.json"
-    _write_trace2(
-        trace_path,
-        "update-ref",
-        ["git", "update-ref", "HEAD", AFTER_SHA],
-        module.PROJECT_ROOT,
-        head_mutated=True,
-    )
-
-    assert module._trace_has_project_head_mutation(trace_path)
+    assert module._trace_has_project_head_mutation(trace_path) is expected
 
 
 def test_trace_detects_update_ref_write_to_checked_out_branch(tmp_path, monkeypatch):
@@ -675,89 +599,52 @@ def test_check_head_change_warns_when_unrelated_branch_write_coincides_with_comm
         )
 
 
-def test_check_head_change_fails_for_marked_reflog_action(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("reflog_found", "trace_found"),
+    [(True, False), (False, True)],
+    ids=["marked_reflog_action", "traced_head_mutation"],
+)
+def test_check_head_change_fails_for_attributed_mutation(
+    tmp_path, monkeypatch, reflog_found, trace_found
+):
+    """Either attribution signal on its own blames the test, never the concurrent commit."""
     module = _load_root_conftest()
-    monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: True)
-    monkeypatch.setattr(
-        module,
-        "_trace_has_project_head_mutation",
-        lambda _path: False,
-    )
+    monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: reflog_found)
+    monkeypatch.setattr(module, "_trace_has_project_head_mutation", lambda _path: trace_found)
+    trace_path = tmp_path / "git-trace.json"
 
     with pytest.raises(pytest.fail.Exception, match="test-launched Git command"):
-        module._check_head_change(
-            BEFORE_SHA,
-            AFTER_SHA,
-            "pytest-head-guard:test",
-            tmp_path / "trace.json",
-        )
-
-
-def test_check_head_change_fails_for_traced_head_mutation(tmp_path, monkeypatch):
-    module = _load_root_conftest()
-    monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: False)
-    monkeypatch.setattr(
-        module,
-        "_trace_has_project_head_mutation",
-        lambda _path: True,
-    )
-
-    with pytest.raises(pytest.fail.Exception, match="test-launched Git command"):
-        module._check_head_change(
-            BEFORE_SHA,
-            AFTER_SHA,
-            "pytest-head-guard:test",
-            tmp_path / "trace.json",
-        )
+        module._check_head_change(BEFORE_SHA, AFTER_SHA, "pytest-head-guard:test", trace_path)
 
 
 def test_check_head_change_warns_for_external_concurrent_commit(tmp_path, monkeypatch):
     module = _load_root_conftest()
     _silence_subject(module, monkeypatch)
     monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: False)
-    monkeypatch.setattr(
-        module,
-        "_trace_has_project_head_mutation",
-        lambda _path: False,
-    )
+    monkeypatch.setattr(module, "_trace_has_project_head_mutation", lambda _path: False)
+    trace_path = tmp_path / "git-trace.json"
 
     with pytest.warns(UserWarning, match="concurrent external commit"):
-        module._check_head_change(
-            BEFORE_SHA,
-            AFTER_SHA,
-            "pytest-head-guard:test",
-            tmp_path / "trace.json",
-        )
+        module._check_head_change(BEFORE_SHA, AFTER_SHA, "pytest-head-guard:test", trace_path)
 
 
-def test_check_head_change_fails_when_trace_is_malformed(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "break_trace",
+    [
+        lambda path: path.write_text("not-json\n", encoding="utf-8"),
+        lambda path: path.mkdir(),
+    ],
+    ids=["malformed_json", "unreadable_directory"],
+)
+def test_check_head_change_fails_when_trace_cannot_be_read(tmp_path, monkeypatch, break_trace):
+    """An unattributable trace fails loudly instead of being read as an external commit."""
     module = _load_root_conftest()
     monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: False)
     trace_path = tmp_path / "git-trace.json"
-    trace_path.write_text("not-json\n", encoding="utf-8")
+    break_trace(trace_path)
 
     with pytest.raises(pytest.fail.Exception, match="could not attribute"):
-        module._check_head_change(
-            BEFORE_SHA,
-            AFTER_SHA,
-            "pytest-head-guard:test",
-            trace_path,
-        )
-
-
-def test_check_head_change_fails_when_trace_is_unreadable(tmp_path, monkeypatch):
-    module = _load_root_conftest()
-    monkeypatch.setattr(module, "_reflog_contains_action", lambda _marker: False)
-    trace_path = tmp_path / "git-trace"
-    trace_path.mkdir()
-
-    with pytest.raises(pytest.fail.Exception, match="could not attribute"):
-        module._check_head_change(
-            BEFORE_SHA,
-            AFTER_SHA,
-            "pytest-head-guard:test",
-            trace_path,
-        )
+        module._check_head_change(BEFORE_SHA, AFTER_SHA, "pytest-head-guard:test", trace_path)
 
 
 def test_guard_fixture_does_not_blame_test_for_external_commit(monkeypatch):


### PR DESCRIPTION
## Summary

Remove two Git subprocesses per test from the common HEAD-guard path.

## Changes

- Read detached HEAD and loose symbolic branch refs directly.
- Preserve per-test before and after attribution.
- Fall back to `git rev-parse HEAD` for packed refs, reftable, non-UTF8, malformed, unsafe, unreadable, or unsupported state.
- Reject Windows path forms before filesystem access.
- Split fast-path tests into a focused module.

## Validation

- [x] Full pytest suite passed.
- [x] Common loose-ref path completed 10,000 reads in 0.845 seconds with zero subprocess calls.
- [x] Packed-ref and every unproven state use authoritative Git fallback.
- [x] Windows path, linked worktree, detached, unborn, Unicode, permission, and fallback tests passed.
- [x] Security review approved with no exploitable or fail-open findings.

## Stack

Base: `fix/hook-lint-scope`

Next: `fix/coverage-pin-dedup`

Refs #4710
