### PR TITLE
fix(github): reconcile set_issue_labels label parsing with docs

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-14-session-14706.json
+++ b/.agents/memory/episodes/episode-2026-08-14-session-14706.json
@@ -1,0 +1,66 @@
+{
+  "id": "episode-2026-08-14-session-14706",
+  "session": "2026-08-14-session-14706",
+  "timestamp": "2026-08-14T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Autofix PR 4988 required CI and complete merge readiness",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fetched full Validate PR failure logs after a live-state gate.",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-14-session-14706"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated the PR implementation in a dedicated external worktree.",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-14-session-14706"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Created SHA-bound QA evidence for the validated source commit.",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-14-session-14706"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-14T18:25:18+00:00",
+      "type": "commit",
+      "content": "Commit: 27fa3cbd37c5f5f74bac81fb31ebad1ca833c1f5",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-14-session-14706"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/qa/pr-4988-set-issue-labels-qa-report.md
+++ b/.agents/qa/pr-4988-set-issue-labels-qa-report.md
@@ -1,0 +1,34 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-14-session-14706.json
+qaCommit: 27fa3cbd37c5f5f74bac81fb31ebad1ca833c1f5
+---
+
+# PR 4988 set issue labels QA report
+
+## Result
+
+PASS. The documented comma-separated and repeated `--labels` forms are
+accepted, normalized, and covered by focused regression tests.
+
+## CI root cause
+
+The full `Validate PR` log contained one required failure:
+
+```text
+No QA report found for code changes
+```
+
+No compile, lint, dependency, or test failure appeared in the failed job log.
+
+## Evidence
+
+- `uv run pytest -q tests/skills/github/test_set_issue_labels.py`: 31 passed.
+- `uv run python build/scripts/build_all.py --check`: completed successfully.
+- `git status --short`: clean after generation validation.
+- Validation ran in `/tmp/ai-agents-pr-4988`, an external PR worktree.
+
+## Scope
+
+The focused suite covers comma-separated labels, repeated label arguments,
+whitespace normalization, help text, and the generated Copilot CLI mirror.

--- a/.agents/sessions/2026-08-14-session-14706.json
+++ b/.agents/sessions/2026-08-14-session-14706.json
@@ -1,0 +1,137 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14706,
+    "date": "2026-08-14",
+    "branch": "fix/4967-set-issue-labels-docs",
+    "startingCommit": "40a26590a4857cb4c5788883722270cccdbc271d",
+    "objective": "Autofix PR 4988 required CI and complete merge readiness"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Called Serena initial_instructions and read the returned operating manual."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena instructions were loaded before creating QA evidence."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Existing branch state, PR metadata, full failing check logs, and prior QA report patterns were read."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded pr-autofix, session-log-fixer, and session-init; used the GitHub PR scripts."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Followed the repository GitHub-script and external-worktree requirements."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Applied the PR live-state, SHA safety, required-CI, and four-condition merge constraints."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Relevant GitHub, CI, session protocol, and testing memories were supplied by the memory hook."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4967-set-issue-labels-docs"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/4967-set-issue-labels-docs"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Dedicated external worktree was clean before QA evidence creation."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "40a26590a4857cb4c5788883722270cccdbc271d"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST session-start and session-end entries contain concrete evidence."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was not modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No new durable memory was warranted; existing memories were preserved."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The PR-specific QA Markdown report passed markdownlint-cli2."
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/pr-4988-set-issue-labels-qa-report.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Source and test changes are committed through 27fa3cbd37c5f5f74bac81fb31ebad1ca833c1f5."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "31 focused tests passed and build/scripts/build_all.py completed with a clean worktree."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Autofix workflow todos track triage, logs, worktree, validation, push, and completion."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not required for this narrow CI evidence repair."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Fetched full Validate PR failure logs after a live-state gate.",
+      "outcome": "The only required failure was No QA report found for code changes."
+    },
+    {
+      "action": "Validated the PR implementation in a dedicated external worktree.",
+      "outcome": "31 focused tests passed and generated mirrors remained clean after build_all.py."
+    },
+    {
+      "action": "Created SHA-bound QA evidence for the validated source commit.",
+      "outcome": "QA report binds this session to 27fa3cbd37c5f5f74bac81fb31ebad1ca833c1f5."
+    }
+  ],
+  "endingCommit": "27fa3cbd37c5f5f74bac81fb31ebad1ca833c1f5",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-08-14-session-14706.json
+++ b/.agents/sessions/2026-08-14-session-14706.json
@@ -84,7 +84,7 @@
       "serenaMemoryUpdated": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "No new durable memory was warranted; existing memories were preserved."
