### PR TITLE
docs(memory): record three git lessons from the worktree GC work

### DIFF
--- a/.serena/memories/git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md
+++ b/.serena/memories/git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md
@@ -1,0 +1,71 @@
+# A review subagent will clean the worktree you gave it
+
+A subagent dispatched into the worktree you are working in will run
+`git reset --hard` and `git clean` on it. Not because it was told to. Because
+a clean tree is what a reviewer needs, and it cannot tell your work from
+leftover noise. A prompt saying "do not modify the repository" does not stop
+this; it is a request, not a control.
+
+Observed twice in one session, same worktree, same agent:
+
+1. First pass destroyed a 589-line uncommitted change. The prompt said
+   "Do NOT modify anything inside the repository."
+2. Second pass ran `git reset --hard <pushed tip>` and wiped **four commits**
+   that had already landed on the local branch. The agent then reported the
+   repository was clean and reminded me to stop touching it.
+
+Committing is not enough. Only a pushed ref or an object outside the worktree
+survives.
+
+## What to do instead
+
+Give the reviewer its own worktree, or do not dispatch one at all while your
+tree holds work you cannot afford to lose:
+
+```bash
+git worktree add ~/src/scratch/review-<topic> <sha>
+# point the subagent at ~/src/scratch/review-<topic>, never at your own tree
+```
+
+Before dispatch, make the work durable somewhere the subagent cannot reach:
+
+```bash
+git branch -f backup/<topic> HEAD
+git bundle create ~/src/scratch/<topic>.bundle backup/<topic>
+```
+
+`git bundle create <file> <sha>` fails with "Refusing to create empty bundle"
+when the argument is a bare SHA. Bundle a **ref**, not a commit id.
+
+## Recovery when it has already happened
+
+The reset is recorded, so nothing is lost yet. Read the reflog before doing
+anything else, because more git activity in that worktree can expire it:
+
+```bash
+git reflog -12          # find the commit above the "reset: moving to" line
+git reset --hard <that sha>
+```
+
+For uncommitted work destroyed by `git clean`, the stash object survives as an
+unreachable commit. Find it by subject:
+
+```bash
+for c in $(git fsck --unreachable --no-progress | awk '/commit/{print $3}'); do
+  git log -1 --format="$c %s" "$c"
+done | grep 'On <branch>:'
+git stash apply <sha>
+```
+
+Do not run `git stash drop` until the content is committed **and pushed**. The
+drop removes the last handle you have while the object is still the only copy.
+
+## The general shape
+
+Uncommitted work plus another agent in the same directory is an unprotected
+write. Local commits plus another agent in the same directory is a slower
+unprotected write. Treat "a subagent has a shell in this worktree" as
+equivalent to "this worktree may be reset to its pushed state at any moment".
+
+Related: `git/git-a-subagent-in-your-worktree-moves-your-head.md` records the
+narrower HEAD-movement case.

--- a/.serena/memories/git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md
+++ b/.serena/memories/git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md
@@ -23,16 +23,25 @@ Give the reviewer its own worktree, or do not dispatch one at all while your
 tree holds work you cannot afford to lose:
 
 ```bash
-git worktree add ~/src/scratch/review-<topic> <sha>
-# point the subagent at ~/src/scratch/review-<topic>, never at your own tree
+TOPIC=my-review-topic
+SHA=$(git rev-parse HEAD)
+git worktree add "$HOME/src/scratch/review-$TOPIC" "$SHA"
+# point the subagent at that path, never at your own tree
 ```
 
 Before dispatch, make the work durable somewhere the subagent cannot reach:
 
 ```bash
-git branch -f backup/<topic> HEAD
-git bundle create ~/src/scratch/<topic>.bundle backup/<topic>
+git branch -f "backup/$TOPIC" HEAD
+git bundle create "$HOME/src/scratch/$TOPIC.bundle" "backup/$TOPIC"
 ```
