### PR TITLE
fix(ci): isolate GIT_* for every count-ratchet git subprocess

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -178,7 +178,7 @@
   "metrics": {
     "duration_minutes": null,
     "tool_calls": null,
-    "errors": 17,
+    "errors": 8,
     "recoveries": 0,
     "commits": 2,
     "files_changed": 6

--- a/.agents/memory/episodes/episode-2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/memory/episodes/episode-2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -1,0 +1,187 @@
+{
+  "id": "episode-2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_",
+  "session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_",
+  "timestamp": "2026-08-13T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix issue 4914: isolate GIT_* environment for every git subprocess in scripts/ci/count_ratchet.py so linked-worktree pushes do not read the wrong tree",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #4914 discourse (body, triage comment, CodeRabbit enrichment) and checked for existing PR coverage",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced the mechanism on git 2.43.0 with a real linked worktree",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified git exports GIT_DIR to pre-push only from a linked worktree",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured whether merge_tree_materialization.isolated_git_environment could be reused directly",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added git_environment() to count_ratchet and routed every git subprocess through it",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrote tests/ci/test_count_ratchet_git_environment.py against real git",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified the tests detect the defect by reverting the isolation and re-running",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "error",
+      "content": "Verified the tests detect the defect by reverting the isolation and re-running    8 of 17 failed with isolation removed, including the guard on both modules; all 17 pass with it restored",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced the issue's exact failure end to end via ruff_count_ratchet.current_count(<scratch>)",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Recovered from self-inflicted damage: an early throwaway harness ran git add -A and git commit with GIT_DIR exported and cwd in a scratch dir",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the gates",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-13T00:00:00+00:00",
+      "type": "test",
+      "content": "tests/ci 2416 passed; all five count ratchets OK; pre_pr.py all validations passed; commit hooks green",
+      "caused_by": [],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-13T15:03:03+00:00",
+      "type": "commit",
+      "content": "Commit: 0cd0a70d3c",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009",
+        "e010",
+        "e011",
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-08-13T15:28:06+00:00",
+      "type": "commit",
+      "content": "Commit: e009b85af365b3c479765fd914cadd7088cb007c",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 17,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/qa/issue-4914-count-ratchet-git-env-qa.md
+++ b/.agents/qa/issue-4914-count-ratchet-git-env-qa.md
@@ -1,0 +1,143 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+qaCommit: e009b85af365b3c479765fd914cadd7088cb007c
+---
+
+# Issue 4914 QA Report
+
+## Verdict
+
+PASS. Every gate below was re-run on commit `e009b85af365b3c479765fd914cadd7088cb007c`, the last commit
+carrying non-evidence changes, before this evidence was added. The code fix itself
+landed in `0cd0a70d3cb53df6ebbef8fc03dcf4fb3dcd61fd`; `e009b85af3` adds only the
+Serena memory and its index rows.
+
+## Scope
+
+`scripts/ci/count_ratchet.py` and `scripts/ci/ruff_count_ratchet.py` ran every git
+subprocess with the ambient environment. A `git push` from a linked worktree exports
+`GIT_DIR` into the pre-push hook, and an exported `GIT_DIR` outranks the `-C <root>`
+argument, so the counters read the pushing worktree instead of the root they were
+handed. The fix adds `git_environment()` and routes every git call site through it.
+
+## Defect reproduced before the fix
+
+Run directly on git 2.43.0. A scratch repository tracks only `keep.py`; `GIT_DIR`
+names a second repository that also tracks `scripts/validation/only_on_branch.py`.
+
+```text
+$ git -C <scratch> ls-files                          # clean environment
+keep.py
+
+$ GIT_DIR=<other gitdir> git -C <scratch> ls-files   # the WRONG tree
+keep.py
+scripts/validation/only_on_branch.py
+```
+
+Git exports the variable only from a linked worktree. Measured by dumping the hook
+environment on both pushes:
+
+| Push origin | `GIT_DIR` in the pre-push environment |
+|-------------|----------------------------------------|
+| Linked worktree | `<main>/.git/worktrees/<name>` |
+| Ordinary checkout | absent |
+
+## End-to-end, the issue's own failure
+
+`ruff_count_ratchet.current_count(<scratch>)` against a scratch tree that does not
+carry the branch-only file, with `GIT_DIR` pointing at a disposable repository that
+does. Same command, isolation removed and then restored.
+
+```text
+before: ruff could not read <scratch>/scripts/validation/
+        check_unreachable_after_terminator.py: No such file or directory (os error 2)
+        current_count(scratch) -> None
+
+after:  current_count(scratch) -> 0
+```
+
+The `None` is what `merge-tree-ratchet` and `pre-pr-validation` report as
+`counter returned None`, and it is what blocked five pushes on PR #4912.
+
+## Tests
+
+`tests/ci/test_count_ratchet_git_environment.py`, 17 tests, run against real git
+rather than a `subprocess.run` stand-in. A stand-in would assert that some dict was
+passed and would pass just as happily if git ignored it, which is the whole question.
+
+| Class | Count | What it pins |
+|-------|-------|--------------|
+| Positive | 6 | Correct listing with no `GIT_*` set; the strip preserves a clean environment unchanged; `PATH`, `HOME` and a `DIGIT_COUNT` lookalike survive |
+| Negative | 5 | Foreign `GIT_DIR` must not reach `tracked_files`, `baseline_at_ref`, `baseline_absent_at_ref`, `changed_files`, or the `ruff_count_ratchet` duplicate |
+| Edge | 4 | Lowercase `git_dir`; result is a copy, not a view; a non-repository still returns `None` rather than `[]`; launch failure still returns `None` |
+| Guard | 2 | AST check that no git `subprocess.run` in either module omits `env=`, plus the guard's own negative control |
+
+Two of those deserve naming. `test_foreign_git_dir_would_win_without_isolation`
+asserts the override is still real, so the negative controls cannot start passing
+for a reason unrelated to the fix. `test_tracked_files_still_reports_failure_under_isolation`
+pins that isolation does not convert a git failure into an empty listing, which
+would score a tree as zero violations and pass by failing.
+
+### Tests fail without the fix
+
+The isolation was reverted and the module re-run:
+
+```text
+8 failed, 9 passed
+FAILED test_tracked_files_ignores_a_foreign_git_dir
+FAILED test_tracked_files_still_reports_failure_under_isolation
+FAILED test_baseline_at_ref_ignores_a_foreign_git_dir
+FAILED test_baseline_absent_at_ref_ignores_a_foreign_git_dir
+FAILED test_changed_files_ignores_a_foreign_git_dir
+FAILED test_ruff_ratchet_baseline_at_ref_ignores_a_foreign_git_dir
+FAILED test_every_git_subprocess_passes_an_env[count_ratchet]
+FAILED test_every_git_subprocess_passes_an_env[ruff_count_ratchet]
+```
+
+Restored: `17 passed`.
+
+## Gates
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Unit and integration | `uv run pytest tests/ci/ -q` | 2416 passed, 10 skipped |
+| New module | `uv run pytest tests/ci/test_count_ratchet_git_environment.py -q` | 17 passed |
+| Lint | `uv run ruff check scripts/ci/count_ratchet.py scripts/ci/ruff_count_ratchet.py` | All checks passed |
+| ruff count ratchet | `python scripts/ci/ruff_count_ratchet.py --base-ref origin/main` | OK, count == baseline 27 |
+| taste count ratchet | `python scripts/ci/taste_count_ratchet.py --base-ref origin/main` | OK, 580 <= 583 |
+| type-ignore ratchet | `python scripts/ci/type_ignore_count_ratchet.py --base-ref origin/main` | OK, count == baseline 44 |
+| subprocess encoding ratchet | `python scripts/ci/subprocess_encoding_count_ratchet.py --base-ref origin/main` | OK, count == baseline 238 |
+| cli exit contract ratchet | `python scripts/ci/cli_exit_contract_ratchet.py --base-ref origin/main` | OK, count == baseline 27 |
+| Pre-PR | `uv run python scripts/validation/pre_pr.py` | RESULT: All validations passed |
+| Commit hooks | lefthook pre-commit and commit-msg | all green |
+
+The real gate was also exercised under the defect's own conditions:
+`GIT_DIR=<this worktree gitdir> python scripts/ci/ruff_count_ratchet.py --base-ref origin/main`
+returned `OK (count == baseline 27)` with exit 0.
+
+## Divergence from the canonical helper, and why
+
+`scripts/ci/merge_tree_materialization.py::isolated_git_environment` is the existing
+pattern. It was not imported. Two measured reasons, both recorded in the new helper's
+docstring:
+
+1. `count_ratchet` is stdlib-only by contract, because the gates run by path in CI.
+   That module imports `scripts.cli_exec`, so importing it would put the project's
+   import graph behind every ratchet.
+2. That helper also blanks `HOME` and the global git config. These gates run git
+   against the real checkout, where `actions/checkout` records `safe.directory` in
+   the global config. Measured: a global `safe.directory` that `git config --get-all`
+   returns under the ambient environment (rc 0) is invisible under that helper's
+   environment (rc 1).
+
+So the `GIT_*` half of its rule is mirrored verbatim, including `name.upper()`, and
+nothing else is dropped.
+
+## Residual risk
+
+| Risk | Assessment |
+|------|------------|
+| A new git call site omits `env=` | Covered by the AST guard on both modules. A git call built outside a list literal would evade it; none exists today. |
+| Stripping `GIT_*` breaks a needed variable | All four call sites are local read-only reads (`ls-files`, `diff`, `show`, `ls-tree`, `rev-parse`). None contacts a remote, so `GIT_SSH_COMMAND` and `GIT_ASKPASS` are not load-bearing. `GIT_EXEC_PATH` falls back to git's compiled-in path, and the canonical helper already strips it in the same hook context. |
+| `ruff_count_ratchet.baseline_at_ref` is dead | It is a duplicate that only its own test calls. It was fixed rather than deleted; deleting it is out of scope and is recorded in the session log's next steps. |

--- a/.agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md
+++ b/.agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
-qaCommit: e009b85af365b3c479765fd914cadd7088cb007c
+qaCommit: b8727c8d32ae895e1dec6027d77c718271e44a6f
 ---
 
 # PR 4970 QA Report (issue #4914)
@@ -141,3 +141,13 @@ nothing else is dropped.
 | A new git call site omits `env=` | Covered by the AST guard on both modules. A git call built outside a list literal would evade it; none exists today. |
 | Stripping `GIT_*` breaks a needed variable | All four call sites are local read-only reads (`ls-files`, `diff`, `show`, `ls-tree`, `rev-parse`). None contacts a remote, so `GIT_SSH_COMMAND` and `GIT_ASKPASS` are not load-bearing. `GIT_EXEC_PATH` falls back to git's compiled-in path, and the canonical helper already strips it in the same hook context. |
 | `ruff_count_ratchet.baseline_at_ref` is dead | It is a duplicate that only its own test calls. It was fixed rather than deleted; deleting it is out of scope and is recorded in the session log's next steps. |
+
+## Review Fix Addendum (b8727c8d3)
+
+Non-behavioral changes addressing Copilot review findings:
+
+1. Episode JSON: corrected metrics.errors from 17 to 8 (matching source session)
+2. Memory file: added non-binding disclaimer per knowledge-persistence.md
+3. PR description: fixed QA evidence path reference
+
+No code logic changes. All original test evidence remains valid.

--- a/.agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md
+++ b/.agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md
@@ -4,7 +4,7 @@ qaSessionLog: .agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914
 qaCommit: e009b85af365b3c479765fd914cadd7088cb007c
 ---
 
-# Issue 4914 QA Report
+# PR 4970 QA Report (issue #4914)
 
 ## Verdict
 

--- a/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -145,7 +145,7 @@
     },
     {
       "action": "Verified the tests detect the defect by reverting the isolation and re-running",
-      "outcome": "8 of 17 failed with isolation removed, including the guard on both modules; all 17 pass with it restored"
+      "outcome": "8 failed out of 17 with isolation removed, including the guard on both modules; all 17 pass with it restored"
     },
     {
       "action": "Reproduced the issue's exact failure end to end via ruff_count_ratchet.current_count(<scratch>)",

--- a/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -160,7 +160,7 @@
       "outcome": "tests/ci 2416 passed; all five count ratchets OK; pre_pr.py all validations passed; commit hooks green"
     }
   ],
