### PR TITLE
fix(memory): align the frontmatter gate with the canonical loader

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-14-session-14708.json
+++ b/.agents/memory/episodes/episode-2026-08-14-session-14708.json
@@ -96,7 +96,8 @@
         "e004",
         "e005",
         "e006",
-        "e007"
+        "e007",
+        "e015"
       ],
       "leads_to": [
         "e009"
@@ -176,6 +177,43 @@
       "caused_by": [
         "e013"
       ],
+      "leads_to": [
+        "e016"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Address the independent review on PR 5004",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-08-14T22:10:21+00:00",
+      "type": "commit",
+      "content": "Commit: 8972531ef",
+      "caused_by": [
+        "e014"
+      ],
+      "leads_to": [
+        "e017"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-08-14T23:20:03+00:00",
+      "type": "commit",
+      "content": "Commit: 5b51f5b98d97f40fe56096b75fc078780d5c801e",
+      "caused_by": [
+        "e016"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-14-session-14708"
     }
@@ -185,8 +223,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 7,
-    "files_changed": 6
+    "commits": 9,
+    "files_changed": 9
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-14-session-14708.json
+++ b/.agents/memory/episodes/episode-2026-08-14-session-14708.json
@@ -1,0 +1,192 @@
+{
+  "id": "episode-2026-08-14-session-14708",
+  "session": "2026-08-14-session-14708",
+  "timestamp": "2026-08-14T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Resolve issue 4918 end to end: repair implementation-008 frontmatter and close the frontmatter gate parity gap",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue 4918 discourse and check for an existing PR",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verify the frontmatter repair against the canonical loader",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Probe the gate for parity with python-frontmatter",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Close the parity gap and document the divergences",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Clear the taste count ratchet regression the branch carried",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Integrate the concurrent autofix session that pushed to the same branch",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-14T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replace the branch after the placeholder-identity guard blocked every push",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: fbec84e94",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: 8f7b685db",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: cd0e9c38a",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": [
+        "e011"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: f8caac4b0",
+      "caused_by": [
+        "e010"
+      ],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: ab659dbf5",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-14T22:08:48+00:00",
+      "type": "commit",
+      "content": "Commit: d0becf519",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ],
+      "_source_session": "2026-08-14-session-14708"
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-08-14T22:10:21+00:00",
+      "type": "commit",
+      "content": "Commit: 8972531ef003950827b30aeb5c8a1a34ef1a798e",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-14-session-14708"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 7,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/qa/pr-5004-issue-4918-frontmatter-gate.md
+++ b/.agents/qa/pr-5004-issue-4918-frontmatter-gate.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-14-session-14708.json
-qaCommit: 8972531ef003950827b30aeb5c8a1a34ef1a798e
+qaCommit: 5b51f5b98d97f40fe56096b75fc078780d5c801e
 ---
 
 # PR 5004 Issue 4918 Frontmatter Repair and Gate QA
@@ -27,7 +27,7 @@ Quoted verbatim from issue 4918:
 
 ## Verdict
 
-**PASS.** All three criteria verified at commit `8972531ef003950827b30aeb5c8a1a34ef1a798e`.
+**PASS.** All three criteria verified at commit `5b51f5b98d97f40fe56096b75fc078780d5c801e`.
 
 ## Evidence
 
@@ -36,7 +36,7 @@ Quoted verbatim from issue 4918:
 | 1 | Valid YAML, meaning preserved | `frontmatter.loads` on the repaired file, compare `description` to the original text | Parsed value equals `Constraints for writing spec artifacts (REQ/DESIGN/TASK): read spec-schemas.md first; validate enums before committing` (`True`) |
 | 2 | Zero malformed warnings | `uv run --frozen python -m memory_enhancement verify-all` piped to `grep -ci "malformed YAML frontmatter"` | `0` |
 | 3 | Index validator | `uv run --frozen python scripts/validation/memory_index.py --path .serena/memories --ci --orphan-policy ratchet` | `Result: PASSED`, exit 0, 567 indexed files, 0 missing, 0 keyword issues |
-| 3 | Targeted tests | `uv run --frozen python -m pytest tests/test_validation_memory_index.py -q` | `185 passed` |
+| 3 | Targeted tests | `uv run --frozen python -m pytest tests/test_validation_memory_index.py -q` | `190 passed` |
 
 ## Negative Control
 
@@ -81,7 +81,7 @@ docstring; each one silently discards metadata under the loader.
 
 | Gate | Command | Result |
 |------|---------|--------|
-| Unit tests | `pytest tests/test_validation_memory_index.py -q` | 185 passed |
+| Unit tests | `pytest tests/test_validation_memory_index.py -q` | 190 passed |
 | Lint | `ruff check scripts/validation/memory_index.py tests/test_validation_memory_index.py` | All checks passed |
 | Types | `mypy scripts/validation/memory_index.py` | Success, no issues |
 | Token counts | `scripts/update_memory_index_tokens.py --check` | current |
@@ -110,6 +110,17 @@ which `AGENTS.md` prohibits. This branch replays the same content from
 `origin/main` under a compliant identity with the logical commit boundaries
 preserved, and the `strip()` parity contribution from that session is carried in
 its own commit with attribution.
+
+## Review Findings Addressed
+
+Copilot raised three findings on PR 5004; all three were adopted, with the
+inverse case closed in the same commit (`5b51f5b98`).
+
+| Finding | Verified against canonical | Change |
+|---|---|---|
+| A BOM in front of a *valid* block still loses metadata, and the gate passed it | `frontmatter.loads("\ufeff" + valid).metadata == {}` | Any BOM before the delimiter now fails, whatever the block holds. Tests cover BOM+valid, BOM+malformed, and BOM+plain (not a defect: no metadata to lose) |
+| `str.splitlines()` breaks on `\v`, `\f`, `\x85`, `\u2028`; `re.MULTILINE` anchors only around `\n` | canonical pattern carries `re.MULTILINE` | Split on `\n` alone, with a `\u2028` regression test |
+| Fixed-input differential tests do not catch upstream pattern drift | `YAMLHandler.FM_BOUNDARY.pattern` | Added a direct assertion that the local pattern equals the canonical one, and that the flag difference is the only difference |
 
 ## Residual Risk
 

--- a/.agents/qa/pr-5004-issue-4918-frontmatter-gate.md
+++ b/.agents/qa/pr-5004-issue-4918-frontmatter-gate.md
@@ -1,0 +1,118 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-14-session-14708.json
+qaCommit: 8972531ef003950827b30aeb5c8a1a34ef1a798e
+---
+
+# PR 5004 Issue 4918 Frontmatter Repair and Gate QA
+
+## Scope
+
+Validate the repair of `.serena/memories/implementation/implementation-008-spec-schema-validation.md`,
+the frontmatter gate in `scripts/validation/memory_index.py`, its tests in
+`tests/test_validation_memory_index.py`, and the memory plus index mirrors added
+under `.serena/memories/`.
+
+This branch replaces `fix/4918-implementation-008-frontmatter` (PR 4985). See
+"Branch Replacement" below; the content is identical, re-verified here.
+
+## Acceptance Criteria
+
+Quoted verbatim from issue 4918:
+
+1. "`description` value is valid YAML (quoted or restructured) without changing meaning"
+2. "`memory_enhancement verify-all` runs against `.serena/memories` with zero
+   `malformed YAML frontmatter` warnings"
+3. "Memory index validator and targeted memory integration tests pass"
+
+## Verdict
+
+**PASS.** All three criteria verified at commit `8972531ef003950827b30aeb5c8a1a34ef1a798e`.
+
+## Evidence
+
+| # | Criterion | Command | Result |
+|---|-----------|---------|--------|
+| 1 | Valid YAML, meaning preserved | `frontmatter.loads` on the repaired file, compare `description` to the original text | Parsed value equals `Constraints for writing spec artifacts (REQ/DESIGN/TASK): read spec-schemas.md first; validate enums before committing` (`True`) |
+| 2 | Zero malformed warnings | `uv run --frozen python -m memory_enhancement verify-all` piped to `grep -ci "malformed YAML frontmatter"` | `0` |
+| 3 | Index validator | `uv run --frozen python scripts/validation/memory_index.py --path .serena/memories --ci --orphan-policy ratchet` | `Result: PASSED`, exit 0, 567 indexed files, 0 missing, 0 keyword issues |
+| 3 | Targeted tests | `uv run --frozen python -m pytest tests/test_validation_memory_index.py -q` | `185 passed` |
+
+## Negative Control
+
+A gate that never fires also reports zero warnings. Replaying the pre-fix file
+content through the canonical loader still reproduces the original symptom:
+
+```text
+Warning: malformed YAML frontmatter, treating as plain markdown
+```
+
+The gate flags that same content with an actionable message, so the zero in
+criterion 2 is a repair and not a silenced check.
+
+## Differential Parity Probe
+
+The gate must fire exactly where `frontmatter.loads` raises `yaml.YAMLError`,
+which is the site of the warning in
+`scripts/memory_enhancement/serena_integration.py`. A probe compared both over 16
+frontmatter shapes and found three false negatives in the original gate: 4-dash
+boundaries, 5-dash boundaries, and leading blank lines. python-frontmatter's
+canonical constant is
+
+```python
+FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
+```
+
+while the gate keyed on `line == "---"`, and `frontmatter.parse` normalizes with
+`text = u(text, encoding).strip()` before detecting, which the gate did not do.
+Both are now mirrored.
+
+| Probe outcome | Before | After |
+|---------------|--------|-------|
+| False negatives (loader warns, gate silent) | 3 | 0 |
+| False positives on the real memory tree | 0 | 0 |
+
+Four shapes are flagged by the gate although the loader stays quiet: unclosed
+delimiter, list block, scalar block, and BOM. These are deliberate
+stricter-than-canonical cases documented in the `_parse_leading_frontmatter`
+docstring; each one silently discards metadata under the loader.
+
+## Quality Gates
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Unit tests | `pytest tests/test_validation_memory_index.py -q` | 185 passed |
+| Lint | `ruff check scripts/validation/memory_index.py tests/test_validation_memory_index.py` | All checks passed |
+| Types | `mypy scripts/validation/memory_index.py` | Success, no issues |
+| Token counts | `scripts/update_memory_index_tokens.py --check` | current |
+| Taste ratchet | `scripts/ci/taste_count_ratchet.py` | 582 <= baseline 583 |
+| Pre-PR | `scripts/validation/pre_pr.py` (pre-push `pre-pr-validation` job) | passed |
+| Full test suite | pre-push `python-tests` job | passed in 348 seconds |
+
+## Taste Ratchet Regression Closed
+
+Adding the frontmatter section pushed `format_markdown` to cyclomatic complexity
+12 against a ceiling of 10. The formatter was decomposed into `_bullet_section`
+and `_domain_section` rather than raising `scripts/ci/taste_count_baseline.txt`.
+The formatter had two tests and none covered the optional sections, so four were
+added: missing files, orphans, malformed frontmatter, and an empty case proving
+absent sections stay absent.
+
+## Branch Replacement
+
+PR 4985 on `fix/4918-implementation-008-frontmatter` carries the same fix and
+cannot accept further compliant pushes: nine commits on it were authored and
+committed as `Test <test@test.com>` by a concurrent `pr-autofix` session, and the
+pre-push `placeholder-identity` guard evaluates the whole branch delta
+(`merge-base(origin/main, HEAD)..HEAD`), so every push from a hook-enabled
+environment is rejected. Clearing it needs a history rewrite plus a force push,
+which `AGENTS.md` prohibits. This branch replays the same content from
+`origin/main` under a compliant identity with the logical commit boundaries
+preserved, and the `strip()` parity contribution from that session is carried in
+its own commit with attribution.
+
+## Residual Risk
+
+`scripts/validation/memory_index.py` is 1,726 lines and `main()` has complexity
+14. Both are pre-existing taste errors present on `origin/main`, outside this
+issue's scope, and recorded in the session log's next steps.

--- a/.agents/sessions/2026-08-14-session-14708.json
+++ b/.agents/sessions/2026-08-14-session-14708.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14708,
+    "date": "2026-08-14",
+    "branch": "fix/4918-frontmatter-gate-parity",
+    "startingCommit": "e60e3b896",
+    "objective": "Resolve issue 4918 end to end: repair implementation-008 frontmatter and close the frontmatter gate parity gap"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP tools responded for this project; activate_project is not exposed by this registration"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions completed at session start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read as read-only context (never edited)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file, created by .claude/skills/session/scripts/session_init.py"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "scripts/check_skill_exists.py --list-available completed"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md and .agents/governance/GENERATOR-FILES.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "memory-index, skills-validation-index, and memory-tier memories loaded"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4918-frontmatter-gate-parity in worktree ai-agents-worktrees/issue-4918-clean, created from origin/main e60e3b896"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/4918-frontmatter-gate-parity"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status --short clean at worktree creation (HEAD e60e3b896)"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e60e3b896"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST start and end items recorded with evidence in this file"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read only; not modified in any commit on this branch"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/memories/validation/validation-frontmatter-gate-parity.md added and indexed in skills-validation-index.md (commit ab659dbf5)"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 config excludes .serena/**; the only other markdown is under .agents/qa/, checked by the pre-commit markdown job"
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/pr-5004-issue-4918-frontmatter-gate.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fbec84e94 (frontmatter repair), 8f7b685db (unclosed/list/scalar gaps), cd0e9c38a (canonical alignment), f8caac4b0 (delimiter parity), ab659dbf5 (memory + index mirrors), d0becf519 (formatter decomposition), 8972531ef (strip parity)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre-push jobs passed with no bypass: pre-pr-validation, python-tests (348s), taste-count-ratchet, merge-tree-ratchet, python-type-check"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue 4918 claimed via .claude/skills/github/scripts/issue/claim_issue.py; PR 5004 opened; PR 4985 closed as superseded"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Lesson captured as a Serena memory instead of a retrospective document"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Read issue 4918 discourse and check for an existing PR",
+      "outcome": "Found open PR 4985 already linked to the issue (closingIssuesReferences 4918) and extended it first. check_existing_pr_for_issue.py reported 0 competing PRs because it self-excludes the current branch's own PR."
+    },
+    {
+      "task": "Verify the frontmatter repair against the canonical loader",
+      "outcome": "memory_enhancement verify-all emits zero malformed-frontmatter warnings; a negative control replaying the pre-fix content still reproduces the warning, and the parsed description string is byte-identical to the original meaning."
+    },
+    {
+      "task": "Probe the gate for parity with python-frontmatter",
+      "outcome": "A 16-shape differential probe found 3 false negatives: 4-dash boundaries, 5-dash boundaries, and leading blank lines. The loader's YAMLHandler.FM_BOUNDARY is re.compile(r'^-{3,}\\s*$', re.MULTILINE) and frontmatter.parse strips first, while the gate keyed on line == '---' over unstripped text."
+    },
+    {
+      "task": "Close the parity gap and document the divergences",
+      "outcome": "Added _FM_BOUNDARY mirroring the canonical constant verbatim plus the canonical strip, with 6 tests including a parametrized differential test that drives the real frontmatter.loads. Probe now reports zero false negatives; the real memory tree still passes, so no false positives."
+    },
+    {
+      "task": "Clear the taste count ratchet regression the branch carried",
+      "outcome": "format_markdown had reached complexity 12 (ceiling 10) when the frontmatter section was added. Extracted _bullet_section and _domain_section, added 4 formatter tests that were missing entirely. Count is 582 against baseline 583."
+    },
+    {
+      "task": "Integrate the concurrent autofix session that pushed to the same branch",
+      "outcome": "origin had diverged twice with an autofix session fixing the same false negative. Merged rather than force-pushed, resolving conflicts as a union: kept the documented _FM_BOUNDARY constant and the decomposed formatter, adopted their text.strip() after verifying with inspect.getsource that frontmatter.parse strips before detecting, and kept their leading-whitespace test."
+    },
+    {
+      "task": "Replace the branch after the placeholder-identity guard blocked every push",
+      "outcome": "Nine commits on fix/4918-implementation-008-frontmatter were authored as 'Test <test@test.com>' by that autofix session, and the pre-push guard evaluates the whole branch delta, so no compliant push was possible. Owner chose a clean branch over a history rewrite. Cherry-picked the six compliant commits onto origin/main e60e3b896, replayed the autofix session's strip parity as one attributed commit, and confirmed the resulting tree is byte-identical to the verified tree on the old branch."
+    }
+  ],
+  "endingCommit": "8972531ef003950827b30aeb5c8a1a34ef1a798e",
+  "nextSteps": [
+    "Watch PR 5004 CI, especially Validate PR (QA report gate) and the session protocol job",
+    "File a defect for the pr-autofix session committing as 'Test <test@test.com>' (issue #2466 pattern); no CI check catches it, so the identity reaches main when such a PR merges",
+    "Consider decomposing scripts/validation/memory_index.py (1726 lines) and main() (complexity 14); both are pre-existing taste errors outside this issue's scope"
+  ]
+}

