### PR TITLE
fix(forgetful): align export security boundary

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -144,7 +144,8 @@
         "e008",
         "e009",
         "e010",
-        "e011"
+        "e011",
+        "e015"
       ],
       "leads_to": [
         "e013"
@@ -172,6 +173,43 @@
       "caused_by": [
         "e013"
       ],
+      "leads_to": [
+        "e016"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Resolved the pull request CodeQL clear-text logging alert",
+      "caused_by": [],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-08-13T11:16:30+00:00",
+      "type": "commit",
+      "content": "Commit: 3ddc2952e",
+      "caused_by": [
+        "e014"
+      ],
+      "leads_to": [
+        "e017"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-08-13T11:43:54+00:00",
+      "type": "commit",
+      "content": "Commit: a1ddfa0ef7906df9d6d807e1a40349ba67a6d582",
+      "caused_by": [
+        "e016"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     }
@@ -181,8 +219,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 3,
-    "files_changed": 6
+    "commits": 5,
+    "files_changed": 8
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -1,0 +1,110 @@
+{
+  "id": "episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter",
+  "session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter",
+  "timestamp": "2026-08-13T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "partial",
+  "task": "Fix issue 4950 Forgetful exporter security review CLI and UUID false positives",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated issue 4950 against current origin/main in an external worktree",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read the issue body and both comments as untrusted project data",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced both reported defects before implementation",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated the smallest implementation and its inverse",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Attempted the recommended shared-memory import",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Implemented the positional CLI boundary and field-scoped UUID exemption",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Completed inline security review using the security-review skill",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran adversarial review with the Copilot CLI requesting gpt-5.6-sol",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran focused and repository validation",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured repository-wide Ruff baseline",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -145,7 +145,8 @@
         "e009",
         "e010",
         "e011",
-        "e015"
+        "e015",
+        "e018"
       ],
       "leads_to": [
         "e013"
@@ -210,6 +211,56 @@
       "caused_by": [
         "e016"
       ],
+      "leads_to": [
+        "e019"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Resolved both Copilot review findings",
+      "caused_by": [],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e019",
+      "timestamp": "2026-08-13T11:43:54+00:00",
+      "type": "commit",
+      "content": "Commit: a1ddfa0ef",
+      "caused_by": [
+        "e017"
+      ],
+      "leads_to": [
+        "e020"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e020",
+      "timestamp": "2026-08-13T12:22:24+00:00",
+      "type": "commit",
+      "content": "Commit: bf3bcd60c",
+      "caused_by": [
+        "e019"
+      ],
+      "leads_to": [
+        "e021"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e021",
+      "timestamp": "2026-08-13T12:22:47+00:00",
+      "type": "commit",
+      "content": "Commit: fa6b62a07bd0fa50af40dc90f904a1a8bb879792",
+      "caused_by": [
+        "e020"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     }
@@ -219,8 +270,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 5,
-    "files_changed": 8
+    "commits": 8,
+    "files_changed": 12
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -3,7 +3,7 @@
   "session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter",
   "timestamp": "2026-08-13T00:00:00+00:00",
   "causal_order_version": 2,
-  "outcome": "partial",
+  "outcome": "success",
   "task": "Fix issue 4950 Forgetful exporter security review CLI and UUID false positives",
   "decisions": [],
   "events": [
@@ -13,7 +13,9 @@
       "type": "milestone",
       "content": "Validated issue 4950 against current origin/main in an external worktree",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -22,7 +24,9 @@
       "type": "milestone",
       "content": "Read the issue body and both comments as untrusted project data",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -31,7 +35,9 @@
       "type": "milestone",
       "content": "Reproduced both reported defects before implementation",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -40,7 +46,9 @@
       "type": "milestone",
       "content": "Validated the smallest implementation and its inverse",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -49,7 +57,9 @@
       "type": "milestone",
       "content": "Attempted the recommended shared-memory import",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -58,7 +68,9 @@
       "type": "milestone",
       "content": "Implemented the positional CLI boundary and field-scoped UUID exemption",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -67,7 +79,9 @@
       "type": "milestone",
       "content": "Completed inline security review using the security-review skill",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -76,7 +90,9 @@
       "type": "milestone",
       "content": "Ran adversarial review with the Copilot CLI requesting gpt-5.6-sol",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -85,7 +101,9 @@
       "type": "milestone",
       "content": "Ran focused and repository validation",
       "caused_by": [],
-      "leads_to": [],
+      "leads_to": [
+        "e012"
+      ],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     },
     {
@@ -94,6 +112,66 @@
       "type": "milestone",
       "content": "Measured repository-wide Ruff baseline",
       "caused_by": [],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Completed QA validation at the final implementation commit",
+      "caused_by": [],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-13T11:12:58+00:00",
+      "type": "commit",
+      "content": "Commit: 62b03a1a1",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e011"
+      ],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-13T11:14:09+00:00",
+      "type": "commit",
+      "content": "Commit: 9a3dec8d7",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ],
+      "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-08-13T11:16:30+00:00",
+      "type": "commit",
+      "content": "Commit: 3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225",
+      "caused_by": [
+        "e013"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter"
     }
@@ -103,7 +181,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 3,
     "files_changed": 6
   },
   "lessons": []

--- a/.agents/qa/2026-08-13-issue-4950-forgetful-security.md
+++ b/.agents/qa/2026-08-13-issue-4950-forgetful-security.md
@@ -1,0 +1,45 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+qaCommit: 3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225
+---
+
+# QA Validation: Issue 4950 Forgetful Export Security
+
+## Scope
+
+- Positional scanner CLI invocation from the Forgetful exporter
+- Generic secret detection around Forgetful `id` and `user_id` UUID values
+- Fail-closed behavior when the mandatory scanner is absent
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Focused tests | 42 passed |
+| Scanner tests | 27 passed |
+| Scanner branch coverage | 98%, with only the `__main__` dispatch line uncollected |
+| Real CLI boundary | Clean, sensitive, whitespace, and dash-leading paths exercised |
+| UUID inverse cases | Neutral fields, malformed values, extended values, duplicate UUIDs, and same-line tokens remain detected |
+| Ruff | Changed Python files passed |
+| Taste lints | Six changed files scanned, no violations |
+| CWE-78 scan | Four changed Python files scanned, no findings |
+| Repository tests | 27,947 passed, 37 skipped, 2 warnings on the implementation parent before the scanner-only complexity extraction |
+
+The real subprocess tests execute the scanner entry point that in-process
+coverage reports as the single uncovered line. Focused tests passed again at
+`3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225` after the extraction.
+
+## Positive, Negative, and Edge Selectors
+
+- Positive: `TestRunSecurityReviewForgetful::test_clean_export_passes_real_cli_boundary`
+- Negative: `TestRunSecurityReviewForgetful::test_sensitive_export_fails_real_cli_boundary`
+- Edge: `TestRunSecurityReviewForgetful::test_dash_leading_relative_path_passes_real_cli_boundary`
+- Positive detection: `TestScanFile::test_generic_34_character_token_returns_1`
+- Negative detection: `TestScanFile::test_forgetful_uuid_returns_0`
+- Edge detection: `TestScanFile::test_uuid_like_token_returns_1`
+
+## Verdict
+
+PASS. The changed behavior meets issue 4950 and preserves detection for
+generic and UUID-like tokens outside the two Forgetful identifier fields.

--- a/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
+++ b/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
-qaCommit: a1ddfa0ef7906df9d6d807e1a40349ba67a6d582
+qaCommit: fa6b62a07bd0fa50af40dc90f904a1a8bb879792
 ---
 
 # QA Validation: PR 4957, Issue 4950 Forgetful Export Security
@@ -9,28 +9,30 @@ qaCommit: a1ddfa0ef7906df9d6d807e1a40349ba67a6d582
 ## Scope
 
 - Positional scanner CLI invocation from the Forgetful exporter
+- Positional scanner CLI invocation from all three Claude-Mem exporters
 - Generic secret detection around Forgetful `id` and `user_id` UUID values
+- Explicit Forgetful export mode for the identifier UUID policy
 - Fail-closed behavior when the mandatory scanner is absent
 
 ## Evidence
 
 | Check | Result |
 |---|---|
-| Focused tests | 42 passed |
-| Scanner tests | 27 passed |
+| Focused tests | 57 passed |
+| Scanner tests | 29 passed |
 | Scanner branch coverage | 98%, with only the `__main__` dispatch line uncollected |
-| Real CLI boundary | Clean, sensitive, whitespace, and dash-leading paths exercised |
-| UUID inverse cases | Neutral fields, malformed values, extended values, duplicate UUIDs, and same-line tokens remain detected |
+| Real CLI boundary | Forgetful clean, sensitive, whitespace, and dash-leading paths plus all three Claude-Mem callers exercised |
+| UUID inverse cases | Default scans, neutral fields, malformed values, extended values, duplicate UUIDs, and same-line tokens remain detected |
 | Sensitive output | Matched values and detection expressions are absent from reports |
-| Ruff | Changed Python files passed |
-| Taste lints | Six changed files scanned, no violations |
-| CWE-78 scan | Four changed Python files scanned, no findings |
-| Repository tests | 27,947 passed, 37 skipped, 2 warnings at `a1ddfa0ef7906df9d6d807e1a40349ba67a6d582` |
+| Ruff | Seven review follow-up Python files passed |
+| Taste lints | Seven review follow-up files scanned, no violations |
+| CWE-78 scan | Seven review follow-up files scanned, no findings |
+| Repository tests | 27,952 passed, 37 skipped, 2 warnings at `fa6b62a07bd0fa50af40dc90f904a1a8bb879792` |
 
 The real subprocess tests execute the scanner entry point that in-process
 coverage reports as the single uncovered line. Focused tests passed again at
-`a1ddfa0ef7906df9d6d807e1a40349ba67a6d582` after the clear-text reporting
-hardening.
+`fa6b62a07bd0fa50af40dc90f904a1a8bb879792` after scoping the UUID exception
+and migrating the remaining callers.
 
 ## Positive, Negative, and Edge Selectors
 
@@ -40,10 +42,13 @@ hardening.
 - Positive detection and output safety: `TestScanFile::test_generic_34_character_token_returns_1_without_logging_secret`
 - Negative detection: `TestScanFile::test_forgetful_uuid_returns_0`
 - Edge detection: `TestScanFile::test_uuid_like_token_returns_1`
+- Default-mode detection: `TestScanFile::test_forgetful_uuid_without_export_mode_returns_1`
+- Sibling boundaries: `TestSecurityReviewBoundary::test_passes_export_path_positionally`
 
 ## Verdict
 
 PASS. The changed behavior meets issue 4950 and preserves detection for
 generic and UUID-like tokens outside the two Forgetful identifier fields.
 Reports contain categories, counts, and line numbers without secret values or
-detection expressions.
+detection expressions. Generic scans retain UUID detection unless the Forgetful
+exporter explicitly selects its measured identifier policy.

--- a/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
+++ b/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
@@ -4,7 +4,7 @@ qaSessionLog: .agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950
 qaCommit: 3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225
 ---
 
-# QA Validation: Issue 4950 Forgetful Export Security
+# QA Validation: PR 4957, Issue 4950 Forgetful Export Security
 
 ## Scope
 

--- a/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
+++ b/.agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
-qaCommit: 3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225
+qaCommit: a1ddfa0ef7906df9d6d807e1a40349ba67a6d582
 ---
 
 # QA Validation: PR 4957, Issue 4950 Forgetful Export Security
@@ -21,21 +21,23 @@ qaCommit: 3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225
 | Scanner branch coverage | 98%, with only the `__main__` dispatch line uncollected |
 | Real CLI boundary | Clean, sensitive, whitespace, and dash-leading paths exercised |
 | UUID inverse cases | Neutral fields, malformed values, extended values, duplicate UUIDs, and same-line tokens remain detected |
+| Sensitive output | Matched values and detection expressions are absent from reports |
 | Ruff | Changed Python files passed |
 | Taste lints | Six changed files scanned, no violations |
 | CWE-78 scan | Four changed Python files scanned, no findings |
-| Repository tests | 27,947 passed, 37 skipped, 2 warnings on the implementation parent before the scanner-only complexity extraction |
+| Repository tests | 27,947 passed, 37 skipped, 2 warnings at `a1ddfa0ef7906df9d6d807e1a40349ba67a6d582` |
 
 The real subprocess tests execute the scanner entry point that in-process
 coverage reports as the single uncovered line. Focused tests passed again at
-`3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225` after the extraction.
+`a1ddfa0ef7906df9d6d807e1a40349ba67a6d582` after the clear-text reporting
+hardening.
 
 ## Positive, Negative, and Edge Selectors
 
 - Positive: `TestRunSecurityReviewForgetful::test_clean_export_passes_real_cli_boundary`
 - Negative: `TestRunSecurityReviewForgetful::test_sensitive_export_fails_real_cli_boundary`
 - Edge: `TestRunSecurityReviewForgetful::test_dash_leading_relative_path_passes_real_cli_boundary`
-- Positive detection: `TestScanFile::test_generic_34_character_token_returns_1`
+- Positive detection and output safety: `TestScanFile::test_generic_34_character_token_returns_1_without_logging_secret`
 - Negative detection: `TestScanFile::test_forgetful_uuid_returns_0`
 - Edge detection: `TestScanFile::test_uuid_like_token_returns_1`
 
@@ -43,3 +45,5 @@ coverage reports as the single uncovered line. Focused tests passed again at
 
 PASS. The changed behavior meets issue 4950 and preserves detection for
 generic and UUID-like tokens outside the two Forgetful identifier fields.
+Reports contain categories, counts, and line numbers without secret values or
+detection expressions.

--- a/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Implementation commits: 62b03a1a1, 9a3dec8d7, 3ddc2952e, a1ddfa0ef"
+        "Evidence": "Implementation commits: 62b03a1a1, 9a3dec8d7, 3ddc2952e, a1ddfa0ef, bf3bcd60c, fa6b62a07"
       },
       "validationPassed": {
         "level": "MUST",
@@ -161,14 +161,18 @@
     },
     {
       "action": "Completed QA validation at the final implementation commit",
-      "outcome": "PASS report records 42 focused tests, 27947 repository tests, 98% scanner branch coverage with only the subprocess-executed dispatch line uncollected, scoped Ruff, taste lints, and security scan evidence"
+      "outcome": "PASS report records 57 focused tests, 27952 repository tests, 98% scanner branch coverage with only the subprocess-executed dispatch line uncollected, scoped Ruff, taste lints, and security scan evidence"
     },
     {
       "action": "Resolved the pull request CodeQL clear-text logging alert",
       "outcome": "Scanner reports retain categories, counts, and line numbers without printing matched values or detection expressions; the focused inverse test passed"
+    },
+    {
+      "action": "Resolved both Copilot review findings",
+      "outcome": "Forgetful UUID exemptions now require explicit exporter mode, default scans retain UUID detection, and all three shipped Claude-Mem callers use the positional scanner contract with real boundary coverage"
     }
   ],
-  "endingCommit": "a1ddfa0ef7906df9d6d807e1a40349ba67a6d582",
+  "endingCommit": "fa6b62a07bd0fa50af40dc90f904a1a8bb879792",
   "nextSteps": [
     "Push the CI fixes, wait for all PR 4957 checks and comments, merge when clean, and verify origin/main"
   ]

--- a/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Implementation commits: 62b03a1a1, 9a3dec8d7, 3ddc2952e"
+        "Evidence": "Implementation commits: 62b03a1a1, 9a3dec8d7, 3ddc2952e, a1ddfa0ef"
       },
       "validationPassed": {
         "level": "MUST",
@@ -161,11 +161,15 @@
     },
     {
       "action": "Completed QA validation at the final implementation commit",
-      "outcome": "PASS report records 42 focused tests, 98% scanner branch coverage with only the subprocess-executed dispatch line uncollected, scoped Ruff, taste lints, and security scan evidence"
+      "outcome": "PASS report records 42 focused tests, 27947 repository tests, 98% scanner branch coverage with only the subprocess-executed dispatch line uncollected, scoped Ruff, taste lints, and security scan evidence"
+    },
+    {
+      "action": "Resolved the pull request CodeQL clear-text logging alert",
+      "outcome": "Scanner reports retain categories, counts, and line numbers without printing matched values or detection expressions; the focused inverse test passed"
     }
   ],
-  "endingCommit": "3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225",
+  "endingCommit": "a1ddfa0ef7906df9d6d807e1a40349ba67a6d582",
   "nextSteps": [
-    "Commit the implementation, record QA evidence, run pre-PR validation, and open the issue 4950 pull request"
+    "Push the CI fixes, wait for all PR 4957 checks and comments, merge when clean, and verify origin/main"
   ]
 }

