### PR TITLE
fix(triage): require reproduction verification before closing with PR/commit citation

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-15-session-5021-closure-reproduction-gate.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-5021-closure-reproduction-gate.json
@@ -1,0 +1,66 @@
+{
+  "id": "episode-2026-08-15-session-5021-closure-reproduction-gate",
+  "session": "2026-08-15-session-5021-closure-reproduction-gate",
+  "timestamp": "2026-08-15T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Implement reproduction verification gate for issue #4624",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "reproduce",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-5021-closure-reproduction-gate"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "implement",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-5021-closure-reproduction-gate"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "test",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-5021-closure-reproduction-gate"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-15T06:14:29+00:00",
+      "type": "commit",
+      "content": "Commit: 287042d7bade7c3ef76de86edd74d61bbcf353e9",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-15-session-5021-closure-reproduction-gate"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/qa/pr-5021-closure-reproduction-gate.md
+++ b/.agents/qa/pr-5021-closure-reproduction-gate.md
@@ -1,0 +1,38 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-15-session-5021-closure-reproduction-gate.json
+qaCommit: 287042d7bade7c3ef76de86edd74d61bbcf353e9
+---
+
+# PR 5021 Closure Reproduction Gate QA Report
+
+## Scope
+
+Validates the reproduction_verified gate added to _apply_close (issue #4624).
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Defect reproduction on main | Confirmed: close succeeds without reproduction |
+| Negative test (PR cited, no reproduction) | SKIPPED with correct message |
+| Positive test (PR cited, reproduction verified) | APPLIED |
+| Edge test (no citation, no reproduction) | APPLIED (bypass correct) |
+| Dry-run gate | Blocks correctly in planning mode |
+| from_raw parsing (true) | Parsed correctly |
+| from_raw parsing (default) | Defaults to false |
+| from_raw parsing (non-bool) | Rejected, defaults to false |
+| Full test suite | 107 tests passed |
+| Ruff lint | All checks passed |
+| mypy type check | 0 errors on 3 source files |
+| Pre-PR validation | All validations passed |
+| Pre-push hooks | All passed including python-tests (463.60s) |
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|---|---|
+| Open PR cited is refused | PASS (via PR #4716 verify_pr_merged) |
+| Merged PR not on main is refused | PASS (via PR #4716 ancestry check) |
+| Merged PR on main requires green reproduction | PASS (this PR) |
+| Refusal names PR state | PASS (via PR #4716) |

--- a/.agents/sessions/2026-08-15-session-5021-closure-reproduction-gate.json
+++ b/.agents/sessions/2026-08-15-session-5021-closure-reproduction-gate.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 5021,
+    "date": "2026-08-15",
+    "branch": "fix/closure-reproduction-gate",
+    "startingCommit": "333a80b74a",
+    "objective": "Implement reproduction verification gate for issue #4624"
+  },
+  "endingCommit": "287042d7bade7c3ef76de86edd74d61bbcf353e9",
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "SHOULD: implementer session; item not applicable"
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "SHOULD: implementer session; item not applicable"
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read HANDOFF.md, AGENTS.md, CLAUDE.md"
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Created 2026-08-15-session-5021-closure-reproduction-gate.json"
+      },
+      "skillScriptsListed": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "SHOULD: implementer session; item not applicable"
+      },
+      "usageMandatoryRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read AGENTS.md root and .agents/AGENT-INSTRUCTIONS.md"
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read project constraints from AGENTS.md"
+      },
+      "memoriesLoaded": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "SHOULD: implementer session; item not applicable"
+      },
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "fix/closure-reproduction-gate"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "On fix/closure-reproduction-gate"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "All items recorded"
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No handoff changes"
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "SHOULD: implementer session; item not applicable"
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No markdown changes in code commit"
+      },
+      "qaValidation": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/qa/pr-5021-closure-reproduction-gate.md"
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "All changes committed and pushed"
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "107 tests passed, ruff clean, mypy clean"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "reproduce",
+      "detail": "Confirmed defect: close succeeds without reproduction verification on current main"
+    },
+    {
+      "action": "implement",
+      "detail": "Added reproduction_verified field to ManifestAction and gate in _apply_close"
+    },
+    {
+      "action": "test",
+      "detail": "Added 8 tests in TestReproductionGate, updated existing scope-gate tests"
+    }
+  ],
+  "nextSteps": [],
+  "outcome": {
+    "status": "COMPLETE",
+    "summary": "Added reproduction_verified gate to _apply_close in triage_batch_apply.py",
+    "filesChanged": [
+      "scripts/triage_batch_apply.py",
+      "tests/test_triage_batch_apply.py",
+      "tests/test_triage_gateway.py"
+    ],
+    "testsAdded": 8,
+    "testsTotal": 107,
+    "testsPassed": true
+  }
+}

--- a/scripts/triage_batch_apply.py
+++ b/scripts/triage_batch_apply.py
@@ -92,6 +92,7 @@ class ManifestAction:
     rationale: str = ""
     labels: tuple[str, ...] = ()
     priority: str = ""