--- a/.agents/sessions/2026-08-14-session-14708.json
+++ b/.agents/sessions/2026-08-14-session-14708.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "fbec84e94 (frontmatter repair), 8f7b685db (unclosed/list/scalar gaps), cd0e9c38a (canonical alignment), f8caac4b0 (delimiter parity), ab659dbf5 (memory + index mirrors), d0becf519 (formatter decomposition), 8972531ef (strip parity)"
+        "Evidence": "fbec84e94 (frontmatter repair), 8f7b685db (unclosed/list/scalar gaps), cd0e9c38a (canonical alignment), f8caac4b0 (delimiter parity), ab659dbf5 (memory + index mirrors), d0becf519 (formatter decomposition), 8972531ef (strip parity), 5b51f5b98 (review findings)"
       },
       "validationPassed": {
         "level": "MUST",
@@ -146,9 +146,13 @@
     {
       "task": "Replace the branch after the placeholder-identity guard blocked every push",
       "outcome": "Nine commits on fix/4918-implementation-008-frontmatter were authored as 'Test <test@test.com>' by that autofix session, and the pre-push guard evaluates the whole branch delta, so no compliant push was possible. Owner chose a clean branch over a history rewrite. Cherry-picked the six compliant commits onto origin/main e60e3b896, replayed the autofix session's strip parity as one attributed commit, and confirmed the resulting tree is byte-identical to the verified tree on the old branch."
+    },
+    {
+      "task": "Address the independent review on PR 5004",
+      "outcome": "Copilot raised three findings and all three held on inspection: a BOM in front of a VALID block also loses metadata silently and the gate passed it, str.splitlines() invents line boundaries that re.MULTILINE does not anchor, and fixed-input differential tests cannot catch upstream pattern drift. Fixed all three in one commit with the inverse cases covered: BOM+valid, BOM+malformed, BOM+plain, a \\u2028 regression, and a direct assertion that _FM_BOUNDARY.pattern equals YAMLHandler.FM_BOUNDARY.pattern. 190 tests pass."
     }
   ],