--- a/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -73,43 +73,43 @@
     "sessionEnd": {
       "checklistComplete": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "All MUST items complete"
       },
       "handoffPreserved": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged"
       },
       "serenaMemoryUpdated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "No durable memory added; issue-specific behavior is pinned by focused tests and the QA report"
       },
       "markdownLintRun": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Lint selected 0 files: NOT LINTED because the changed .agents Markdown path is excluded"
       },
       "qaValidation": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/qa/2026-08-13-issue-4950-forgetful-security.md"
       },
       "changesCommitted": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Implementation commits: 62b03a1a1, 9a3dec8d7, 3ddc2952e"
       },
       "validationPassed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit 0"
       },
       "tasksUpdated": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "No local project plan task exists; GitHub issue 4950 is authoritative"
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
@@ -158,9 +158,13 @@
     {
       "action": "Measured repository-wide Ruff baseline",
       "outcome": "Repository-wide Ruff reported 27 pre-existing findings outside the four changed Python files; no unrelated files were modified"
+    },
+    {
+      "action": "Completed QA validation at the final implementation commit",
+      "outcome": "PASS report records 42 focused tests, 98% scanner branch coverage with only the subprocess-executed dispatch line uncollected, scoped Ruff, taste lints, and security scan evidence"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "3ddc2952ecf0a7ddd90c19db7e6eb1efa9560225",
   "nextSteps": [
     "Commit the implementation, record QA evidence, run pre-PR validation, and open the issue 4950 pull request"
   ]

--- a/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -94,7 +94,7 @@
       "qaValidation": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": ".agents/qa/2026-08-13-issue-4950-forgetful-security.md"
+        "Evidence": ".agents/qa/2026-08-13-pr-4957-issue-4950-forgetful-security.md"
       },
       "changesCommitted": {
         "level": "MUST",

--- a/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
+++ b/.agents/sessions/2026-08-13-session-14695-becfc98b8-fix-issue-4950-forgetful-exporter.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14695,
+    "date": "2026-08-13",
+    "branch": "fix/4950-forgetful-security",
+    "startingCommit": "90be321b3",
+    "objective": "Fix issue 4950 Forgetful exporter security review CLI and UUID false positives"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena project tools operational; activation function is not exposed by this runtime"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions output present"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; no *-4950-handoff.md file exists"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "GitHub skill script inventory listed in transcript"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena usage-mandatory memory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "memory-index, skills-session-init-index, skills-github-cli-index, skills-pr-review-index, push, and security-gate memories read"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4950-forgetful-security"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/4950-forgetful-security"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Only this new session log was untracked at startup"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "90be321b3"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Validated issue 4950 against current origin/main in an external worktree",
+      "outcome": "No competing PR or prior issue handoff exists; branch starts at 90be321b3"
+    },
+    {
+      "action": "Read the issue body and both comments as untrusted project data",
+      "outcome": "Acceptance criterion requires positional scanner input, a real CLI-boundary regression test, and UUID-safe detection"
+    },
+    {
+      "action": "Reproduced both reported defects before implementation",
+      "outcome": "Unsupported option exited 2; the committed backup and a single canonical UUID each exited 1"
+    },
+    {
+      "action": "Validated the smallest implementation and its inverse",
+      "outcome": "Pass the path positionally and exempt only a complete canonical UUID; real 34-character and UUID-like token strings must still fail"
+    },
+    {
+      "action": "Attempted the recommended shared-memory import",
+      "outcome": "Import unavailable because the configured Claude-Mem marketplace script is absent; Serena project memories loaded successfully"
+    },
+    {
+      "action": "Implemented the positional CLI boundary and field-scoped UUID exemption",
+      "outcome": "Exporter uses the argv option sentinel, missing scanner fails closed, and only exact id or user_id UUID values bypass the generic pattern"
+    },
+    {
+      "action": "Completed inline security review using the security-review skill",
+      "outcome": "OK: argv remains shell-free, UUID exemption is span-scoped to measured Forgetful ID fields, neutral and credential-like UUID values remain detected, and scanner absence fails closed"
+    },
+    {
+      "action": "Ran adversarial review with the Copilot CLI requesting gpt-5.6-sol",
+      "outcome": "Four completed review rounds found testable defects that were fixed; final response was PASS. Model identity remained unconfirmed because no readable CLI transcript was available"
+    },
+    {
+      "action": "Ran focused and repository validation",
+      "outcome": "42 focused tests and 27947 repository tests passed; 37 repository tests skipped with 2 warnings; scoped Ruff and CWE-78 scan passed"
+    },
+    {
+      "action": "Measured repository-wide Ruff baseline",
+      "outcome": "Repository-wide Ruff reported 27 pre-existing findings outside the four changed Python files; no unrelated files were modified"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Commit the implementation, record QA evidence, run pre-PR validation, and open the issue 4950 pull request"
+  ]
+}

