### PR TITLE
fix(ci): restore script entry point portability

### DIFF
--- a/.github/workflows/backlog-triage.yml
+++ b/.github/workflows/backlog-triage.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: >-
-          uv run --frozen python scripts/issue_triage.py
+          uv run --frozen python -m scripts.issue_triage
           --limit "$BACKLOG_MAX_ISSUES"
           --ai
           --github-output "$GITHUB_OUTPUT"

--- a/scripts/homework_scanner.py
+++ b/scripts/homework_scanner.py
@@ -23,9 +23,14 @@ import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from scripts.github_core.api import gh_api_paginated
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.api import gh_api_paginated  # noqa: E402
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/scripts/invoke_batch_pr_review.py
+++ b/scripts/invoke_batch_pr_review.py
@@ -20,8 +20,12 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
-from scripts.github_core.worktree_identity import reset_worktree_identity
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
+from scripts.github_core.worktree_identity import reset_worktree_identity  # noqa: E402
 
 SUBPROCESS_TIMEOUT_SECONDS = 60
 

--- a/scripts/invoke_pr_maintenance.py
+++ b/scripts/invoke_pr_maintenance.py
@@ -29,11 +29,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from scripts.github_core import (
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core import (  # noqa: E402
     check_workflow_rate_limit,
     resolve_repo_params,
 )
-from scripts.pr_maintenance_rollup import (
+from scripts.pr_maintenance_rollup import (  # noqa: E402
     complete_status_check_rollups,
     fetch_status_context_page_with_gh,
     rollup_has_failing_checks,

--- a/scripts/invoke_session_start_gate.py
+++ b/scripts/invoke_session_start_gate.py
@@ -26,7 +26,11 @@ import sys
 from datetime import date
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 
 def run_git(*args: str, timeout: int = 10) -> subprocess.CompletedProcess[str]:

--- a/scripts/issue_triage.py
+++ b/scripts/issue_triage.py
@@ -54,7 +54,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from scripts.github_core.validation import is_github_name_valid
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.validation import is_github_name_valid  # noqa: E402
 
 DEFAULT_STALE_DAYS = 60
 DEFAULT_DUP_THRESHOLD = 0.7
@@ -619,7 +623,8 @@ def write_ai_github_outputs(matrix: dict[str, object], output_path: str) -> None
     """Write matrix metadata to GitHub Actions output format."""
 
     include = matrix.get("include")
-    count = int(matrix.get("count") or 0)
+    count_value = matrix.get("count")
+    count = int(count_value) if isinstance(count_value, int | str) else 0
     github_matrix = {"include": include if isinstance(include, list) else []}
     with Path(output_path).open("a", encoding="utf-8") as handle:
         handle.write(f"matrix={json.dumps(github_matrix)}\n")

--- a/scripts/maintenance/gc_worktrees.py
+++ b/scripts/maintenance/gc_worktrees.py
@@ -53,7 +53,12 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 if TYPE_CHECKING:
     from scripts.maintenance import _gc_apply, _gc_parse, _gc_reasons, _gc_remote, _gc_stale
@@ -73,12 +78,12 @@ else:
         import _gc_remote
         import _gc_stale
 
-from scripts.maintenance.worktree_occupancy import (
+from scripts.maintenance.worktree_occupancy import (  # noqa: E402
     Occupancy,
     is_occupied,
     occupied_paths,
 )
-from scripts.maintenance.worktree_report import (
+from scripts.maintenance.worktree_report import (  # noqa: E402
     KEEP_BARE,
     KEEP_DETACHED,
     KEEP_DIRTY,

--- a/scripts/memory/detect_stale.py
+++ b/scripts/memory/detect_stale.py
@@ -22,7 +22,11 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 
 @dataclass

--- a/scripts/memory/memory_health.py
+++ b/scripts/memory/memory_health.py
@@ -19,7 +19,11 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 # Thresholds from memory-size-001-decomposition-thresholds
 MAX_CHARS = 10_000

--- a/scripts/memory_sync/__main__.py
+++ b/scripts/memory_sync/__main__.py
@@ -1,6 +1,13 @@
 """Entry point for python -m memory_sync."""
 
-from scripts.memory_sync.cli import main
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.memory_sync.cli import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/scripts/memory_sync/cli.py
+++ b/scripts/memory_sync/cli.py
@@ -25,10 +25,14 @@ import sys
 import tempfile
 from pathlib import Path
 
-from scripts.memory_sync.freshness import check_freshness
-from scripts.memory_sync.mcp_client import McpClient, McpError
-from scripts.memory_sync.models import FreshnessStatus, SyncOperation
-from scripts.memory_sync.sync_engine import (
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.memory_sync.freshness import check_freshness  # noqa: E402
+from scripts.memory_sync.mcp_client import McpClient, McpError  # noqa: E402
+from scripts.memory_sync.models import FreshnessStatus, SyncOperation  # noqa: E402
+from scripts.memory_sync.sync_engine import (  # noqa: E402
     StateError,
     detect_changes,
     is_memory_file,

--- a/scripts/new_validated_pr.py
+++ b/scripts/new_validated_pr.py
@@ -21,7 +21,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 SKILL_RELPATH = Path(".claude/skills/github/scripts/pr/new_pr.py")
 """Dispatch target, relative to the repo root.

--- a/scripts/security/invoke_precommit_security.py
+++ b/scripts/security/invoke_precommit_security.py
@@ -27,7 +27,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,

--- a/scripts/security/invoke_security_retrospective.py
+++ b/scripts/security/invoke_security_retrospective.py
@@ -27,7 +27,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,

--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -39,7 +39,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from scripts.github_core.repo import get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,

--- a/scripts/sync_mcp_config.py
+++ b/scripts/sync_mcp_config.py
@@ -25,7 +25,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from scripts.github_core.repo import get_repo_root as _shared_get_repo_root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.github_core.repo import get_repo_root as _shared_get_repo_root  # noqa: E402
 
 
 def get_repo_root(override: str | None = None) -> Path:

--- a/tests/test_issue_triage.py
+++ b/tests/test_issue_triage.py
@@ -7,7 +7,9 @@ stale detection, missing priority label, and missing area label.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -51,11 +53,78 @@ from scripts.issue_triage import (
     write_ai_github_outputs,
 )
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ISSUE_TRIAGE = _REPO_ROOT / "scripts" / "issue_triage.py"
+
 
 @pytest.fixture
 def now() -> datetime:
     """Anchor 'now' so tests are deterministic."""
     return datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC)
+
+
+def _run_issue_triage_cli(
+    invocation: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    if invocation == "direct":
+        command = [sys.executable, "-I", "-S", str(_ISSUE_TRIAGE), *args]
+    else:
+        command = [
+            sys.executable,
+            "-S",
+            "-m",
+            "scripts.issue_triage",
+            *args,
+        ]
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        cwd=_REPO_ROOT,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("invocation", ["direct", "module"])
+def test_cli_help_succeeds_without_the_editable_install(invocation: str) -> None:
+    result = _run_issue_triage_cli(invocation, "--help")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Phase 1 mechanical issue triage scanner" in result.stdout
+
+
+@pytest.mark.parametrize("invocation", ["direct", "module"])
+def test_cli_invalid_stale_days_returns_config_exit(invocation: str) -> None:
+    result = _run_issue_triage_cli(invocation, "--stale-days", "-1")
+
+    assert result.returncode == 2
+    assert result.stderr.strip() == "--stale-days must be >= 0"
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("invocation", ["direct", "module"])
+def test_cli_empty_input_returns_empty_report(
+    invocation: str, tmp_path: Path
+) -> None:
+    input_path = tmp_path / "issues.json"
+    input_path.write_text("[]", encoding="utf-8")
+
+    result = _run_issue_triage_cli(
+        invocation,
+        "--input",
+        str(input_path),
+        "--format",
+        "json",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["issues_scanned"] == 0
+    assert result.stderr == ""
 
 
 def make_issue(

--- a/tests/validation/test_validation_entry_point_imports.py
+++ b/tests/validation/test_validation_entry_point_imports.py
@@ -1,9 +1,8 @@
-"""Validation entry points must import when run as a plain script.
+"""Script entry points must import when run as a plain script.
 
-CI invokes several validators as ``python3 scripts/validation/<name>.py`` after
-``actions/setup-python`` with no project install. In that mode ``sys.path[0]``
-is ``scripts/validation``, not the repository root, so an absolute
-``scripts.validation.*`` import fails unless the entry point puts the root on
+CI and documentation invoke scripts through file paths. In that mode
+``sys.path[0]`` is the script's directory, not the repository root, so an
+absolute ``scripts.*`` import fails unless the entry point puts the root on
 ``sys.path`` itself.
 
 Local runs never reproduce this. ``uv`` installs the project in editable mode,
@@ -23,6 +22,7 @@ Refs #4210 (recurrence catalogue), #3073 (the first fix of this shape).
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -30,8 +30,15 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
 MAIN_GUARD = '__name__ == "__main__"'
+MODULE_ONLY_ENTRY_POINTS = frozenset(
+    {
+        SCRIPTS_DIR / "memory_enhancement" / "__main__.py",
+        SCRIPTS_DIR / "memory_enhancement" / "hooks" / "post_tool_call_memory.py",
+        SCRIPTS_DIR / "memory_enhancement" / "hooks" / "session_end_memory.py",
+    }
+)
 
 # Reproduce a bare `python3 <script>` interpreter: repository root absent from
 # `sys.path`, editable-install finders removed, script directory present.
@@ -51,6 +58,10 @@ _RUNNER = (
 
 def _import_as_script(script: Path, repo_root: Path) -> subprocess.CompletedProcess[str]:
     """Import ``script`` with the repository root off the import path."""
+    env = os.environ.copy()
+    plugin_root = str(repo_root / ".claude")
+    env["COPILOT_PLUGIN_ROOT"] = plugin_root
+    env["CLAUDE_PLUGIN_ROOT"] = plugin_root
     return subprocess.run(
         [sys.executable, "-c", _RUNNER, str(repo_root), str(script)],
         capture_output=True,
@@ -58,14 +69,16 @@ def _import_as_script(script: Path, repo_root: Path) -> subprocess.CompletedProc
         timeout=120,
         cwd=str(repo_root),
         check=False,
+        env=env,
     )
 
 
 def _entry_points() -> list[Path]:
     return sorted(
         path
-        for path in VALIDATION_DIR.glob("*.py")
-        if MAIN_GUARD in path.read_text(encoding="utf-8")
+        for path in SCRIPTS_DIR.rglob("*.py")
+        if path not in MODULE_ONLY_ENTRY_POINTS
+        and MAIN_GUARD in path.read_text(encoding="utf-8")
     )
 
 
@@ -75,7 +88,10 @@ def _entry_point_ids() -> list[str]:
 
 def test_the_scan_finds_entry_points() -> None:
     """Guard the population: an empty scan would make every case vacuous."""
-    assert len(_entry_points()) >= 20
+    entry_points = _entry_points()
+
+    assert len(entry_points) >= 250
+    assert SCRIPTS_DIR / "issue_triage.py" in entry_points
 
 
 @pytest.mark.parametrize("script", _entry_points(), ids=_entry_point_ids())

--- a/tests/workflows/test_backlog_triage.py
+++ b/tests/workflows/test_backlog_triage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +29,7 @@ def _step(job: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(f"missing step {name!r}")
 
 
-def _workflow_dispatch(workflow: dict[str, Any]) -> dict[str, Any]:
+def _workflow_dispatch(workflow: dict[Any, Any]) -> dict[str, Any]:
     trigger = workflow.get("on") or workflow.get(True)
     assert isinstance(trigger, dict)
     dispatch = trigger.get("workflow_dispatch")
@@ -47,6 +48,22 @@ class TestRecommendationArtifacts:
 
         fail = _step(recommend, "Fail on incomplete recommendation manifest")
         assert fail["if"] == "steps.recommend.outcome == 'failure'"
+
+
+class TestIssueDiscovery:
+    def test_issue_triage_runs_as_module(self) -> None:
+        workflow = _load_workflow()
+        discover = workflow["jobs"]["discover-issues"]
+        step = _step(discover, "Discover open issues for AI triage")
+
+        assert shlex.split(step["run"])[:6] == [
+            "uv",
+            "run",
+            "--frozen",
+            "python",
+            "-m",
+            "scripts.issue_triage",
+        ]
 
 
 class TestApplyApprovalGate:


### PR DESCRIPTION
## Summary

- Restores direct file execution for 15 script entry points that import the repository package.
- Runs backlog discovery through module invocation.
- Expands the import portability gate from validation scripts to all supported script entry points.
- Adds direct and module CLI tests for success, config error exit 2, and empty input.

## Reproduction

On current main, direct invocation failed before argument parsing:

```text
env -u PYTHONPATH /usr/bin/python3 scripts/issue_triage.py --help
ModuleNotFoundError: No module named 'scripts'
exit 1
```

Module invocation already exited 0. The scheduled workflow avoided the failure through the project environment, but the script contract and recurrence gate remained incomplete.

## Validation

```text
410 targeted tests passed
23,678 repository tests passed, 33 skipped
Ruff passed
Mypy passed on 18 changed Python files
50 pre-PR validations passed
Backlog Triage discover job dry-run passed
15 direct script entry points exited 0 under system Python with site packages disabled
Issue triage module invocation exited 0
```

Mutation controls killed both the missing bootstrap and the workflow path invocation. Independent code and security reviews found no actionable issues.

Fixes #4210