-  "endingCommit": "8972531ef003950827b30aeb5c8a1a34ef1a798e",
+  "endingCommit": "5b51f5b98d97f40fe56096b75fc078780d5c801e",
   "nextSteps": [
     "Watch PR 5004 CI, especially Validate PR (QA report gate) and the session protocol job",
     "File a defect for the pr-autofix session committing as 'Test <test@test.com>' (issue #2466 pattern); no CI check catches it, so the identity reaches main when such a PR merges",

--- a/.serena/memories/implementation/implementation-008-spec-schema-validation.md
+++ b/.serena/memories/implementation/implementation-008-spec-schema-validation.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-008-spec-schema-validation
-description: Constraints for writing spec artifacts (REQ/DESIGN/TASK): read spec-schemas.md first; validate enums before committing
+description: "Constraints for writing spec artifacts (REQ/DESIGN/TASK): read spec-schemas.md first; validate enums before committing"
 type: feedback
 ---
 

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -80,7 +80,7 @@
 |code smell refactoring bloaters couplers dispensables taxonomy Fowler: [quality/code-smells-catalog](quality/code-smells-catalog.md) (1118)
 |prompt engineering quality gate AI assessment template: [quality/quality-prompt-engineering-gates](quality/quality-prompt-engineering-gates.md) (1419)
 |code quality changed-only regression gate absolute debt issue: [validation/code-quality-changed-only-regression-gate](validation/code-quality-changed-only-regression-gate.md) (287)
-|validation quality lint false-positive gate test: [skills-validation-index](skills-validation-index.md) (503)
+|validation quality lint false-positive gate test: [skills-validation-index](skills-validation-index.md) (539)
 |linting markdown autofix config exclude language backtick: [skills-linting-index](skills-linting-index.md) (173)
 |markdownlint scratch argv command length process startup batch exit code empty output issue 4892: [linting/linting-exclusions](linting/linting-exclusions.md) (2065)
 

--- a/.serena/memories/skills-validation-index.md
+++ b/.serena/memories/skills-validation-index.md
@@ -16,3 +16,4 @@
 | ADR numbering conflicts QA final renumber duplicate verification | [validation/validation-474-adr-numbering-qa-final](validation/validation-474-adr-numbering-qa-final.md) |
 | portability git timeout diagnostics fail closed operation context | [portability/git-timeout-diagnostics](portability/git-timeout-diagnostics.md) |
 | revert experiment injected code runs for real guard proof coverage | [testing/testing-a-revert-experiment-that-injects-code-runs-it-for-real](testing/testing-a-revert-experiment-that-injects-code-runs-it-for-real.md) |
+| frontmatter delimiter FM_BOUNDARY colon-space loader mirror parity false-negative | [validation/validation-frontmatter-gate-parity](validation/validation-frontmatter-gate-parity.md) |

--- a/.serena/memories/validation/validation-frontmatter-gate-parity.md
+++ b/.serena/memories/validation/validation-frontmatter-gate-parity.md
@@ -1,0 +1,54 @@
+---
+name: validation-frontmatter-gate-parity
+description: "Guard parity rule (issue #4918): copy the canonical parser's own delimiter pattern, never an approximation of it"
+type: feedback
+---
+
+# Validation: A Frontmatter Gate Must Copy the Parser, Not Approximate It
+
+**Statement**: When a validator exists to stop what another tool only warns
+about, it must reuse that tool's own detection pattern verbatim. An
+approximation that looks equivalent produces false negatives, and a gate with
+false negatives is decorative.
+
+**Context**: Writing a CI or hook gate that mirrors a runtime loader, parser,
+or validator.
+
+## Evidence (issue #4918, PR #4985)
+
+Two distinct defects, one incident:
+
+1. `.serena/memories/implementation/implementation-008-spec-schema-validation.md`
+   carried an unquoted `description` whose value contained a colon-space:
+   `... (REQ/DESIGN/TASK): read spec-schemas.md first`. YAML reads
+   `(REQ/DESIGN/TASK): read ...` as a nested mapping, `frontmatter.loads`
+   raised `yaml.YAMLError`, and `serena_integration._extract_metadata` caught
+   it, printed `Warning: malformed YAML frontmatter, treating as plain
+   markdown` to stderr, and dropped the file's `name` and `type`. A warning on
+   stderr fails nothing, so the corruption merged and sat on main.
+
+2. The first gate written to stop recurrence keyed on `line == "---"`. The
+   parser it mirrors, python-frontmatter's `YAMLHandler`, uses
+   `FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)`. A file opening with
+   `----` therefore had real, broken frontmatter to the loader (which warned)
+   and no frontmatter at all to the gate (which passed). A differential probe
+   over 14 delimiter shapes found the two false negatives; asserting the gate
+   flags every shape the real parser raises on now guards it.
+
+## Pattern
+
+- Quote any YAML scalar containing `: `. Unquoted colon-space is the single
+  most common frontmatter corruption.
+- Before mirroring a tool, open its source and copy the constant. Quote it in a
+  comment beside your copy so the next reader can diff the two.
+- Test the mirror against the real dependency, not a restatement of it. Driving
+  `frontmatter.loads` in the test means an upstream pattern change fails the
+  test instead of silently reopening the gap.
+- A warning that no gate reads is not a control. Decide whether the condition
+  fails the build, then make it fail.
+
+## Related
+
+- [validation-007-frontmatter-validation-compliance](validation-007-frontmatter-validation-compliance.md)
+- [validation-006-self-report-verification](validation-006-self-report-verification.md)
+- [validation-tooling-patterns](validation-tooling-patterns.md)

--- a/.serena/memories/validation/validation-frontmatter-gate-parity.md
+++ b/.serena/memories/validation/validation-frontmatter-gate-parity.md
@@ -14,7 +14,7 @@ false negatives is decorative.
 **Context**: Writing a CI or hook gate that mirrors a runtime loader, parser,
 or validator.
 
-## Evidence (issue #4918, PR #4985)
+## Evidence (issue #4918, PR #5004)
 
 Two distinct defects, one incident:
 
@@ -29,11 +29,30 @@ Two distinct defects, one incident:
 
 2. The first gate written to stop recurrence keyed on `line == "---"`. The
    parser it mirrors, python-frontmatter's `YAMLHandler`, uses
-   `FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)`. A file opening with
-   `----` therefore had real, broken frontmatter to the loader (which warned)
-   and no frontmatter at all to the gate (which passed). A differential probe
-   over 14 delimiter shapes found the two false negatives; asserting the gate
-   flags every shape the real parser raises on now guards it.
+   `FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)`, and
+   `frontmatter.parse` normalizes with `text = u(text, encoding).strip()`
+   before matching. A file opening with `----`, or with a blank first line,
+   therefore had real, broken frontmatter to the loader (which warned) and no
+   frontmatter at all to the gate (which passed). A differential probe over 16
+   shapes found three false negatives; asserting the gate flags every shape the
+   real parser raises on now guards it.
+
+## Mirror Both Directions
+
+Copying the pattern closes only the false negatives you thought to probe. Two
+more came from review:
+
+- **Pin the constant, not just the behavior.** Fixed-input tests stay green
+  when upstream changes a pattern that still matches those inputs. Assert
+  `local.pattern == canonical.pattern` so the drift itself fails.
+- **A valid block behind a BOM is lost too.** `FM_BOUNDARY.match` fails on
+  `\ufeff---`, so the loader reads the file as plain Markdown and drops
+  metadata with no warning at all. A gate that only flags BOM-plus-malformed
+  leaves the silent case open. Ask what the mirrored tool does with the
+  *valid* input, not only the broken one.
+- **Split lines the way the pattern anchors.** `str.splitlines()` breaks on
+  `\v`, `\f`, `\x85`, `\u2028` and more; `re.MULTILINE` anchors only around
+  `\n`. Splitting more widely invents delimiters the parser cannot see.
 
 ## Pattern
 

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -912,11 +912,13 @@ def _parse_leading_frontmatter(
     - ``(True, None, error)`` when the opening delimiter never closes or the
       block is not parseable YAML. ``error`` is a one-line reason.
 
-    Detection mirrors ``frontmatter.loads``: a block opens only when the FIRST
-    line is a ``_FM_BOUNDARY`` delimiter, so a horizontal rule later in the body
-    is never misread as frontmatter, and it closes at the next delimiter line,
-    whose dash count need not match the opening one (the canonical
-    ``FM_BOUNDARY.split(text, 2)`` does not require that either).
+    Detection mirrors ``frontmatter.loads``: surrounding whitespace is stripped
+    first, as ``frontmatter.parse`` does with "text = u(text, encoding).strip()",
+    a block opens only when the FIRST remaining line is a ``_FM_BOUNDARY``
+    delimiter, so a horizontal rule later in the body is never misread as
+    frontmatter, and it closes at the next delimiter line, whose dash count need
+    not match the opening one (the canonical ``FM_BOUNDARY.split(text, 2)`` does
+    not require that either).
 
     Stricter/looser/different than canonical:
 
@@ -929,7 +931,7 @@ def _parse_leading_frontmatter(
     """
     if text.startswith("\ufeff"):
         text = text[1:]
-    lines = text.splitlines()
+    lines = text.strip().splitlines()
     if not lines or not _FM_BOUNDARY.match(lines[0]):
         return False, None, None
     for idx in range(1, len(lines)):

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -877,10 +877,23 @@ def check_naming_convention(memory_path: Path) -> NamingConventionResult:
 
     return result
 
+
 # File names the canonical memory loader skips. Kept in parity with
 # scripts/memory_enhancement/serena_integration.py load_memories so this gate
 # guards exactly the files that reach the loader (PR #4985 review).
 _CANONICAL_SKIP_NAMES = frozenset({"README.md", "CLAUDE.md"})
+
+# Delimiter that opens and closes a frontmatter block. Copied from the parser
+# the canonical loader calls, python-frontmatter's YAMLHandler, quoted verbatim
+# from frontmatter/default_handlers.py:
+#     FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
+# THREE OR MORE dashes, not exactly three. A differential probe over both
+# implementations found the difference: `----` opened a block for the loader,
+# which then raised YAMLError and printed the #4918 warning, while a gate
+# keying on `== "---"` stayed silent. Matching the parser's own pattern closes
+# that false negative. re.MULTILINE is dropped here because this matches one
+# already-split line rather than scanning a whole document.
+_FM_BOUNDARY = re.compile(r"^-{3,}\s*$")
 
 
 def _parse_leading_frontmatter(
@@ -898,18 +911,28 @@ def _parse_leading_frontmatter(
     - ``(True, None, error)`` when the opening delimiter never closes or the
       block is not parseable YAML. ``error`` is a one-line reason.
 
-    Stricter than ``frontmatter.loads``, which silently returns empty metadata
-    for an unclosed delimiter, a list, or a scalar (issue #4918). Detection
-    keys on the first line being exactly ``---`` so a horizontal rule later in
-    the body is never misread as frontmatter.
+    Detection mirrors ``frontmatter.loads``: a block opens only when the FIRST
+    line is a ``_FM_BOUNDARY`` delimiter, so a horizontal rule later in the body
+    is never misread as frontmatter, and it closes at the next delimiter line,
+    whose dash count need not match the opening one (the canonical
+    ``FM_BOUNDARY.split(text, 2)`` does not require that either).
+
+    Stricter/looser/different than canonical:
+
+    - STRICTER on an unclosed delimiter, a list block, and a scalar block.
+      ``frontmatter.loads`` returns empty metadata for all three and warns for
+      none, which is how corruption reaches main (issue #4918).
+    - STRICTER on a leading UTF-8 BOM. ``FM_BOUNDARY.match`` fails on the BOM,
+      so the loader reads a BOM-prefixed file as plain Markdown and silently
+      drops its metadata; this gate strips the BOM and validates the block.
     """
     if text.startswith("\ufeff"):
         text = text[1:]
     lines = text.splitlines()
-    if not lines or lines[0].rstrip() != "---":
+    if not lines or not _FM_BOUNDARY.match(lines[0]):
         return False, None, None
     for idx in range(1, len(lines)):
-        if lines[idx].rstrip() == "---":
+        if _FM_BOUNDARY.match(lines[idx]):
             block = "\n".join(lines[1:idx])
             try:
                 metadata = yaml.safe_load(block)
@@ -925,9 +948,10 @@ def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
 
     Scans .md files under memory_path recursively, skipping only ``README.md``
     and ``CLAUDE.md`` to match the canonical loader's selection (see the comment
-    below). A file that opens with a frontmatter block (first line exactly
-    ``---``) must close that block and carry a YAML mapping. A file with no
-    leading frontmatter is fine: frontmatter is optional in existing Serena
+    below). A file that opens with a frontmatter block (first line matching
+    ``_FM_BOUNDARY``, three or more dashes) must close that block and carry a
+    YAML mapping. A file with no leading frontmatter is fine: frontmatter is
+    optional in existing Serena
     memories (issue #4900), so a plain-Markdown file, or one with a later
     horizontal rule, is not a violation.
 

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -39,7 +39,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-import frontmatter
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -879,21 +878,57 @@ def check_naming_convention(memory_path: Path) -> NamingConventionResult:
     return result
 
 
+def _parse_leading_frontmatter(
+    text: str,
+) -> tuple[bool, object, str | None]:
+    """Parse a leading YAML frontmatter block directly.
+
+    Returns ``(has_frontmatter, metadata, error)``:
+
+    - ``(False, None, None)`` when the file has no leading frontmatter block.
+      Frontmatter is optional (issue #4900), so plain Markdown, or a file whose
+      only ``---`` is a horizontal rule in the body, is not frontmatter.
+    - ``(True, metadata, None)`` when a closed block parsed successfully.
+      ``metadata`` is whatever YAML produced (dict, list, scalar, or None).
+    - ``(True, None, error)`` when the opening delimiter never closes or the
+      block is not parseable YAML. ``error`` is a one-line reason.
+
+    Stricter than ``frontmatter.loads``, which silently returns empty metadata
+    for an unclosed delimiter, a list, or a scalar (issue #4918). Detection
+    keys on the first line being exactly ``---`` so a horizontal rule later in
+    the body is never misread as frontmatter.
+    """
+    if text.startswith("\ufeff"):
+        text = text[1:]
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return False, None, None
+    for idx in range(1, len(lines)):
+        if lines[idx].rstrip() == "---":
+            block = "\n".join(lines[1:idx])
+            try:
+                metadata = yaml.safe_load(block)
+            except yaml.YAMLError as exc:
+                detail = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
+                return True, None, detail
+            return True, metadata, None
+    return True, None, "unclosed frontmatter delimiter (missing closing '---')"
+
+
 def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
     """Validate that leading YAML frontmatter parses on every memory file.
 
-    Scans all .md files under memory_path (recursively). A file that opens
-    with a frontmatter block must contain valid YAML in that block. A file
-    with no leading frontmatter is fine: frontmatter is optional in existing
-    Serena memories (issue #4900), so a plain-Markdown file, or one with a
-    later horizontal rule, is not a violation.
+    Scans all .md files under memory_path (recursively). A file that opens with
+    a frontmatter block (first line exactly ``---``) must close that block and
+    carry a YAML mapping. A file with no leading frontmatter is fine:
+    frontmatter is optional in existing Serena memories (issue #4900), so a
+    plain-Markdown file, or one with a later horizontal rule, is not a
+    violation.
 
-    The detection mirrors the ``memory_enhancement verify-all`` warning site
-    in ``scripts/memory_enhancement/serena_integration.py``: it flags exactly
-    the files that tool warns about, so a repaired tree stays repaired
-    (issue #4918). ``frontmatter.loads`` raises ``yaml.YAMLError`` only when a
-    leading block exists and fails to parse; it returns empty metadata without
-    raising for frontmatter-free content.
+    Three malformed shapes that ``frontmatter.loads`` accepted as empty
+    metadata are now violations (issue #4918): an unclosed opening delimiter, a
+    block that parses to a list, and a block that parses to a scalar. An empty
+    block (``None``) stays valid because it carries no colon-space corruption.
     """
     result = FrontmatterResult()
 
@@ -904,17 +939,28 @@ def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
         relative = f.relative_to(memory_path)
         if any(part.startswith(".") for part in relative.parts):
             continue
-        try:
-            frontmatter.loads(f.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
+        has_frontmatter, metadata, error = _parse_leading_frontmatter(
+            f.read_text(encoding="utf-8")
+        )
+        if not has_frontmatter:
+            continue
+        rel_posix = relative.as_posix()
+        if error is not None:
             result.passed = False
-            rel_posix = relative.as_posix()
             result.invalid_files.append(rel_posix)
-            detail = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
             result.issues.append(
-                f"Malformed YAML frontmatter: {rel_posix} ({detail}). "
-                f"Quote values that contain a colon-space, or remove the "
-                f"frontmatter block."
+                f"Malformed YAML frontmatter: {rel_posix} ({error}). "
+                f"Quote values that contain a colon-space, close the block with "
+                f"a '---' delimiter, or remove the frontmatter block."
+            )
+            continue
+        if metadata is not None and not isinstance(metadata, dict):
+            result.passed = False
+            result.invalid_files.append(rel_posix)
+            result.issues.append(
+                f"Malformed YAML frontmatter: {rel_posix} (frontmatter must be "
+                f"a mapping, got {type(metadata).__name__}). Use 'key: value' "
+                f"lines, or remove the frontmatter block."
             )
 
     return result

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -39,6 +39,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+import frontmatter
+import yaml
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
@@ -127,6 +130,13 @@ class NamingConventionResult(ValidationIssues):
 
 
 @dataclass
+class FrontmatterResult(ValidationIssues):
+    """Result of frontmatter YAML validity validation."""
+
+    invalid_files: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Orphan:
     """An orphaned file not referenced by any index."""
 
@@ -172,6 +182,7 @@ class ValidationReport:
     domain_results: dict[str, DomainResult] = field(default_factory=dict)
     memory_index_result: MemoryIndexRefResult | None = None
     naming_convention: NamingConventionResult | None = None
+    frontmatter_validity: FrontmatterResult | None = None
     orphans: list[Orphan] = field(default_factory=list)
     summary: ValidationSummary = field(default_factory=ValidationSummary)
 
@@ -868,6 +879,47 @@ def check_naming_convention(memory_path: Path) -> NamingConventionResult:
     return result
 
 
+def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
+    """Validate that leading YAML frontmatter parses on every memory file.
+
+    Scans all .md files under memory_path (recursively). A file that opens
+    with a frontmatter block must contain valid YAML in that block. A file
+    with no leading frontmatter is fine: frontmatter is optional in existing
+    Serena memories (issue #4900), so a plain-Markdown file, or one with a
+    later horizontal rule, is not a violation.
+
+    The detection mirrors the ``memory_enhancement verify-all`` warning site
+    in ``scripts/memory_enhancement/serena_integration.py``: it flags exactly
+    the files that tool warns about, so a repaired tree stays repaired
+    (issue #4918). ``frontmatter.loads`` raises ``yaml.YAMLError`` only when a
+    leading block exists and fails to parse; it returns empty metadata without
+    raising for frontmatter-free content.
+    """
+    result = FrontmatterResult()
+
+    if not memory_path.exists():
+        return result
+
+    for f in sorted(memory_path.rglob("*.md")):
+        relative = f.relative_to(memory_path)
+        if any(part.startswith(".") for part in relative.parts):
+            continue
+        try:
+            frontmatter.loads(f.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            result.passed = False
+            rel_posix = relative.as_posix()
+            result.invalid_files.append(rel_posix)
+            detail = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
+            result.issues.append(
+                f"Malformed YAML frontmatter: {rel_posix} ({detail}). "
+                f"Quote values that contain a colon-space, or remove the "
+                f"frontmatter block."
+            )
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # P1 validators
 # ---------------------------------------------------------------------------
@@ -1328,6 +1380,20 @@ def run_validation(
                 f"({len(naming_result.violations)}):"
             )
             for issue in naming_result.issues:
+                print(f"  - {issue}")
+
+    # P0: Frontmatter YAML validity (issue #4918)
+    frontmatter_result = check_frontmatter_validity(memory_path)
+    report.frontmatter_validity = frontmatter_result
+
+    if not frontmatter_result.passed:
+        report.passed = False
+        if output_format == "console":
+            print(
+                f"\n[P0] Malformed frontmatter "
+                f"({len(frontmatter_result.invalid_files)}):"
+            )
+            for issue in frontmatter_result.issues:
                 print(f"  - {issue}")
 
     return report

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -877,6 +877,11 @@ def check_naming_convention(memory_path: Path) -> NamingConventionResult:
 
     return result
 
+# File names the canonical memory loader skips. Kept in parity with
+# scripts/memory_enhancement/serena_integration.py load_memories so this gate
+# guards exactly the files that reach the loader (PR #4985 review).
+_CANONICAL_SKIP_NAMES = frozenset({"README.md", "CLAUDE.md"})
+
 
 def _parse_leading_frontmatter(
     text: str,
@@ -918,12 +923,13 @@ def _parse_leading_frontmatter(
 def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
     """Validate that leading YAML frontmatter parses on every memory file.
 
-    Scans all .md files under memory_path (recursively). A file that opens with
-    a frontmatter block (first line exactly ``---``) must close that block and
-    carry a YAML mapping. A file with no leading frontmatter is fine:
-    frontmatter is optional in existing Serena memories (issue #4900), so a
-    plain-Markdown file, or one with a later horizontal rule, is not a
-    violation.
+    Scans .md files under memory_path recursively, skipping only ``README.md``
+    and ``CLAUDE.md`` to match the canonical loader's selection (see the comment
+    below). A file that opens with a frontmatter block (first line exactly
+    ``---``) must close that block and carry a YAML mapping. A file with no
+    leading frontmatter is fine: frontmatter is optional in existing Serena
+    memories (issue #4900), so a plain-Markdown file, or one with a later
+    horizontal rule, is not a violation.
 
     Three malformed shapes that ``frontmatter.loads`` accepted as empty
     metadata are now violations (issue #4918): an unclosed opening delimiter, a
@@ -935,10 +941,29 @@ def check_frontmatter_validity(memory_path: Path) -> FrontmatterResult:
     if not memory_path.exists():
         return result
 
+    # File selection and YAML handling here stay in parity with the canonical
+    # memory loader, scripts/memory_enhancement/serena_integration.py, so this
+    # gate guards the exact files that reach it. Canonical selection
+    # (load_memories), quoted verbatim:
+    #     skip_names = {"README.md", "CLAUDE.md"}
+    #     for md_file in sorted(memories_dir.rglob("*.md")):
+    #         if md_file.name in skip_names:
+    #             continue
+    # Canonical YAML handling (_extract_metadata), quoted verbatim:
+    #     try:
+    #         post = frontmatter.loads(raw_text)
+    #     except yaml.YAMLError:
+    #         # Malformed YAML frontmatter; treat as plain markdown
+    # Divergence: the loader warns and falls back to plain Markdown on a
+    # YAMLError and treats empty metadata as "no frontmatter". This gate
+    # instead FAILS (records a violation) on an unclosed delimiter, a
+    # non-mapping block, or unparseable YAML, because merging that corruption
+    # is the defect #4918 exists to stop. Hidden directories are not skipped:
+    # the loader still reads a malformed '.trash/*.md', so this gate must too.
     for f in sorted(memory_path.rglob("*.md")):
-        relative = f.relative_to(memory_path)
-        if any(part.startswith(".") for part in relative.parts):
+        if f.name in _CANONICAL_SKIP_NAMES:
             continue
+        relative = f.relative_to(memory_path)
         has_frontmatter, metadata, error = _parse_leading_frontmatter(
             f.read_text(encoding="utf-8")
         )
@@ -1508,6 +1533,13 @@ def format_markdown(report: ValidationReport) -> str:
         lines.append("")
         for v in report.naming_convention.violations:
             lines.append(f"- {v}")
+        lines.append("")
+
+    if report.frontmatter_validity and report.frontmatter_validity.issues:
+        lines.append("## Malformed Frontmatter")
+        lines.append("")
+        for issue in report.frontmatter_validity.issues:
+            lines.append(f"- {issue}")
         lines.append("")
 
     return "\n".join(lines)

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -920,20 +920,35 @@ def _parse_leading_frontmatter(
     not match the opening one (the canonical ``FM_BOUNDARY.split(text, 2)`` does
     not require that either).
 
+    Lines are split on ``\\n`` only. ``str.splitlines()`` would also break on
+    ``\\v``, ``\\f``, ``\\x1c``-``\\x1e``, ``\\x85``, ``\\u2028`` and
+    ``\\u2029``, while the canonical ``re.MULTILINE`` anchors exist only around
+    ``\\n``. Splitting the same way keeps a delimiter the canonical parser
+    cannot see from becoming one here (PR #5004 review).
+
     Stricter/looser/different than canonical:
 
     - STRICTER on an unclosed delimiter, a list block, and a scalar block.
       ``frontmatter.loads`` returns empty metadata for all three and warns for
       none, which is how corruption reaches main (issue #4918).
-    - STRICTER on a leading UTF-8 BOM. ``FM_BOUNDARY.match`` fails on the BOM,
-      so the loader reads a BOM-prefixed file as plain Markdown and silently
-      drops its metadata; this gate strips the BOM and validates the block.
+    - STRICTER on a UTF-8 BOM in front of the delimiter, whatever the block
+      contains. ``FM_BOUNDARY.match`` fails on the BOM, so the loader reads the
+      whole file as plain Markdown and drops the metadata without warning. A
+      valid block behind a BOM is therefore just as lost as a malformed one,
+      so both are reported (PR #5004 review).
     """
-    if text.startswith("\ufeff"):
-        text = text[1:]
-    lines = text.strip().splitlines()
-    if not lines or not _FM_BOUNDARY.match(lines[0]):
+    normalized = text.strip()
+    bom_prefixed = normalized.startswith("\ufeff")
+    if bom_prefixed:
+        normalized = normalized[1:].strip()
+    lines = normalized.split("\n")
+    if not _FM_BOUNDARY.match(lines[0]):
         return False, None, None
+    if bom_prefixed:
+        return True, None, (
+            "UTF-8 BOM before the frontmatter delimiter; the loader reads the "
+            "whole file as plain Markdown and drops the metadata"
+        )
     for idx in range(1, len(lines)):
         if _FM_BOUNDARY.match(lines[idx]):
             block = "\n".join(lines[1:idx])

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -35,6 +35,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -1499,6 +1500,44 @@ def run_validation(
 # ---------------------------------------------------------------------------
 
 
+def _bullet_section(heading: str, items: Iterable[str]) -> list[str]:
+    """Render a heading over a bullet list, or nothing when there are no items.
+
+    Every optional section of the report has the same shape, and inlining that
+    shape five times is what pushed ``format_markdown`` past the complexity
+    ceiling the taste ratchet enforces.
+    """
+    bullets = [f"- {item}" for item in items]
+    if not bullets:
+        return []
+    return [heading, "", *bullets, ""]
+
+
+def _domain_section(domain: str, result: DomainResult) -> list[str]:
+    """Render one domain's status, file issues, and keyword uniqueness table."""
+    lines = [
+        f"## Domain: {domain}",
+        "",
+        f"**Status**: {'PASS' if result.passed else 'FAIL'}",
+        "",
+    ]
+    lines.extend(_bullet_section("### File Issues", result.file_references.issues))
+
+    densities = result.keyword_density.densities
+    if densities:
+        lines.append("### Keyword Uniqueness")
+        lines.append("")
+        lines.append("| File | Uniqueness |")
+        lines.append("|------|------------|")
+        for file_name, density in densities.items():
+            pct = round(density * 100)
+            status = "OK" if density >= 0.40 else "LOW"
+            lines.append(f"| {file_name} | {pct}% ({status}) |")
+        lines.append("")
+
+    return lines
+
+
 def format_markdown(report: ValidationReport) -> str:
     """Format validation report as markdown."""
     lines: list[str] = [
@@ -1521,50 +1560,29 @@ def format_markdown(report: ValidationReport) -> str:
     ]
 
     for domain, result in report.domain_results.items():
-        lines.append(f"## Domain: {domain}")
-        lines.append("")
-        lines.append(f"**Status**: {'PASS' if result.passed else 'FAIL'}")
-        lines.append("")
+        lines.extend(_domain_section(domain, result))
 
-        if result.file_references.issues:
-            lines.append("### File Issues")
-            for issue in result.file_references.issues:
-                lines.append(f"- {issue}")
-            lines.append("")
-
-        if result.keyword_density.densities:
-            lines.append("### Keyword Uniqueness")
-            lines.append("")
-            lines.append("| File | Uniqueness |")
-            lines.append("|------|------------|")
-            for file_name, density in result.keyword_density.densities.items():
-                pct = round(density * 100)
-                status = "OK" if density >= 0.40 else "LOW"
-                lines.append(f"| {file_name} | {pct}% ({status}) |")
-            lines.append("")
-
-    if report.orphans:
-        lines.append("## Orphaned Files")
-        lines.append("")
-        for orphan in report.orphans:
-            lines.append(
-                f"- {orphan.file} - add to {orphan.expected_index}"
-            )
-        lines.append("")
-
-    if report.naming_convention and report.naming_convention.violations:
-        lines.append("## Naming Convention Violations")
-        lines.append("")
-        for v in report.naming_convention.violations:
-            lines.append(f"- {v}")
-        lines.append("")
-
-    if report.frontmatter_validity and report.frontmatter_validity.issues:
-        lines.append("## Malformed Frontmatter")
-        lines.append("")
-        for issue in report.frontmatter_validity.issues:
-            lines.append(f"- {issue}")
-        lines.append("")
+    lines.extend(
+        _bullet_section(
+            "## Orphaned Files",
+            (
+                f"{orphan.file} - add to {orphan.expected_index}"
+                for orphan in report.orphans
+            ),
+        )
+    )
+    lines.extend(
+        _bullet_section(
+            "## Naming Convention Violations",
+            report.naming_convention.violations if report.naming_convention else [],
+        )
+    )
+    lines.extend(
+        _bullet_section(
+            "## Malformed Frontmatter",
+            report.frontmatter_validity.issues if report.frontmatter_validity else [],
+        )
+    )
 
     return "\n".join(lines)
 

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -2274,6 +2274,44 @@ Intro paragraph.
 Second section after a horizontal rule.
 """
 
+# Opening delimiter with no closing '---'. frontmatter.loads accepted this as
+# empty metadata; the tightened check must flag it (issue #4918).
+_UNCLOSED_DELIMITER = """\
+---
+title: Broken memory
+description: never closed
+
+# Body that was meant to follow frontmatter
+"""
+
+# Block parses to a YAML list, not a mapping. Must flag (issue #4918).
+_LIST_METADATA = """\
+---
+- one
+- two
+---
+
+# Body
+"""
+
+# Block parses to a bare scalar, not a mapping. Must flag (issue #4918).
+_SCALAR_METADATA = """\
+---
+just a bare string scalar
+---
+
+# Body
+"""
+
+# Empty frontmatter block carries no metadata and no colon-space corruption.
+# It stays valid (issue #4900): frontmatter is optional.
+_EMPTY_FRONTMATTER = """\
+---
+---
+
+# Body
+"""
+
 
 class TestCheckFrontmatterValidity:
     """Tests for YAML frontmatter validity validation (issue #4918)."""
@@ -2300,6 +2338,38 @@ class TestCheckFrontmatterValidity:
 
     def test_later_horizontal_rule_passes(self, tmp_path: Path) -> None:
         (tmp_path / "hr-memory.md").write_text(_HR_LATER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_unclosed_delimiter_detected(self, tmp_path: Path) -> None:
+        # frontmatter.loads returned empty metadata here; the tightened check
+        # must fail on the missing closing delimiter (issue #4918).
+        (tmp_path / "unclosed-memory.md").write_text(_UNCLOSED_DELIMITER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["unclosed-memory.md"]
+        assert "unclosed" in result.issues[0]
+
+    def test_list_metadata_detected(self, tmp_path: Path) -> None:
+        # A YAML list is not a metadata mapping; must be flagged (issue #4918).
+        (tmp_path / "list-memory.md").write_text(_LIST_METADATA)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["list-memory.md"]
+        assert "must be a mapping" in result.issues[0]
+
+    def test_scalar_metadata_detected(self, tmp_path: Path) -> None:
+        # A bare scalar is not a metadata mapping; must be flagged (issue #4918).
+        (tmp_path / "scalar-memory.md").write_text(_SCALAR_METADATA)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["scalar-memory.md"]
+        assert "must be a mapping" in result.issues[0]
+
+    def test_empty_frontmatter_block_passes(self, tmp_path: Path) -> None:
+        # An empty block carries no corruption; optional frontmatter (#4900).
+        (tmp_path / "empty-fm-memory.md").write_text(_EMPTY_FRONTMATTER)
         result = check_frontmatter_validity(tmp_path)
         assert result.passed is True
         assert result.invalid_files == []

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -12,7 +12,9 @@ from collections import Counter
 from pathlib import Path
 from unittest.mock import patch
 
+import frontmatter
 import pytest
+import yaml
 
 from scripts.validation.memory_index import (
     DomainIndex,
@@ -2373,6 +2375,44 @@ _EMPTY_FRONTMATTER = """\
 # Body
 """
 
+# python-frontmatter's boundary is `^-{3,}\\s*$`, so four dashes open a real
+# block for the canonical loader: it raises YAMLError and prints the #4918
+# warning. A gate keying on `== "---"` stayed silent on these two shapes, which
+# is the false negative a differential probe found (PR #4985 review).
+_MALFORMED_FOUR_DASH = """\
+----
+description: Constraints for spec artifacts (REQ/DESIGN/TASK): read first
+----
+
+# Body
+"""
+
+_MALFORMED_FIVE_DASH = """\
+-----
+description: Constraints for spec artifacts (REQ/DESIGN/TASK): read first
+-----
+
+# Body
+"""
+
+# Opening and closing dash counts differ. The canonical split takes the next
+# boundary line whatever its width, so this parses and must not be flagged.
+_VALID_MIXED_DASH_WIDTHS = """\
+---
+title: Valid memory
+-----
+
+# Body
+"""
+
+# `--- ---` is not a boundary under `^-{3,}\\s*$`: the trailing dashes are not
+# whitespace. Plain Markdown, no frontmatter, no violation.
+_DASHES_WITH_TRAILING_TEXT = """\
+--- ---
+
+Body text with a colon: value that is not frontmatter.
+"""
+
 
 class TestCheckFrontmatterValidity:
     """Tests for YAML frontmatter validity validation (issue #4918)."""
@@ -2434,6 +2474,68 @@ class TestCheckFrontmatterValidity:
         result = check_frontmatter_validity(tmp_path)
         assert result.passed is True
         assert result.invalid_files == []
+
+    def test_four_dash_delimiter_malformed_detected(self, tmp_path: Path) -> None:
+        # Four dashes open a block for python-frontmatter (`^-{3,}\s*$`), so
+        # the loader warns while a `== "---"` check stayed silent (PR #4985).
+        (tmp_path / "four-dash-memory.md").write_text(_MALFORMED_FOUR_DASH)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["four-dash-memory.md"]
+
+    def test_five_dash_delimiter_malformed_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "five-dash-memory.md").write_text(_MALFORMED_FIVE_DASH)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["five-dash-memory.md"]
+
+    def test_mixed_delimiter_widths_pass(self, tmp_path: Path) -> None:
+        # The canonical split closes at the next boundary of any width, so a
+        # `---` open with a `-----` close is valid, not an unclosed block.
+        (tmp_path / "mixed-memory.md").write_text(_VALID_MIXED_DASH_WIDTHS)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_dashes_with_trailing_text_not_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        # Widening the delimiter must not widen it into `--- ---`, which the
+        # canonical boundary rejects because `-` is not whitespace.
+        (tmp_path / "hr-text-memory.md").write_text(_DASHES_WITH_TRAILING_TEXT)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            _MALFORMED_FRONTMATTER,
+            _MALFORMED_FOUR_DASH,
+            _MALFORMED_FIVE_DASH,
+        ],
+        ids=["three-dash", "four-dash", "five-dash"],
+    )
+    def test_gate_flags_every_shape_the_loader_warns_about(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        """Differential guard: no false negative against the canonical parser.
+
+        The gate exists to stop what `memory_enhancement verify-all` only warns
+        about, so the loader raising `yaml.YAMLError` and the gate staying
+        silent is the one failure that makes it decorative. Driving the real
+        `frontmatter.loads` here means a future upstream change to
+        `FM_BOUNDARY` fails this test rather than silently reopening the gap.
+        """
+        with pytest.raises(yaml.YAMLError):
+            frontmatter.loads(content)
+
+        (tmp_path / "probe-memory.md").write_text(content)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False, (
+            "canonical loader raised YAMLError but the gate stayed silent"
+        )
+        assert result.invalid_files == ["probe-memory.md"]
 
     def test_only_malformed_flagged_in_mixed_tree(self, tmp_path: Path) -> None:
         (tmp_path / "good.md").write_text(_VALID_FRONTMATTER)

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -22,6 +22,7 @@ from scripts.validation.memory_index import (
     check_domain_prefix_naming,
     check_duplicate_entries,
     check_file_references,
+    check_frontmatter_validity,
     check_index_format,
     check_keyword_density,
     check_memory_index_references,
@@ -1838,10 +1839,62 @@ class TestRunValidation:
         assert report.passed is True
         assert report.orphans == []
 
+    def test_malformed_frontmatter_fails_validation(self, tmp_path: Path) -> None:
+        """A malformed frontmatter file must set report.passed = False (#4918).
 
-# ---------------------------------------------------------------------------
-# Output formatting
-# ---------------------------------------------------------------------------
+        Before this fix, memory_index.py --ci exited 0 even when a memory file
+        carried unparseable YAML frontmatter, so the corruption in
+        implementation-008 merged silently.
+        """
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha beta gamma delta epsilon | test-indexed |\n"
+            ),
+            "test-indexed.md": (
+                "---\n"
+                "description: Constraints for artifacts (REQ/DESIGN): read it\n"
+                "---\n\n"
+                "indexed content\n"
+            ),
+            "memory-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| test | [skills-test-index](skills-test-index.md) |\n"
+            ),
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        assert report.passed is False, (
+            "malformed frontmatter must cause report.passed = False (#4918)"
+        )
+        assert report.frontmatter_validity is not None
+        assert report.frontmatter_validity.invalid_files == ["test-indexed.md"]
+
+    def test_valid_frontmatter_passes_validation(self, tmp_path: Path) -> None:
+        """Valid frontmatter is the negative control for #4918."""
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha beta gamma delta epsilon | test-indexed |\n"
+            ),
+            "test-indexed.md": (
+                "---\n"
+                "description: Constraints for artifacts, read spec first\n"
+                "---\n\n"
+                "indexed content\n"
+            ),
+            "memory-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| test | [skills-test-index](skills-test-index.md) |\n"
+            ),
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        assert report.passed is True
+        assert report.frontmatter_validity is not None
+        assert report.frontmatter_validity.passed is True
 
 
 class TestFormatMarkdown:
@@ -2175,6 +2228,112 @@ class TestCheckNamingConvention:
 
     def test_empty_directory_passes(self, tmp_path: Path) -> None:
         result = check_naming_convention(tmp_path)
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# check_frontmatter_validity (issue #4918)
+# ---------------------------------------------------------------------------
+
+
+_VALID_FRONTMATTER = """\
+---
+title: Valid memory
+description: A plain description with no problematic punctuation
+---
+
+# Body
+"""
+
+# Unquoted value containing a colon-space: yaml reads it as a nested mapping
+# and raises. This is the exact corruption repaired in implementation-008.
+_MALFORMED_FRONTMATTER = """\
+---
+title: Broken memory
+description: Constraints for spec artifacts (REQ/DESIGN/TASK): read first
+---
+
+# Body
+"""
+
+# No leading frontmatter block. Optional per issue #4900, must not flag.
+_NO_FRONTMATTER = """\
+# Plain markdown
+
+Body text with a colon: value that is not frontmatter.
+"""
+
+# A horizontal rule appears later in the body, not at the top. Must not flag.
+_HR_LATER = """\
+# Plain markdown
+
+Intro paragraph.
+
+---
+
+Second section after a horizontal rule.
+"""
+
+
+class TestCheckFrontmatterValidity:
+    """Tests for YAML frontmatter validity validation (issue #4918)."""
+
+    def test_valid_frontmatter_passes(self, tmp_path: Path) -> None:
+        (tmp_path / "valid-memory.md").write_text(_VALID_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_malformed_frontmatter_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "broken-memory.md").write_text(_MALFORMED_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["broken-memory.md"]
+        assert "Malformed YAML frontmatter" in result.issues[0]
+        assert "broken-memory.md" in result.issues[0]
+
+    def test_missing_frontmatter_passes(self, tmp_path: Path) -> None:
+        (tmp_path / "plain-memory.md").write_text(_NO_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_later_horizontal_rule_passes(self, tmp_path: Path) -> None:
+        (tmp_path / "hr-memory.md").write_text(_HR_LATER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_only_malformed_flagged_in_mixed_tree(self, tmp_path: Path) -> None:
+        (tmp_path / "good.md").write_text(_VALID_FRONTMATTER)
+        (tmp_path / "plain.md").write_text(_NO_FRONTMATTER)
+        (tmp_path / "bad.md").write_text(_MALFORMED_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["bad.md"]
+
+    def test_subdirectory_files_checked(self, tmp_path: Path) -> None:
+        subdir = tmp_path / "implementation"
+        subdir.mkdir()
+        (subdir / "impl-bad.md").write_text(_MALFORMED_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["implementation/impl-bad.md"]
+
+    def test_dotfiles_skipped(self, tmp_path: Path) -> None:
+        dotdir = tmp_path / ".trash"
+        dotdir.mkdir()
+        (dotdir / "bad.md").write_text(_MALFORMED_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_nonexistent_path_passes(self, tmp_path: Path) -> None:
+        result = check_frontmatter_validity(tmp_path / "does-not-exist")
+        assert result.passed is True
+
+    def test_empty_directory_passes(self, tmp_path: Path) -> None:
+        result = check_frontmatter_validity(tmp_path)
         assert result.passed is True
 
 

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -2021,6 +2021,67 @@ class TestMain:
         exit_code = main(["--path", str(tmp_path), "--ci"])
         assert exit_code == 1
 
+    def test_malformed_frontmatter_ci_fails(self, tmp_path: Path) -> None:
+        """The CLI entrypoint must exit 1 on malformed frontmatter (#4918).
+
+        Guards the report-to-CLI wiring: an in-process report failure that never
+        reached main() could silently green the gate.
+        """
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha beta gamma delta epsilon | test-indexed |\n"
+            ),
+            "test-indexed.md": (
+                "---\n"
+                "description: Constraints for artifacts (REQ/DESIGN): read it\n"
+                "---\n\n"
+                "indexed content\n"
+            ),
+            "memory-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| test | [skills-test-index](skills-test-index.md) |\n"
+            ),
+        })
+        exit_code = main(["--path", str(tmp_path), "--ci"])
+        assert exit_code == 1
+
+    def test_malformed_frontmatter_markdown_reports_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Markdown output must name the malformed file, not just FAILED (#4918).
+
+        Without a frontmatter section the markdown report shows a generic
+        FAILED status with no filename or remediation.
+        """
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha beta gamma delta epsilon | test-indexed |\n"
+            ),
+            "test-indexed.md": (
+                "---\n"
+                "description: Constraints for artifacts (REQ/DESIGN): read it\n"
+                "---\n\n"
+                "indexed content\n"
+            ),
+            "memory-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| test | [skills-test-index](skills-test-index.md) |\n"
+            ),
+        })
+        exit_code = main(
+            ["--path", str(tmp_path), "--format", "markdown", "--ci"]
+        )
+        assert exit_code == 1
+        out = capsys.readouterr().out
+        assert "## Malformed Frontmatter" in out
+        assert "test-indexed.md" in out
+
     def test_inherited_memory_index_target_over_limit_ci_fails(
         self, tmp_path: Path
     ) -> None:
@@ -2390,10 +2451,22 @@ class TestCheckFrontmatterValidity:
         assert result.passed is False
         assert result.invalid_files == ["implementation/impl-bad.md"]
 
-    def test_dotfiles_skipped(self, tmp_path: Path) -> None:
+    def test_trash_dir_files_checked(self, tmp_path: Path) -> None:
+        # The canonical loader (serena_integration.load_memories) scans hidden
+        # directories, so a malformed `.trash/*.md` still breaks it. This gate
+        # must flag it too, not skip it (PR #4985 review).
         dotdir = tmp_path / ".trash"
         dotdir.mkdir()
         (dotdir / "bad.md").write_text(_MALFORMED_FRONTMATTER)
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == [".trash/bad.md"]
+
+    def test_readme_and_claude_skipped(self, tmp_path: Path) -> None:
+        # The canonical loader skips these two names; this gate skips them too,
+        # so a doc file with no frontmatter is never a violation (PR #4985).
+        (tmp_path / "README.md").write_text(_MALFORMED_FRONTMATTER)
+        (tmp_path / "CLAUDE.md").write_text(_MALFORMED_FRONTMATTER)
         result = check_frontmatter_validity(tmp_path)
         assert result.passed is True
         assert result.invalid_files == []

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -2471,6 +2471,16 @@ _DASHES_WITH_TRAILING_TEXT = """\
 Body text with a colon: value that is not frontmatter.
 """
 
+# `frontmatter.parse` strips before detecting ("text = u(text, encoding).strip()"),
+# so blank leading lines do not stop the loader from opening this block, warning,
+# and dropping the metadata. The gate strips for the same reason.
+_MALFORMED_LEADING_WHITESPACE = (
+    "\n  \n----\n"
+    "title: Broken memory\n"
+    "description: invalid: nested mapping\n"
+    "----\n\n# Body\n"
+)
+
 
 class TestCheckFrontmatterValidity:
     """Tests for YAML frontmatter validity validation (issue #4918)."""
@@ -2571,8 +2581,9 @@ class TestCheckFrontmatterValidity:
             _MALFORMED_FRONTMATTER,
             _MALFORMED_FOUR_DASH,
             _MALFORMED_FIVE_DASH,
+            _MALFORMED_LEADING_WHITESPACE,
         ],
-        ids=["three-dash", "four-dash", "five-dash"],
+        ids=["three-dash", "four-dash", "five-dash", "leading-whitespace"],
     )
     def test_gate_flags_every_shape_the_loader_warns_about(
         self, tmp_path: Path, content: str
@@ -2594,6 +2605,18 @@ class TestCheckFrontmatterValidity:
             "canonical loader raised YAMLError but the gate stayed silent"
         )
         assert result.invalid_files == ["probe-memory.md"]
+
+    def test_leading_whitespace_is_normalized_like_loader(
+        self, tmp_path: Path
+    ) -> None:
+        # Blank leading lines survive `frontmatter.parse`'s strip, so the
+        # loader still opens the block and warns; the gate must too.
+        (tmp_path / "leading-space-memory.md").write_text(
+            _MALFORMED_LEADING_WHITESPACE
+        )
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["leading-space-memory.md"]
 
     def test_only_malformed_flagged_in_mixed_tree(self, tmp_path: Path) -> None:
         (tmp_path / "good.md").write_text(_VALID_FRONTMATTER)

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -1929,6 +1929,64 @@ class TestFormatMarkdown:
         md = format_markdown(report)
         assert "## Domain: test" in md
 
+    def test_reports_missing_file_issues(self, tmp_path: Path) -> None:
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha bravo charlie | test-absent |\n"
+            ),
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        md = format_markdown(report)
+        assert "### File Issues" in md
+        assert "- Missing file: test-absent.md" in md
+
+    def test_reports_orphaned_files(self, tmp_path: Path) -> None:
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha bravo charlie | test-skill |\n"
+            ),
+            "test-skill.md": "c",
+            "test-stray.md": "c",
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        md = format_markdown(report)
+        assert "## Orphaned Files" in md
+        assert "- test-stray - add to skills-test-index.md" in md
+
+    def test_reports_malformed_frontmatter(self, tmp_path: Path) -> None:
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha bravo charlie | test-skill |\n"
+            ),
+            "test-skill.md": _MALFORMED_FRONTMATTER,
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        md = format_markdown(report)
+        assert "## Malformed Frontmatter" in md
+        assert "- Malformed YAML frontmatter: test-skill.md" in md
+
+    def test_omits_sections_with_nothing_to_report(self, tmp_path: Path) -> None:
+        create_memory_structure(tmp_path, {
+            "skills-test-index.md": (
+                "| Keywords | File |\n"
+                "|----------|------|\n"
+                "| alpha bravo charlie delta echo | test-skill |\n"
+            ),
+            "test-skill.md": "c",
+        })
+        report = run_validation(tmp_path, "json", Counter())
+        md = format_markdown(report)
+        assert "### File Issues" not in md
+        assert "## Orphaned Files" not in md
+        assert "## Naming Convention Violations" not in md
+        assert "## Malformed Frontmatter" not in md
+
 
 class TestFormatJson:
     """Tests for JSON output format."""

--- a/tests/test_validation_memory_index.py
+++ b/tests/test_validation_memory_index.py
@@ -7,6 +7,7 @@ duplicate detection, orphan detection, memory-index references, and output forma
 
 from __future__ import annotations
 
+import re
 import subprocess
 from collections import Counter
 from pathlib import Path
@@ -17,6 +18,7 @@ import pytest
 import yaml
 
 from scripts.validation.memory_index import (
+    _FM_BOUNDARY,
     DomainIndex,
     IndexEntry,
     _load_base_reference_counts,
@@ -2617,6 +2619,81 @@ class TestCheckFrontmatterValidity:
         result = check_frontmatter_validity(tmp_path)
         assert result.passed is False
         assert result.invalid_files == ["leading-space-memory.md"]
+
+    def test_local_boundary_pattern_matches_canonical(self) -> None:
+        """Pin the copied delimiter to the parser's own constant.
+
+        The behavior cases below use fixed inputs, so an upstream `FM_BOUNDARY`
+        that still recognizes those inputs would leave them green while the
+        local copy drifts (PR #5004 review). Comparing the pattern text catches
+        the drift itself.
+
+        The flags differ on purpose: the canonical constant carries
+        `re.MULTILINE` because it scans a whole document, while `_FM_BOUNDARY`
+        matches one already-split line.
+        """
+        canonical = frontmatter.default_handlers.YAMLHandler.FM_BOUNDARY
+        assert _FM_BOUNDARY.pattern == canonical.pattern
+        assert canonical.flags & re.MULTILINE
+        assert not _FM_BOUNDARY.flags & re.MULTILINE
+
+    def test_bom_before_valid_frontmatter_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """A BOM loses valid metadata as surely as a malformed block does.
+
+        `FM_BOUNDARY.match` fails on `\ufeff---`, so the loader reads the whole
+        file as plain Markdown and drops the metadata without warning. Flagging
+        only BOM-plus-malformed would leave that silent loss open
+        (PR #5004 review).
+        """
+        content = "\ufeff" + _VALID_FRONTMATTER
+        assert frontmatter.loads(content).metadata == {}
+
+        (tmp_path / "bom-valid-memory.md").write_text(content, encoding="utf-8")
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["bom-valid-memory.md"]
+        assert "BOM" in result.issues[0]
+
+    def test_bom_before_malformed_frontmatter_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        content = "\ufeff" + _MALFORMED_FRONTMATTER
+        (tmp_path / "bom-bad-memory.md").write_text(content, encoding="utf-8")
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert result.invalid_files == ["bom-bad-memory.md"]
+
+    def test_bom_without_frontmatter_is_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        # No metadata means nothing to lose, so a BOM alone is not a defect.
+        (tmp_path / "bom-plain-memory.md").write_text(
+            "\ufeff" + _NO_FRONTMATTER, encoding="utf-8"
+        )
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is True
+        assert result.invalid_files == []
+
+    def test_unicode_line_separator_does_not_close_a_block(
+        self, tmp_path: Path
+    ) -> None:
+        """Only `\\n` starts a line, because only `\\n` anchors `re.MULTILINE`.
+
+        `str.splitlines()` would treat the `\\u2028` here as a line break and
+        find a closing delimiter the canonical parser cannot see, turning an
+        unclosed block into a parsed one (PR #5004 review). The block stays
+        unclosed for both, which this gate reports as the documented
+        stricter-than-canonical case.
+        """
+        content = "---\ntitle: Broken\u2028---\n\n# Body\n"
+        assert frontmatter.loads(content).metadata == {}
+
+        (tmp_path / "u2028-memory.md").write_text(content, encoding="utf-8")
+        result = check_frontmatter_validity(tmp_path)
+        assert result.passed is False
+        assert "unclosed frontmatter delimiter" in result.issues[0]
 
     def test_only_malformed_flagged_in_mixed_tree(self, tmp_path: Path) -> None:
         (tmp_path / "good.md").write_text(_VALID_FRONTMATTER)


### PR DESCRIPTION
# Pull Request

## Summary

### What

Repairs the unquoted YAML `description` in `implementation-008-spec-schema-validation.md` and closes the validator gap that let it reach `main`. The memory-index gate now detects a frontmatter block exactly the way `frontmatter.loads` does, so any file the loader warns about and silently strips is caught before push.

### Why

`memory_enhancement verify-all` printed `Warning: malformed YAML frontmatter, treating as plain markdown` and dropped that memory's metadata. The value `description: Implementation-focused: spec schema validation` is a colon-space inside an unquoted scalar, which YAML reads as a nested mapping. Quoting the value fixes the file; without a gate that mirrors the loader, the next such file lands the same way.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4918 | Memory corruption: implementation-008-spec-schema-validation.md has malformed YAML frontmatter |
| **Spec** | N/A | Bug fix; acceptance criteria are stated in the issue |

## Changes

- `.serena/memories/implementation/implementation-008-spec-schema-validation.md`: quote the `description` value. The parsed string is byte-identical to the original text, so the meaning does not change.
- `scripts/validation/memory_index.py`: `check_frontmatter_validity` now parses the leading block through `_parse_leading_frontmatter`, which mirrors `frontmatter.loads`:
  - `_FM_BOUNDARY = re.compile(r"^-{3,}\s*$")` mirrors python-frontmatter's `YAMLHandler.FM_BOUNDARY`, quoted verbatim at the definition. The old check compared `line == "---"`, so 4-dash and 5-dash blocks were invisible to the gate while the loader warned on them.
  - The text is stripped first, because `frontmatter.parse` runs `text = u(text, encoding).strip()` (verified with `inspect.getsource`). Leading blank lines therefore do not hide a malformed block from the gate.
  - Documented divergences from canonical live in the docstring under "Stricter/looser/different than canonical": BOM handling, unclosed blocks, and non-mapping blocks are flagged even though the loader tolerates them.
- `scripts/validation/memory_index.py`: `format_markdown` split into `_bullet_section` and `_domain_section`. It had reached cyclomatic complexity 12 against a ceiling of 10 and was over the taste ratchet baseline.
- `tests/test_validation_memory_index.py`: positive, negative, and edge coverage, including a parametrized differential test that drives the real `frontmatter.loads` and asserts the gate flags every shape the loader warns about.
- `.serena/memories/validation/validation-frontmatter-gate-parity.md` plus its `skills-validation-index.md` row and the `memory-index.md` token count: the mirror policy for new memories.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted review, standard scrutiny, no rush.

**Focus areas**: `_parse_leading_frontmatter` in `scripts/validation/memory_index.py`. The gate is deliberately stricter than the loader in three named cases; the docstring lists them. If you disagree with any of the three, say which, because each one is a policy call rather than a parity call.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence, all re-run on this branch:

| Check | Command | Result |
|---|---|---|
| Acceptance criterion 1 | parse the repaired `description` | value equals the original string |
| Acceptance criterion 2 | `python -m memory_enhancement verify-all` | 0 `malformed YAML frontmatter` warnings |
| Acceptance criterion 3 | `memory_index.py --path .serena/memories --ci --orphan-policy ratchet` | `Result: PASSED`, 567 files, 0 keyword issues |
| Targeted tests | `pytest tests/test_validation_memory_index.py` | 185 passed |
| Differential parity probe | 16 frontmatter shapes against the real loader | 0 false negatives |
| Lint / types | `ruff check`, `mypy` on both changed files | clean |
| Ratchet | `scripts/ci/taste_count_ratchet.py` | 582 <= baseline 583 |
| Pre-PR | `scripts/validation/pre_pr.py` | 51/51 passed |

A negative control confirms the gate is load-bearing: replaying the pre-fix content reproduces the warning, and the gate flags it.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

No authentication, authorization, secrets, CI, or hook files are touched. The changed validator reads memory files from a caller-supplied directory and reports; it writes nothing.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

This PR replaces #4985, which carried the same fix. That branch cannot accept further compliant pushes: nine commits on it were authored and committed as `Test <test@test.com>` by a concurrent `pr-autofix` session, and the pre-push `placeholder-identity` guard evaluates the whole branch delta, so every push from a hook-enabled environment is rejected. Clearing it would need a history rewrite plus a force push, which `AGENTS.md` prohibits. This branch replays the same content from `origin/main` under a compliant identity, with the logical commit boundaries preserved. #4985 is closed as superseded, not abandoned; the `strip()` parity improvement that the autofix session contributed is carried here in its own commit and credited in that commit's message.

## Related Issues

Fixes #4918
