### PR TITLE
fix(validation): preserve partial child output on subprocess timeout

### DIFF
--- a/.agents/qa/000-pr-4986-qa.md
+++ b/.agents/qa/000-pr-4986-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-14-session-pr-4986-autofix.json
-qaCommit: 5bb182f6f6487c2012782cecc0ed2acf2077b9a2
+qaCommit: 2ec94f2bcb57e7b3f94e94ba372d926d794ea667
 ---
 
 # PR 4986 QA Report

--- a/.agents/qa/000-pr-4986-qa.md
+++ b/.agents/qa/000-pr-4986-qa.md
@@ -1,0 +1,37 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-14-session-pr-4986-autofix.json
+qaCommit: 5bb182f6f6487c2012782cecc0ed2acf2077b9a2
+---
+
+# PR 4986 QA Report
+
+## Verdict
+
+PASS. All 12 unit and integration tests pass on the rebased branch.
+
+## Evidence
+
+Focused suite covering the PR's changes:
+
+- `uv run --frozen pytest tests/validation/test_subprocess_runner.py -v`
+  Result: 12 passed in 3.31s.
+
+Test coverage:
+
+- `TestDecodeStream`: 4 tests covering None, str passthrough, UTF-8 bytes, non-UTF-8 replacement
+- `TestRunSubprocessBaseline`: 2 tests covering normal completion and command-not-found
+- `TestRunSubprocessTimeoutRealChild`: 3 tests with real child processes verifying partial stdout/stderr preservation, no-output marker, and non-UTF-8 handling
+- `TestRunSubprocessTimeoutFaked`: 3 tests with monkeypatched subprocess.run covering stderr-only, Windows str attributes, and populated-output-never-flips-to-success
+
+Merge conflict resolution verified:
+
+- `checks_common.py` conflict resolved: kept PR's deletion of `_run_subprocess` (moved to `subprocess_runner.py`)
+- `subprocess_runner.py` updated to integrate `resolve_executable` from main
+- Dead `resolve_executable` import removed from `checks_common.py`
+
+## Scope
+
+Covers `scripts/validation/subprocess_runner.py` (the extracted module) and its
+test file. The merge conflict resolution integrates the `resolve_executable`
+enhancement that landed on main after the PR was opened.

--- a/.agents/sessions/2026-08-14-session-pr-4986-autofix.json
+++ b/.agents/sessions/2026-08-14-session-pr-4986-autofix.json
@@ -4,6 +4,6 @@
   "pr": 4986,
   "objective": "Respond to PR review comments, rebase to resolve merge conflicts, integrate resolve_executable from main",
   "status": "complete",
-  "endingCommit": "5bb182f6f6487c2012782cecc0ed2acf2077b9a2",
-  "commits": ["5bb182f6f6487c2012782cecc0ed2acf2077b9a2"]
+  "endingCommit": "2ec94f2bcb57e7b3f94e94ba372d926d794ea667",
+  "commits": ["2ec94f2bcb57e7b3f94e94ba372d926d794ea667"]
 }

--- a/.agents/sessions/2026-08-14-session-pr-4986-autofix.json
+++ b/.agents/sessions/2026-08-14-session-pr-4986-autofix.json
@@ -1,0 +1,9 @@
+{
+  "session_id": "2026-08-14-session-pr-4986-autofix",
+  "date": "2026-08-14",
+  "pr": 4986,
+  "objective": "Respond to PR review comments, rebase to resolve merge conflicts, integrate resolve_executable from main",
+  "status": "complete",
+  "endingCommit": "5bb182f6f6487c2012782cecc0ed2acf2077b9a2",
+  "commits": ["5bb182f6f6487c2012782cecc0ed2acf2077b9a2"]
+}

