### PR TITLE
chore(memory): split memory updates from PR #4956

### DIFF
--- a/.serena/memories/agents-two-pipeline-mirror-recipe.md
+++ b/.serena/memories/agents-two-pipeline-mirror-recipe.md
@@ -31,20 +31,17 @@ Editing any agent's shared behavior. See `.claude/rules/claude-agents.md` MUST-1
 
 Source: issue/PR #2707 (MERGED); `.claude/rules/claude-agents.md`; `build/scripts/detect_agent_drift.py`.
 
-## Correction (2026-08-03): four hand-maintained surfaces, not two
+## Verified application (2026-08-03)
 
-The recipe above names two files to edit. Measurement says four. `build_all.py`
-prints `Output Root: <repo>/src` and writes only `src/copilot-cli/agents/` and
-`src/vs-code-agents/`. Every other agent surface is hand-maintained, so a
-one-character fix to the shared body has to be repeated by hand in three more
-places:
+The recipe above remains current. A shared agent has four hand-maintained
+surfaces and two generated surfaces:
 
 | Surface | Written by | Checked by |
 |---|---|---|
 | `templates/agents/<a>.shared.md` | hand | source of the two generated copies |
 | `src/claude/<a>.md` | hand | co-change parity (`validate_install_parity.py`) |
 | `.claude/agents/<a>.md` | hand | `check_agent_content_parity.py`: byte-identical to `src/claude/` |
-| `.github/agents/<a>.prompt.md` | hand | `detect_agent_drift.py` install-copy comparison vs `.claude/agents/` |
+| `.github/agents/<a>.agent.md` | hand | co-change parity and install drift checks |
 | `src/copilot-cli/agents/<a>.agent.md` | `build_all.py` | drift gate |
 | `src/vs-code-agents/<a>.agent.md` | `build_all.py` | drift gate |
 

--- a/.serena/memories/agents-two-pipeline-mirror-recipe.md
+++ b/.serena/memories/agents-two-pipeline-mirror-recipe.md
@@ -31,21 +31,27 @@ Editing any agent's shared behavior. See `.claude/rules/claude-agents.md` MUST-1
 
 Source: issue/PR #2707 (MERGED); `.claude/rules/claude-agents.md`; `build/scripts/detect_agent_drift.py`.
 
-## Verified application (2026-08-13)
+## Correction (2026-08-03): four hand-maintained surfaces, not two
 
-The recipe above remains current. A shared agent has four hand-maintained
-surfaces and two generated surfaces:
+The recipe above names two files to edit. Measurement says four. `build_all.py`
+prints `Output Root: <repo>/src` and writes only `src/copilot-cli/agents/` and
+`src/vs-code-agents/`. Every other agent surface is hand-maintained, so a
+one-character fix to the shared body has to be repeated by hand in three more
+places:
 
 | Surface | Written by | Checked by |
 |---|---|---|
 | `templates/agents/<a>.shared.md` | hand | source of the two generated copies |
 | `src/claude/<a>.md` | hand | co-change parity (`validate_install_parity.py`) |
 | `.claude/agents/<a>.md` | hand | `check_agent_content_parity.py`: byte-identical to `src/claude/` |
-| `.github/agents/<a>.agent.md` | hand | co-change parity and install drift checks |
-| `src/copilot-cli/agents/<a>.agent.md` | `build/generate_agents.py` | generator validation and drift checks |
-| `src/vs-code-agents/<a>.agent.md` | `build/generate_agents.py` | generator validation and drift checks |
+| `.github/agents/<a>.prompt.md` | hand | `detect_agent_drift.py` install-copy comparison vs `.claude/agents/` |
+| `src/copilot-cli/agents/<a>.agent.md` | `build_all.py` | drift gate |
+| `src/vs-code-agents/<a>.agent.md` | `build_all.py` | drift gate |
 
-Issue #2707 established the recipe. Session 14695 applied it to
-`code-reviewer`, `code-simplifier`, `pr-test-analyzer`, and
-`silent-failure-hunter`. The explicit six-file install-parity check passed for
-each changed agent after regeneration.
+Also: `build/scripts/generate_agents.py` does not exist. `build_all.py` imports
+the module and calls it; invoking the path directly gives Errno 2.
+
+Evidence: PR #4069, 2026-08-03. A bare `|` inside a backticked grep pattern in a
+table cell tripped MD056 in all six copies. Running `build_all.py` fixed two of
+them. `check_agent_content_parity.py` then reported the trees byte-identical only
+after the remaining three were edited by hand.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -67,7 +67,6 @@
 
 [Implementation and Quality]
 |implementation code feature bug fix test TDD additive: [skills-implementation-index](skills-implementation-index.md) (304)
-|model pin migration ADR-080 alias rationale sweep retirement: [tasks/issue-2840-model-pin-migration](tasks/issue-2840-model-pin-migration.md) (870)
 |quality qa DoD definition-of-done test strategy critique: [skills-quality-index](skills-quality-index.md) (290)
 |sentinel zero None unknown unmeasured tri-state exit code: [quality/add-missing-state-not-sentinel](quality/add-missing-state-not-sentinel.md) (811)
 |quality gate unknown verdict infra downgrade fail closed: [quality/unknown-verdict-infra-downgrade-stays-blocking](quality/unknown-verdict-infra-downgrade-stays-blocking.md) (226)
@@ -148,9 +147,9 @@
 
 [Retrospective and Learning]
 |retrospective learning session failure skill persistence extract artifact: [skills-retrospective-index](skills-retrospective-index.md) (376), [retrospective/retrospective-artifact-efficiency-pattern](retrospective/retrospective-artifact-efficiency-pattern.md) (986)