+
+Write these with shell variables, not with angle-bracket placeholders. `<topic>`
+and `<sha>` are redirection operators: `git worktree add ~/x-<topic> <sha>` is a
+hard syntax error, and `git branch -f backup/<topic> HEAD` is worse, because it
+parses cleanly, reads from a file named `topic`, and truncates a file named
+`HEAD`. A memory whose commands are copy-pasted is a memory whose placeholders
+must survive being copy-pasted.
 
 `git bundle create <file> <sha>` fails with "Refusing to create empty bundle"
 when the argument is a bare SHA. Bundle a **ref**, not a commit id.
@@ -44,18 +53,25 @@ anything else, because more git activity in that worktree can expire it:
 
 ```bash
 git reflog -12          # find the commit above the "reset: moving to" line
-git reset --hard <that sha>
+git reset --hard "$RECOVERY_SHA"
 ```
 
-For uncommitted work destroyed by `git clean`, the stash object survives as an
-unreachable commit. Find it by subject:
+Work that was stashed and whose stash entry was then **dropped** survives as an
+unreachable commit until it is pruned. Find it by subject:
 
 ```bash
 for c in $(git fsck --unreachable --no-progress | awk '/commit/{print $3}'); do
   git log -1 --format="$c %s" "$c"
-done | grep 'On <branch>:'
-git stash apply <sha>
+done | grep "On $BRANCH:"
+git stash apply "$STASH_SHA"
 ```
+
+This path exists only because something created a stash first. `git reset
+--hard` and `git clean` create no stash object, so work destroyed by either,
+having never been added or stashed, has **no** equivalent recovery. That is the
+whole reason the backup above happens before dispatch rather than after the
+loss. The recovery in this incident worked because the content had been stashed
+and the stash was later dropped, not because `clean` left something behind.
 
 Do not run `git stash drop` until the content is committed **and pushed**. The
 drop removes the last handle you have while the object is still the only copy.
@@ -67,5 +83,5 @@ write. Local commits plus another agent in the same directory is a slower
 unprotected write. Treat "a subagent has a shell in this worktree" as
 equivalent to "this worktree may be reset to its pushed state at any moment".
 
-Related: `git/git-a-subagent-in-your-worktree-moves-your-head.md` records the
+Related: `git-a-subagent-in-your-worktree-moves-your-head.md` records the
 narrower HEAD-movement case.

--- a/.serena/memories/git/git-a-squash-merge-severs-a-stacked-pr.md
+++ b/.serena/memories/git/git-a-squash-merge-severs-a-stacked-pr.md
@@ -138,12 +138,21 @@ touching the working tree, so the result can be measured before the merge is
 committed:
 
 ```bash
+set -euo pipefail
+export LC_ALL=C
+
 tree=$(git write-tree)
-git diff --name-only "$base" "$tree" | sort > merged.txt
-git diff --name-only "$parent_tip" "$child" | sort > expected.txt
+git diff --name-only "$base" "$tree" -- | sort > merged.txt
+git diff --name-only "$parent_tip" "$child" -- | sort > expected.txt
 comm -23 merged.txt expected.txt   # BASE content this merge dropped
 comm -13 merged.txt expected.txt   # CHILD content this merge lost
 ```
+
+`set -euo pipefail` and explicit refs are load bearing, not decoration. With an
+unset or misspelled ref both `git diff` calls exit fatally, `sort` still exits 0
+and writes an empty file, and both `comm` results come back empty. The check
+then certifies a tree nobody compared. An empty `comm` is only evidence when
+you can show both inputs were non-empty.
 
 Both differences empty is necessary and not sufficient. An adversarial review
 of this repair (grok-4.5, 2026-08-06) built the counterexample: substitute a
@@ -151,33 +160,53 @@ third blob on any one of those paths and the path still differs from BASE, so
 it stays in the name list, both `comm` results stay empty, and the content is
 wrong. Name-set equality proves which paths differ, never what they contain.
 