+        "Evidence": "Extracted .agents/memory/episodes/episode-2026-08-14-session-14706.json from the completed session."
       },
       "markdownLintRun": {
         "level": "MUST",

--- a/.claude/skills/github/scripts/issue/set_issue_labels.py
+++ b/.claude/skills/github/scripts/issue/set_issue_labels.py
@@ -121,10 +121,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=None,
         help=(
-            "Label names to apply. Accepts space-separated arguments and "
-            "comma-separated values interchangeably, so 'bug enhancement' and "
-            "'bug,enhancement' are equivalent. Repeat the flag to add more. "
-            "Whitespace is trimmed; multi-word names (no comma) are preserved."
+            "Label names to apply. To apply two labels 'bug' and "
+            "'enhancement', use either unquoted space-separated arguments "
+            "(--labels bug enhancement) or a quoted comma-separated string "
+            "(--labels \"bug,enhancement\"). Only commas split names, so a "
+            "quoted space-separated string (--labels \"bug enhancement\") is "
+            "one label named 'bug enhancement'. Repeat the flag to add more; "
+            "surrounding whitespace on each name is trimmed."
         ),
     )
     parser.add_argument(

--- a/.claude/skills/github/scripts/issue/set_issue_labels.py
+++ b/.claude/skills/github/scripts/issue/set_issue_labels.py
@@ -79,6 +79,35 @@ def compute_priority_removals(
     ]
 
 
+def expand_labels(raw_labels: list[object]) -> list[str]:
+    """Flatten ``--labels`` arguments into individual label names (issue #4967).
+
+    Accepts both public forms so the documented comma syntax and the historical
+    space syntax agree:
+
+    - Space-separated arguments from ``nargs="*"``: ``--labels bug enhancement``.
+    - Comma-separated values inside any argument: ``--labels "bug,enhancement"``.
+    - Repeated ``--labels`` flags (``action="append"`` yields nested lists),
+      which accumulate instead of silently dropping earlier groups.
+
+    Commas act as separators, so a label may not contain a literal comma. A
+    single argument may still contain spaces, so multi-word names such as
+    ``needs discussion`` survive intact. Whitespace around each name is trimmed
+    and empty results are dropped.
+    """
+    names: list[str] = []
+    for group in raw_labels:
+        tokens = group if isinstance(group, list) else [group]
+        for token in tokens:
+            if not isinstance(token, str):
+                continue
+            for part in token.split(","):
+                stripped = part.strip()
+                if stripped:
+                    names.append(stripped)
+    return names
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Apply labels to a GitHub Issue with auto-creation support.",
@@ -89,8 +118,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--labels",
         nargs="*",
-        default=[],
-        help="Label names to apply",
+        action="append",
+        default=None,
+        help=(
+            "Label names to apply. Accepts space-separated arguments and "
+            "comma-separated values interchangeably, so 'bug enhancement' and "
+            "'bug,enhancement' are equivalent. Repeat the flag to add more. "
+            "Whitespace is trimmed; multi-word names (no comma) are preserved."
+        ),
     )
     parser.add_argument(
         "--priority",
@@ -288,10 +323,8 @@ def main(argv: list[str] | None = None) -> int:
     create_missing = not args.no_create_missing
 
     all_labels: list[dict[str, str]] = []
-    for label in args.labels:
-        stripped = label.strip()
-        if stripped:
-            all_labels.append({"name": stripped, "color": args.default_color})
+    for name in expand_labels(args.labels or []):
+        all_labels.append({"name": name, "color": args.default_color})
 
     if args.priority:
         all_labels.append({"name": f"priority:{args.priority}", "color": args.priority_color})

--- a/src/copilot-cli/skills/github/scripts/issue/set_issue_labels.py
+++ b/src/copilot-cli/skills/github/scripts/issue/set_issue_labels.py
@@ -121,10 +121,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=None,
         help=(
-            "Label names to apply. Accepts space-separated arguments and "
-            "comma-separated values interchangeably, so 'bug enhancement' and "
-            "'bug,enhancement' are equivalent. Repeat the flag to add more. "
-            "Whitespace is trimmed; multi-word names (no comma) are preserved."
+            "Label names to apply. To apply two labels 'bug' and "
+            "'enhancement', use either unquoted space-separated arguments "
+            "(--labels bug enhancement) or a quoted comma-separated string "
+            "(--labels \"bug,enhancement\"). Only commas split names, so a "
+            "quoted space-separated string (--labels \"bug enhancement\") is "
+            "one label named 'bug enhancement'. Repeat the flag to add more; "
+            "surrounding whitespace on each name is trimmed."
         ),
     )
     parser.add_argument(

--- a/src/copilot-cli/skills/github/scripts/issue/set_issue_labels.py
+++ b/src/copilot-cli/skills/github/scripts/issue/set_issue_labels.py
@@ -79,6 +79,35 @@ def compute_priority_removals(
     ]
 
 
+def expand_labels(raw_labels: list[object]) -> list[str]:
+    """Flatten ``--labels`` arguments into individual label names (issue #4967).
+
+    Accepts both public forms so the documented comma syntax and the historical
+    space syntax agree:
+
+    - Space-separated arguments from ``nargs="*"``: ``--labels bug enhancement``.
+    - Comma-separated values inside any argument: ``--labels "bug,enhancement"``.
+    - Repeated ``--labels`` flags (``action="append"`` yields nested lists),
+      which accumulate instead of silently dropping earlier groups.
+
+    Commas act as separators, so a label may not contain a literal comma. A
+    single argument may still contain spaces, so multi-word names such as
+    ``needs discussion`` survive intact. Whitespace around each name is trimmed
+    and empty results are dropped.
+    """
+    names: list[str] = []
+    for group in raw_labels:
+        tokens = group if isinstance(group, list) else [group]
+        for token in tokens:
+            if not isinstance(token, str):
+                continue
+            for part in token.split(","):
+                stripped = part.strip()
+                if stripped:
+                    names.append(stripped)
+    return names
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Apply labels to a GitHub Issue with auto-creation support.",
@@ -89,8 +118,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--labels",
         nargs="*",
-        default=[],
-        help="Label names to apply",
+        action="append",
+        default=None,
+        help=(
+            "Label names to apply. Accepts space-separated arguments and "
+            "comma-separated values interchangeably, so 'bug enhancement' and "
+            "'bug,enhancement' are equivalent. Repeat the flag to add more. "
+            "Whitespace is trimmed; multi-word names (no comma) are preserved."
+        ),
     )
     parser.add_argument(
         "--priority",
@@ -288,10 +323,8 @@ def main(argv: list[str] | None = None) -> int:
     create_missing = not args.no_create_missing
 
     all_labels: list[dict[str, str]] = []
-    for label in args.labels:
-        stripped = label.strip()
-        if stripped:
-            all_labels.append({"name": stripped, "color": args.default_color})
+    for name in expand_labels(args.labels or []):
+        all_labels.append({"name": name, "color": args.default_color})
 
     if args.priority:
         all_labels.append({"name": f"priority:{args.priority}", "color": args.priority_color})

--- a/tests/skills/github/test_set_issue_labels.py
+++ b/tests/skills/github/test_set_issue_labels.py
@@ -61,6 +61,62 @@ class TestSetIssueLabels:
         assert result["Data"]["applied"] == ["bug", "P1"]
         assert result["Data"]["total_applied"] == 2
 
+    def test_apply_comma_separated_labels(self, _import_module, capsys):
+        mod = _import_module
+        # Documented comma form (#4967): one --labels arg, three names applied.
+        with (
+            patch("set_issue_labels.assert_gh_authenticated"),
+            patch("set_issue_labels.resolve_repo_params", return_value=_mock_repo()),
+            patch("set_issue_labels._get_issue_labels", return_value=[]),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    make_completed_process(),  # _label_exists "security"
+                    make_completed_process(),  # _apply_label "security"
+                    make_completed_process(),  # _label_exists "area-workflows"
+                    make_completed_process(),  # _apply_label "area-workflows"
+                    make_completed_process(),  # _label_exists "technical-debt"
+                    make_completed_process(),  # _apply_label "technical-debt"
+                ],
+            ),
+        ):
+            rc = mod.main(
+                ["--issue", "1", "--labels", "security,area-workflows,technical-debt"]
+            )
+        assert rc == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["Data"]["applied"] == [
+            "security",
+            "area-workflows",
+            "technical-debt",
+        ]
+        assert result["Data"]["total_applied"] == 3
+
+    def test_apply_comma_separated_with_priority_label(self, _import_module, capsys):
+        mod = _import_module
+        # Comma form carrying a priority label (#4967): the priority applies and
+        # a stale conflicting priority is reconciled away (#2623).
+        with (
+            patch("set_issue_labels.assert_gh_authenticated"),
+            patch("set_issue_labels.resolve_repo_params", return_value=_mock_repo()),
+            patch("set_issue_labels._get_issue_labels", return_value=["priority:P3"]),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    make_completed_process(),  # _label_exists "security"
+                    make_completed_process(),  # _apply_label "security"
+                    make_completed_process(),  # _label_exists "priority:P2"
+                    make_completed_process(),  # _apply_label "priority:P2"
+                    make_completed_process(),  # _remove_label "priority:P3"
+                ],
+            ),
+        ):
+            rc = mod.main(["--issue", "1", "--labels", "security,priority:P2"])
+        assert rc == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["Data"]["applied"] == ["security", "priority:P2"]
+        assert result["Data"]["removed"] == ["priority:P3"]
+
     def test_mutating_label_calls_include_timeout(self, _import_module):
         mod = _import_module
         with patch("subprocess.run", return_value=make_completed_process()) as run:
@@ -264,3 +320,49 @@ class TestPriorityMutualExclusion:
         ):
             labels = mod._get_issue_labels("o", "r", 1)
         assert labels == []
+
+
+class TestExpandLabels:
+    """Parser-level contract: comma and space label forms agree (#4967)."""
+
+    def _names(self, mod, label_args):
+        parser = mod.build_parser()
+        args = parser.parse_args(["--issue", "1", *label_args])
+        return mod.expand_labels(args.labels or [])
+
+    def test_single_label(self, _import_module):
+        assert self._names(_import_module, ["--labels", "bug"]) == ["bug"]
+
+    def test_comma_separated(self, _import_module):
+        assert self._names(
+            _import_module, ["--labels", "security,area-workflows,priority:P2"]
+        ) == ["security", "area-workflows", "priority:P2"]
+
+    def test_space_separated(self, _import_module):
+        assert self._names(
+            _import_module, ["--labels", "security", "area-workflows", "priority:P2"]
+        ) == ["security", "area-workflows", "priority:P2"]
+
+    def test_comma_and_space_agree(self, _import_module):
+        comma = self._names(_import_module, ["--labels", "a,b,c"])
+        space = self._names(_import_module, ["--labels", "a", "b", "c"])
+        assert comma == space == ["a", "b", "c"]
+
+    def test_repeated_flag_accumulates(self, _import_module):
+        assert self._names(
+            _import_module, ["--labels", "bug", "--labels", "enhancement,priority:P1"]
+        ) == ["bug", "enhancement", "priority:P1"]
+
+    def test_label_with_space_preserved(self, _import_module):
+        assert self._names(_import_module, ["--labels", "needs discussion"]) == [
+            "needs discussion"
+        ]
+
+    def test_empty_value_dropped(self, _import_module):
+        assert self._names(_import_module, ["--labels", ""]) == []
+
+    def test_whitespace_only_dropped(self, _import_module):
+        assert self._names(_import_module, ["--labels", "  ", "good"]) == ["good"]
+
+    def test_no_labels_flag(self, _import_module):
+        assert self._names(_import_module, []) == []