-  "endingCommit": "e009b85af365b3c479765fd914cadd7088cb007c",
+  "endingCommit": "b8727c8d32ae895e1dec6027d77c718271e44a6f",
   "nextSteps": [
     "Monitor CI on PR #4970",
     "Consider a follow-up to delete the dead duplicate ruff_count_ratchet.baseline_at_ref, which only its own test calls; out of scope here"

--- a/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -1,0 +1,168 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14696,
+    "date": "2026-08-13",
+    "branch": "fix/4914-count-ratchet-git-env",
+    "startingCommit": "ab9c636de5",
+    "objective": "Fix issue 4914: isolate GIT_* environment for every git subprocess in scripts/ci/count_ratchet.py so linked-worktree pushes do not read the wrong tree"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena tools available in-session; memories listed via list_memories(topic=ci)"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions returned the Serena Instructions Manual"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read (read-only per ADR-014); .agents/sessions/handoffs/ listed, no *-4914-handoff.md exists"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/skills/ listed; session-init and github skills used"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, .agents/AGENT-INSTRUCTIONS.md, .agents/CLAUDE.md read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".github/instructions/ci-scripts.instructions.md read (applyTo scripts/**)"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ci/run-count-ratchets-before-the-expensive-pre-push read; ci and git topics enumerated"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4914-count-ratchet-git-env"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/4914-count-ratchet-git-env"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status clean in new worktree at origin/main ab9c636de5"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ab9c636de5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not modified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ci/git-dir-from-a-linked-worktree-push-outranks-git-c written and indexed in skills-ci-infrastructure-index.md; memory_index.py PASSED, no longer orphaned"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "NOT LINTED, every changed markdown path is ignored by .markdownlint-cli2.yaml (.agents/** and .serena/**); markdownlint-cli2 reported 'Linting: 0 files'"
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/issue-4914-count-ratchet-git-env-qa.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commits 0cd0a70d3c (fix + tests), e009b85af3 (memory)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run python scripts/validation/pre_pr.py: RESULT All validations passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #4914 already assigned to rjmurillo; PR opened with Fixes #4914"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not invoked: single-defect fix, no process finding beyond the memory written"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Read issue #4914 discourse (body, triage comment, CodeRabbit enrichment) and checked for existing PR coverage",
+      "outcome": "No open or merged PR addresses count_ratchet GIT_DIR; issue assigned to rjmurillo, unclaimed by any branch"
+    },
+    {
+      "action": "Reproduced the mechanism on git 2.43.0 with a real linked worktree",
+      "outcome": "GIT_DIR=<worktree gitdir> git -C <scratch> ls-files leaked scripts/validation/only_on_branch.py from the wrong tree; clean env listed keep.py only"
+    },
+    {
+      "action": "Verified git exports GIT_DIR to pre-push only from a linked worktree",
+      "outcome": "Linked-worktree push hook env had GIT_DIR=<main>/.git/worktrees/<name>; main-checkout push hook env had none. Confirms the issue's claim"
+    },
+    {
+      "action": "Measured whether merge_tree_materialization.isolated_git_environment could be reused directly",
+      "outcome": "Rejected: it imports scripts.cli_exec (count_ratchet is stdlib-only by contract) and blanks the global git config, where actions/checkout records safe.directory. Measured: a global safe.directory readable under ambient env (rc 0) is invisible under that helper's env (rc 1)"
+    },
+    {
+      "action": "Added git_environment() to count_ratchet and routed every git subprocess through it",
+      "outcome": "tracked_files and baseline_at_ref now delegate to _git_run; git launch sites cut from 4 to 2, both passing env=. Same fix applied to the duplicate ruff_count_ratchet.baseline_at_ref"
+    },
+    {
+      "action": "Wrote tests/ci/test_count_ratchet_git_environment.py against real git",
+      "outcome": "17 tests: positive, foreign-GIT_DIR negative control, a test pinning the override itself so the control cannot pass vacuously, edge cases, and an AST guard with its own negative control"
+    },
+    {
+      "action": "Verified the tests detect the defect by reverting the isolation and re-running",
+      "outcome": "8 of 17 failed with isolation removed, including the guard on both modules; all 17 pass with it restored"
+    },
+    {
+      "action": "Reproduced the issue's exact failure end to end via ruff_count_ratchet.current_count(<scratch>)",
+      "outcome": "Without isolation: 'ruff could not read <scratch>/scripts/validation/check_unreachable_after_terminator.py: No such file or directory' then None. With isolation: 0"
+    },
+    {
+      "action": "Recovered from self-inflicted damage: an early throwaway harness ran git add -A and git commit with GIT_DIR exported and cwd in a scratch dir",
+      "outcome": "It wrote commit 51babf7380 'snap' onto this branch through the very defect under fix. git reset --mixed ab9c636de5 restored the branch; working tree untouched. Later harnesses build fixtures with a GIT_*-free env and point GIT_DIR only at a disposable repo"
+    },
+    {
+      "action": "Ran the gates",
+      "outcome": "tests/ci 2416 passed; all five count ratchets OK; pre_pr.py all validations passed; commit hooks green"
+    }
+  ],
+  "endingCommit": "e009b85af365b3c479765fd914cadd7088cb007c",
+  "nextSteps": [
+    "Monitor CI on the PR for issue #4914",
+    "Consider a follow-up to delete the dead duplicate ruff_count_ratchet.baseline_at_ref, which only its own test calls; out of scope here"
+  ]
+}

--- a/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
+++ b/.agents/sessions/2026-08-13-session-14696-b8dd33c5e-fix-issue-4914-isolate-git_.json
@@ -94,7 +94,7 @@
       "qaValidation": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": ".agents/qa/issue-4914-count-ratchet-git-env-qa.md"
+        "Evidence": ".agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md"
       },
       "changesCommitted": {
         "level": "MUST",
@@ -162,7 +162,7 @@
   ],
   "endingCommit": "e009b85af365b3c479765fd914cadd7088cb007c",
   "nextSteps": [
-    "Monitor CI on the PR for issue #4914",
+    "Monitor CI on PR #4970",
     "Consider a follow-up to delete the dead duplicate ruff_count_ratchet.baseline_at_ref, which only its own test calls; out of scope here"
   ]
 }

--- a/.serena/memories/ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md
+++ b/.serena/memories/ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md
@@ -60,7 +60,10 @@ before you doubt the branch.
 Workaround if you are blocked right now: push from a non-linked clone. All
 hooks still run there.
 
-## Do this in any script that runs git against a caller-supplied root
+## Guidance: isolating GIT_* in scripts that run git against a caller-supplied root
+
+> **Non-binding incident guidance.** This is a Serena memory note, not a project rule.
+> Cross-harness conventions must live under `.claude/rules/` per `.claude/rules/knowledge-persistence.md`.
 
 Pass an environment, never inherit one:
 

--- a/.serena/memories/ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md
+++ b/.serena/memories/ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md
@@ -1,0 +1,110 @@
+# A push from a linked worktree exports GIT_DIR, and it outranks `git -C`
+
+## The trap
+
+`git -C <root> <cmd>` does not win against an exported `GIT_DIR`. The `-C` only
+changes the working directory; `GIT_DIR` names the repository, and it takes
+precedence. Measured on git 2.43.0, scratch repo tracking only `keep.py`:
+
+```text
+$ git -C <scratch> ls-files                          # clean environment
+keep.py
+
+$ GIT_DIR=<other gitdir> git -C <scratch> ls-files   # reads the OTHER repo
+keep.py
+scripts/validation/only_on_branch.py
+```
+
+## Why it only bites agents
+
+`git push` exports `GIT_DIR` into the pre-push hook environment **only from a
+linked worktree**. Measured by dumping `env | grep ^GIT_` from a pre-push hook
+on git 2.43.0:
+
+| Push origin | `GIT_DIR` in the hook environment |
+|-------------|-----------------------------------|
+| Linked worktree (`git worktree add`) | `<main>/.git/worktrees/<name>` |
+| Ordinary checkout | absent |
+
+Worktrees are the documented pattern here, so every agent is on the affected
+path and no one working in a plain clone can reproduce it.
+
+## How it surfaced
+
+`scripts/ci/count_ratchet.py::tracked_files` ran with the ambient environment.
+`merge_tree_ratchet_check` calls `current_count(<scratch>)`, so `ls-files`
+listed the *pushing worktree's* index against the *scratch* tree. Any file the
+branch carries that `origin/main` deleted was then handed to ruff as a scratch
+path that does not exist:
+
+```text
+ruff could not read <scratch>/scripts/validation/check_unreachable_after_terminator.py:
+No such file or directory
+counter returned None
+```
+
+`merge-tree-ratchet` and `pre-pr-validation` then blocked the push, naming a
+file the branch legitimately has. Issue #4914; it cost five pushes and about 40
+minutes on PR #4912 before anyone looked at the environment.
+
+Fixed by `count_ratchet.git_environment()`, which strips `GIT_*` from a copy of
+`os.environ`, and by routing every git call site in that module through it.
+
+## The symptom to recognize
+
+A gate reports a path that **exists on your branch and does not exist in the
+tree the gate says it is measuring**. That shape means the tool is reading a
+different repository than the one it was pointed at. Check `env | grep ^GIT_`
+before you doubt the branch.
+
+Workaround if you are blocked right now: push from a non-linked clone. All
+hooks still run there.
+
+## Do this in any script that runs git against a caller-supplied root
+
+Pass an environment, never inherit one:
+
+```python
+env = {k: v for k, v in os.environ.items() if not k.upper().startswith("GIT_")}
+subprocess.run(["git", "-C", str(root), ...], env=env, check=False)
+```
+
+`name.upper()` matters: Windows folds environment names case-insensitively, so
+a lowercased `git_dir` set there is the same variable.
+
+Do **not** reach for
+`scripts/ci/merge_tree_materialization.py::isolated_git_environment` by reflex.
+It is right for a repo the script just created and owns, but it also blanks
+`HOME` and the global git config. `actions/checkout` records `safe.directory`
+in the global config, and blanking it invites "detected dubious ownership" on a
+runner. Measured: a global `safe.directory` that `git config --get-all` returns
+under the ambient environment (rc 0) is invisible under that helper's
+environment (rc 1). Against a real checkout, strip `GIT_*` and nothing else.
+
+## This will bite your throwaway diagnostic script too
+
+While diagnosing #4914 a scratch harness ran
+
+```python
+subprocess.run(["git", "-C", scratch, "add", "-A"])   # GIT_DIR still exported
+subprocess.run(["git", "-C", scratch, "commit", "-qm", "snap"])
+```
+
+with `GIT_DIR` pointing at the live worktree. Git used `GIT_DIR` as the
+repository and `scratch` as the work tree, so `add -A` staged every real file
+as **deleted**, and the commit landed on the working branch. `git reset --mixed
+<origin/main sha>` recovered it; the working tree was untouched.
+
+Two rules for any repro script:
+
+1. Build fixtures with a `GIT_*`-free environment.
+2. Point `GIT_DIR` only at a disposable repository. An unisolated write goes
+   *through* it.
+
+## Related
+
+- `git/git-shallow-is-shared-across-every-worktree` - another worktree-scoped
+  git state that leaks across checkouts.
+- `ci/run-count-ratchets-before-the-expensive-pre-push` - run the cheap ratchets
+  first, which is also how you see this failure in seconds instead of after the
+  twelve-minute suite.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -105,7 +105,7 @@
 |AI quality gate Aggregate Results all agents NEEDS_REVIEW: [ci/ci-ai-gate-blocks-when-the-security-review-did-not-run](ci/ci-ai-gate-blocks-when-the-security-review-did-not-run.md) (2000)
 |copilot skill mirror two canonical sources generate_skills generate_commands: [copilot/copilot-skill-mirror-has-two-sources](copilot/copilot-skill-mirror-has-two-sources.md) (848)
 |mutation testing line swap stale bytecode __pycache__ false: [ci/ci-line-swap-mutations-reuse-stale-bytecode](ci/ci-line-swap-mutations-reuse-stale-bytecode.md) (834)
-|CI CD workflow actions runner ARM: [skills-ci-infrastructure-index](skills-ci-infrastructure-index.md) (1004)
+|CI CD workflow actions runner ARM: [skills-ci-infrastructure-index](skills-ci-infrastructure-index.md) (1068)
 |workflow pattern composite matrix artifact verdict report: [skills-workflow-patterns-index](skills-workflow-patterns-index.md) (284)
 |dorny paths-filter checkout base ref PR changes: [ci/ci-infrastructure-dorny-paths-filter-checkout](ci/ci-infrastructure-dorny-paths-filter-checkout.md) (930)
 |lefthook group parallel serial summary sum arithmetic config: [decision-read-the-config-not-the-run-summary](decision-read-the-config-not-the-run-summary.md) (964)

--- a/.serena/memories/skills-ci-infrastructure-index.md
+++ b/.serena/memories/skills-ci-infrastructure-index.md
@@ -21,4 +21,5 @@
 | copilot-cli frontmatter regression agent model argument-hint version pin auto-update diagnostic runbook | [copilot/copilot-cli-frontmatter-regression-runbook](copilot/copilot-cli-frontmatter-regression-runbook.md) |
 | job log truncated blob redirect gh api exits zero empty grep silent wc bytes allow-escape-sequences | [ci/ci-a-truncated-job-log-greps-exactly-like-a-clean-one](ci/ci-a-truncated-job-log-greps-exactly-like-a-clean-one.md) |
 | episode ratchet metrics violations grew push blocked episode predates commit timestamp | [ci/episode-ratchet-trips-because-the-episode-predates-the-commit](ci/episode-ratchet-trips-because-the-episode-predates-the-commit.md) |
+| GIT_DIR linked worktree pre-push hook export git -C outranks wrong tree count ratchet counter returned None scratch blocked push isolate environment | [ci/git-dir-from-a-linked-worktree-push-outranks-git-c](ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md) |
 | shallow fetch depth graft merge-base merge-tree unrelated histories checkout fetch-depth unshallow | [decision-shallow-fetch-kills-merge-base-in-ci](decision-shallow-fetch-kills-merge-base-in-ci.md) |

--- a/scripts/ci/count_ratchet.py
+++ b/scripts/ci/count_ratchet.py
@@ -34,8 +34,17 @@ recorded in ``.github/AGENTS.md`` under "Ratchet Baselines and the Concurrent
 Merge Race". The regression test that proves the gate blocks lives in
 ``tests/ci/test_count_ratchet_concurrent_merge.py``.
 
+Every git subprocess here runs under ``git_environment()``, never the ambient
+environment. A ``git push`` from a linked worktree exports ``GIT_DIR`` into the
+pre-push hook, and an exported ``GIT_DIR`` outranks the ``-C <root>`` argument,
+so the counters read the pushing worktree instead of the root they were handed
+(issue #4914). See that helper for the measurement.
+
 Stdlib only: these gates run by path in CI (``python scripts/ci/<name>.py``) and
-must not depend on the project's import graph.
+must not depend on the project's import graph. That is why the ``GIT_*`` strip
+below is a local copy of the rule in ``merge_tree_materialization.py`` rather
+than an import of it: that module imports ``scripts.cli_exec``, and reaching it
+from here would put the project's import graph behind every ratchet.
 
 Exit codes (AGENTS.md contract):
     0 - ok (count <= baseline, or --update records a decrease)
@@ -47,6 +56,7 @@ Exit codes (AGENTS.md contract):
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from collections.abc import Callable, Sequence
@@ -63,19 +73,95 @@ EXIT_EXTERNAL = 3
 ARGV_BUDGET_BYTES = 24000
 
 
-def tracked_files(repo_root: Path, globs: Sequence[str]) -> list[str] | None:
-    """Git-tracked paths matching ``globs``, or None when git could not run."""
+def git_environment() -> dict[str, str]:
+    """The ambient environment with every ``GIT_*`` variable removed.
+
+    ``git -C <root>`` does not win against an exported ``GIT_DIR``. Measured on
+    git 2.43.0 against a scratch repo holding only ``keep.py``, with ``GIT_DIR``
+    pointed at a linked worktree that also tracks
+    ``scripts/validation/only_on_branch.py``::
+
+        $ git -C <scratch> ls-files                        # clean environment
+        keep.py
+        $ GIT_DIR=<worktree gitdir> git -C <scratch> ls-files
+        keep.py
+        scripts/validation/only_on_branch.py               # the WRONG tree
+
+    That second listing is issue #4914. ``git push`` exports ``GIT_DIR`` into
+    the pre-push hook from a linked worktree and not from an ordinary checkout
+    (measured on git 2.43.0: ``GIT_DIR=<main>/.git/worktrees/<name>`` present in
+    the hook environment for the linked push, absent for the main-checkout
+    push). ``merge_tree_ratchet_check`` then calls ``current_count(<scratch>)``,
+    ``tracked_files`` lists the pushing worktree's index instead of the scratch
+    index, and the linter is handed scratch paths that do not exist. The
+    counter returns None and the push is blocked with a message that names a
+    file the branch legitimately carries. Five pushes on PR #4912 were spent
+    before the cause was found.
+
+    Mirrors the ``GIT_*`` half of
+    ``scripts/ci/merge_tree_materialization.py::isolated_git_environment``,
+    whose rule is verbatim::
+
+        env = os.environ.copy()
+        isolated_names = {"GNUPGHOME", "HOME", "LEFTHOOK", "USERPROFILE", "XDG_CONFIG_HOME"}
+        for name in tuple(env):
+            normalized = name.upper()
+            if normalized.startswith("GIT_") or normalized in isolated_names:
+                env.pop(name)
+
+    ``normalized = name.upper()`` is kept, so a lowercased ``git_dir`` that a
+    case-insensitive platform folds into ``GIT_DIR`` is stripped here too.
+
+    Stricter/looser/different than canonical: narrower on purpose. That helper
+    also drops ``HOME``, ``USERPROFILE``, ``XDG_CONFIG_HOME``, ``GNUPGHOME`` and
+    ``LEFTHOOK``, and repoints them at a scratch home with an empty global
+    config. It may, because it only ever runs git against a repository it just
+    created and owns. These ratchets run git against the real checkout, where
+    the global config is load-bearing: ``actions/checkout`` records
+    ``safe.directory`` there, and blanking it invites "detected dubious
+    ownership" on a runner. Measured with that helper's own environment, a
+    global ``safe.directory`` entry that ``git config --get-all`` returns under
+    the ambient environment (rc 0) is invisible under the isolated one (rc 1).
+    So this strips the variable that causes the defect and nothing else. It also
+    takes no scratch directory and needs no cleanup, which keeps a read-only
+    path free of the temporary-tree failure modes that isolation carries.
+
+    Returns a fresh dict; ``os.environ`` is never mutated.
+    """
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if not name.upper().startswith("GIT_")
+    }
+
+
+def _git_run(repo_root: Path, argv: Sequence[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a git command, or None when git could not be launched."""
     try:
-        proc = subprocess.run(
-            ["git", "-C", str(repo_root), "ls-files", "-z", "--", *globs],
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *argv],
             capture_output=True,
             text=True,
             errors="replace",
             encoding="utf-8",
             check=False,
+            env=git_environment(),
         )
     except (FileNotFoundError, OSError) as exc:
         sys.stderr.write(f"git could not be launched: {exc}\n")
+        return None
+
+
+def _git_rc(repo_root: Path, argv: Sequence[str]) -> int | None:
+    """Exit status of a git command, or None when git could not be launched."""
+    proc = _git_run(repo_root, argv)
+    return None if proc is None else proc.returncode
+
+
+def tracked_files(repo_root: Path, globs: Sequence[str]) -> list[str] | None:
+    """Git-tracked paths matching ``globs``, or None when git could not run."""
+    proc = _git_run(repo_root, ["ls-files", "-z", "--", *globs])
+    if proc is None:
         return None
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)
@@ -98,6 +184,7 @@ def _diff_paths(repo_root: Path, spec: str, scope: str) -> frozenset[str]:
             errors="replace",
             encoding="utf-8",
             check=False,
+            env=git_environment(),
         )
     except (FileNotFoundError, OSError) as exc:
         sys.stderr.write(f"diagnostic ordering degraded: git could not be launched: {exc}\n")
@@ -237,28 +324,6 @@ def _baseline_rel(repo_root: Path, baseline: Path) -> str:
         return baseline.as_posix()
 
 
-def _git_run(repo_root: Path, argv: Sequence[str]) -> subprocess.CompletedProcess[str] | None:
-    """Run a git command, or None when git could not be launched."""
-    try:
-        return subprocess.run(
-            ["git", "-C", str(repo_root), *argv],
-            capture_output=True,
-            text=True,
-            errors="replace",
-            encoding="utf-8",
-            check=False,
-        )
-    except (FileNotFoundError, OSError) as exc:
-        sys.stderr.write(f"git could not be launched: {exc}\n")
-        return None
-
-
-def _git_rc(repo_root: Path, argv: Sequence[str]) -> int | None:
-    """Exit status of a git command, or None when git could not be launched."""
-    proc = _git_run(repo_root, argv)
-    return None if proc is None else proc.returncode
-
-
 def baseline_absent_at_ref(repo_root: Path, ref: str, baseline: Path) -> bool:
     """True when ``ref`` resolves but records no baseline file yet.
 
@@ -295,17 +360,8 @@ def baseline_absent_at_ref(repo_root: Path, ref: str, baseline: Path) -> bool:
 def baseline_at_ref(repo_root: Path, ref: str, baseline: Path) -> int | None:
     """Baseline value recorded at ``ref``, or None when it cannot be read."""
     rel = _baseline_rel(repo_root, baseline)
-    try:
-        proc = subprocess.run(
-            ["git", "-C", str(repo_root), "show", f"{ref}:{rel}"],
-            capture_output=True,
-            text=True,
-            errors="replace",
-            encoding="utf-8",
-            check=False,
-        )
-    except (FileNotFoundError, OSError) as exc:
-        sys.stderr.write(f"git could not be launched: {exc}\n")
+    proc = _git_run(repo_root, ["show", f"{ref}:{rel}"])
+    if proc is None:
         return None
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)

--- a/scripts/ci/ruff_count_ratchet.py
+++ b/scripts/ci/ruff_count_ratchet.py
@@ -42,6 +42,7 @@ from scripts.ci.count_ratchet import (
     EXIT_REGRESSION,
     build_parser,
     chunk,
+    git_environment,
     run,
     tracked_files,
 )
@@ -137,6 +138,11 @@ def baseline_at_ref(repo_root: Path, ref: str, baseline: Path) -> int | None:
     exceeds the baseline, so raising the baseline in the same PR that adds the
     violations passes as an improvement. Comparing against the base branch is
     what makes the baseline monotonic rather than merely advisory.
+
+    Runs under ``git_environment()`` for the reason recorded there: an exported
+    ``GIT_DIR`` outranks ``-C <root>``, so a push from a linked worktree would
+    resolve ``ref`` in the pushing worktree rather than in ``repo_root``
+    (issue #4914).
     """
     try:
         rel = baseline.resolve().relative_to(repo_root.resolve()).as_posix()
@@ -151,6 +157,7 @@ def baseline_at_ref(repo_root: Path, ref: str, baseline: Path) -> int | None:
             errors="replace",
             encoding="utf-8",
             check=False,
+            env=git_environment(),
         )
     except (FileNotFoundError, OSError) as exc:
         sys.stderr.write(f"git could not be launched: {exc}\n")

--- a/tests/ci/test_count_ratchet_git_environment.py
+++ b/tests/ci/test_count_ratchet_git_environment.py
@@ -1,0 +1,414 @@
+"""Git subprocess isolation for the count ratchets (issue #4914).
+
+A ``git push`` from a linked worktree exports ``GIT_DIR`` into the pre-push
+hook environment. An exported ``GIT_DIR`` outranks the ``-C <root>`` argument,
+so every counter subprocess reads the pushing worktree instead of the root it
+was handed. ``merge_tree_ratchet_check`` calls ``current_count(<scratch>)``, so
+the effect is a file list from the wrong tree: the linter is handed scratch
+paths that do not exist, the counter returns None, and the push is blocked.
+
+These run git itself. A stand-in for ``subprocess.run`` would assert that some
+dict was passed and would pass just as happily if git ignored it, which is the
+whole question here. The negative control is a real second repository whose
+index holds a file the tree under test does not: if isolation regresses, that
+foreign path appears in the listing.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import count_ratchet
+from scripts.ci import ruff_count_ratchet as ruff_ratchet
+from tests.ci.count_ratchet_git_harness import commit_all as _commit_all
+from tests.ci.count_ratchet_git_harness import init_repo as _init_repo
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
+
+_FOREIGN_ONLY = "scripts/validation/only_in_foreign.py"
+_SHARED = "keep.py"
+
+
+def _foreign_repo(tmp_path: Path) -> Path:
+    """A repository whose index holds ``_FOREIGN_ONLY``; stands in for the pusher.
+
+    Its gitdir is what a linked-worktree push exports as ``GIT_DIR``. Whether
+    it is literally a linked worktree does not change the mechanism: git reads
+    the variable, and any gitdir that is not the tree under test proves the
+    override. Using a plain repository keeps the fixture readable and portable.
+    """
+    repo = tmp_path / "foreign"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / _SHARED).write_text("y = 2\n", encoding="utf-8")
+    target = repo / _FOREIGN_ONLY
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n", encoding="utf-8")
+    _commit_all(repo, "foreign tree")
+    return repo
+
+
+def _tree_under_test(tmp_path: Path) -> Path:
+    """The scratch tree the ratchet was pointed at. It never holds ``_FOREIGN_ONLY``."""
+    repo = tmp_path / "scratch"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / _SHARED).write_text("y = 2\n", encoding="utf-8")
+    _commit_all(repo, "scratch snapshot")
+    return repo
+
+
+def _gitdir(repo: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--absolute-git-dir"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+# --------------------------------------------------------------------------
+# git_environment() itself
+# --------------------------------------------------------------------------
+
+
+def test_git_variables_are_removed(monkeypatch):
+    """Every variable git uses to relocate the repository is dropped.
+
+    Not just ``GIT_DIR``. ``GIT_WORK_TREE``, ``GIT_INDEX_FILE``,
+    ``GIT_OBJECT_DIRECTORY`` and ``GIT_COMMON_DIR`` redirect the same lookups,
+    and git exports more than one of them into a hook. Stripping the prefix
+    closes the class rather than the one instance that was reported.
+    """
+    for name in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+        "GIT_CEILING_DIRECTORIES",
+    ):
+        monkeypatch.setenv(name, "/somewhere/else")
+
+    env = count_ratchet.git_environment()
+
+    assert [name for name in env if name.upper().startswith("GIT_")] == []
+
+
+def test_non_git_variables_survive(monkeypatch):
+    """The strip is narrow on purpose.
+
+    ``PATH`` has to survive or git cannot be launched at all, and ``HOME`` has
+    to survive because ``actions/checkout`` records ``safe.directory`` in the
+    global config; dropping it invites "detected dubious ownership" on a
+    runner. This is the documented divergence from
+    ``merge_tree_materialization.isolated_git_environment``, which drops both.
+    """
+    monkeypatch.setenv("GIT_DIR", "/somewhere/else")
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("DIGIT_COUNT", "keep-me")
+
+    env = count_ratchet.git_environment()
+
+    assert env["HOME"] == "/home/tester"
+    assert env["DIGIT_COUNT"] == "keep-me"
+    assert "PATH" in env
+    assert "GIT_DIR" not in env
+
+
+def test_lowercase_git_prefix_is_removed(monkeypatch):
+    """``name.upper()`` is load-bearing, and is what the canonical helper does.
+
+    Windows folds environment names case-insensitively, so ``git_dir`` set
+    there is the same variable git reads. Matching on the raw name would leave
+    it in place on exactly the platform that created it.
+    """
+    monkeypatch.setenv("git_dir", "/somewhere/else")
+
+    assert "git_dir" not in count_ratchet.git_environment()
+
+
+def test_returns_a_copy_not_a_view(monkeypatch):
+    """Mutating the result must not reach back into the process environment."""
+    monkeypatch.setenv("GIT_DIR", "/somewhere/else")
+    monkeypatch.setenv("RATCHET_PROBE", "original")
+
+    env = count_ratchet.git_environment()
+    env["RATCHET_PROBE"] = "mutated"
+
+    assert os.environ["RATCHET_PROBE"] == "original"
+    assert os.environ["GIT_DIR"] == "/somewhere/else"
+
+
+def test_clean_environment_is_passed_through(monkeypatch):
+    """With no ``GIT_*`` set, the result is the ambient environment unchanged.
+
+    The positive control for the strip: it must not be quietly deleting things
+    when there is nothing to fix.
+    """
+    for name in [n for n in os.environ if n.upper().startswith("GIT_")]:
+        monkeypatch.delenv(name, raising=False)
+
+    assert count_ratchet.git_environment() == dict(os.environ)
+
+
+# --------------------------------------------------------------------------
+# tracked_files(): the call site that blocked PR #4912
+# --------------------------------------------------------------------------
+
+
+@requires_git
+def test_tracked_files_reads_the_named_root_without_git_dir(tmp_path, monkeypatch):
+    """Positive: ordinary push, no ``GIT_DIR``, correct listing."""
+    for name in [n for n in os.environ if n.upper().startswith("GIT_")]:
+        monkeypatch.delenv(name, raising=False)
+    scratch = _tree_under_test(tmp_path)
+
+    assert count_ratchet.tracked_files(scratch, ["*.py"]) == [_SHARED]
+
+
+@requires_git
+def test_tracked_files_ignores_a_foreign_git_dir(tmp_path, monkeypatch):
+    """Negative control: the reported bug, asserted directly.
+
+    ``GIT_DIR`` names a repository that tracks ``_FOREIGN_ONLY``; the tree
+    under test does not. Before the fix this returned the foreign path, which
+    was then handed to ruff as ``<scratch>/scripts/validation/...`` and failed
+    to open. The listing must be identical to the clean-environment listing.
+    """
+    scratch = _tree_under_test(tmp_path)
+    foreign = _foreign_repo(tmp_path)
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    listed = count_ratchet.tracked_files(scratch, ["*.py", "scripts/**/*.py"])
+
+    assert _FOREIGN_ONLY not in listed
+    assert listed == [_SHARED]
+
+
+@requires_git
+def test_foreign_git_dir_would_win_without_isolation(tmp_path, monkeypatch):
+    """The mechanism, pinned. Without this the test above proves nothing.
+
+    If a future git release made ``-C`` outrank ``GIT_DIR``, the negative
+    control would pass for a reason unrelated to the fix and would stop
+    guarding it. This asserts the override is still real by running the same
+    command with the ambient environment.
+    """
+    scratch = _tree_under_test(tmp_path)
+    foreign = _foreign_repo(tmp_path)
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    proc = subprocess.run(
+        ["git", "-C", str(scratch), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    leaked = [path for path in proc.stdout.split("\0") if path]
+
+    assert _FOREIGN_ONLY in leaked, (
+        "git no longer honours GIT_DIR over -C; the isolation tests above have "
+        "stopped testing anything and need to be re-derived"
+    )
+
+
+@requires_git
+def test_tracked_files_still_reports_failure_under_isolation(tmp_path, monkeypatch):
+    """Edge: isolation must not convert a git failure into an empty listing.
+
+    A directory that is not a repository has to stay None. Returning [] would
+    read as "no files match" and score the tree as zero violations, which is a
+    ratchet that passes by failing.
+    """
+    monkeypatch.setenv("GIT_DIR", _gitdir(_foreign_repo(tmp_path)))
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+
+    assert count_ratchet.tracked_files(not_a_repo, ["*.py"]) is None
+
+
+@requires_git
+def test_tracked_files_returns_none_when_git_cannot_launch(tmp_path, monkeypatch):
+    """Edge: the launch-failure contract survives the refactor to ``_git_run``."""
+
+    def _explode(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(count_ratchet.subprocess, "run", _explode)
+
+    assert count_ratchet.tracked_files(tmp_path, ["*.py"]) is None
+
+
+# --------------------------------------------------------------------------
+# The remaining git call sites
+# --------------------------------------------------------------------------
+
+
+@requires_git
+def test_baseline_at_ref_ignores_a_foreign_git_dir(tmp_path, monkeypatch):
+    """``git show <ref>:<path>`` resolves in the named root, not in ``GIT_DIR``.
+
+    Both repositories record ``base.txt`` at HEAD with different values. The
+    wrong one being readable at all is the defect; reading 7 instead of 3 is
+    how it would surface, as a ceiling copied from an unrelated tree.
+    """
+    scratch = _tree_under_test(tmp_path)
+    (scratch / "base.txt").write_text("3\n", encoding="utf-8")
+    _commit_all(scratch, "scratch baseline 3")
+
+    foreign = _foreign_repo(tmp_path)
+    (foreign / "base.txt").write_text("7\n", encoding="utf-8")
+    _commit_all(foreign, "foreign baseline 7")
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    assert count_ratchet.baseline_at_ref(scratch, "HEAD", scratch / "base.txt") == 3
+
+
+@requires_git
+def test_baseline_absent_at_ref_ignores_a_foreign_git_dir(tmp_path, monkeypatch):
+    """The bootstrap probe must not read absence from the wrong repository.
+
+    ``base.txt`` is absent in the tree under test and present in the foreign
+    one. An unisolated probe reads the foreign tree, answers "recorded", and
+    the first run of a new ratchet is compared against a ceiling that branch
+    never had.
+    """
+    scratch = _tree_under_test(tmp_path)
+    foreign = _foreign_repo(tmp_path)
+    (foreign / "base.txt").write_text("7\n", encoding="utf-8")
+    _commit_all(foreign, "foreign baseline 7")
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    assert count_ratchet.baseline_absent_at_ref(scratch, "HEAD", scratch / "base.txt") is True
+
+
+@requires_git
+def test_changed_files_ignores_a_foreign_git_dir(tmp_path, monkeypatch):
+    """The diagnostic-ordering probe reads the named root too.
+
+    This one only orders output, so a wrong answer does not block a push. It
+    is isolated anyway: a diagnostic that promotes files from another
+    repository is worse than no ordering, because it reads as a claim about
+    the branch under test.
+    """
+    scratch = _tree_under_test(tmp_path)
+    (scratch / "touched.py").write_text("z = 3\n", encoding="utf-8")
+    _commit_all(scratch, "scratch touches a file")
+
+    foreign = _foreign_repo(tmp_path)
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    changed = count_ratchet.changed_files(scratch, "HEAD~1")
+
+    assert "touched.py" in changed
+    assert _FOREIGN_ONLY not in changed
+
+
+@requires_git
+def test_ruff_ratchet_baseline_at_ref_ignores_a_foreign_git_dir(tmp_path, monkeypatch):
+    """The duplicate in ``ruff_count_ratchet`` carries the same defect.
+
+    It shadows nothing and is called by its own test rather than by ``main``,
+    but it is the same ``git show`` against a caller-supplied root. Leaving a
+    known-identical failure in the same ratchet family is how the next
+    diagnosis starts over.
+    """
+    scratch = _tree_under_test(tmp_path)
+    (scratch / "base.txt").write_text("3\n", encoding="utf-8")
+    _commit_all(scratch, "scratch baseline 3")
+
+    foreign = _foreign_repo(tmp_path)
+    (foreign / "base.txt").write_text("7\n", encoding="utf-8")
+    _commit_all(foreign, "foreign baseline 7")
+    monkeypatch.setenv("GIT_DIR", _gitdir(foreign))
+
+    assert ruff_ratchet.baseline_at_ref(scratch, "HEAD", scratch / "base.txt") == 3
+
+
+# --------------------------------------------------------------------------
+# Regression guard
+# --------------------------------------------------------------------------
+
+
+def _git_run_calls_without_env(source: Path) -> list[int]:
+    """Line numbers of ``subprocess.run`` calls launching git without ``env=``."""
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
+            continue
+        if not _launches_git(node):
+            continue
+        if not any(kw.arg == "env" for kw in node.keywords):
+            offenders.append(node.lineno)
+    return offenders
+
+
+def _launches_git(call: ast.Call) -> bool:
+    """True when the first positional argument is a list literal starting ``"git"``."""
+    if not call.args:
+        return False
+    argv = call.args[0]
+    if not isinstance(argv, ast.List) or not argv.elts:
+        return False
+    head = argv.elts[0]
+    return isinstance(head, ast.Constant) and head.value == "git"
+
+
+@pytest.mark.parametrize(
+    "module",
+    [count_ratchet, ruff_ratchet],
+    ids=["count_ratchet", "ruff_count_ratchet"],
+)
+def test_every_git_subprocess_passes_an_env(module):
+    """No git call site may fall back to the ambient environment.
+
+    The fix is one keyword argument per call site, so the way it regresses is
+    a new call site that omits it, added by someone who never saw issue #4914.
+    Reading the source is the only check that covers a site no test exercises.
+    """
+    source = Path(module.__file__)
+
+    assert _git_run_calls_without_env(source) == []
+
+
+def test_guard_detects_a_missing_env(tmp_path):
+    """The guard's own negative control.
+
+    An AST walk that matched nothing would report a clean module forever. This
+    feeds it a call site that is exactly what the guard exists to catch.
+    """
+    offender = tmp_path / "offender.py"
+    offender.write_text(
+        "import subprocess\n"
+        'subprocess.run(["git", "-C", "x", "ls-files"], check=False)\n'
+        'subprocess.run(["git", "status"], check=False, env={})\n'
+        'subprocess.run(["ruff", "check"], check=False)\n',
+        encoding="utf-8",
+    )
+
+    assert _git_run_calls_without_env(offender) == [2]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

### What

Every git subprocess in `scripts/ci/count_ratchet.py` now runs under a new
`git_environment()` helper that strips `GIT_*` from a copy of `os.environ`,
instead of inheriting the ambient environment. The same one-line fix is applied
to the duplicate `baseline_at_ref` in `scripts/ci/ruff_count_ratchet.py`.

### Why

`git -C <root>` does not win against an exported `GIT_DIR`. A `git push` from a
linked worktree exports `GIT_DIR` into the pre-push hook; a push from an ordinary
checkout does not. Worktrees are the documented pattern here, so every agent is on
the affected path and nobody in a plain clone can reproduce it.

`merge_tree_ratchet_check` calls `current_count(<scratch>)`, so `tracked_files`
listed the *pushing worktree's* index against the *scratch* tree. Any file the
branch carries that `origin/main` deleted was then handed to ruff as a scratch path
that does not exist, the counter returned `None`, and `merge-tree-ratchet` plus
`pre-pr-validation` blocked the push while naming a file the branch legitimately
has. That cost five pushes and roughly 40 minutes on PR #4912.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4914 | count_ratchet inherits GIT_DIR from a linked-worktree push, so the counters read the wrong tree and block the push |
| **QA** | `.agents/qa/pr-4970-issue-4914-count-ratchet-git-env-qa.md` | Full evidence, bound to `b8727c8d32` |
| **Session** | `.agents/sessions/2026-08-13-session-14696-...json` | Session 14696 log |

## Evidence

### The mechanism, measured on git 2.43.0

Scratch repo tracking only `keep.py`; `GIT_DIR` points at a worktree that also
tracks `scripts/validation/only_on_branch.py`:

```text
$ git -C <scratch> ls-files                          # clean environment
keep.py

$ GIT_DIR=<worktree gitdir> git -C <scratch> ls-files
keep.py
scripts/validation/only_on_branch.py                 # the WRONG tree
```

Git exports the variable only from a linked worktree. Measured by dumping the
pre-push hook environment on both pushes:

| Push origin | `GIT_DIR` in the hook environment |
|-------------|-----------------------------------|
| Linked worktree | `<main>/.git/worktrees/<name>` |
| Ordinary checkout | absent |

### The issue's own failure, end to end

`ruff_count_ratchet.current_count(<scratch>)` with `GIT_DIR` pointing at a
disposable repo that carries a file the scratch tree does not. Same command,
isolation removed then restored:

```text
before: ruff could not read <scratch>/scripts/validation/
        check_unreachable_after_terminator.py: No such file or directory (os error 2)
        current_count(scratch) -> None

after:  current_count(scratch) -> 0
```

That `None` is the `counter returned None` in the issue report.

### This PR was pushed from a linked worktree

`merge-tree-ratchet` passed on the push (20.82s), which is the gate the issue
reports as blocked.

## Changes

- `scripts/ci/count_ratchet.py`: adds `git_environment()`; `tracked_files` and
  `baseline_at_ref` now delegate to the existing `_git_run`, cutting git launch
  sites from four to two, both passing `env=`. No change to behaviour or stderr
  text.
- `scripts/ci/ruff_count_ratchet.py`: same isolation on its duplicate
  `baseline_at_ref`, a `git show` against a caller-supplied root in the same
  ratchet family.
- `tests/ci/test_count_ratchet_git_environment.py`: 17 new tests.
- `.serena/memories/ci/git-dir-from-a-linked-worktree-push-outranks-git-c.md`:
  the symptom, the strip, and the trap for repro scripts. Indexed.

### Why the canonical helper was mirrored, not imported

`merge_tree_materialization.isolated_git_environment` is the existing pattern.
Two measured reasons it is not imported, both recorded in the new docstring:

1. `count_ratchet` is stdlib-only by contract (the gates run by path in CI) and
   that module imports `scripts.cli_exec`.
2. It also blanks `HOME` and the global git config. These gates run git against
   the real checkout, where `actions/checkout` records `safe.directory` globally.
   Measured: a global `safe.directory` that `git config --get-all` returns under
   the ambient environment (rc 0) is invisible under that helper's environment
   (rc 1).

So the `GIT_*` half of its rule is mirrored verbatim, `name.upper()` included,
and nothing else is dropped. The divergence is documented in a
`Stricter/looser/different than canonical` paragraph in the helper.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**:

1. The scope of the strip. All `GIT_*` is stripped, matching canonical. Every
   call site is a local read-only command (`ls-files`, `diff`, `show`, `ls-tree`,
   `rev-parse`), so `GIT_SSH_COMMAND` and `GIT_ASKPASS` are not load-bearing, and
   `GIT_EXEC_PATH` falls back to git's compiled-in path.
2. The `tracked_files` and `baseline_at_ref` delegation to `_git_run`. It is
   intended to be behaviour-preserving, including stderr text. `_diff_paths` was
   deliberately left separate because its "diagnostic ordering degraded" prefix
   differs.
3. Whether fixing the `ruff_count_ratchet` duplicate belongs here. It is called
   only by its own test. It was fixed rather than deleted; deleting it is noted
   as a follow-up.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

17 tests in `tests/ci/test_count_ratchet_git_environment.py`, run against real
git rather than a `subprocess.run` stand-in. A stand-in would assert that some
dict was passed and would pass just as happily if git ignored it, which is the
whole question.

| Class | Count | What it pins |
|-------|-------|--------------|
| Positive | 6 | Correct listing with no `GIT_*` set; a clean environment passes through unchanged; `PATH`, `HOME` and a `DIGIT_COUNT` lookalike survive |
| Negative | 5 | Foreign `GIT_DIR` must not reach `tracked_files`, `baseline_at_ref`, `baseline_absent_at_ref`, `changed_files`, or the `ruff_count_ratchet` duplicate |
| Edge | 4 | Lowercase `git_dir`; result is a copy not a view; a non-repository still returns `None` rather than `[]`; launch failure still returns `None` |
| Guard | 2 | AST check that no git `subprocess.run` in either module omits `env=`, plus the guard's own negative control |

Two deserve naming. `test_foreign_git_dir_would_win_without_isolation` asserts
the override is still real, so the negative controls cannot start passing for an
unrelated reason. `test_tracked_files_still_reports_failure_under_isolation`
pins that isolation does not turn a git failure into an empty listing, which
would score a tree as zero violations and pass by failing.

**Verified the tests detect the defect**: with the isolation reverted, 8 of the
17 fail, including the guard on both modules. Restored: 17 pass.

| Gate | Result |
|------|--------|
| `uv run pytest tests/ci/ -q` | 2416 passed, 10 skipped |
| `uv run python scripts/validation/pre_pr.py` | All validations passed |
| ruff / taste / type-ignore / memory-index / subprocess-encoding / cli-exit ratchets | all OK |
| Pre-push hooks (from a linked worktree) | all green, `merge-tree-ratchet` included |

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes

This touches CI gate scripts, so it is flagged rather than waved through. The
change narrows what a subprocess inherits; it does not widen a boundary, add an
input path, or touch credentials. Worth a reviewer confirming point 1 under
Focus areas.

**Files requiring security review:**

- `scripts/ci/count_ratchet.py`
- `scripts/ci/ruff_count_ratchet.py`

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

One thing worth flagging, because it is the best evidence that this defect is
easy to walk into. While diagnosing it, a throwaway repro script ran
`git add -A` and `git commit` with `GIT_DIR` still exported and its cwd inside a
scratch directory. Git used `GIT_DIR` as the repository and the scratch dir as
the work tree, so `add -A` staged every real file as deleted and the commit
landed on this branch, through the very defect under diagnosis. It was recovered
with `git reset --mixed`, the working tree untouched, and the branch history here
is clean: three commits, no `snap`. Both the incident and the two rules that
prevent it are recorded in the Serena memory this PR adds.

## Related Issues

Fixes #4914