-Add one content check, either of these:
+Add a content check that compares whole tree entries, with rename detection off:
 
 ```bash
-# blob equality on every path the child owns
-git diff --name-only "$parent_tip" "$child" | while read -r f; do
-  [ "$(git rev-parse "$tree:$f")" = "$(git rev-parse "$child:$f")" ] || echo "MISMATCH $f"
+set -euo pipefail
+git diff --name-only --no-renames -z "$parent_tip" "$child" -- |
+while IFS= read -r -d '' f; do
+  [ "$(git ls-tree "$tree" -- "$f")" = "$(git ls-tree "$child" -- "$f")" ] \
+    || { echo "MISMATCH $f"; exit 1; }
 done
-
-# or normalized patch equality, index lines stripped
-diff <(git diff "$parent_tip" "$child" | grep -v '^index ') \
-     <(git diff "$base" "$tree"        | grep -v '^index ')
 ```
 
-Measured on this repair: 0 blob mismatches across 31 paths, patches byte
-identical, and the full 8397-path tree listing equals CHILD plus BASE's one
-restored file exactly.
+Three details each close a hole a second review (gpt-5.6-sol, 2026-08-06)
+demonstrated:
+
+- **`--no-renames`.** With rename detection on, a rename shows only the new
+  path, so a tree that wrongly kept the old path too passes. Disabling it lists
+  both sides, and the old path then mismatches.
+- **`git ls-tree` rather than `git rev-parse "$tree:$f"`.** `ls-tree` compares
+  mode, type, and object id, so a `100644` to `100755` flip is caught. It also
+  prints nothing for an absent path instead of failing, which makes present
+  against absent a visible mismatch rather than an error.
+- **`-z` with `read -d ''`.** A path containing a newline or a quote otherwise
+  splits or arrives escaped.
+
+Normalized patch equality (`git diff ... | grep -v '^index '` on both sides) is
+a weaker second opinion, not a substitute: two distinct binary blobs produce
+identical patch text once the index lines are stripped.
+
+Measured on this repair: 0 mismatches across 31 paths, and the full 8397-path
+tree listing equals CHILD plus BASE's one restored file exactly. This incident
+had 23 modifications, 8 additions, no deletions, no renames, and no binary
+files, so the weaker checks happened to agree here. That is luck, not evidence.
 
 ## Two side effects to expect
 
 **The push ceiling can trip.** `_unpushed_commit_count`
-(`scripts/validation/git_hook_policy.py`) excludes commits that some other
-remote branch already carries. GitHub deletes the squashed branch on merge, so
-the ~20 commits CHILD inherited from PARENT stop being excluded by any remote
-ref and begin counting against CHILD. Measured here: raw 43, stack-aware 21,
-limit 20, genuinely new 3. Splitting is not the remedy for an overage that the
-repair merge itself caused; the `commit-limit-bypass` label is, with the
-measurement recorded on the PR.
+(`scripts/validation/git_hook_policy.py`) counts with
+`git rev-list --count <sha> --not --exclude=origin/<branch> --remotes=origin`,
+so it excludes commits carried by any *other* `refs/remotes/origin/*` ref. That
+is a **local** ref namespace. Deleting the squashed PARENT branch on GitHub
+therefore changes nothing on its own; the count moves only once the local
+tracking ref is pruned, which is a separate event you control. Measured here
+with the PARENT tracking ref still present: raw 43, counted 21, limit 20,
+genuinely new 3. Removing that tracking ref raises the counted figure to 35
+rather than lowering it. Splitting is not the remedy for an overage the repair
+merge itself caused; the `commit-limit-bypass` label is, with the measurement
+recorded on the PR.
 
 **The Commits tab looks heavier than the diff.** After the repair,
 `git rev-list --first-parent "$base".."$merge"` counts 35 here while the three