--- a/.claude-mem/scripts/export_claude_mem_direct.py
+++ b/.claude-mem/scripts/export_claude_mem_direct.py
@@ -243,7 +243,7 @@ def _run_security_review_direct(output_path: Path) -> int:
     print("\nRunning security review...")
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, str(security_script), "--export-file", str(output_path)]
+        [sys.executable, str(security_script), "--", str(output_path)]
     )
     if result.returncode != 0:
         print("ERROR: Security review FAILED.", file=sys.stderr)

--- a/.claude-mem/scripts/export_claude_mem_full_backup.py
+++ b/.claude-mem/scripts/export_claude_mem_full_backup.py
@@ -131,7 +131,7 @@ def _run_security_review(output_path: Path) -> int:
     print("\nRunning security review...")
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, str(security_script), "--export-file", str(output_path)]
+        [sys.executable, str(security_script), "--", str(output_path)]
     )
     if result.returncode != 0:
         print("ERROR: Security review FAILED.", file=sys.stderr)

--- a/.claude-mem/scripts/export_claude_mem_memories.py
+++ b/.claude-mem/scripts/export_claude_mem_memories.py
@@ -78,7 +78,7 @@ def _run_security_review_memories(output_path: Path) -> int:
     print("\nRunning mandatory security review...")
     sys.stdout.flush()
     sec_result = subprocess.run(
-        [sys.executable, str(security_script), "--export-file", str(output_path)]
+        [sys.executable, str(security_script), "--", str(output_path)]
     )
     if sec_result.returncode != 0:
         print("ERROR: Security review FAILED.", file=sys.stderr)