-|skill sidecar observations learnings eval-harness fixtures build-model parity drift prompt-optimization ci-infrastructure: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (2449), [eval-harness-observations](eval-harness-observations.md) (2714), [ci-infrastructure-observations](ci-infrastructure-observations.md) (924)
-|eval fixture provenance corpus closed-loop author-worded synthetic trigger-eval upper-bound: [decision-eval-fixture-provenance-closed-loop](decision-eval-fixture-provenance-closed-loop.md) (1509)
-|implementation contracts PreToolUse advisory envelope hookSpecificOutput two-pipeline agent: [hooks-pretooluse-advisory-envelope-contract](hooks-pretooluse-advisory-envelope-contract.md) (393), [agents-two-pipeline-mirror-recipe](agents-two-pipeline-mirror-recipe.md) (1005), [eval/eval-multiprovider-transport](eval/eval-multiprovider-transport.md) (632), [lsp-first-enforcement-adr062](lsp-first-enforcement-adr062.md) (425)
+|skill sidecar observations learnings eval-harness fixtures build-model parity: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (2449), [eval-harness-observations](eval-harness-observations.md) (2714), [ci-infrastructure-observations](ci-infrastructure-observations.md) (924)
+|eval fixture provenance corpus closed-loop author-worded synthetic trigger-eval: [decision-eval-fixture-provenance-closed-loop](decision-eval-fixture-provenance-closed-loop.md) (1509)
+|implementation contracts PreToolUse advisory envelope hookSpecificOutput two-pipeline agent: [hooks-pretooluse-advisory-envelope-contract](hooks-pretooluse-advisory-envelope-contract.md) (393), [agents-two-pipeline-mirror-recipe](agents-two-pipeline-mirror-recipe.md) (1133), [eval/eval-multiprovider-transport](eval/eval-multiprovider-transport.md) (632), [lsp-first-enforcement-adr062](lsp-first-enforcement-adr062.md) (425)
 
 [Memory and Context]
 |context engineering token optimization progressive disclosure just-in-time token: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -67,6 +67,7 @@
 
 [Implementation and Quality]
 |implementation code feature bug fix test TDD additive: [skills-implementation-index](skills-implementation-index.md) (304)
+|model pin migration ADR-080 alias rationale sweep retirement: [tasks/issue-2840-model-pin-migration](tasks/issue-2840-model-pin-migration.md) (870)
 |quality qa DoD definition-of-done test strategy critique: [skills-quality-index](skills-quality-index.md) (290)
 |sentinel zero None unknown unmeasured tri-state exit code: [quality/add-missing-state-not-sentinel](quality/add-missing-state-not-sentinel.md) (811)
 |quality gate unknown verdict infra downgrade fail closed: [quality/unknown-verdict-infra-downgrade-stays-blocking](quality/unknown-verdict-infra-downgrade-stays-blocking.md) (226)
@@ -147,9 +148,9 @@
 
 [Retrospective and Learning]
 |retrospective learning session failure skill persistence extract artifact: [skills-retrospective-index](skills-retrospective-index.md) (376), [retrospective/retrospective-artifact-efficiency-pattern](retrospective/retrospective-artifact-efficiency-pattern.md) (986)
-|skill sidecar observations learnings eval-harness fixtures build-model parity: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (2449), [eval-harness-observations](eval-harness-observations.md) (2714), [ci-infrastructure-observations](ci-infrastructure-observations.md) (924)
-|eval fixture provenance corpus closed-loop author-worded synthetic trigger-eval: [decision-eval-fixture-provenance-closed-loop](decision-eval-fixture-provenance-closed-loop.md) (1509)
-|implementation contracts PreToolUse advisory envelope hookSpecificOutput two-pipeline agent: [hooks-pretooluse-advisory-envelope-contract](hooks-pretooluse-advisory-envelope-contract.md) (393), [agents-two-pipeline-mirror-recipe](agents-two-pipeline-mirror-recipe.md) (1133), [eval/eval-multiprovider-transport](eval/eval-multiprovider-transport.md) (632), [lsp-first-enforcement-adr062](lsp-first-enforcement-adr062.md) (425)
+|skill sidecar observations learnings eval-harness fixtures build-model parity drift prompt-optimization ci-infrastructure: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (2449), [eval-harness-observations](eval-harness-observations.md) (2714), [ci-infrastructure-observations](ci-infrastructure-observations.md) (924)
+|eval fixture provenance corpus closed-loop author-worded synthetic trigger-eval upper-bound: [decision-eval-fixture-provenance-closed-loop](decision-eval-fixture-provenance-closed-loop.md) (1509)
+|implementation contracts PreToolUse advisory envelope hookSpecificOutput two-pipeline agent: [hooks-pretooluse-advisory-envelope-contract](hooks-pretooluse-advisory-envelope-contract.md) (393), [agents-two-pipeline-mirror-recipe](agents-two-pipeline-mirror-recipe.md) (1053), [eval/eval-multiprovider-transport](eval/eval-multiprovider-transport.md) (632), [lsp-first-enforcement-adr062](lsp-first-enforcement-adr062.md) (425)
 
 [Memory and Context]
 |context engineering token optimization progressive disclosure just-in-time token: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)


### PR DESCRIPTION
Move memory changes out of the skill-code PR per .claude/rules/claude-agents.md:42 (MUST NOT bundle skill code changes with memory changes in the same PR).

Changes:
- agents-two-pipeline-mirror-recipe.md: correct 4 surfaces not 2
- memory-index.md: update word counts and remove stale entry

Split from: #4956