--- a/.serena/memories/git/git-a-squash-merge-severs-a-stacked-pr.md
+++ b/.serena/memories/git/git-a-squash-merge-severs-a-stacked-pr.md
@@ -1,0 +1,206 @@
+# A Squash Merge Severs a Stacked Pull Request
+
+**Category**: Git Operations
+**Source**: 2026-08-06, PR #4708 and PR #4718. Verified on git 2.43.0
+against `origin/fix/worktree-walk-timeouts`,
+`origin/fix/gc-worktrees-one-decision`, and
+`origin/fix/gc-worktrees-stale-entries`. GitHub recorded
+`automatic_base_change_succeeded` at 2026-08-07T00:15:48Z.
+
+Symptom this explains: merging a new base into a stacked child reports 17
+conflicts, including 11 `add/add` conflicts, on paths inherited through the
+stack.
+
+## Statement
+
+The stack was:
+
+```text
+main
+  fix/worktree-walk-timeouts
+    fix/gc-worktrees-one-decision
+      fix/gc-worktrees-stale-entries
+```
+
+PR #4708 squash-merged `fix/gc-worktrees-one-decision` into
+`fix/worktree-walk-timeouts` as `0d386e7a5`. A squash commit copies content
+onto a brand-new commit. It does not retain the merged branch tip as a parent.
+
+That distinction is easy to miss because the readable history looks correct:
+
+| observation | result |
+|---|---|
+| BASE tip | `0d386e7a5 fix(maintenance): make worktree GC answer one safety question in one place (#4708)` |
+| squash commit parent | `74722a9f80988768c88dd38699e3a2cc96a74dc0` |
+| PARENT tip | `efc27ee9ba68d36a46a749211517be554368f3af` |
+| PARENT ancestor of BASE | no, `git merge-base --is-ancestor` exited 1 |
+| PARENT ancestor of CHILD | yes, `git merge-base --is-ancestor` exited 0 |
+
+The commit subject says PR #4708 landed. The parent graph says PARENT never
+became part of BASE. Only `merge-base --is-ancestor` answers the ancestry
+question.
+
+GitHub then retargeted PR #4718. PR #4708 merged at
+2026-08-07T00:15:46Z. Two seconds later, its timeline recorded
+`automatic_base_change_succeeded`. PR #4718 now targets
+`fix/worktree-walk-timeouts`, not the merged parent branch.
+
+The new BASE to CHILD merge base fell back to
+`b574071db8024ab51b2cffcd9818bd8d00f943d0`. That commit predates every path
+reported as `add/add`:
+
+| conflict measure | value |
+|---|---|
+| merge base | `b574071db8024ab51b2cffcd9818bd8d00f943d0` |
+| total conflicted paths | 17 |
+| `add/add` conflicts | 11 |
+| content conflicts | 6 |
+| `add/add` paths absent at the merge base | 11 of 11 |
+| content-conflict paths present at the merge base | 6 of 6 |
+
+An `add/add` conflict on a path inherited through a stack is the tell. Git is
+not comparing the two branches from their real shared parent. Its selected
+merge base predates the path.
+
+The content comparison decides whether a bulk resolution is safe:
+
+| measure | value |
+|---|---|
+| PARENT to squash changed paths | 1 |
+| changed path | `tests/ci/test_walkers_skip_worktrees.py` |
+| changed path overlaps the 17 conflicts | no |
+| conflicted paths where BASE differs from PARENT | 0 of 17 |
+| conflicted paths where CHILD differs from PARENT | 17 of 17 |
+
+Commit `74722a9f8` changed
+`tests/ci/test_walkers_skip_worktrees.py` on BASE after PARENT diverged.
+Every conflicted BASE blob still equals PARENT. CHILD descends from PARENT and
+changes all 17 conflicted paths. Keeping CHILD therefore loses no BASE change
+on those paths. The correct tree is CHILD plus BASE's version of the one
+independently changed path.
+
+## Prevention
+
+Before resolving a stacked conflict after a squash, compare ancestry and
+content. Save the pre-squash parent tip because GitHub may delete its branch.
+
+```bash
+base=origin/fix/worktree-walk-timeouts
+child=origin/fix/gc-worktrees-stale-entries
+parent_tip=efc27ee9ba68d36a46a749211517be554368f3af
+squash=0d386e7a564d1150344644452424e255cda24cd5
+
+if git merge-base --is-ancestor "$parent_tip" "$base"; then
+  echo "ancestry intact"
+else
+  echo "ancestry severed"
+fi
+
+git merge-base "$base" "$child"
+git diff --name-status "$parent_tip" "$squash"
+git merge-tree --write-tree --name-only "$child" "$base"
+```
+
+An empty parent-to-squash diff means the squash copied PARENT's tree exactly.
+Use CHILD for every inherited path.
+
+A short diff means the same rule applies outside the listed paths. Compare
+those paths with the conflict list. Restore BASE's version for each independent
+BASE change.
+
+A large diff means the squash changed the tree during merge. Judge each path
+instead of applying one bulk choice.
+
+## Repair
+
+This incident needs one merge and one explicit path restore:
+
+```bash
+base=origin/fix/worktree-walk-timeouts
+
+git merge -s ours --no-commit "$base"
+git checkout "$base" -- tests/ci/test_walkers_skip_worktrees.py
+git commit
+```
+
+The `ours` strategy keeps CHILD's complete tree and records BASE as the second
+parent. The checkout then restores BASE's sole independent change. The commit
+repairs ancestry without rewriting the published CHILD branch.
+
+Rebase is not a compliant alternative. It rewrites CHILD, so publishing it
+needs a force push. `.claude/rules/universal.md` MUST NOT item 1 forbids
+force-pushing a shared branch.
+
+## Prove the repair before committing
+
+`git write-tree` writes the index to a tree object without moving any ref or
+touching the working tree, so the result can be measured before the merge is
+committed:
+
+```bash
+tree=$(git write-tree)
+git diff --name-only "$base" "$tree" | sort > merged.txt
+git diff --name-only "$parent_tip" "$child" | sort > expected.txt
+comm -23 merged.txt expected.txt   # BASE content this merge dropped
+comm -13 merged.txt expected.txt   # CHILD content this merge lost
+```
+
+Both differences empty is necessary and not sufficient. An adversarial review
+of this repair (grok-4.5, 2026-08-06) built the counterexample: substitute a
+third blob on any one of those paths and the path still differs from BASE, so
+it stays in the name list, both `comm` results stay empty, and the content is
+wrong. Name-set equality proves which paths differ, never what they contain.
+
+Add one content check, either of these:
+
+```bash
+# blob equality on every path the child owns
+git diff --name-only "$parent_tip" "$child" | while read -r f; do
+  [ "$(git rev-parse "$tree:$f")" = "$(git rev-parse "$child:$f")" ] || echo "MISMATCH $f"
+done
+
+# or normalized patch equality, index lines stripped
+diff <(git diff "$parent_tip" "$child" | grep -v '^index ') \
+     <(git diff "$base" "$tree"        | grep -v '^index ')
+```
+
+Measured on this repair: 0 blob mismatches across 31 paths, patches byte
+identical, and the full 8397-path tree listing equals CHILD plus BASE's one
+restored file exactly.
+
+## Two side effects to expect
+
+**The push ceiling can trip.** `_unpushed_commit_count`
+(`scripts/validation/git_hook_policy.py`) excludes commits that some other
+remote branch already carries. GitHub deletes the squashed branch on merge, so
+the ~20 commits CHILD inherited from PARENT stop being excluded by any remote
+ref and begin counting against CHILD. Measured here: raw 43, stack-aware 21,
+limit 20, genuinely new 3. Splitting is not the remedy for an overage that the
+repair merge itself caused; the `commit-limit-bypass` label is, with the
+measurement recorded on the PR.
+
+**The Commits tab looks heavier than the diff.** After the repair,
+`git rev-list --first-parent "$base".."$merge"` counts 35 here while the three
+dot diff is exactly CHILD's 31 files. The 14 extra are PARENT-line commits
+whose trees are already in BASE through the squash. Confirmed display only:
+the intersection of the PARENT-to-BASE and BASE-to-merge path lists is empty,
+so no content is applied twice.
+
+## Do not
+
+Do not treat a PR number in `git log` as ancestry proof. Do not resolve 17
+paths one at a time before checking the merge base. Do not treat a one-path
+parent-to-squash diff as empty. Do not confuse `git merge -s ours` with
+`git merge -X ours`; this repair keeps the whole CHILD tree, then restores
+named BASE paths. Do not accept name-set equality as proof that a merge
+resolution preserved content; it answers which paths differ, never what is in
+them.
+
+## Related
+
+- `git-rebase-after-push-costs-two-cycles.md`. A published branch cannot use
+  rebase without a non-fast-forward push.
+- `../quality/verify-squash-merge-by-content-not-ancestry.md`. Verify squash
+  results by content rather than commit reachability.
+- `../decision-squash-only-breaks-ancestry-merge-detection.md`. A negative
+  ancestry result does not mean a squash merge failed.