--- a/scripts/forgetful/export_forgetful_memories.py
+++ b/scripts/forgetful/export_forgetful_memories.py
@@ -5,7 +5,7 @@ Exports all data from Forgetful SQLite database to JSON file for backup,
 version control, and sharing across team members and installations.
 
 IMPORTANT: Security review is REQUIRED before committing exports to git.
-Run: python3 scripts/review_memory_export_security.py --export-file [file].json
+Run: python3 scripts/review_memory_export_security.py [file].json
 
 EXIT CODES:
   0  - Success
@@ -126,14 +126,15 @@ def _build_forgetful_output_path(args: argparse.Namespace) -> Path:
 
 
 def _run_security_review_forgetful(output_path: Path) -> int:
-    """Run the memory-export security review script; return 0 on pass or absence."""
+    """Run the memory-export security review script; return 0 only on pass."""
     security_script = _SCRIPT_DIR.parent / "review_memory_export_security.py"
     if not security_script.exists():
-        return 0
+        print(f"ERROR: Security review script not found: {security_script}", file=sys.stderr)
+        return 1
     print("\nRunning mandatory security review...")
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, str(security_script), "--export-file", str(output_path)]
+        [sys.executable, str(security_script), "--", str(output_path)]
     )
     if result.returncode != 0:
         print("ERROR: Security review FAILED.", file=sys.stderr)

--- a/scripts/forgetful/export_forgetful_memories.py
+++ b/scripts/forgetful/export_forgetful_memories.py
@@ -134,7 +134,13 @@ def _run_security_review_forgetful(output_path: Path) -> int:
     print("\nRunning mandatory security review...")
     sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, str(security_script), "--", str(output_path)]
+        [
+            sys.executable,
+            str(security_script),
+            "--forgetful-export",
+            "--",
+            str(output_path),
+        ]
     )
     if result.returncode != 0:
         print("ERROR: Security review FAILED.", file=sys.stderr)