--- a/tests/skills/github/test_set_issue_labels.py
+++ b/tests/skills/github/test_set_issue_labels.py
@@ -366,3 +366,55 @@ class TestExpandLabels:
 
     def test_no_labels_flag(self, _import_module):
         assert self._names(_import_module, []) == []
+
+
+class TestLabelHelpTextMatchesBehavior:
+    """The --labels help text must describe real parser behavior (#4967).
+
+    A false help string is the same doc/parser contradiction the issue was
+    filed for, so the documented spellings are asserted against actual
+    expand_labels output. Nothing else validated the help text, which is how
+    the earlier false 'bug enhancement equals bug,enhancement' claim shipped.
+    """
+
+    def _labels_help(self, mod) -> str:
+        parser = mod.build_parser()
+        for action in parser._actions:
+            if action.dest == "labels":
+                return action.help or ""
+        raise AssertionError("no --labels action found")
+
+    def _names(self, mod, label_args):
+        parser = mod.build_parser()
+        args = parser.parse_args(["--issue", "1", *label_args])
+        return mod.expand_labels(args.labels or [])
+
+    def test_help_shows_both_multi_label_spellings(self, _import_module):
+        help_text = self._labels_help(_import_module)
+        assert "--labels bug enhancement" in help_text
+        assert '--labels "bug,enhancement"' in help_text
+
+    def test_help_states_quoted_space_is_one_label(self, _import_module):
+        help_text = self._labels_help(_import_module)
+        assert '--labels "bug enhancement"' in help_text
+        assert "one label" in help_text
+
+    def test_documented_unquoted_space_form_yields_two_labels(self, _import_module):
+        # --labels bug enhancement  (shell splits into two argv tokens)
+        assert self._names(_import_module, ["--labels", "bug", "enhancement"]) == [
+            "bug",
+            "enhancement",
+        ]
+
+    def test_documented_quoted_comma_form_yields_two_labels(self, _import_module):
+        # --labels "bug,enhancement"  (one argv token, comma splits it)
+        assert self._names(_import_module, ["--labels", "bug,enhancement"]) == [
+            "bug",
+            "enhancement",
+        ]
+
+    def test_documented_quoted_space_form_yields_one_label(self, _import_module):
+        # --labels "bug enhancement"  (one argv token, no comma, stays one)
+        assert self._names(_import_module, ["--labels", "bug enhancement"]) == [
+            "bug enhancement",
+        ]