--- a/.serena/memories/git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md
+++ b/.serena/memories/git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md
@@ -29,11 +29,19 @@ To see them, read the files. Walk `<admin>/refs/**`, skip `ref: ` symrefs (they
 anchor nothing on their own) and the null oid, and feed the oids into the same
 `git rev-list --no-walk --stdin --not --all` query the reflog oids already use.
 An unreadable or unparsable ref file must answer "unknown", never "no risk".
-See `_worktree_ref_oids` and `unreachable_admin_commits` in
-`scripts/maintenance/_gc_stale.py`.
+See `worktree_ref_oids` in `scripts/maintenance/_gc_anchors.py` and
+`unreachable_admin_commits` in `scripts/maintenance/_gc_stale.py`, at commit
+`6fb7054d1` in PR #4728. An earlier draft named `_worktree_ref_oids` in
+`_gc_stale.py`; commit `6fb7054d1` renamed it and moved it, so that path no
+longer resolves.
 
-The rescue is `git update-ref refs/heads/<name> <oid>` from the main checkout,
-which promotes the anchor into the shared store before the worktree goes away.
+The rescue promotes the anchor into the shared store before the worktree goes
+away, run from the main checkout:
+
+```bash
+OID=$(cat .git/worktrees/wt/refs/worktree/mywork)
+git update-ref refs/heads/recovered-work "$OID"
+```
 
 Seven adversarial review rounds. This was the seventh distinct loss channel,
 and the fourth one that a mock-based test suite reported as safe.

