### PR TITLE
docs(memory): record PR autofix worktree rule

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete.json
+++ b/.agents/memory/episodes/episode-2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete.json
@@ -1,0 +1,90 @@
+{
+  "id": "episode-2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete",
+  "session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete",
+  "timestamp": "2026-08-11T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix PR 4887 review thread and complete merge gates",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Acquired and supervised the PR 4887 branch lease",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read PR 4887, issue 4884, and linked work-item discussions",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified the review finding against the canonical workflow",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Corrected the operational sequence and token count",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran focused validation",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-11T09:37:53+00:00",
+      "type": "commit",
+      "content": "Commit: 3c5948945fd5bc3e726407087f2a328f8f19e7ef",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/qa/PR-4887-review-fix.md
+++ b/.agents/qa/PR-4887-review-fix.md
@@ -1,0 +1,32 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete.json
+qaCommit: 3c5948945fd5bc3e726407087f2a328f8f19e7ef
+---
+
+# PR 4887 Review Fix
+
+## Scope
+
+Review thread `PRRT_kwDOQoWRls6YImrQ` on the PR worktree memory.
+
+## Finding
+
+Confirmed. The memory required lease acquisition from an existing worktree.
+The canonical PR autofix workflow requires acquisition before worktree creation.
+
+## Change
+
+The sequence now acquires first, treats bare-root `local_head_sha` as
+diagnostic, switches to the PR worktree, then renews before mutation.
+
+## Validation
+
+- `scripts/validation/memory_index.py --ci`: passed
+- `scripts/ci/memory_index_token_ratchet.py`: passed
+- Scoped `markdownlint-cli2`: passed
+- Prohibited dash scan on changed memories: passed
+
+## Verdict
+
+Pass. The change matches issue 4884 and the canonical PR autofix workflow.

--- a/.agents/sessions/2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete.json
+++ b/.agents/sessions/2026-08-11-session-14681-b64ba451f-fix-4887-review-thread-complete.json
@@ -1,0 +1,145 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14681,
+    "date": "2026-08-11",
+    "branch": "docs/4884-pr-autofix-worktree-memory",
+    "startingCommit": "39a4e5bcb",
+    "objective": "Fix PR 4887 review thread and complete merge gates"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena tools active for repository; explicit activation tool unavailable in this harness"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions completed"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; no issue 4884 or PR 4887 handoff exists"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded pr-autofix, pr-comment-responder, github, reviewer-findings, and session-init skills"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "usage-mandatory Serena memory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "memory-index, pr-autofix/bare-root-requires-pr-worktree-for-sha-audit, and pr-autofix/pr-4323-late-base-refresh read"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "docs/4884-pr-autofix-worktree-memory"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On docs/4884-pr-autofix-worktree-memory"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "PR worktree was clean at 39a4e5bcb before edits"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "39a4e5bcb"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All required session end fields completed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged; no issue handoff existed"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/memories/pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md updated"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 on both changed memory files exited 0"
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/PR-4887-review-fix.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commit: 3c5948945fd5bc3e726407087f2a328f8f19e7ef"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Memory index validation, token ratchet, scoped markdownlint, and dash scan passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Fleet todo pr-4887-fix-threads marked in_progress; final status follows completion gate"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Acquired and supervised the PR 4887 branch lease",
+      "result": "Initial acquire returned ACT. Renewal moved to the dedicated PR worktree, where local HEAD, origin branch tip, and PR head matched 39a4e5bcb."
+    },
+    {
+      "action": "Read PR 4887, issue 4884, and linked work-item discussions",
+      "result": "One unresolved Copilot thread identified at the worktree memory operational pattern. The linked issue requires worktree use before renewal or mutation."
+    },
+    {
+      "action": "Verified the review finding against the canonical workflow",
+      "result": ".claude/commands/pr-autofix.md requires lease acquisition before worktree creation. The memory incorrectly restricted bare-root helpers to read-only use."
+    },
+    {
+      "action": "Corrected the operational sequence and token count",
+      "result": "The memory now acquires first, treats bare-root local_head_sha as diagnostic, switches worktrees, then renews before mutation. Memory index count changed from 279 to 299."
+    },
+    {
+      "action": "Ran focused validation",
+      "result": "Memory index validation, token ratchet, and scoped markdownlint all exited 0."
+    }
+  ],
+  "endingCommit": "3c5948945fd5bc3e726407087f2a328f8f19e7ef",
+  "nextSteps": []
+}

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -28,7 +28,7 @@
 |github pr issue cli gh api review comment batch response label milestone create tag priority: [skills-github-cli-index](skills-github-cli-index.md) (597), [skills-pr-review-index](skills-pr-review-index.md) (1096), [pr-review/pr-review-batch-response-pattern](pr-review/pr-review-batch-response-pattern.md) (699), [project/project-labels-milestones](project/project-labels-milestones.md) (325)
 |graphql mutation query resolve thread reply batch nested: [skills-graphql-index](skills-graphql-index.md) (111)
 |jq json parse filter select map array object string: [skills-jq-index](skills-jq-index.md) (356)