### PR DESCRIPTION
# Pull Request

## Summary

### What

`set_issue_labels.py` documented comma separated labels (`--labels "a,b,c"`),
but the parser used `nargs="*"`, which splits on whitespace and treats a comma
value as one literal label. The documented syntax and the parser disagreed.
This change makes the parser accept both comma separated values and repeated
`--labels` flags, then normalizes them, so the documented contract works.

### Why

Issue #4967 reported that the label documentation contradicts the
`set_issue_labels.py` argument parsing. A caller following the docs
(`--labels "bug,triage"`) created a single label named `bug,triage` instead of
two labels. The parser was the wrong side: the comma contract is the better one
because a shell word can carry a comma but not a space boundary, and other
issue scripts document comma separated lists.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4967 | label documentation contradicts set_issue_labels argument parsing |

## Changes

- `.claude/skills/github/scripts/issue/set_issue_labels.py`: add `expand_labels()` that splits each `--labels` value on commas, trims whitespace, and drops empty tokens; change `--labels` to `nargs="*", action="append", default=None` so repeated flags accumulate; feed `expand_labels(args.labels or [])` into the update.
- `src/copilot-cli/skills/github/scripts/issue/set_issue_labels.py`: regenerated mirror of the canonical script (identical content).
- `tests/skills/github/test_set_issue_labels.py`: add coverage for single label, comma separated labels, repeated flag, label containing a space, empty value, and whitespace only value.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

`uv run --frozen python -m pytest tests/skills/github/test_set_issue_labels.py`
reports 26 passed. The suite covers single label, comma separated labels,
repeated flag, a label containing a space, an empty value, and a whitespace
only value.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #4967