--- a/.serena/memories/git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md
+++ b/.serena/memories/git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md
@@ -1,0 +1,39 @@
+# rev-list --not --all cannot see another worktree's local refs
+
+`refs/worktree/`, `refs/bisect/`, and `refs/rewritten/` are per-worktree ref
+namespaces. Git stores them under the worktree's own admin directory
+(`.git/worktrees/<name>/refs/`), not in the shared ref store. Every ref query
+run from the main checkout is therefore blind to them.
+
+Reproduced against real git 2.43.0:
+
+```bash
+git worktree add wt -b feature
+cd wt
+OID=$(git commit-tree HEAD^{tree} -p HEAD -m mywork)
+git update-ref refs/worktree/mywork "$OID"
+cat ../.git/worktrees/wt/refs/worktree/mywork   # the oid lives here
+cd ..
+git rev-list --no-walk "$OID" --not --all       # prints the oid: unreachable
+git for-each-ref --contains "$OID"              # empty
+grep -c "$OID" .git/worktrees/wt/logs/HEAD      # 0
+```
+
+`update-ref` on a worktree-local ref writes no reflog entry for HEAD, so a
+reflog probe finds nothing either. Every ordinary safety check reads clean, and
+`git worktree remove` deletes the admin directory with the ref inside it. The
+commit survives until the next `git gc --prune=now`, then `cat-file` is fatal.
+Verified end to end, with a negative control that loses the commit.
+
+To see them, read the files. Walk `<admin>/refs/**`, skip `ref: ` symrefs (they
+anchor nothing on their own) and the null oid, and feed the oids into the same
+`git rev-list --no-walk --stdin --not --all` query the reflog oids already use.
+An unreadable or unparsable ref file must answer "unknown", never "no risk".
+See `_worktree_ref_oids` and `unreachable_admin_commits` in
+`scripts/maintenance/_gc_stale.py`.
+
+The rescue is `git update-ref refs/heads/<name> <oid>` from the main checkout,
+which promotes the anchor into the shared store before the worktree goes away.
+
+Seven adversarial review rounds. This was the seventh distinct loss channel,
+and the fourth one that a mock-based test suite reported as safe.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -101,7 +101,7 @@
 |utility script markdown fence PathInfo security pattern: [skills-utilities-index](skills-utilities-index.md) (225)
 |edit file read search replace text operation: [patterns/edit-001-read-before-edit-pattern](patterns/edit-001-read-before-edit-pattern.md) (464), [patterns/edit-002-unique-context-for-edit-matching](patterns/edit-002-unique-context-for-edit-matching.md) (368)
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
-|git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (411)
+|git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (471)
 |git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |subagent sandbox worktree checkout moves head wrong commit pushed reverts unstaged edit throwaway clone push sha not head: [git/git-a-subagent-in-your-worktree-moves-your-head](git/git-a-subagent-in-your-worktree-moves-your-head.md) (1729)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -101,7 +101,7 @@
 |utility script markdown fence PathInfo security pattern: [skills-utilities-index](skills-utilities-index.md) (225)
 |edit file read search replace text operation: [patterns/edit-001-read-before-edit-pattern](patterns/edit-001-read-before-edit-pattern.md) (464), [patterns/edit-002-unique-context-for-edit-matching](patterns/edit-002-unique-context-for-edit-matching.md) (368)
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
-|git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (471)
+|git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (590)
 |git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |subagent sandbox worktree checkout moves head wrong commit pushed reverts unstaged edit throwaway clone push sha not head: [git/git-a-subagent-in-your-worktree-moves-your-head](git/git-a-subagent-in-your-worktree-moves-your-head.md) (1729)