--- a/scripts/validation/checks_common.py
+++ b/scripts/validation/checks_common.py
@@ -4,8 +4,12 @@
 Extracted from ``scripts/validation/pre_pr.py`` (issue #2223) so the pre-PR
 runner stays under the file-size limit and the area-specific check modules
 (``checks_tooling``, ``checks_dash``, ``checks_spec``, ``checks_plugin``,
-``checks_coverage``) share one home for the subprocess wrapper, the
-SKIP control-flow signal, and the git base-ref resolution helpers.
+``checks_coverage``) share one home for the SKIP control-flow signal and the
+git base-ref resolution helpers.
+
+The subprocess wrapper itself lives in ``subprocess_runner`` (issue #4955, so
+the timeout path can preserve partial child output without pushing this module
+past the file-size ceiling) and is re-exported here as ``_run_subprocess``.
 
 This began as a behavior-preserving move from ``pre_pr.py``. Later fixes can
 land in these extracted modules directly while ``pre_pr`` re-exports them so
@@ -17,12 +21,23 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-from scripts.cli_exec import resolve_executable
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+if TYPE_CHECKING:
+    # Type checkers resolve the sibling via its package path so the wrapper's
+    # ``tuple[int, str, str]`` return type is preserved. Runtime uses the bare
+    # import because ``pre_pr`` and ``checks_ratchet`` load this module as a
+    # top-level name after inserting ``_SCRIPT_DIR`` on ``sys.path``.
+    from scripts.validation.subprocess_runner import _run_subprocess
+else:
+    from subprocess_runner import _run_subprocess
+
 
 
 class MissingScriptSkip(Exception):  # noqa: N818 - control-flow signal, not an error condition
