### PR TITLE
fix(ci): document close/reopen recovery for missing required checks

### DIFF
--- a/.claude/skills/github/fix-ci.md
+++ b/.claude/skills/github/fix-ci.md
@@ -137,6 +137,38 @@ For each failure snippet, determine:
 | `npm ERR!`, `dotnet restore failed` | Dependency | MAYBE |
 | `secret.*not found` | Missing secret | NO (blocked) |
 | `rate limit`, `timeout` | Infrastructure | RETRY |
+| `MissingRequiredChecks` (from `get_pr_checks.py`) | Never-reported checks | RECOVER |
+
+### Missing Required Checks Recovery (Issue #4359)
+
+When `get_pr_checks.py` reports `MissingRequiredChecks`, required workflow runs never
+fired (typically because GitHub dropped the `synchronize` event after a force-push or
+conflict resolution). The PR looks green to tooling but cannot merge.
+
+#### Diagnosis
+
+```bash
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-.claude}/skills/github/scripts"
+python3 "$SCRIPTS_DIR/pr/get_pr_checks.py" --pull-request <PR_NUMBER> --output-format json \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('MissingRequiredChecks'))"
+```
+
+#### Recovery (no new commit needed)
+
+```bash
+gh pr close <PR_NUMBER>
+gh pr reopen <PR_NUMBER>
+```
+
+Closing and reopening fires the `reopened` event, which re-triggers all
+`pull_request` workflows. Verified on PRs #4009, #4110, #4095 (0 runs before,
+36-37 runs after). This does not consume the repository's commit cap and
+preserves review state.
+
+#### When to apply Only when `MissingRequiredChecks` is non-empty and no code
+
+change is expected to fix the situation. If checks are failing (not missing),
+use the standard fix workflow below instead.
 
 **Root Cause Analysis:**
 

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -729,7 +729,9 @@ def _resolve_status(
     if missing:
         return (
             f"PR #{number}: {len(missing)} required check(s) never reported "
-            f"(MISSING: {', '.join(missing[:3])}{'...' if len(missing) > 3 else ''})",
+            f"(MISSING: {', '.join(missing[:3])}{'...' if len(missing) > 3 else ''}). "
+            "Recovery: close and reopen the PR to re-fire workflow triggers "
+            "(no new commit needed).",
             "FAIL",
         )
     if output["FailedCount"] > 0:

--- a/.claude/skills/github/scripts/pr/why_pr_blocked.py
+++ b/.claude/skills/github/scripts/pr/why_pr_blocked.py
@@ -626,7 +626,10 @@ def main(argv: list[str] | None = None) -> int:
     else:
         parts = []
         if missing:
-            parts.append(f"{len(missing)} missing required check(s)")
+            parts.append(
+                f"{len(missing)} missing required check(s) "
+                "(recovery: close and reopen the PR)"
+            )
         if failing:
             parts.append(f"{len(failing)} failing required check(s)")
         if pending:

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -729,7 +729,9 @@ def _resolve_status(
     if missing:
         return (
             f"PR #{number}: {len(missing)} required check(s) never reported "
-            f"(MISSING: {', '.join(missing[:3])}{'...' if len(missing) > 3 else ''})",
+            f"(MISSING: {', '.join(missing[:3])}{'...' if len(missing) > 3 else ''}). "
+            "Recovery: close and reopen the PR to re-fire workflow triggers "
+            "(no new commit needed).",
             "FAIL",
         )
     if output["FailedCount"] > 0:

--- a/src/copilot-cli/skills/github/scripts/pr/why_pr_blocked.py
+++ b/src/copilot-cli/skills/github/scripts/pr/why_pr_blocked.py
@@ -626,7 +626,10 @@ def main(argv: list[str] | None = None) -> int:
     else:
         parts = []
         if missing:
-            parts.append(f"{len(missing)} missing required check(s)")
+            parts.append(
+                f"{len(missing)} missing required check(s) "
+                "(recovery: close and reopen the PR)"
+            )
         if failing:
             parts.append(f"{len(failing)} failing required check(s)")
         if pending:

--- a/tests/skills/github/test_why_pr_blocked.py
+++ b/tests/skills/github/test_why_pr_blocked.py
@@ -740,3 +740,22 @@ class TestMain:
         out = capsys.readouterr().out
         assert rc == 0
         assert "mergeable" in out.lower() or "no blocking" in out.lower()
+
+    def test_human_output_missing_checks_includes_recovery_hint(self, capsys):
+        """Human summary for missing required checks recommends close/reopen."""
+        gql = _gql_pr(
+            overall_state="SUCCESS",
+            check_nodes=[_check_run_node("Run Python Tests", "SUCCESS")],
+        )
+        with patch("why_pr_blocked.assert_gh_authenticated"), patch(
+            "why_pr_blocked.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch("why_pr_blocked.gh_graphql", return_value=gql), patch(
+            "why_pr_blocked.fetch_ruleset_required_contexts",
+            return_value=["Run Python Tests", "Validate PR"],
+        ):
+            rc = main(["--pull-request", "42", "--output-format", "human"])
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "close and reopen" in out.lower()

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -1947,6 +1947,28 @@ class TestMissingRequired:
         assert set(data["MissingRequiredChecks"]) == {"Validate PR", "PR Validation"}
         assert data["AllPassing"] is False
 
+    def test_missing_required_human_summary_includes_recovery_hint(self, capsys):
+        """Human output recommends close/reopen recovery for missing checks."""
+        rollup = self._green_rollup("Run Python Tests")
+        ruleset = ["Run Python Tests", "Validate PR"]
+
+        with patch("get_pr_checks.assert_gh_authenticated"), patch(
+            "get_pr_checks.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_pr_checks.gh_graphql", return_value=rollup
+        ), patch(
+            "get_pr_checks.fetch_ruleset_required_contexts",
+            return_value=ruleset,
+        ):
+            main(["--pull-request", "4009", "--output-format", "human"])
+
+        captured = capsys.readouterr()
+        combined = (captured.out + captured.err).lower()
+        assert "close and reopen" in combined, (
+            "Human summary must include close/reopen recovery hint"
+        )
+
     def test_ruleset_fetch_failure_exits_3(self, capsys):
         """Ruleset API failure cannot report passing checks."""
         rollup = self._green_rollup()


### PR DESCRIPTION
## Summary

Closes the remaining acceptance gap for #4359: documenting the close/reopen recovery
procedure for required checks that never report.

`get_pr_checks.py` already detects `MissingRequiredChecks` (landed in PR #4578).
This PR adds:

1. **Recovery hint in human output** - both `get_pr_checks.py` and `why_pr_blocked.py`
   now recommend `gh pr close` / `gh pr reopen` when missing checks are detected.
2. **Troubleshooting section in fix-ci.md** - documents the failure mode, diagnosis
   commands, recovery procedure, and when to apply it.
3. **Tests** - verify the recovery hint appears in human-facing output.

### Verified recovery data (from issue #4359)

| PR | runs before close/reopen | runs after |
|----|--------------------------|------------|
| #4009 | 0 | 37 |
| #4110 | 0 | 37 |
| #4095 | 0 | 36 |

No new commit needed; closing and reopening fires the `reopened` event.

Fixes #4359