### PR TITLE
docs(memory): record that a __file__-rooted script validates its own worktree

### DIFF
--- a/.serena/memories/git/git-a-script-run-by-absolute-path-validates-its-own-worktree.md
+++ b/.serena/memories/git/git-a-script-run-by-absolute-path-validates-its-own-worktree.md
@@ -1,0 +1,175 @@
+# A script that derives its root from `__file__` reads its own worktree, whatever directory you are standing in
+
+## The trap
+
+Many scripts in this repository find the repository root from their own
+location on disk rather than from the current directory.
+`scripts/update_memory_index_tokens.py:171` is the shape:
+
+```python
+repo_root = Path(__file__).resolve().parent.parent
+```
+
+With `git worktree`, that is a silent correctness hole. Standing in worktree B
+and invoking worktree A's copy of a validator makes the validator read, check,
+and report on **A's** files. It exits 0 because A is fine. You conclude B is
+fine. B was never examined.
+
+The failure is silent and it inverts the signal: the more worktrees you run, the
+more confident and the more wrong the PASS becomes.
+
+## Measured proof
+
+Observed 2026-08-05. Same working directory, only the script copy differs.
+
+Setup: in worktree `wt-scriptroot`, edit one recorded token count in
+`.serena/memories/memory-index.md` from `1132` to `9999`. That worktree's index
+is now provably stale. The other clone's index is untouched and current.
+
+Direction A, the other tree's script by absolute path:
+
+```
+$ cd ~/src/scratch/wt-scriptroot
+$ uv run --frozen python ~/src/GitHub/rjmurillo/ai-agents/scripts/update_memory_index_tokens.py --check
+Creating virtual environment at: .venv
+   Building ai-agents @ file:///home/richard/src/scratch/wt-scriptroot
+memory-index.md token counts are current
+exit=0
+```
+
+Direction B, this worktree's own copy, unchanged cwd, unchanged file:
+
+```
+$ cd ~/src/scratch/wt-scriptroot
+$ uv run --frozen python scripts/update_memory_index_tokens.py --check
+memory-index.md token counts are stale:
+  git/git-shallow-is-shared-across-every-worktree.md: recorded 9999, actual 1132
+exit=1
+```
+
+A reports current because it never looked at the stale file; it examined the
+other clone. B reports stale. The only variable is which copy of the script ran.
+
+Note the `Built ai-agents @ file:///home/richard/src/scratch/wt-scriptroot` line
+in direction A. `uv` resolved the project from cwd correctly, and the script
+still read the wrong tree, because `uv` has no influence on a `__file__`-derived
+path. A correct `uv` project does not save you.
+
+## What this does and does not prove
+
+**Proven**: the script targets the tree containing the script. `--check`
+therefore reports on that tree, so a false PASS about the tree you are editing
+is real and reproducible.
+
+**Not proven by the experiment above**: that the mutating form necessarily
+writes. Read the code rather than assuming. `update_memory_index_tokens.py:140`
+writes only when the content changed:
+
+```python
+if updated != original:
+    index_path.write_text(updated, encoding="utf-8")
+```
+
+So without `--check`, any needed correction lands in the **script's** tree, and
+only if that tree's index was itself stale. A clean tree is left alone. Either
+way the tree you meant to fix is untouched.
+
+## The hook is not fooled, and normally repairs rather than rejects
+
+Do not expect the commit hook to catch this for you, and do not expect it to
+reject. In `lefthook.yml` the pre-commit sequence is piped and ordered:
+
+1. `memory-token-update` (line 260) runs the updater without `--check`, repairing counts.
+2. `stage-memory-index` (line 268) stages the repaired index.
+3. `memory-token-counts` (line 291) runs `--check`, which then passes.
+
+Each of those invocations is a relative path inside the tree being committed, so
+the hook operates on the right tree regardless of what you ran at the desk.
+
+Rejection at step 3 is the exception, not the rule. Steps 1 and 2 both carry
+`skip: [merge, "test $SKIP_AUTOFIX = 1"]`, so the check only sees stale counts
+when the commit is a merge or `SKIP_AUTOFIX=1` is set. That matches
+`.claude/rules/knowledge-persistence.md` MUST-6, which documents the same
+skip-driven staleness from the other direction.
+
+## The actual invariant
+
+The rule is not "use a relative path". An absolute path that lands inside the
+intended worktree is fine, and a relative path that resolves through a symlink
+into another worktree is not.
+
+**The resolved script path must be contained by the worktree you intend to
+operate on.** Invoking relatively from that worktree's root is simply the
+cheapest way to guarantee it:
+
+```bash
+set -euo pipefail
+WORKTREE="$(git rev-parse --show-toplevel)"
+SCRIPT="scripts/update_memory_index_tokens.py"
+cd "$WORKTREE"
+test -f "$SCRIPT" || { echo "script missing in this tree"; exit 1; }
+uv run --frozen python "$SCRIPT" --check
+```
+
+## Checking a candidate invocation
+
+A detector must inspect the path you are **about to run**, so it has to take
+that path as input. A check that rebuilds the path from the current tree is
+tautological: it can only ever report a path inside the current tree, so it
+never fires.
+
+```bash
+set -euo pipefail
+CANDIDATE="${1:?pass the script path you intend to run}"
+python3 - "$CANDIDATE" <<'PY'
+import os, subprocess, sys
+from pathlib import Path
+
+candidate = Path(sys.argv[1]).resolve()
+for var in ("GIT_DIR", "GIT_WORK_TREE"):
+    if var in os.environ:
+        sys.exit(f"{var} is set; resolve it before trusting this check")
+top = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True, check=True,
+).stdout.strip()
+tree = Path(top).resolve()
+if not candidate.is_relative_to(tree):
+    sys.exit(f"WRONG TREE\n  candidate: {candidate}\n  this tree: {tree}")
+print(f"contained by {tree}")
+PY
+```
+
+Python does the resolution because `realpath` is absent on stock macOS, and
+`Path.resolve` follows symlinks on both paths so a symlinked script cannot
+escape the containment test. `git rev-parse --show-toplevel` is correct inside a
+linked worktree; `--git-common-dir` would be wrong, since it names the shared
+metadata directory rather than this checkout.
+
+## Scope: common, not universal
+
+Do not over-apply this. Measured in this repository:
+
+| Measure | Count |
+|---|---|
+| files under `scripts/` matching `Path(__file__).resolve().parent` | 119 |
+| Python files under `scripts/` (recursive) | 431 |
+| Python files at the top level of `scripts/` | 60 |
+
+So the pattern appears in roughly 28 percent of the tree, and a bare substring
+match does not prove the expression controls that script's operational root.
+Counterexamples that correctly derive from cwd:
+
+- `scripts/restructure_memories.py:394`, `repo_root = Path.cwd()`
+- `scripts/validation/check_unreachable_code.py:119`, `repo_root = Path.cwd()`
+
+Confirmed to carry the trap alongside the token updater:
+`scripts/check_skill_exists.py`.
+
+Treat an absolute-path invocation from a different worktree as unproven for any
+script you have not read, rather than assuming every script is affected.
+
+## Related
+
+- [git/git-shallow-is-shared-across-every-worktree](git-shallow-is-shared-across-every-worktree.md), the opposite shape: state shared across worktrees when you expect it to be per-tree.
+- [git/git-stash-is-shared-across-every-worktree](git-stash-is-shared-across-every-worktree.md), same family.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -105,6 +105,7 @@
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (644)
 |git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