--- a/.serena/memories/skills-git-index.md
+++ b/.serena/memories/skills-git-index.md
@@ -5,6 +5,8 @@
 | stale branch delete prune cleanup obsolete local-only tracking | [git/git-branch-cleanup-pattern](git/git-branch-cleanup-pattern.md) |
 | merge pre-flight deletion upstream conflict detect | [git/git-merge-preflight](git/git-merge-preflight.md) |
 | squash merge stacked PR chain automatic base retarget merge-base ancestor collapsed add/add conflict ours strategy content-faithful force-push | [git/git-a-squash-merge-severs-a-stacked-pr](git/git-a-squash-merge-severs-a-stacked-pr.md) |
+| rev-list not-all blind refs/worktree bisect rewritten per-worktree namespace admin dir gc prune orphan | [git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs](git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md) |
+| subagent reviewer wipes tree reset --hard destroys commits bundle backup dispatch isolation reflog rescue | [git/git-a-review-subagent-will-clean-the-worktree-you-gave-it](git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md) |
 | worktree parallel isolation PR cross-contamination | [git/git-worktree-parallel](git/git-worktree-parallel.md) |
 | worktree cleanup remove temporary session end | [git/git-worktree-cleanup](git/git-worktree-cleanup.md) |
 | conflict modify/delete upstream local accept resolution | [git/git-conflict-deleted-file](git/git-conflict-deleted-file.md) |

--- a/.serena/memories/skills-git-index.md
+++ b/.serena/memories/skills-git-index.md
@@ -4,6 +4,7 @@
 | checkout drift stale steering system prompt behind main detached superseded rule | [git/git-checkout-drift-feeds-stale-agent-steering](git/git-checkout-drift-feeds-stale-agent-steering.md) |
 | stale branch delete prune cleanup obsolete local-only tracking | [git/git-branch-cleanup-pattern](git/git-branch-cleanup-pattern.md) |
 | merge pre-flight deletion upstream conflict detect | [git/git-merge-preflight](git/git-merge-preflight.md) |
