### PR TITLE
fix(pr-autofix): stop delayed child after lease loss

### DIFF
--- a/.claude/commands/pr-autofix.md
+++ b/.claude/commands/pr-autofix.md
@@ -204,6 +204,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
                 cleanup_pr_autofix
                 return 75
             fi
+            stop_mutation_group "$mutation_pid"
             return "$mutation_rc"
         fi
         sleep 0.01
@@ -222,6 +223,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
                 cleanup_pr_autofix
                 return 75
             fi
+            stop_mutation_group "$mutation_pid"
             return "$mutation_rc"
         fi
         kill "$mutation_pid" 2>/dev/null || true
@@ -264,6 +266,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
         cleanup_pr_autofix
         return 75
     fi
+    stop_mutation_group "$mutation_pid"
     return "$mutation_rc"
 }
 # lease-renewal:end

--- a/src/copilot-cli/skills/pr-autofix/SKILL.md
+++ b/src/copilot-cli/skills/pr-autofix/SKILL.md
@@ -206,6 +206,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
                 cleanup_pr_autofix
                 return 75
             fi
+            stop_mutation_group "$mutation_pid"
             return "$mutation_rc"
         fi
         sleep 0.01
@@ -224,6 +225,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
                 cleanup_pr_autofix
                 return 75
             fi
+            stop_mutation_group "$mutation_pid"
             return "$mutation_rc"
         fi
         kill "$mutation_pid" 2>/dev/null || true
@@ -266,6 +268,7 @@ os.execvp(sys.argv[1], sys.argv[1:])' \
         cleanup_pr_autofix
         return 75
     fi
+    stop_mutation_group "$mutation_pid"
     return "$mutation_rc"
 }
 # lease-renewal:end


### PR DESCRIPTION
## Summary

`run_mutation_with_lease_monitor` had three exit paths that returned without calling `stop_mutation_group`. Under CPU contention, the monitoring loop's 50ms sleep could stretch beyond the child's 300ms window, allowing orphaned children to complete their mutations before the kill signal arrived.

## Root Cause

When the mutation process exited fast and `lease_renewal_failed` returned false at check time (scheduling race between file creation visibility and shell evaluation), the function returned the mutation's exit code without killing the process group. Any child spawned by the mutation continued running.

## Fix

Call `stop_mutation_group "$mutation_pid"` unconditionally before every `return "$mutation_rc"` in the function. Three paths are affected in both `.claude/commands/pr-autofix.md` and `src/copilot-cli/skills/pr-autofix/SKILL.md`.

## Verification

```console
uv run --frozen pytest tests/test_pr_autofix_late_live_state_gate.py -q
30 passed
```

Related test suites also pass: `test_pr_autofix_force_push_lease.py` (14 passed), `test_pr_autofix_worktree_identity.py` (20 passed).

Fixes #4926