+|script absolute path wrong worktree repo_root __file__ validates own tree false pass token updater containment check candidate path: [git/git-a-script-run-by-absolute-path-validates-its-own-worktree](git/git-a-script-run-by-absolute-path-validates-its-own-worktree.md) (1736)
 |subagent sandbox worktree checkout moves head wrong commit pushed reverts unstaged edit throwaway clone push sha not head: [git/git-a-subagent-in-your-worktree-moves-your-head](git/git-a-subagent-in-your-worktree-moves-your-head.md) (1729)
 |agent steering system prompt renders from live checkout stale behind main detached superseded rule no gate catches: [git/git-checkout-drift-feeds-stale-agent-steering](git/git-checkout-drift-feeds-stale-agent-steering.md) (943)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)


### PR DESCRIPTION
## Summary

A repo script invoked by absolute path from a different worktree validates the
**script's** worktree, not the one you are standing in. It then reports a clean
PASS for a tree you never checked.

This adds one Serena memory recording the trap, what was measured, and how to
check a candidate invocation before you run it.

## Why this matters

The failure is silent and it fails in the safe-looking direction. You get exit 0
and "counts are current" while the tree you actually care about is stale. Nothing
in the output names the tree that was read.

## Measured proof, two directions

Planted a deliberately stale token count (1132 changed to 9999) in a worktree's
`memory-index.md`, then ran the same validator two ways against the same file and
the same working directory.