@@ -32,32 +47,6 @@ class MissingScriptSkip(Exception):  # noqa: N818 - control-flow signal, not an 
     expunged. Their absence should not produce a misleading [FAIL]; instead the
     validation is reported as SKIP and does not affect the overall exit code.
     """
-
-
-def _run_subprocess(
-    args: list[str],
-    timeout: int = 300,
-    cwd: Path | str | None = None,
-    env: dict[str, str] | None = None,
-) -> tuple[int, str, str]:
-    """Run a subprocess after resolving its executable for the target platform."""
-    try:
-        executable = args[0] if os.path.dirname(args[0]) else resolve_executable(args[0], env=env)
-        command = [executable, *args[1:]]
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout,
-            cwd=cwd,
-            env=env,
-        )
-        return result.returncode, result.stdout, result.stderr
-    except FileNotFoundError:
-        return -1, "", f"Command not found: {args[0]}"
-    except subprocess.TimeoutExpired:
-        return -1, "", f"Command timed out after {timeout}s"
 
 
 def _git_subprocess_env() -> dict[str, str]:

--- a/scripts/validation/subprocess_runner.py
+++ b/scripts/validation/subprocess_runner.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Subprocess wrapper shared by the pre-PR validation check modules.
+
+Split out of ``checks_common`` (issue #4955) so the timeout path can preserve
+the partial stdout and stderr Python leaves on ``TimeoutExpired``. Discarding
+that output hid the ratchet or validator result that ran just before a
+merge-tree timeout (issue #4876): the maintainer saw the timeout but not the
+diagnostic that explained where the child stopped.
+
+``checks_common`` re-exports :func:`_run_subprocess`, so every existing
+``from checks_common import _run_subprocess`` keeps resolving.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.cli_exec import resolve_executable
+
+
+def _decode_stream(data: bytes | str | None) -> str:
+    """Decode a captured subprocess stream with UTF-8 replacement semantics.
+
+    ``subprocess.run(encoding="utf-8", errors="replace")`` returns ``str`` on
+    the happy path, but a timeout raises inside ``Popen`` before the decode
+    step, so ``TimeoutExpired.stdout`` and ``.stderr`` arrive as raw ``bytes``
+    on POSIX and as already-decoded ``str`` on the Windows
+    kill-then-communicate path. Match the happy-path ``errors="replace"``
+    decode and treat a missing stream as empty.
+    """
+    if data is None:
+        return ""
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="replace")
+    return data
+
+
+def _run_subprocess(
+    args: list[str],
+    timeout: int = 300,
+    cwd: Path | str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    """Run a subprocess after resolving its executable for the target platform.
+
+    When ``env`` is provided it replaces the child environment entirely, so
+    callers that only want to add a variable should merge it with
+    ``os.environ`` themselves before passing it in.
+
+    On ``subprocess.TimeoutExpired`` the partial stdout and stderr the child
+    flushed before the timeout are preserved (issue #4955) instead of being
+    discarded. The timeout stays a failure: the exit code is ``-1`` and the
+    ``Command timed out after Ns`` marker stays in the returned stderr, after
+    any partial stderr the child produced.
+    """
+    try:
+        executable = args[0] if os.path.dirname(args[0]) else resolve_executable(args[0], env=env)
+        command = [executable, *args[1:]]
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return -1, "", f"Command not found: {args[0]}"
+    except subprocess.TimeoutExpired as exc:
+        partial_stdout = _decode_stream(exc.stdout)
+        partial_stderr = _decode_stream(exc.stderr)
+        marker = f"Command timed out after {timeout}s"
+        combined_stderr = f"{partial_stderr}\n{marker}" if partial_stderr else marker
+        return -1, partial_stdout, combined_stderr

--- a/tests/validation/test_checks_common.py
+++ b/tests/validation/test_checks_common.py
@@ -5,22 +5,22 @@ from __future__ import annotations
 import sys
 from unittest.mock import patch
 
-from scripts.validation import checks_common
+from scripts.validation import subprocess_runner
 
 
 def test_subprocess_resolves_windows_command_shim() -> None:
-    completed = checks_common.subprocess.CompletedProcess(
+    completed = subprocess_runner.subprocess.CompletedProcess(
         ["npx.cmd", "--version"], 0, "11.17.0\n", ""
     )
     with (
         patch.object(
-            checks_common,
+            subprocess_runner,
             "resolve_executable",
             return_value=r"C:\Program Files\nodejs\npx.cmd",
         ) as resolver,
-        patch.object(checks_common.subprocess, "run", return_value=completed) as run,
+        patch.object(subprocess_runner.subprocess, "run", return_value=completed) as run,
     ):
-        result = checks_common._run_subprocess(["npx", "--version"])
+        result = subprocess_runner._run_subprocess(["npx", "--version"])
 
     assert result == (0, "11.17.0\n", "")
     resolver.assert_called_once_with("npx", env=None)
@@ -31,14 +31,14 @@ def test_subprocess_resolves_windows_command_shim() -> None:
 
 
 def test_subprocess_preserves_explicit_executable_path() -> None:
-    completed = checks_common.subprocess.CompletedProcess(
+    completed = subprocess_runner.subprocess.CompletedProcess(
         [sys.executable, "--version"], 0, "Python\n", ""
     )
     with (
-        patch.object(checks_common, "resolve_executable") as resolver,
-        patch.object(checks_common.subprocess, "run", return_value=completed) as run,
+        patch.object(subprocess_runner, "resolve_executable") as resolver,
+        patch.object(subprocess_runner.subprocess, "run", return_value=completed) as run,
     ):
-        result = checks_common._run_subprocess([sys.executable, "--version"])
+        result = subprocess_runner._run_subprocess([sys.executable, "--version"])
 
     assert result == (0, "Python\n", "")
     resolver.assert_not_called()

--- a/tests/validation/test_subprocess_runner.py
+++ b/tests/validation/test_subprocess_runner.py
@@ -1,0 +1,164 @@
+"""Tests for the shared subprocess wrapper (issue #4955).
+
+``_run_subprocess`` used to discard the partial stdout and stderr Python
+preserves on ``subprocess.TimeoutExpired``. A merge-tree ratchet that flushed
+its result and then exceeded the timeout reported only the timeout, hiding the
+diagnostic that explained where it stopped (issue #4876). These tests pin the
+repaired contract: partial output is surfaced, the timeout stays a failure, and
+the timeout marker stays present.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from scripts.validation.subprocess_runner import _decode_stream, _run_subprocess
+
+# A child that flushes its streams, then sleeps well past any test timeout. The
+# 1-second wrapper timeout fires first, so the sleep duration only has to exceed
+# it comfortably; the test never waits the full sleep.
+_TIMEOUT_SECONDS = 1
+_CHILD_SLEEP = 30
+
+
+def _child(body: str) -> list[str]:
+    return [sys.executable, "-c", body]
+
+
+def _raise_timeout(output: bytes | str | None, stderr: bytes | str | None) -> object:
+    """Return a fake ``subprocess.run`` that raises ``TimeoutExpired``.
+
+    Lets a test control the exact ``stdout``/``stderr`` types the exception
+    carries, including the ``str`` values only the Windows
+    kill-then-communicate path produces (unreachable on the POSIX CI host).
+    """
+
+    def _fake_run(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(
+            cmd=["fake"],
+            timeout=_TIMEOUT_SECONDS,
+            output=output,
+            stderr=stderr,
+        )
+
+    return _fake_run
+
+
+# ---------------------------------------------------------------------------
+# _decode_stream
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeStream:
+    def test_none_becomes_empty_string(self) -> None:
+        assert _decode_stream(None) == ""
+
+    def test_str_passes_through_unchanged(self) -> None:
+        assert _decode_stream("already text") == "already text"
+
+    def test_utf8_bytes_decode(self) -> None:
+        assert _decode_stream("café".encode()) == "café"
+
+    def test_non_utf8_bytes_use_replacement(self) -> None:
+        # 0xFF is invalid UTF-8; the replace codec yields U+FFFD.
+        decoded = _decode_stream(b"raw\xff")
+        assert decoded == "raw\ufffd"
+
+
+# ---------------------------------------------------------------------------
+# _run_subprocess: happy path and command-not-found (unchanged behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubprocessBaseline:
+    def test_normal_completion_preserves_output(self) -> None:
+        exit_code, stdout, stderr = _run_subprocess(
+            _child("import sys; sys.stdout.write('out'); sys.stderr.write('err')")
+        )
+        assert exit_code == 0
+        assert stdout == "out"
+        assert stderr == "err"
+
+    def test_command_not_found_returns_marker(self) -> None:
+        exit_code, stdout, stderr = _run_subprocess(["nonexistent_command_xyz_123"])
+        assert exit_code == -1
+        assert stdout == ""
+        assert "Command not found" in stderr
+
+
+# ---------------------------------------------------------------------------
+# _run_subprocess: timeout path (issue #4955) with real children
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubprocessTimeoutRealChild:
+    def test_partial_stdout_and_stderr_reach_the_failure(self) -> None:
+        """The merge-tree wrapper contract: flushed output reaches the caller."""
+        body = (
+            "import sys, time;"
+            "sys.stdout.write('RATCHET-RESULT');sys.stdout.flush();"
+            "sys.stderr.write('DIAGNOSTIC');sys.stderr.flush();"
+            f"time.sleep({_CHILD_SLEEP})"
+        )
+        exit_code, stdout, stderr = _run_subprocess(_child(body), timeout=_TIMEOUT_SECONDS)
+
+        assert exit_code == -1, "a timeout must stay a failure, not become success"
+        assert "RATCHET-RESULT" in stdout
+        assert "DIAGNOSTIC" in stderr
+        assert f"Command timed out after {_TIMEOUT_SECONDS}s" in stderr
+
+    def test_no_output_reports_only_the_marker(self) -> None:
+        body = f"import time; time.sleep({_CHILD_SLEEP})"
+        exit_code, stdout, stderr = _run_subprocess(_child(body), timeout=_TIMEOUT_SECONDS)
+
+        assert exit_code == -1
+        assert stdout == ""
+        assert stderr == f"Command timed out after {_TIMEOUT_SECONDS}s"
+
+    def test_non_utf8_partial_output_uses_replacement(self) -> None:
+        body = (
+            "import sys, time;"
+            "sys.stdout.buffer.write(b'\\xff\\xfe raw');sys.stdout.buffer.flush();"
+            f"time.sleep({_CHILD_SLEEP})"
+        )
+        exit_code, stdout, stderr = _run_subprocess(_child(body), timeout=_TIMEOUT_SECONDS)
+
+        assert exit_code == -1
+        assert "\ufffd" in stdout, "invalid bytes must decode with U+FFFD, not crash"
+        assert f"Command timed out after {_TIMEOUT_SECONDS}s" in stderr
+
+
+# ---------------------------------------------------------------------------
+# _run_subprocess: timeout path branches driven with a faked run
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubprocessTimeoutFaked:
+    def test_stderr_only_child_keeps_marker_after_partial(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _raise_timeout(None, b"boom"))
+        exit_code, stdout, stderr = _run_subprocess(["fake"], timeout=5)
+        assert exit_code == -1
+        assert stdout == ""
+        assert stderr == "boom\nCommand timed out after 5s"
+
+    def test_windows_str_attributes_are_not_double_decoded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Windows path leaves ``str`` on the exception; pass it through."""
+        monkeypatch.setattr(subprocess, "run", _raise_timeout("win-out", "win-err"))
+        exit_code, stdout, stderr = _run_subprocess(["fake"], timeout=2)
+        assert exit_code == -1
+        assert stdout == "win-out"
+        assert stderr == "win-err\nCommand timed out after 2s"
+
+    def test_populated_output_never_flips_timeout_to_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _raise_timeout(b"partial", b"partial"))
+        exit_code, _stdout, _stderr = _run_subprocess(["fake"], timeout=3)
+        assert exit_code == -1


### PR DESCRIPTION
## Summary

### What

`_run_subprocess` in the pre-PR validation helpers discarded the stdout and
stderr a child flushed before a `subprocess.TimeoutExpired`. It now surfaces
that partial output while keeping the timeout a failure.

### Why

A merge-tree ratchet printed its result, then exceeded the timeout. The wrapper
returned only the timeout marker and dropped the flushed diagnostic, so the
maintainer saw the timeout but not where the child stopped (issue #4876). The
lost bytes were the exact evidence needed to triage the incident.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4955 | bug(validation): subprocess timeouts discard partial child output |
| **Issue** | Refs #4876 | motivating merge-tree timeout incident |

## Changes

- Add `scripts/validation/subprocess_runner.py` with `_run_subprocess` and a
  `_decode_stream` helper. On `TimeoutExpired`, decode `exc.stdout` and
  `exc.stderr` with UTF-8 replacement semantics and return them. Exit code
  stays `-1`; the `Command timed out after Ns` marker stays in stderr, after
  any partial stderr the child produced.
- `scripts/validation/checks_common.py` re-exports `_run_subprocess` from the
  new module, so every existing `from checks_common import _run_subprocess`
  keeps resolving. The wrapper moved to a sibling module so the fix lands
  without pushing `checks_common` past the 500-line file-size ceiling.
- Add `tests/validation/test_subprocess_runner.py` covering the timeout
  contract and the decode helper.

## Acceptance Criteria

- [x] Partial stdout the child flushed before the timeout reaches the caller
- [x] Partial stderr the child flushed before the timeout reaches the caller
- [x] Timeout stays a failure: exit code `-1`, marker retained in stderr
- [x] Partial bytes decode with UTF-8 replacement, invalid bytes do not crash
- [x] No output at timeout returns the marker alone
- [x] `check_subprocess_encoding` convention satisfied (`errors="replace"`)

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted review, standard scrutiny, no rush

**Focus areas**: the `TimeoutExpired` branch in `subprocess_runner.py` and the
bytes vs str handling in `_decode_stream` (POSIX yields bytes, the Windows
kill-then-communicate path yields str).

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Test coverage in `tests/validation/test_subprocess_runner.py`:

- Positive: normal completion preserves stdout and stderr; `_decode_stream`
  passes str through and decodes UTF-8 bytes.
- Negative: command-not-found returns the `Command not found` marker;
  populated partial output never flips a timeout to success.
- Edge: partial stdout and stderr both reach the failure at timeout; no-output
  timeout returns the marker alone; non-UTF-8 partial output decodes with
  U+FFFD; stderr-only child keeps the marker after the partial; Windows str
  attributes are not double-decoded.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #4955
Refs #4876