+    reproduction_verified: bool = False
 
     @classmethod
     def from_raw(cls, raw: object) -> ManifestAction | None:
@@ -116,12 +117,15 @@ class ManifestAction:
             if isinstance(labels_raw, list)
             else ()
         )
+        reproduction_raw = raw.get("reproduction_verified")
+        reproduction_verified = reproduction_raw is True
         return cls(
             issue=issue,
             category=category,
             rationale=str(raw.get("rationale") or ""),
             labels=labels,
             priority=str(raw.get("priority") or "").strip(),
+            reproduction_verified=reproduction_verified,
         )
 
 
@@ -287,10 +291,20 @@ def _apply_close(
             action.issue, action.category, OUTCOME_SKIPPED,
             f"close aborted: unverified {', '.join(unverified)}",
         )
-    # Unresolved-scope gate (#4625): if a human commented AFTER the fix
-    # evidence, the issue may have unaddressed scope. Block and report.
+    # Reproduction gate (#4624): a verified citation (PR merged on main, or
+    # commit exists) is necessary but not sufficient. The issue's falsifiable
+    # reproduction must have been run against main and passed. Without this,
+    # the campaign can close an issue whose defect is still reproducible.
     cited_prs = extract_pr_numbers(action.rationale)
     cited_shas = extract_commit_shas(action.rationale)
+    if (cited_prs or cited_shas) and not action.reproduction_verified:
+        return ActionOutcome(
+            action.issue, action.category, OUTCOME_SKIPPED,
+            "close aborted: reproduction not verified against main "
+            "(reproduction_verified must be true when citing a PR or commit)",
+        )
+    # Unresolved-scope gate (#4625): if a human commented AFTER the fix
+    # evidence, the issue may have unaddressed scope. Block and report.
     fix_ts: datetime.datetime | None = None
     for pr_num in cited_prs:
         fix_ts = gateway.get_pr_merge_time(pr_num)

--- a/tests/test_triage_batch_apply.py
+++ b/tests/test_triage_batch_apply.py
@@ -274,6 +274,7 @@ class TestCloseVerificationGate:
             issue=5,
             category=ACTION_CLOSE,
             rationale="resolved by commit abc1234",
+            reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_APPLIED
@@ -294,7 +295,10 @@ class TestCloseVerificationGate:
 
     def test_cited_merged_pr_proceeds(self):
         gw = FakeGateway({5: _open(5)}, merged_prs=frozenset({1024}))
-        action = ManifestAction(issue=5, category=ACTION_CLOSE, rationale="closed via PR #1024")
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE, rationale="closed via PR #1024",
+            reproduction_verified=True,
+        )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_APPLIED
         assert gw.closed == [5]
@@ -317,6 +321,82 @@ class TestCloseVerificationGate:
         outcome = apply_action(action, gw, mutate=False)
         assert outcome.outcome == OUTCOME_SKIPPED
         assert "unverified" in outcome.detail
+
+
+class TestReproductionGate:
+    """Issue #4624: a merged-on-main PR still requires a green reproduction."""
+
+    def test_cited_pr_without_reproduction_blocks_close(self):
+        gw = FakeGateway({5: _open(5)}, merged_prs=frozenset({1024}))
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE, rationale="closed via PR #1024",
+            reproduction_verified=False,
+        )
+        outcome = apply_action(action, gw, mutate=True)
+        assert outcome.outcome == OUTCOME_SKIPPED
+        assert "reproduction not verified" in outcome.detail
+        assert gw.closed == []
+
+    def test_cited_commit_without_reproduction_blocks_close(self):
+        gw = FakeGateway({5: _open(5)}, known_commits=frozenset({"abc1234"}))
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE,
+            rationale="resolved by commit abc1234",
+            reproduction_verified=False,
+        )
+        outcome = apply_action(action, gw, mutate=True)
+        assert outcome.outcome == OUTCOME_SKIPPED
+        assert "reproduction not verified" in outcome.detail
+        assert gw.closed == []
+
+    def test_cited_pr_with_reproduction_verified_proceeds(self):
+        gw = FakeGateway({5: _open(5)}, merged_prs=frozenset({1024}))
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE, rationale="closed via PR #1024",
+            reproduction_verified=True,
+        )
+        outcome = apply_action(action, gw, mutate=True)
+        assert outcome.outcome == OUTCOME_APPLIED
+        assert gw.closed == [5]
+
+    def test_no_citation_does_not_require_reproduction(self):
+        gw = FakeGateway({5: _open(5)})
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE,
+            rationale="stale, superseded by new design",
+            reproduction_verified=False,
+        )
+        outcome = apply_action(action, gw, mutate=True)
+        assert outcome.outcome == OUTCOME_APPLIED
+        assert gw.closed == [5]
+
+    def test_reproduction_gate_applies_in_dry_run(self):
+        gw = FakeGateway({5: _open(5)}, merged_prs=frozenset({99}))
+        action = ManifestAction(
+            issue=5, category=ACTION_CLOSE, rationale="fixed via PR #99",
+            reproduction_verified=False,
+        )
+        outcome = apply_action(action, gw, mutate=False)
+        assert outcome.outcome == OUTCOME_SKIPPED
+        assert "reproduction not verified" in outcome.detail
+
+    def test_from_raw_parses_reproduction_verified_true(self):
+        raw = {"issue": 1, "category": "close", "reproduction_verified": True}
+        action = ManifestAction.from_raw(raw)
+        assert action is not None
+        assert action.reproduction_verified is True
+
+    def test_from_raw_defaults_reproduction_verified_false(self):
+        raw = {"issue": 1, "category": "close"}
+        action = ManifestAction.from_raw(raw)
+        assert action is not None
+        assert action.reproduction_verified is False
+
+    def test_from_raw_rejects_non_bool_reproduction_verified(self):
+        raw = {"issue": 1, "category": "close", "reproduction_verified": "yes"}
+        action = ManifestAction.from_raw(raw)
+        assert action is not None
+        assert action.reproduction_verified is False
 
 
 class TestParseActions:
@@ -487,6 +567,7 @@ class TestCommitOnlyClosureScopeGate:
             issue=5,
             category=ACTION_CLOSE,
             rationale="resolved by commit abc1234",
+            reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_SKIPPED
@@ -500,6 +581,7 @@ class TestCommitOnlyClosureScopeGate:
             issue=5,
             category=ACTION_CLOSE,
             rationale="resolved by commit abc1234",
+            reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_SKIPPED

--- a/tests/test_triage_gateway.py
+++ b/tests/test_triage_gateway.py
@@ -218,7 +218,7 @@ class TestUnresolvedScopeWiring:
         gw._merge_times = {100: fix_time}
         action = ManifestAction(
             issue=5, category=ACTION_CLOSE,
-            rationale="Fixed via PR #100",
+            rationale="Fixed via PR #100", reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_SKIPPED
@@ -239,7 +239,7 @@ class TestUnresolvedScopeWiring:
         gw._merge_times = {100: fix_time}
         action = ManifestAction(
             issue=5, category=ACTION_CLOSE,
-            rationale="Fixed via PR #100",
+            rationale="Fixed via PR #100", reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_APPLIED
@@ -252,7 +252,7 @@ class TestUnresolvedScopeWiring:
         gw._merge_times = {100: fix_time}
         action = ManifestAction(
             issue=5, category=ACTION_CLOSE,
-            rationale="Fixed via PR #100",
+            rationale="Fixed via PR #100", reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_SKIPPED
@@ -284,7 +284,7 @@ class TestUnresolvedScopeWiring:
         gw._merge_times = {200: fix_time}
         action = ManifestAction(
             issue=7, category=ACTION_CLOSE,
-            rationale="Resolved via PR #200",
+            rationale="Resolved via PR #200", reproduction_verified=True,
         )
         outcome = apply_action(action, gw, mutate=True)
         assert outcome.outcome == OUTCOME_SKIPPED


### PR DESCRIPTION
## Summary

Implements the final acceptance criterion from issue #4624:

> A merged PR on main still requires a green reproduction.

PR #4716 (merged 2026-08-07) unified the `pr_is_merged` check and added
merge-commit ancestry verification. However, the closure path still allowed
closing an issue citing a merged-on-main PR without evidence that the defect
was actually fixed on main. A PR can merge while the underlying problem
persists (wrong scope, partial fix, regression in a sibling path).

## Changes

**`scripts/triage_batch_apply.py`**: Add `reproduction_verified: bool` field
to `ManifestAction`. In `_apply_close`, when the rationale cites a PR or
commit, block the close unless `reproduction_verified` is `true`. Non-citation
closes (stale, superseded) are unaffected.

**`tests/test_triage_batch_apply.py`**: Add `TestReproductionGate` class with
8 tests covering positive (verified passes), negative (unverified blocks),
edge (no citations bypass gate), dry-run, and `from_raw` parsing.

**`tests/test_triage_gateway.py`**: Update existing scope-gate wiring tests to
set `reproduction_verified=True` so they reach the scope gate (the new gate
fires first for citation-bearing actions).

## Reproduction of defect (on current main)

```python
# Before this fix: a close citing a merged PR succeeds without reproduction
action = ManifestAction(issue=3975, category='close', rationale='Fixed via PR #4716 (MERGED).')
result = _apply_close(action, FakeGW(), mutate=True)
assert result.outcome == 'applied'  # BUG: defect might still exist
```

After this fix the same action returns `skipped` with:
`close aborted: reproduction not verified against main`

## Acceptance criteria coverage

| Criterion | Implementation |
|-----------|---------------|
| Open PR cited → refused | `verify_pr_merged` (PR #4716) |
| Merged PR not on main → refused | ancestry check (PR #4716) |
| **Merged PR on main → requires green reproduction** | **This PR** |
| Refusal names PR state | `verify_pr_merged` (PR #4716) |

Fixes #4624