| Invocation | Reads | Verdict | Exit |
| --- | --- | --- | --- |
| Main clone's copy, by absolute path | the main clone | "token counts are current" | 0 |
| The worktree's own copy | the worktree | "stale: recorded 9999, actual 1132" | 1 |

`uv` does not save you. It printed `Built ai-agents @ file:///.../wt-scriptroot`,
correctly resolving the project from the working directory, while the script still
read the other tree.

## The actual invariant

Not "use a relative path." An absolute path inside the intended worktree is safe,
and a relative path resolving through a symlink into another worktree is not. The
invariant is that the **resolved script path must be contained by the intended
worktree**.

The memory ships a detector that takes the candidate path as an argument and tests
containment in Python. It was verified in three directions: in-tree returns
"contained by" exit 0, the other tree returns "WRONG TREE" exit 1, and a set
`GIT_DIR` returns a guard message exit 1.

## Scope, measured rather than asserted

| Measure | Count |
| --- | --- |
| Files under `scripts/` matching `Path(__file__).resolve().parent` | 119 |
| Python files under `scripts/` recursively | 431 |

That is about 28 percent, so the pattern is common rather than universal.
`restructure_memories.py:394` and `check_unreachable_code.py:119` correctly use
the working directory instead.

## The pre-commit hook is not fooled

`lefthook.yml` invokes the updater by relative path from inside the committed tree,
so the hook itself cannot hit this. It also repairs before it checks:
`memory-token-update` (line 260) and `stage-memory-index` (line 268) both run
before `memory-token-counts --check` (line 291). Rejection needs a merge commit or
`SKIP_AUTOFIX=1`, which matches `.claude/rules/knowledge-persistence.md` MUST-6.

## Adversarial review

Reviewed by `gpt-5.6-sol` (different model family from the author). Verdict came
back **INCORRECT** with three High findings. Every finding was independently
re-verified against source before being accepted, per the Sol integrity rule, and
all of them held:

1. The original draft claimed the hook rejects stale counts. It repairs them.
2. The original draft claimed an unconditional mutation. The write at
   `update_memory_index_tokens.py:140` is conditional on a diff.
3. The original detector rebuilt its input as `$TREE/$SCRIPT`, so it was
   tautological and could never fire.

The memory was rewritten around all three and the detector replaced.

## Testing

- Two-direction control on the trap, above.
- Three-direction control on the corrected detector.
- `memory_index.py --ci`: 326 files indexed, 0 missing, 0 keyword issues.
- Token counts recomputed with the updater, never hand-edited.
- Style gate: zero em/en dashes, zero banned words, every bash fence passes
  `bash -n`, zero angle-bracket placeholders, both `Related` targets resolve.

Refs #4415