--- a/scripts/review_memory_export_security.py
+++ b/scripts/review_memory_export_security.py
@@ -104,29 +104,39 @@ def _line_has_sensitive_match(
     return any(not _is_forgetful_id_uuid(line, match) for match in matches)
 
 
-def _scan_pattern(category: str, pattern: str, lines: list[str]) -> _Issue | None:
+def _scan_pattern(
+    category: str,
+    pattern: str,
+    lines: list[str],
+) -> tuple[_Issue | None, int]:
     try:
         compiled = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
-        return {
-            "category": f"{category} (SCAN FAILED)",
-            "pattern": pattern,
-            "count": 1,
-            "lines": f"Error: {exc}",
-        }
+        return (
+            {
+                "category": f"{category} (SCAN FAILED)",
+                "pattern": pattern,
+                "count": 1,
+                "lines": f"Error: {exc}",
+            },
+            0,
+        )
     match_lines = [
         number
         for number, line in enumerate(lines, 1)
         if _line_has_sensitive_match(line, pattern, compiled)
     ]
     if not match_lines:
-        return None
-    return {
-        "category": category,
-        "pattern": pattern,
-        "count": len(match_lines),
-        "lines": ", ".join(str(number) for number in match_lines[:3]),
-    }
+        return None, 0
+    return (
+        {
+            "category": category,
+            "pattern": pattern,
+            "count": len(match_lines),
+            "lines": ", ".join(str(number) for number in match_lines[:3]),
+        },
+        len(match_lines),
+    )
 
 
 def _collect_issues(lines: list[str]) -> tuple[list[_Issue], int]:
@@ -134,11 +144,11 @@ def _collect_issues(lines: list[str]) -> tuple[list[_Issue], int]:
     total_matches = 0
     for category, patterns in SENSITIVE_PATTERNS.items():
         for pattern in patterns:
-            issue = _scan_pattern(category, pattern, lines)
+            issue, match_count = _scan_pattern(category, pattern, lines)
             if issue is None:
                 continue
             found_issues.append(issue)
-            total_matches += issue["count"]
+            total_matches += match_count
     return found_issues, total_matches
 
 

--- a/scripts/review_memory_export_security.py
+++ b/scripts/review_memory_export_security.py
@@ -19,6 +19,17 @@ import re
 import sys
 from pathlib import Path
 
+_GENERIC_SECRET_PATTERN = (
+    r"(?<![a-zA-Z0-9~_.-])[a-zA-Z0-9~_.-]{34,}(?![a-zA-Z0-9~_.-])"
+)
+_FORGETFUL_ID_UUID = re.compile(
+    r'(?<!\\)"(?:id|user_id)"\s*:\s*'
+    r'"(?P<uuid>[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})"'
+)
+_CANONICAL_UUID = re.compile(
+    r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"
+)
+
 SENSITIVE_PATTERNS: dict[str, list[str]] = {
     "API Keys/Tokens": [
         r"api[_-]?key",
@@ -35,7 +46,7 @@ SENSITIVE_PATTERNS: dict[str, list[str]] = {
         r"secret\s*[:=]",
         r"credential",
         r"auth[_-]?key",
-        r"[a-zA-Z0-9~_.-]{34}",
+        _GENERIC_SECRET_PATTERN,
         r"[A-Za-z0-9+/=]{40,}",
     ],
     "Private Keys": [
@@ -64,6 +75,26 @@ SENSITIVE_PATTERNS: dict[str, list[str]] = {
 }
 
 
+def _is_forgetful_id_uuid(line: str, match: re.Match[str]) -> bool:
+    if _CANONICAL_UUID.fullmatch(match.group()) is None:
+        return False
+    return any(
+        id_match.span("uuid") == match.span()
+        for id_match in _FORGETFUL_ID_UUID.finditer(line)
+    )
+
+
+def _line_has_sensitive_match(
+    line: str,
+    pattern: str,
+    compiled: re.Pattern[str],
+) -> bool:
+    matches = compiled.finditer(line)
+    if pattern != _GENERIC_SECRET_PATTERN:
+        return next(matches, None) is not None
+    return any(not _is_forgetful_id_uuid(line, match) for match in matches)
+
+
 def scan_file(export_file: Path, quiet: bool = False) -> int:
     if not quiet:
         print(f"Scanning export file for sensitive data: {export_file}")
@@ -80,7 +111,7 @@ def scan_file(export_file: Path, quiet: bool = False) -> int:
                 compiled = re.compile(pattern, re.IGNORECASE)
                 match_lines: list[int] = []
                 for i, line in enumerate(lines, 1):
-                    if compiled.search(line):
+                    if _line_has_sensitive_match(line, pattern, compiled):
                         match_lines.append(i)
                 if match_lines:
                     total_matches += len(match_lines)

--- a/scripts/review_memory_export_security.py
+++ b/scripts/review_memory_export_security.py
@@ -18,6 +18,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import TypedDict
 
 _GENERIC_SECRET_PATTERN = (
     r"(?<![a-zA-Z0-9~_.-])[a-zA-Z0-9~_.-]{34,}(?![a-zA-Z0-9~_.-])"
@@ -29,6 +30,14 @@ _FORGETFUL_ID_UUID = re.compile(
 _CANONICAL_UUID = re.compile(
     r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"
 )
+
+
+class _Issue(TypedDict):
+    category: str
+    pattern: str
+    count: int
+    lines: str
+
 
 SENSITIVE_PATTERNS: dict[str, list[str]] = {
     "API Keys/Tokens": [
@@ -95,6 +104,44 @@ def _line_has_sensitive_match(
     return any(not _is_forgetful_id_uuid(line, match) for match in matches)
 
 
+def _scan_pattern(category: str, pattern: str, lines: list[str]) -> _Issue | None:
+    try:
+        compiled = re.compile(pattern, re.IGNORECASE)
+    except re.error as exc:
+        return {
+            "category": f"{category} (SCAN FAILED)",
+            "pattern": pattern,
+            "count": 1,
+            "lines": f"Error: {exc}",
+        }
+    match_lines = [
+        number
+        for number, line in enumerate(lines, 1)
+        if _line_has_sensitive_match(line, pattern, compiled)
+    ]
+    if not match_lines:
+        return None
+    return {
+        "category": category,
+        "pattern": pattern,
+        "count": len(match_lines),
+        "lines": ", ".join(str(number) for number in match_lines[:3]),
+    }
+
+
+def _collect_issues(lines: list[str]) -> tuple[list[_Issue], int]:
+    found_issues: list[_Issue] = []
+    total_matches = 0
+    for category, patterns in SENSITIVE_PATTERNS.items():
+        for pattern in patterns:
+            issue = _scan_pattern(category, pattern, lines)
+            if issue is None:
+                continue
+            found_issues.append(issue)
+            total_matches += issue["count"]
+    return found_issues, total_matches
+
+
 def scan_file(export_file: Path, quiet: bool = False) -> int:
     if not quiet:
         print(f"Scanning export file for sensitive data: {export_file}")
@@ -102,32 +149,7 @@ def scan_file(export_file: Path, quiet: bool = False) -> int:
 
     content = export_file.read_text(encoding="utf-8")
     lines = content.splitlines()
-    found_issues: list[dict[str, str | int]] = []
-    total_matches = 0
-
-    for category, patterns in SENSITIVE_PATTERNS.items():
-        for pattern in patterns:
-            try:
-                compiled = re.compile(pattern, re.IGNORECASE)
-                match_lines: list[int] = []
-                for i, line in enumerate(lines, 1):
-                    if _line_has_sensitive_match(line, pattern, compiled):
-                        match_lines.append(i)
-                if match_lines:
-                    total_matches += len(match_lines)
-                    found_issues.append({
-                        "category": category,
-                        "pattern": pattern,
-                        "count": len(match_lines),
-                        "lines": ", ".join(str(n) for n in match_lines[:3]),
-                    })
-            except re.error as e:
-                found_issues.append({
-                    "category": f"{category} (SCAN FAILED)",
-                    "pattern": pattern,
-                    "count": 1,
-                    "lines": f"Error: {e}",
-                })
+    found_issues, total_matches = _collect_issues(lines)
 
     if not found_issues:
         if not quiet:

--- a/scripts/review_memory_export_security.py
+++ b/scripts/review_memory_export_security.py
@@ -34,7 +34,6 @@ _CANONICAL_UUID = re.compile(
 
 class _Issue(TypedDict):
     category: str
-    pattern: str
     count: int
     lines: str
 
@@ -115,7 +114,6 @@ def _scan_pattern(
         return (
             {
                 "category": f"{category} (SCAN FAILED)",
-                "pattern": pattern,
                 "count": 1,
                 "lines": f"Error: {exc}",
             },
@@ -131,7 +129,6 @@ def _scan_pattern(
     return (
         {
             "category": category,
-            "pattern": pattern,
             "count": len(match_lines),
             "lines": ", ".join(str(number) for number in match_lines[:3]),
         },
@@ -173,14 +170,13 @@ def scan_file(export_file: Path, quiet: bool = False) -> int:
         print()
         print(f"Found {total_matches} potential sensitive data matches:")
         print()
-        print(f"{'Category':<30} {'Pattern':<40} {'Matches':<10} {'Sample Lines'}")
-        print("-" * 100)
+        print(f"{'Category':<30} {'Matches':<10} {'Sample Lines'}")
+        print("-" * 60)
         for issue in found_issues:
             cat = issue['category']
-            pat = issue['pattern']
             cnt = issue['count']
             sample = issue['lines']
-            print(f"{cat:<30} {pat:<40} {cnt:<10} {sample}")
+            print(f"{cat:<30} {cnt:<10} {sample}")
         print()
         print("ACTION REQUIRED:")
         print(f"1. Review the export file manually at: {export_file}")

--- a/scripts/review_memory_export_security.py
+++ b/scripts/review_memory_export_security.py
@@ -96,9 +96,13 @@ def _line_has_sensitive_match(
     line: str,
     pattern: str,
     compiled: re.Pattern[str],
+    *,
+    forgetful_export: bool,
 ) -> bool:
     matches = compiled.finditer(line)
     if pattern != _GENERIC_SECRET_PATTERN:
+        return next(matches, None) is not None
+    if not forgetful_export:
         return next(matches, None) is not None
     return any(not _is_forgetful_id_uuid(line, match) for match in matches)
 
@@ -107,6 +111,8 @@ def _scan_pattern(
     category: str,
     pattern: str,
     lines: list[str],
+    *,
+    forgetful_export: bool,
 ) -> tuple[_Issue | None, int]:
     try:
         compiled = re.compile(pattern, re.IGNORECASE)
@@ -122,7 +128,12 @@ def _scan_pattern(
     match_lines = [
         number
         for number, line in enumerate(lines, 1)
-        if _line_has_sensitive_match(line, pattern, compiled)
+        if _line_has_sensitive_match(
+            line,
+            pattern,
+            compiled,
+            forgetful_export=forgetful_export,
+        )
     ]
     if not match_lines:
         return None, 0
@@ -136,12 +147,21 @@ def _scan_pattern(
     )
 
 
-def _collect_issues(lines: list[str]) -> tuple[list[_Issue], int]:
+def _collect_issues(
+    lines: list[str],
+    *,
+    forgetful_export: bool,
+) -> tuple[list[_Issue], int]:
     found_issues: list[_Issue] = []
     total_matches = 0
     for category, patterns in SENSITIVE_PATTERNS.items():
         for pattern in patterns:
-            issue, match_count = _scan_pattern(category, pattern, lines)
+            issue, match_count = _scan_pattern(
+                category,
+                pattern,
+                lines,
+                forgetful_export=forgetful_export,
+            )
             if issue is None:
                 continue
             found_issues.append(issue)
@@ -149,14 +169,22 @@ def _collect_issues(lines: list[str]) -> tuple[list[_Issue], int]:
     return found_issues, total_matches
 
 
-def scan_file(export_file: Path, quiet: bool = False) -> int:
+def scan_file(
+    export_file: Path,
+    quiet: bool = False,
+    *,
+    forgetful_export: bool = False,
+) -> int:
     if not quiet:
         print(f"Scanning export file for sensitive data: {export_file}")
         print()
 
     content = export_file.read_text(encoding="utf-8")
     lines = content.splitlines()
-    found_issues, total_matches = _collect_issues(lines)
+    found_issues, total_matches = _collect_issues(
+        lines,
+        forgetful_export=forgetful_export,
+    )
 
     if not found_issues:
         if not quiet:
@@ -191,13 +219,22 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Security review for memory export files")
     parser.add_argument("export_file", type=Path, help="Path to exported memory JSON file")
     parser.add_argument("--quiet", action="store_true", help="Suppress output, only set exit code")
+    parser.add_argument(
+        "--forgetful-export",
+        action="store_true",
+        help="Allow canonical UUIDs in Forgetful id and user_id fields",
+    )
     args = parser.parse_args(argv)
 
     if not args.export_file.is_file():
         print(f"ERROR: File not found: {args.export_file}", file=sys.stderr)
         return 1
 
-    return scan_file(args.export_file, args.quiet)
+    return scan_file(
+        args.export_file,
+        args.quiet,
+        forgetful_export=args.forgetful_export,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_mem_scripts.py
+++ b/tests/test_claude_mem_scripts.py
@@ -78,6 +78,30 @@ class TestExportBackupValidateOutputPath:
         assert _export_backup.validate_output_path(output, mem_dir) is False
 
 
+class TestSecurityReviewBoundary:
+    @pytest.mark.parametrize(
+        ("module", "runner_name"),
+        [
+            (_export_direct, "_run_security_review_direct"),
+            (_export_memories, "_run_security_review_memories"),
+            (_export_backup, "_run_security_review"),
+        ],
+        ids=["direct", "memories", "full-backup"],
+    )
+    def test_passes_export_path_positionally(
+        self,
+        module: object,
+        runner_name: str,
+        tmp_path: Path,
+    ) -> None:
+        export_file = tmp_path / "memory export.json"
+        export_file.write_text('{"data": "safe content"}', encoding="utf-8")
+
+        runner = getattr(module, runner_name)
+
+        assert runner(export_file) == 0
+
+
 class TestExportDirectMain:
     def test_exits_1_when_sqlite3_missing(self, monkeypatch) -> None:
         monkeypatch.setattr("shutil.which", lambda x: None)

--- a/tests/test_export_forgetful_memories.py
+++ b/tests/test_export_forgetful_memories.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.forgetful.export_forgetful_memories import (
     TABLE_MAPPING,
+    _run_security_review_forgetful,
     export_table,
     run_sqlite3,
     validate_output_path,
@@ -71,6 +72,54 @@ class TestRunSqlite3:
         with patch("subprocess.run", return_value=self._make_result(0, stdout="hello")):
             result = run_sqlite3("/fake/db", "SELECT 1")
         assert result == "hello"
+
+
+class TestRunSecurityReviewForgetful:
+    def test_missing_scanner_fails_closed(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        export_file = tmp_path / "clean.json"
+        with patch(
+            "scripts.forgetful.export_forgetful_memories._SCRIPT_DIR",
+            tmp_path / "forgetful",
+        ):
+            assert _run_security_review_forgetful(export_file) == 1
+        assert "Security review script not found" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("filename", ["clean.json", "memory export.json"])
+    def test_clean_export_passes_real_cli_boundary(
+        self,
+        tmp_path: Path,
+        filename: str,
+    ) -> None:
+        export_file = tmp_path / filename
+        export_file.write_text('{"data": "safe content"}', encoding="utf-8")
+
+        assert _run_security_review_forgetful(export_file) == 0
+
+    def test_dash_leading_relative_path_passes_real_cli_boundary(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        export_file = Path("-dash-leading.json")
+        export_file.write_text('{"data": "safe content"}', encoding="utf-8")
+
+        assert _run_security_review_forgetful(export_file) == 0
+
+    def test_sensitive_export_fails_real_cli_boundary(
+        self,
+        tmp_path: Path,
+        capfd: pytest.CaptureFixture[str],
+    ) -> None:
+        export_file = tmp_path / "sensitive.json"
+        export_file.write_text('{"api_key": "placeholder"}', encoding="utf-8")
+
+        assert _run_security_review_forgetful(export_file) == 1
+        assert "WARNING - Sensitive data patterns detected!" in capfd.readouterr().out
 
 
 class TestExportTable:

--- a/tests/test_review_memory_export_security.py
+++ b/tests/test_review_memory_export_security.py
@@ -67,12 +67,17 @@ class TestScanFile:
         assert scan_file(file_with_api_key) == 1
         assert "WARNING - Sensitive data patterns detected!" in capsys.readouterr().out
 
-    def test_invalid_pattern_fails_closed(self, clean_file: Path) -> None:
+    def test_invalid_pattern_fails_closed(
+        self,
+        clean_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         with patch(
             "scripts.review_memory_export_security.SENSITIVE_PATTERNS",
             {"Invalid": ["["]},
         ):
-            assert scan_file(clean_file, quiet=True) == 1
+            assert scan_file(clean_file) == 1
+        assert "Found 0 potential sensitive data matches" in capsys.readouterr().out
 
     def test_generic_34_character_token_returns_1(self, tmp_path: Path) -> None:
         export_file = tmp_path / "generic-token.json"

--- a/tests/test_review_memory_export_security.py
+++ b/tests/test_review_memory_export_security.py
@@ -79,11 +79,19 @@ class TestScanFile:
             assert scan_file(clean_file) == 1
         assert "Found 0 potential sensitive data matches" in capsys.readouterr().out
 
-    def test_generic_34_character_token_returns_1(self, tmp_path: Path) -> None:
+    def test_generic_34_character_token_returns_1_without_logging_secret(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         export_file = tmp_path / "generic-token.json"
-        export_file.write_text(f'{{"data": "{"t" * 34}"}}', encoding="utf-8")
+        secret = "t" * 34
+        export_file.write_text(f'{{"data": "{secret}"}}', encoding="utf-8")
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file) == 1
+        output = capsys.readouterr().out
+        assert secret not in output
+        assert "{34,}" not in output
 
     def test_generic_33_character_value_returns_0(self, tmp_path: Path) -> None:
         export_file = tmp_path / "short-value.json"

--- a/tests/test_review_memory_export_security.py
+++ b/tests/test_review_memory_export_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -50,8 +51,143 @@ class TestScanFile:
     def test_file_with_home_path_returns_1(self, file_with_home_path: Path) -> None:
         assert scan_file(file_with_home_path, quiet=True) == 1
 
+    def test_clean_file_reports_success(
+        self,
+        clean_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        assert scan_file(clean_file) == 0
+        assert "CLEAN - No sensitive data patterns detected" in capsys.readouterr().out
+
+    def test_sensitive_file_reports_warning(
+        self,
+        file_with_api_key: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        assert scan_file(file_with_api_key) == 1
+        assert "WARNING - Sensitive data patterns detected!" in capsys.readouterr().out
+
+    def test_invalid_pattern_fails_closed(self, clean_file: Path) -> None:
+        with patch(
+            "scripts.review_memory_export_security.SENSITIVE_PATTERNS",
+            {"Invalid": ["["]},
+        ):
+            assert scan_file(clean_file, quiet=True) == 1
+
+    def test_generic_34_character_token_returns_1(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "generic-token.json"
+        export_file.write_text(f'{{"data": "{"t" * 34}"}}', encoding="utf-8")
+
+        assert scan_file(export_file, quiet=True) == 1
+
+    def test_generic_33_character_value_returns_0(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "short-value.json"
+        export_file.write_text(f'{{"data": "{"t" * 33}"}}', encoding="utf-8")
+
+        assert scan_file(export_file, quiet=True) == 0
+
+    @pytest.mark.parametrize(
+        ("field_name", "forgetful_uuid"),
+        [
+            ("id", "550e8400-e29b-41d4-a716-446655440000"),
+            ("user_id", "550E8400-E29B-41D4-A716-446655440000"),
+        ],
+    )
+    def test_forgetful_uuid_returns_0(
+        self,
+        tmp_path: Path,
+        field_name: str,
+        forgetful_uuid: str,
+    ) -> None:
+        export_file = tmp_path / "forgetful-uuid.json"
+        export_file.write_text(
+            f'{{"{field_name}": "{forgetful_uuid}"}}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 0
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ["content", "session", "session_id", "auth_id", "token_id"],
+    )
+    def test_uuid_outside_forgetful_id_field_returns_1(
+        self,
+        tmp_path: Path,
+        field_name: str,
+    ) -> None:
+        export_file = tmp_path / "uuid-value.json"
+        export_file.write_text(
+            f'{{"{field_name}": "550e8400-e29b-41d4-a716-446655440000"}}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 1
+
+    def test_pretty_export_forgetful_uuid_returns_0(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "pretty-export.json"
+        export_file.write_text(
+            '{\n  "id": "550e8400-e29b-41d4-a716-446655440000"\n}\n',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 0
+
+    def test_forgetful_uuid_does_not_hide_other_token(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "uuid-with-token.json"
+        export_file.write_text(
+            f'{{"id": "550e8400-e29b-41d4-a716-446655440000", '
+            f'"data": "{"t" * 34}"}}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 1
+
+    def test_forgetful_uuid_does_not_hide_second_uuid(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "two-uuids.json"
+        export_file.write_text(
+            '{"id": "550e8400-e29b-41d4-a716-446655440000", '
+            '"data": "550e8400-e29b-41d4-a716-446655440000"}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 1
+
+    def test_escaped_id_text_does_not_exempt_uuid(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "escaped-id-text.json"
+        export_file.write_text(
+            '{"data": "embedded {\\"id\\": '
+            '\\"550e8400-e29b-41d4-a716-446655440000\\"}"}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 1
+
+    @pytest.mark.parametrize(
+        "uuid_like_token",
+        [
+            "550e8400-e29b-41d4-a716-44665544000g",
+            "550e8400-e29b-41d4-a716-446655440000x",
+            "t" * 34,
+        ],
+    )
+    def test_uuid_like_token_returns_1(
+        self,
+        tmp_path: Path,
+        uuid_like_token: str,
+    ) -> None:
+        export_file = tmp_path / "uuid-like-token.json"
+        export_file.write_text(f'{{"id": "{uuid_like_token}"}}', encoding="utf-8")
+
+        assert scan_file(export_file, quiet=True) == 1
+
 
 class TestMain:
+    def test_export_file_option_is_rejected(self, clean_file: Path) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--export-file", str(clean_file)])
+        assert exc_info.value.code == 2
+
     def test_missing_file_returns_1(self) -> None:
         assert main(["nonexistent.json"]) == 1
 

--- a/tests/test_review_memory_export_security.py
+++ b/tests/test_review_memory_export_security.py
@@ -118,7 +118,19 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 0
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 0
+
+    def test_forgetful_uuid_without_export_mode_returns_1(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        export_file = tmp_path / "uuid.json"
+        export_file.write_text(
+            '{"id": "550e8400-e29b-41d4-a716-446655440000"}',
+            encoding="utf-8",
+        )
+
+        assert scan_file(export_file, quiet=True) == 1
 
     @pytest.mark.parametrize(
         "field_name",
@@ -135,7 +147,7 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 1
 
     def test_pretty_export_forgetful_uuid_returns_0(self, tmp_path: Path) -> None:
         export_file = tmp_path / "pretty-export.json"
@@ -144,7 +156,7 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 0
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 0
 
     def test_forgetful_uuid_does_not_hide_other_token(self, tmp_path: Path) -> None:
         export_file = tmp_path / "uuid-with-token.json"
@@ -154,7 +166,7 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 1
 
     def test_forgetful_uuid_does_not_hide_second_uuid(self, tmp_path: Path) -> None:
         export_file = tmp_path / "two-uuids.json"
@@ -164,7 +176,7 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 1
 
     def test_escaped_id_text_does_not_exempt_uuid(self, tmp_path: Path) -> None:
         export_file = tmp_path / "escaped-id-text.json"
@@ -174,7 +186,7 @@ class TestScanFile:
             encoding="utf-8",
         )
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 1
 
     @pytest.mark.parametrize(
         "uuid_like_token",
@@ -192,7 +204,7 @@ class TestScanFile:
         export_file = tmp_path / "uuid-like-token.json"
         export_file.write_text(f'{{"id": "{uuid_like_token}"}}', encoding="utf-8")
 
-        assert scan_file(export_file, quiet=True) == 1
+        assert scan_file(export_file, quiet=True, forgetful_export=True) == 1
 
 
 class TestMain:
@@ -209,3 +221,12 @@ class TestMain:
 
     def test_quiet_flag_accepted(self, clean_file: Path) -> None:
         assert main([str(clean_file), "--quiet"]) == 0
+
+    def test_forgetful_export_flag_accepts_id_uuid(self, tmp_path: Path) -> None:
+        export_file = tmp_path / "uuid.json"
+        export_file.write_text(
+            '{"id": "550e8400-e29b-41d4-a716-446655440000"}',
+            encoding="utf-8",
+        )
+
+        assert main(["--forgetful-export", str(export_file), "--quiet"]) == 0


### PR DESCRIPTION
## Summary

### What

Fix the Forgetful exporter security-review boundary and narrow generic secret detection so exact Forgetful `id` and `user_id` UUID values do not trigger false positives.

### Why

`scripts/review_memory_export_security.py` defines the scanner path as a positional argument:

```python
parser.add_argument("export_file", type=Path, help="Path to exported memory JSON file")
```

The Forgetful exporter and three Claude-Mem exporters passed an unsupported named option. The generic 34-character token pattern also matched every canonical UUID substring. The fix keeps default scans and neutral-field, malformed, extended, duplicate, and same-line token values detectable.

## Specification References

| Type | Reference | Description |
|---|---|---|
| **Issue** | Fixes #4950 | Forgetful exporter security-review CLI and UUID false positives |

## Changes

- Pass scanner paths positionally after an argv option sentinel in all four shipped exporters.
- Require the Forgetful exporter to select its explicit UUID policy; generic scans continue detecting UUID-shaped values.
- Fail closed when the mandatory Forgetful scanner is absent.
- Exempt only span-exact canonical UUID values in measured Forgetful `id` and `user_id` fields.
- Keep scanner reports free of matched values and detection expressions.
- Add real CLI-boundary and UUID positive, negative, and edge tests.
- Keep the README unchanged because its scanner commands are already positional.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted security and correctness review, high scrutiny, blocks issue resolution

**Focus areas**: CLI argv construction, explicit Forgetful mode, UUID field scoping, inverse token cases, and fail-closed behavior

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- 57 focused tests passed at the implementation tip.
- 29 scanner tests passed with 98% branch coverage. The only uncollected line is the `__main__` dispatch exercised by real subprocess tests.
- 27,952 repository tests passed, 37 skipped, 2 warnings with six workers.
- Pre-push gates passed, including `python-tests` in 351.10 seconds.
- Pre-PR validation passed 51 of 51 checks.
- Scoped Ruff, taste lints, CWE-78 scan, and Semgrep passed.
- A 48-worker stress run exposed one unrelated shared-temporary-directory race; the isolated test passed, and the repository gate worker count passed the full suite.

## Agent Review

### Security Review

- [ ] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `scripts/review_memory_export_security.py`: secret-detection boundary, explicit Forgetful mode, UUID exception, and metadata-only reporting
- `scripts/forgetful/export_forgetful_memories.py`: mandatory scanner invocation and fail-closed handling
- `.claude-mem/scripts/export_claude_mem_*.py`: positional scanner invocation

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [x] Critic validated implementation plan
- [x] QA verified test coverage

The Copilot CLI was invoked with requested model `gpt-5.6-sol`. Its transcript was unavailable, so actual model identity could not be independently confirmed. The final adversarial response returned PASS after four correction rounds. Two later GitHub Copilot review findings were fixed, replied to, and resolved.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #4950