+| squash merge stacked PR chain automatic base retarget merge-base ancestor collapsed add/add conflict ours strategy content-faithful force-push | [git/git-a-squash-merge-severs-a-stacked-pr](git/git-a-squash-merge-severs-a-stacked-pr.md) |
 | worktree parallel isolation PR cross-contamination | [git/git-worktree-parallel](git/git-worktree-parallel.md) |
 | worktree cleanup remove temporary session end | [git/git-worktree-cleanup](git/git-worktree-cleanup.md) |
 | conflict modify/delete upstream local accept resolution | [git/git-conflict-deleted-file](git/git-conflict-deleted-file.md) |


### PR DESCRIPTION
## Summary

Three git memories written during the worktree garbage collector work. None of
them is about the collector, so they ship here off main rather than inflating
that branch.

The first one is the expensive one. A squash merge writes a brand new commit
and keeps no link to the branch whose content it copied. The moment a stacked
parent merges, the child's parent stops being an ancestor, GitHub retargets the
child on its own, the merge base collapses to a commit that predates the files,
and git reports `add/add` conflicts on paths both branches plainly have. Read
against `git log`, the stack looks intact: the base tip literally says
`fix(...) (#4708)`. Only `git merge-base --is-ancestor` answers the question,
and it answers no.

That cost 17 conflicts and a wasted push cycle on PR #4718 before the shape was
recognized.

## Changes

- `.serena/memories/git/git-a-squash-merge-severs-a-stacked-pr.md`: new. The
  ancestry measurement, the conflict table showing all 11 `add/add` paths absent
  at the collapsed merge base, the content check that decides whether a bulk
  resolution is safe, and the repair that worked here: `git merge -s ours`
  followed by a named restore of the one path the base changed independently.
  Rebase is recorded as non-compliant, since publishing it needs a force push
  that the repository's universal rules forbid on a shared branch.
- `.serena/memories/git/git-a-review-subagent-will-clean-the-worktree-you-gave-it.md`:
  new. A review subagent handed a worktree ran `reset --hard` and `clean` in it
  and destroyed work that was already committed there. Recovery worked because a
  bundle happened to exist, which is luck rather than a control. Carries the
  isolation and backup steps.
- `.serena/memories/git/git-rev-list-not-all-cannot-see-another-worktrees-local-refs.md`:
  new. `refs/worktree` is a per-worktree namespace, so anything reasoning about
  unpushed commits across worktrees reads a false empty.
- `.serena/memories/skills-git-index.md`, `.serena/memories/memory-index.md`:
  index rows for all three, added in the same change.

## Two things the incident taught after the fact

Both are in the memory because neither was knowable when the repair was made.

**Name-set equality is not proof that a merge resolution preserved content.**
The repair was verified with `git write-tree` and two `comm` passes over
`git diff --name-only`, and both differences were empty. An adversarial review
(grok-4.5) then built the counterexample: substitute a third blob on any one of
those paths and the path still differs from the base, so it stays in the name
list, both `comm` results stay empty, and the bytes are wrong. The memory now
carries the blob-equality and normalized-patch checks that do settle it. For the
record, the actual repair passes those too: 0 blob mismatches across 31 paths,
patches byte identical, and full tree equality to the expected construction.

**Deleting the squashed branch trips the child's push ceiling.** GitHub deletes
the merged branch, so the commits the child inherited from it stop being
excluded by any remote ref and start counting against the child. Measured on
#4718: raw 43, stack-aware 21, limit 20, genuinely new 3. Over by exactly one,
and the one is the repair merge itself. Splitting cannot fix that shape.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

Read the squash memory against the claim it makes. Every table in it is a
measurement taken on the live refs at the time, not a reconstruction. The two
SHAs it names as the pre-squash parent tip and the squash commit both resolve.

The one judgement call worth checking: the memory says `-s ours` plus a named
restore is safe *only* when the parent-to-squash diff is empty or short, and
says to judge each path individually when that diff is large. That conditional
is the whole load-bearing part.

## Testing

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

`uv run --frozen python scripts/validation/memory_index.py --ci` passes, 0
keyword issues. All three memories resolve from their index rows, and every
relative reference inside them resolves on disk. Token counts were regenerated
with `scripts/update_memory_index_tokens.py`, not written by hand.

## Agent Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious

Refs #4708, #4718, #2761.