-|pr autofix lease bare checkout wrong branch local head sha mismatch dedicated worktree audit merge-forward: [pr-autofix/bare-root-requires-pr-worktree-for-sha-audit](pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md) (279)
+|pr autofix lease bare checkout wrong branch local head sha mismatch dedicated worktree audit merge-forward: [pr-autofix/bare-root-requires-pr-worktree-for-sha-audit](pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md) (299)
 |gh extension notify combine metrics milestone webhook grep sub-issue: [skills-gh-extensions-index](skills-gh-extensions-index.md) (346)
 |copilot review false-positive triage response cli agent frontmatter regression version pin auto-update diagnostic: [skills-copilot-index](skills-copilot-index.md) (497), [copilot/copilot-cli-frontmatter-regression-runbook](copilot/copilot-cli-frontmatter-regression-runbook.md) (1875)
 |triage stale closure verify history bot superseded duplicate: [pr-review/triage-001-verify-before-stale-closure](pr-review/triage-001-verify-before-stale-closure.md) (435), [pr-review/triage-002-bot-closure-verification](pr-review/triage-002-bot-closure-verification.md) (452)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -28,6 +28,7 @@
 |github pr issue cli gh api review comment batch response label milestone create tag priority: [skills-github-cli-index](skills-github-cli-index.md) (597), [skills-pr-review-index](skills-pr-review-index.md) (1096), [pr-review/pr-review-batch-response-pattern](pr-review/pr-review-batch-response-pattern.md) (699), [project/project-labels-milestones](project/project-labels-milestones.md) (325)
 |graphql mutation query resolve thread reply batch nested: [skills-graphql-index](skills-graphql-index.md) (111)
 |jq json parse filter select map array object string: [skills-jq-index](skills-jq-index.md) (356)
+|pr autofix lease bare checkout wrong branch local head sha mismatch dedicated worktree audit merge-forward: [pr-autofix/bare-root-requires-pr-worktree-for-sha-audit](pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md) (279)
 |gh extension notify combine metrics milestone webhook grep sub-issue: [skills-gh-extensions-index](skills-gh-extensions-index.md) (346)
 |copilot review false-positive triage response cli agent frontmatter regression version pin auto-update diagnostic: [skills-copilot-index](skills-copilot-index.md) (497), [copilot/copilot-cli-frontmatter-regression-runbook](copilot/copilot-cli-frontmatter-regression-runbook.md) (1875)
 |triage stale closure verify history bot superseded duplicate: [pr-review/triage-001-verify-before-stale-closure](pr-review/triage-001-verify-before-stale-closure.md) (435), [pr-review/triage-002-bot-closure-verification](pr-review/triage-002-bot-closure-verification.md) (452)

--- a/.serena/memories/pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md
+++ b/.serena/memories/pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md
@@ -1,0 +1,30 @@
+# PR autofix: bare root requires PR worktree for SHA audit
+
+## Rule
+
+When the repository is opened from a top-level bare checkout (`core.bare=true`),
+use the dedicated PR worktree for lease renewal, SHA audit, merge-forward, and
+push operations.
+
+## Why
+
+GitHub helper scripts can run from the bare root, but
+`pr_autofix_lease.py acquire` reports that checkout's `HEAD` as
+`local_head_sha`. A bare root is not the PR branch tip, so the value is
+diagnostic mismatch evidence, not branch freshness evidence.
+
+## Evidence
+
+PR #4762 on 2026-08-07:
+
+- Acquire from the bare root returned
+  `local_head_sha=4bd7890864bfd29dc64d5cb96180d87a27031021`.
+- The live PR head was `a75687064082d26c2a06f7b13defd169ecf7dc46`.
+- Renewing from the PR worktree returned the live PR head SHA.
+
+## Operational pattern
+
+1. Use helper scripts from the bare root only for read-only PR context.
+2. Switch to the dedicated PR worktree before branch mutation.
+3. Renew or acquire the lease there.
+4. Verify local `HEAD`, remote branch tip, and PR head SHA match before push.

--- a/.serena/memories/pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md
+++ b/.serena/memories/pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md
@@ -24,7 +24,8 @@ PR #4762 on 2026-08-07:
 
 ## Operational pattern
 
-1. Use helper scripts from the bare root only for read-only PR context.
-2. Switch to the dedicated PR worktree before branch mutation.
-3. Renew or acquire the lease there.
-4. Verify local `HEAD`, remote branch tip, and PR head SHA match before push.
+1. Acquire the lease before creating or selecting the PR worktree.
+2. Treat a bare root's `local_head_sha` as diagnostic mismatch evidence only.
+3. Create or switch to the dedicated PR worktree.
+4. Renew the lease from that worktree before branch mutation.
+5. Verify local `HEAD`, remote branch tip, and PR head SHA match before push.


### PR DESCRIPTION
## Summary

- record why bare-root lease output is not PR branch freshness evidence
- require the dedicated PR worktree before mutation and push
- add retrieval keywords to the memory index

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| Issue | #4884 | Document PR autofix worktree SHA audit rule |
| Spec | N/A | Documentation-only memory update |

## Changes

- add the PR autofix worktree memory
- index bare checkout, SHA audit, and lease mismatch terms

## Testing

- memory token counts current
- memory index validation passed
- pre-push suite: 26947 passed, 36 skipped

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #4884
