### PR TITLE
docs(memory): record that git stash -m after -- is parsed as a pathspec

### DIFF
--- a/.serena/memories/git/git-stash-m-after-double-dash-is-a-pathspec.md
+++ b/.serena/memories/git/git-stash-m-after-double-dash-is-a-pathspec.md
@@ -1,0 +1,69 @@
+# `git stash push -m` after `--` is parsed as a pathspec
+
+`git stash push -- <path> -m <message>` does not stash anything. Everything
+after `--` is a pathspec, so git looks for files literally named `-m` and
+`<message>`, finds neither, and exits non-zero without creating a stash.
+
+The flag order is not stylistic. `-m` has to come before `--`.
+
+```bash
+# correct
+git stash push -m scopetests -- tests/test_thing.py
+
+# silently saves nothing
+git stash push -- tests/test_thing.py -m scopetests
+```
+
+## What it actually prints
+
+```
+error: pathspec ':(,prefix:0)-m' did not match any file(s) known to git
+error: pathspec ':(,prefix:0)scopetests' did not match any file(s) known to git
+Did you forget to 'git add'?
+```
+
+Reproduced 2026-08-07 in this repo. The `:(,prefix:0)` wrapper is git echoing
+its own pathspec normalization, which is why the message does not read like a
+flag-order complaint.
+
+## Why it destroys work
+
+The failure is loud only if you are watching. Three things hide it:
+
+1. The stash command is usually one link in a chain, and a following
+   `git checkout <path>` runs regardless.
+2. `2>/dev/null` on the stash call hides both error lines.
+3. `git stash list` afterwards still shows entries, from older stashes on
+   other branches, because the stash stack is shared across every worktree
+   (see `git-stash-is-shared-across-every-worktree`). A non-empty list reads
+   as success.
+
+Measured cost this session: 302 lines of new tests written, stashed with the
+wrong flag order, then discarded by the `git checkout` on the next line. The
+work was recoverable only because the text still existed in the conversation.
+
+## The check that catches it
+
+Compare the stash top before and after. A successful `stash push` always
+changes it.
+
+```bash
+before=$(git rev-parse --quiet --verify refs/stash || echo none)
+git stash push -m "$MSG" -- "$@" || echo "stash failed"
+after=$(git rev-parse --quiet --verify refs/stash || echo none)
+[ "$before" = "$after" ] && echo "NOTHING WAS STASHED, do not checkout" && exit 1
+```
+
+`git stash list | head -1` is not a substitute. It matches an older stash from
+another worktree just as readily.
+
+## The rule
+
+Never pair a stash with a destructive follow-up in one chain. Verify the stash
+landed first, by ref, then destroy. If a stash is only a backup, prefer `cp` to
+a path outside the tree: it has no flag-order trap and no shared stack.
+
+## Related
+
+- `git-stash-is-shared-across-every-worktree`, why `git stash list` is not
+  evidence your own stash exists.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -104,6 +104,7 @@
 |git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (644)
 |git stash shared across worktrees pop takes another agent work switch abort commits to wrong branch: [git/git-stash-is-shared-across-every-worktree](git/git-stash-is-shared-across-every-worktree.md) (965)
+|git stash push -m after double dash parsed as pathspec silent no stash checkout destroys work verify refs/stash: [git/git-stash-m-after-double-dash-is-a-pathspec](git/git-stash-m-after-double-dash-is-a-pathspec.md) (662)
 |git shallow graft depth fetch unshallow blocks push every worktree common dir pin sha: [git/git-shallow-is-shared-across-every-worktree](git/git-shallow-is-shared-across-every-worktree.md) (1132)
 |script absolute path wrong worktree repo_root __file__ validates own tree false pass token updater containment check candidate path: [git/git-a-script-run-by-absolute-path-validates-its-own-worktree](git/git-a-script-run-by-absolute-path-validates-its-own-worktree.md) (1736)
 |merge conflict resolve ours theirs convenience wrong side endingCommit session log stack last merge wins validator proves existence not correctness: [git/git-a-conflict-resolved-for-convenience-records-a-falsehood](git/git-a-conflict-resolved-for-convenience-records-a-falsehood.md) (1185)


### PR DESCRIPTION
## Summary

`git stash push -- <path> -m <msg>` stashes nothing. Everything after `--` is a pathspec, so git looks for files literally named `-m` and `<msg>`, finds neither, and exits without creating a stash.

Cost this session: 302 lines of new tests. The stash was one link in a chain and the `git checkout` on the next line ran regardless.

```bash
# correct
git stash push -m scopetests -- tests/test_thing.py

# silently saves nothing
git stash push -- tests/test_thing.py -m scopetests
```

## Why it is not obvious

Three properties hide the failure:

1. **The error does not mention flag order.** Git echoes its own pathspec normalization: `error: pathspec ':(,prefix:0)-m' did not match any file(s) known to git`. It reads as a missing-file problem.
2. **`2>/dev/null` hides both error lines.** Common on a stash you expect to be a no-op.
3. **`git stash list` afterwards is still non-empty.** The stash stack is shared across every worktree, so an older stash from another worktree reads as success.

## The check that catches it

Compare `refs/stash` before and after. A successful push always moves that ref.

```bash
before=$(git rev-parse --quiet --verify refs/stash || echo none)
git stash push -m "$MSG" -- "$@" || echo "stash failed"
after=$(git rev-parse --quiet --verify refs/stash || echo none)
[ "$before" = "$after" ] && echo "NOTHING WAS STASHED, do not checkout" && exit 1
```

`git stash list | head -1` is not a substitute. It matches another worktree's stash just as readily.

## Verification

Both controls were **executed**, not parsed:

| Control | refs/stash before | after | Result |
|---|---|---|---|
| Wrong order (`--` then `-m`) | `7040d5dda` | `7040d5dda` | unchanged, file still staged, exact error captured |
| Correct order (`-m` then `--`) | `7040d5dda` | `443875aee` | ref moved |

The probe stash was then dropped and `refs/stash` verified back at `7040d5dda`, so the shared stack is exactly as found. This matters here more than usual: the stack is shared across all worktrees, so a leftover probe would be another agent's problem.

- Style gate: zero em-dashes, zero en-dashes, zero banned vocabulary.
- Indexed under the git domain with a `(0)` placeholder; `update_memory_index_tokens.py` computed 662. Not hand-written.
- `scripts/validation/memory_index.py --ci` PASSED: 33 domains, 326 files, 0 missing, 0 keyword issues.

## Related

Cross-references the existing `git-stash-is-shared-across-every-worktree` memory, which explains why `git stash list` is not evidence your own stash exists. That memory happens to use the correct flag order at line 78 but never warns about the wrong one.

Stacked on #4736.

Refs #4718
