### PR TITLE
fix(doc-accuracy): skip unsupported code-example languages

### DIFF
--- a/.agents/qa/issue-4948-doc-accuracy-false-positives.md
+++ b/.agents/qa/issue-4948-doc-accuracy-false-positives.md
@@ -1,5 +1,5 @@
 ---
-qaCommit: 42c419a6883d5295098b48d00d114ddfb435b4f2
+qaCommit: f507b79f87150e27df3bdc7d986b589090f889e4
 qaSessionLog: .agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
 qaVerdict: PASS
 ---
@@ -8,25 +8,33 @@ qaVerdict: PASS
 
 ## Objective
 
-Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, and unmapped code claims.
+Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, unmapped code claims, and code examples in languages that have no `SYMBOL_EXTRACTORS` entry (Go, Rust, Java, and any future addition).
 
 ## Tests
 
 - `uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q`
-- `uv run ruff check .claude/skills/doc-accuracy/scripts/doc_accuracy.py src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
+- `uv run ruff check .claude/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
+- `uv run python build/scripts/build_all.py`
+- `diff .claude/skills/doc-accuracy/scripts/doc_accuracy.py src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py`
+- `uv run python build/scripts/build_all.py --check` (run after committing; run before a commit always reports the just-regenerated file as uncommitted drift, which is expected, not a defect)
 - Temp fixture reproduction with `doc_accuracy.py --target <tmp> --format summary --severity-threshold high`
 
 ## Results
 
 | Check | Result |
 |-------|--------|
-| Targeted pytest | PASS, 83 tests |
-| Ruff | PASS |
-| Reproduction before fix | FAIL, exit 10 with 2 claims and 8 high findings |
-| Reproduction after fix | PASS, exit 0 with 0 claims and 0 findings |
+| Targeted pytest | PASS, 96 tests (was 88 before this round; +8 for the Go/Rust/Java skip and every-supported-language coverage) |
+| Ruff (canonical script + tests) | PASS, "All checks passed!" |
+| `build_all.py` regeneration | PASS, mirror rewritten from canonical, `diff` reports no differences |
+| `build_all.py --check` (post-commit, clean tree) | PASS, exit 0, no staleness reported |
+| Reproduction before the original fix | FAIL, exit 10 with 2 claims and 8 high findings |
+| Reproduction after the original fix | PASS, exit 0 with 0 claims and 0 findings |
 
 ## Notes
 
-- Text fences and Mermaid fences no longer produce claims.
-- PowerShell claims are skipped by Phase 3 when loaded from cached artifacts.
-- Code example claims no longer inherit a fallback source file when no symbol matches.
+- Text fences, Mermaid fences, and PowerShell code examples are unaffected: none of those languages ever had a `SYMBOL_EXTRACTORS` entry, so the switch from the `NON_COMPILABLE_LANGUAGES` denylist to a `SYMBOL_EXTRACTORS`-based allowlist keeps skipping them.
+- `run_claim_extraction` (Phase 2) and `run_compilability_check` (Phase 3) both skip a `code_example` claim when its normalized language is not a key in `SYMBOL_EXTRACTORS` (`csharp`, `python`, `javascript`, `typescript` as of this commit). This closes the gap where Go, Rust, and Java fences were absent from both the old `NON_COMPILABLE_LANGUAGES` set and the old Phase 3 tuple, so their generic identifiers were checked against the Python/C#/JS/TS symbol index and could produce a false `unresolved_symbol` finding.
+- `method_signature` claims (which always carry `language=""`) are never skipped by this check; only `code_example` claims are gated on the fence language.
+- New tests: `test_skips_go_fences`, `test_skips_rust_fences`, `test_skips_java_fences` (Phase 2); `test_skips_go_code_examples`, `test_skips_rust_code_examples`, `test_skips_java_code_examples` (Phase 3); and one `test_resolves_symbol_extractor_languages` test per phase that loops over the live `mod.SYMBOL_EXTRACTORS` keys and asserts `csharp`, `python`, `javascript`, and `typescript` still resolve (Phase 2 still extracts the claim; Phase 3 still reaches the unresolved-symbol check instead of skipping).
+- Code example claims no longer inherit a fallback source file when no symbol matches (unchanged from the original fix).
+

--- a/.agents/qa/issue-4948-doc-accuracy-false-positives.md
+++ b/.agents/qa/issue-4948-doc-accuracy-false-positives.md
@@ -1,0 +1,32 @@
+---
+qaCommit: 42c419a6883d5295098b48d00d114ddfb435b4f2
+qaSessionLog: .agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+qaVerdict: PASS
+---
+
+# QA Report: Issue #4948 - Doc Accuracy False Positives
+
+## Objective
+
+Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, and unmapped code claims.
+
+## Tests
+
+- `uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q`
+- `uv run ruff check .claude/skills/doc-accuracy/scripts/doc_accuracy.py src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
+- Temp fixture reproduction with `doc_accuracy.py --target <tmp> --format summary --severity-threshold high`
+
+## Results
+
+| Check | Result |
+|-------|--------|
+| Targeted pytest | PASS, 83 tests |
+| Ruff | PASS |
+| Reproduction before fix | FAIL, exit 10 with 2 claims and 8 high findings |
+| Reproduction after fix | PASS, exit 0 with 0 claims and 0 findings |
+
+## Notes
+
+- Text fences and Mermaid fences no longer produce claims.
+- PowerShell claims are skipped by Phase 3 when loaded from cached artifacts.
+- Code example claims no longer inherit a fallback source file when no symbol matches.

--- a/.agents/qa/issue-4948-doc-accuracy-false-positives.md
+++ b/.agents/qa/issue-4948-doc-accuracy-false-positives.md
@@ -1,5 +1,5 @@
 ---
-qaCommit: f507b79f87150e27df3bdc7d986b589090f889e4
+qaCommit: aed5d0c14ded588ff6e46b9b43d91e6f2941fa2e
 qaSessionLog: .agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
 qaVerdict: PASS
 ---
@@ -8,7 +8,7 @@ qaVerdict: PASS
 
 ## Objective
 
-Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, unmapped code claims, and code examples in languages that have no `SYMBOL_EXTRACTORS` entry (Go, Rust, Java, and any future addition).
+Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, unmapped code claims, and code examples in languages that have no `SYMBOL_EXTRACTORS` entry (Go, Rust, Java, and any future addition). Also verify the follow-up fix for a regression where the fence-detection regex truncated `c#` to `c`, causing the new `SYMBOL_EXTRACTORS` allowlist to incorrectly skip common C# fences written as ` ```c#`.
 
 ## Tests
 
@@ -23,18 +23,22 @@ Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences
 
 | Check | Result |
 |-------|--------|
-| Targeted pytest | PASS, 96 tests (was 88 before this round; +8 for the Go/Rust/Java skip and every-supported-language coverage) |
+| Targeted pytest | PASS, 99 tests (was 96 after the Go/Rust/Java skip fix; +3 for the c# fence regression: one `_detect_language("c#")` alias pin, one extraction-phase regression test, one end-to-end extraction+compilability-check regression test) |
 | Ruff (canonical script + tests) | PASS, "All checks passed!" |
 | `build_all.py` regeneration | PASS, mirror rewritten from canonical, `diff` reports no differences |
 | `build_all.py --check` (post-commit, clean tree) | PASS, exit 0, no staleness reported |
 | Reproduction before the original fix | FAIL, exit 10 with 2 claims and 8 high findings |
 | Reproduction after the original fix | PASS, exit 0 with 0 claims and 0 findings |
+| Reproduction of the c# regression before the follow-up fix | FAIL, `run_claim_extraction` on a ` ```c#` fence returned `claims: []` (claim silently dropped) |
+| Reproduction of the c# regression after the follow-up fix | PASS, `run_claim_extraction` returns one `code_example` claim with `language == "csharp"` |
 
 ## Notes
 
 - Text fences, Mermaid fences, and PowerShell code examples are unaffected: none of those languages ever had a `SYMBOL_EXTRACTORS` entry, so the switch from the `NON_COMPILABLE_LANGUAGES` denylist to a `SYMBOL_EXTRACTORS`-based allowlist keeps skipping them.
 - `run_claim_extraction` (Phase 2) and `run_compilability_check` (Phase 3) both skip a `code_example` claim when its normalized language is not a key in `SYMBOL_EXTRACTORS` (`csharp`, `python`, `javascript`, `typescript` as of this commit). This closes the gap where Go, Rust, and Java fences were absent from both the old `NON_COMPILABLE_LANGUAGES` set and the old Phase 3 tuple, so their generic identifiers were checked against the Python/C#/JS/TS symbol index and could produce a false `unresolved_symbol` finding.
 - `method_signature` claims (which always carry `language=""`) are never skipped by this check; only `code_example` claims are gated on the fence language.
-- New tests: `test_skips_go_fences`, `test_skips_rust_fences`, `test_skips_java_fences` (Phase 2); `test_skips_go_code_examples`, `test_skips_rust_code_examples`, `test_skips_java_code_examples` (Phase 3); and one `test_resolves_symbol_extractor_languages` test per phase that loops over the live `mod.SYMBOL_EXTRACTORS` keys and asserts `csharp`, `python`, `javascript`, and `typescript` still resolve (Phase 2 still extracts the claim; Phase 3 still reaches the unresolved-symbol check instead of skipping).
+- New tests from the Go/Rust/Java skip fix: `test_skips_go_fences`, `test_skips_rust_fences`, `test_skips_java_fences` (Phase 2); `test_skips_go_code_examples`, `test_skips_rust_code_examples`, `test_skips_java_code_examples` (Phase 3); and one `test_resolves_symbol_extractor_languages` test per phase that loops over the live `mod.SYMBOL_EXTRACTORS` keys and asserts `csharp`, `python`, `javascript`, and `typescript` still resolve (Phase 2 still extracts the claim; Phase 3 still reaches the unresolved-symbol check instead of skipping).
 - Code example claims no longer inherit a fallback source file when no symbol matches (unchanged from the original fix).
+- **c# regression (follow-up fix)**: the fence-detection regex in `run_claim_extraction` captured the info string with `\w*`, which stops at the first non-word character. A ` ```c#` fence therefore passed only `"c"` to `_detect_language`, which has no alias for bare `"c"` (only `"cs"`/`"csharp"`/`"c#"` map to `"csharp"`), so `"c"` was returned unchanged and, having no `SYMBOL_EXTRACTORS` entry, every c# code example was silently skipped by the new allowlist. Fixed by broadening the capture group to `\S*`, which captures the full non-whitespace info-string token (`_detect_language` already tokenizes on whitespace via `.split()[0]`, so this is a no-op for any fence whose info string was already all word characters). `_count_code_blocks` has the same underlying character-class limitation (`^```\w*\s*$`) but is a Phase 1 statistics-only counter, not part of the compilability-gating logic that was the subject of the reported regression; left unchanged per "fix narrowly."
+- New tests from the c# regression fix: `TestDetectLanguage.test_c_sharp_hash_alias` (pins the pre-existing `"c#"` -> `"csharp"` `lang_map` entry so it cannot be silently removed), `TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence` (proves a ` ```c#` fence still produces a `code_example` claim with `language == "csharp"`, i.e., extraction is not skipped), and `TestRunCompilabilityCheck.test_checks_csharp_hash_alias_end_to_end` (runs the real `run_claim_extraction` output for a ` ```c#` fence through `run_compilability_check` and asserts an `unresolved_symbol` finding is produced, i.e., compilability resolution is not skipped either).
 

--- a/.agents/qa/issue-4948-doc-accuracy-false-positives.md
+++ b/.agents/qa/issue-4948-doc-accuracy-false-positives.md
@@ -1,5 +1,5 @@
 ---
-qaCommit: aed5d0c14ded588ff6e46b9b43d91e6f2941fa2e
+qaCommit: 425931199003776028bd4fcca3c006b7ddcf07e4
 qaSessionLog: .agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
 qaVerdict: PASS
 ---
@@ -8,29 +8,34 @@ qaVerdict: PASS
 
 ## Objective
 
-Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, unmapped code claims, and code examples in languages that have no `SYMBOL_EXTRACTORS` entry (Go, Rust, Java, and any future addition). Also verify the follow-up fix for a regression where the fence-detection regex truncated `c#` to `c`, causing the new `SYMBOL_EXTRACTORS` allowlist to incorrectly skip common C# fences written as ` ```c#`.
+Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences, PowerShell examples, unmapped code claims, and code examples in languages that have no `SYMBOL_EXTRACTORS` entry (Go, Rust, Java, and any future addition). Also verify the follow-up fix for a regression where the fence-detection regex truncated `c#` to `c`, causing the new `SYMBOL_EXTRACTORS` allowlist to incorrectly skip common C# fences written as ` ```c#`. Also verify the post-merge repair for a regression introduced by merging `origin/main` (PR #4956), which added a Phase 3 `DID_NOT_RUN` short-circuit that made 6 of this branch's own tests either fail or stop testing what they claimed.
 
 ## Tests
 
 - `uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q`
 - `uv run ruff check .claude/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
+- `uv run python scripts/validation/git_hook_policy.py mypy .claude/skills/doc-accuracy/scripts/doc_accuracy.py src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
 - `uv run python build/scripts/build_all.py`
 - `diff .claude/skills/doc-accuracy/scripts/doc_accuracy.py src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py`
 - `uv run python build/scripts/build_all.py --check` (run after committing; run before a commit always reports the just-regenerated file as uncommitted drift, which is expected, not a defect)
+- `uv run python scripts/validation/pre_pr.py --verbose` (full pre-PR validation suite, 51 checks)
 - Temp fixture reproduction with `doc_accuracy.py --target <tmp> --format summary --severity-threshold high`
 
 ## Results
 
 | Check | Result |
 |-------|--------|
-| Targeted pytest | PASS, 99 tests (was 96 after the Go/Rust/Java skip fix; +3 for the c# fence regression: one `_detect_language("c#")` alias pin, one extraction-phase regression test, one end-to-end extraction+compilability-check regression test) |
+| Targeted pytest | PASS, 105 tests (was 99 after the c# fence fix; merging `origin/main` (PR #4956) added 7 new test functions -- `test_exit_code_documentation_covers_the_cli_contract`, `test_does_not_run_without_source_symbols`, `test_does_not_run_without_source_symbols_or_claims`, `test_did_not_run_is_inconclusive`, `test_includes_did_not_run_reason`, `test_scan_docs_only_repo_is_inconclusive`, `test_scan_with_unresolved_symbol_fails` -- and removed 1 (`test_scan_empty_repo`, superseded by the docs-only-repo coverage), a net of +6; verified via `git diff 64773a8316 5e9da768e -- tests/skills/doc-accuracy/test_doc_accuracy.py`) |
 | Ruff (canonical script + tests) | PASS, "All checks passed!" |
+| Mypy changed-files gate (`git_hook_policy.py mypy`) | PASS, "Success: no issues found" on all 3 files |
 | `build_all.py` regeneration | PASS, mirror rewritten from canonical, `diff` reports no differences |
 | `build_all.py --check` (post-commit, clean tree) | PASS, exit 0, no staleness reported |
+| Full `pre_pr.py --verbose` (post-commit) | PASS, 51/51 validations green, including the whole-repo/merge-tree ruff count ratchet |
 | Reproduction before the original fix | FAIL, exit 10 with 2 claims and 8 high findings |
 | Reproduction after the original fix | PASS, exit 0 with 0 claims and 0 findings |
 | Reproduction of the c# regression before the follow-up fix | FAIL, `run_claim_extraction` on a ` ```c#` fence returned `claims: []` (claim silently dropped) |
 | Reproduction of the c# regression after the follow-up fix | PASS, `run_claim_extraction` returns one `code_example` claim with `language == "csharp"` |
+| Post-merge repro: skip logic disabled + old (empty `source_symbols`) skip tests | Before this round's fix, `test_skips_go/rust/java/powershell_code_examples` passed vacuously (Phase 3 short-circuited to `DID_NOT_RUN` regardless of the skip logic); after adding a non-matching `source_symbols` entry and asserting `status == "COMPLETED"`, temporarily disabling the SYMBOL_EXTRACTORS skip check made all four fail as expected, confirming the tests are now diagnostic |
 
 ## Notes
 
@@ -41,4 +46,7 @@ Verify the fix for `doc-accuracy` false positives on text fences, Mermaid fences
 - Code example claims no longer inherit a fallback source file when no symbol matches (unchanged from the original fix).
 - **c# regression (follow-up fix)**: the fence-detection regex in `run_claim_extraction` captured the info string with `\w*`, which stops at the first non-word character. A ` ```c#` fence therefore passed only `"c"` to `_detect_language`, which has no alias for bare `"c"` (only `"cs"`/`"csharp"`/`"c#"` map to `"csharp"`), so `"c"` was returned unchanged and, having no `SYMBOL_EXTRACTORS` entry, every c# code example was silently skipped by the new allowlist. Fixed by broadening the capture group to `\S*`, which captures the full non-whitespace info-string token (`_detect_language` already tokenizes on whitespace via `.split()[0]`, so this is a no-op for any fence whose info string was already all word characters). `_count_code_blocks` has the same underlying character-class limitation (`^```\w*\s*$`) but is a Phase 1 statistics-only counter, not part of the compilability-gating logic that was the subject of the reported regression; left unchanged per "fix narrowly."
 - New tests from the c# regression fix: `TestDetectLanguage.test_c_sharp_hash_alias` (pins the pre-existing `"c#"` -> `"csharp"` `lang_map` entry so it cannot be silently removed), `TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence` (proves a ` ```c#` fence still produces a `code_example` claim with `language == "csharp"`, i.e., extraction is not skipped), and `TestRunCompilabilityCheck.test_checks_csharp_hash_alias_end_to_end` (runs the real `run_claim_extraction` output for a ` ```c#` fence through `run_compilability_check` and asserts an `unresolved_symbol` finding is produced, i.e., compilability resolution is not skipped either).
+- **Post-merge repair**: merging `origin/main` brought in PR #4956 (`fix(doc-accuracy): handle docs-only targets`), which changed `run_compilability_check` to return `{"status": "DID_NOT_RUN", "findings": [], "reason": ...}` immediately whenever `assessment["source_symbols"]` is empty, rather than reaching the per-claim loop at all. Six of this branch's `TestRunCompilabilityCheck` tests built `assessment = {"source_symbols": []}` intentionally, to prove an unresolvable identifier still produces a finding without any real codebase to check against. After the merge, that empty list instead triggers the new short-circuit before the SYMBOL_EXTRACTORS gate ever runs: `test_resolves_symbol_extractor_languages` and `test_checks_csharp_hash_alias_end_to_end` failed outright (expected 1 finding, got 0), while `test_skips_powershell_code_examples`, `test_skips_go_code_examples`, `test_skips_rust_code_examples`, and `test_skips_java_code_examples` kept passing but became vacuous: they would have passed even with the SYMBOL_EXTRACTORS skip logic deleted entirely, since Phase 3 never reached it. Fixed by giving each of these 6 tests a `source_symbols` entry named `"UnrelatedPlaceholder"` (never referenced by any claim in that test, so it cannot resolve anything) so Phase 3 reaches `status == "COMPLETED"`, and asserting that status explicitly in every one of the 6 tests. Confirmed the fix is not vacuous itself by temporarily disabling the SYMBOL_EXTRACTORS skip check in the canonical script and re-running only these tests: all 4 skip tests failed as expected (they would have passed before this fix), then the mutation was reverted (`git diff` on the canonical script was empty afterward).
+- **Post-merge repair, missing import**: the merge also dropped `from typing import Any` from the test file. Upstream's own two rewritten `DID_NOT_RUN`-adjacent tests stopped needing `Any` (they moved to un-annotated `assessment = {...}` literals), so PR #4956 removed the import along with its own two usages, but this branch's remaining `assessment: dict[str, Any] = {...}` annotations (in the 6 tests above, before they were fixed, and in the parametrized/end-to-end tests) still needed it. This produced exactly 6 F821 ("Undefined name `Any`") errors under `ruff check`, matching the 6 remaining `dict[str, Any]` annotations. Restored the import in sorted position (`pathlib` -> `typing` -> `unittest.mock`).
+- **Post-merge repair, whole-repo ruff count ratchet**: `scripts/validation/pre_pr.py`'s merge-tree ratchet check (`scripts/ci/merge_tree_ratchet_check.py`) materializes `git merge-tree --write-tree origin/main HEAD` into a scratch checkout and re-runs the whole-repo ruff count ratchet there; `origin/main` had advanced two more commits (`333a80b74`, `c387d7b36`) past the tip this branch had already merged, so the check re-evaluated against the newest `origin/main`. Reproduced the reported "33 > baseline 27 (+6)" regression manually via `git archive` on the merge-tree OID; the 6 extra violations were exactly the 6 F821 ("Undefined name `Any`") errors above (same file, same line numbers), present because the merge-tree evaluation reads committed history, not the uncommitted working-tree fix. The regression cleared on its own once the `Any`-import fix was committed: the merge-tree ratchet check and the full `pre_pr.py --verbose` run both went green afterward with no further code change.
 

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits. Resumed in a later session to close the Go/Rust/Java gap: fix commit f507b79f8 replaced the NON_COMPILABLE_LANGUAGES/tuple denylists with a SYMBOL_EXTRACTORS-based allowlist. Resumed again after a Sol review found the allowlist regressed ```c# fences (fence regex truncated 'c#' to 'c'): fix commit aed5d0c14 broadened the capture group to \\S*; this commit records that SHA in endingCommit and corrects the QA evidence."
+        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits. Resumed in a later session to close the Go/Rust/Java gap: fix commit f507b79f8 replaced the NON_COMPILABLE_LANGUAGES/tuple denylists with a SYMBOL_EXTRACTORS-based allowlist. Resumed again after a Sol review found the allowlist regressed ```c# fences (fence regex truncated 'c#' to 'c'): fix commit aed5d0c14 broadened the capture group to \\S*. Resumed again after merging origin/main (merge commit d94d62f6d) exposed 2 test failures and 4 silently-vacuous tests via PR #4956's new Phase 3 DID_NOT_RUN short-circuit, plus 6 F821 Any errors from a dropped import: fix commit 425931199 repairs all 6 affected tests and restores the import; this commit records that SHA in endingCommit and corrects the QA evidence."
       },
       "validationPassed": {
         "level": "MUST",
@@ -163,9 +163,29 @@
     {
       "action": "Re-ran the full targeted validation loop after the c# fix: uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q, uv run ruff check on the canonical script and the test file, uv run python build/scripts/build_all.py to regenerate the Copilot mirror, a byte-for-byte diff of the canonical script against the regenerated mirror, and uv run python build/scripts/build_all.py --check after committing.",
       "outcome": "99 tests passed (up from 96 before this round), ruff reported no issues, the regenerated mirror was byte-identical to canonical, and --check exited 0 with no staleness once the fix commit (aed5d0c14) was in place."
+    },
+    {
+      "action": "Resumed after origin/main was merged into this branch (merge commit d94d62f6d, pulling in PR #4956 'fix(doc-accuracy): handle docs-only targets'). Ran the targeted suite and found 105 collected with 2 failures: test_resolves_symbol_extractor_languages and test_checks_csharp_hash_alias_end_to_end both expected one unresolved_symbol finding but got zero.",
+      "outcome": "Read the merged run_compilability_check and found PR #4956 added a status='DID_NOT_RUN' short-circuit that returns immediately with findings=[] whenever assessment['source_symbols'] is empty; both failing tests (and, silently, 4 sibling skip tests) built assessment={'source_symbols': []}, so Phase 3 never reached the SYMBOL_EXTRACTORS gate at all."
+    },
+    {
+      "action": "Gave all 6 affected TestRunCompilabilityCheck tests (test_skips_powershell_code_examples, test_skips_go_code_examples, test_skips_rust_code_examples, test_skips_java_code_examples, test_resolves_symbol_extractor_languages, test_checks_csharp_hash_alias_end_to_end) a source_symbols entry named UnrelatedPlaceholder that never matches any symbol referenced in that test, and added an explicit status == 'COMPLETED' assertion to each, per the mirror obligation to close the inverse (sibling skip tests were passing vacuously, not just the two named failures).",
+      "outcome": "Verified the fix is not itself vacuous: temporarily disabled the SYMBOL_EXTRACTORS skip check in the canonical script and reran the 5 skip/resolve tests -- all 4 skip tests failed as expected (they passed before this fix) -- then restored the canonical script from a backup and confirmed git diff on it was empty."
+    },
+    {
+      "action": "Found and fixed 6 F821 'Undefined name Any' ruff errors: the merge dropped 'from typing import Any' from the test file (upstream's own rewritten tests stopped needing it) while this branch's remaining dict[str, Any] annotations still needed it. Restored the import in sorted position (pathlib -> typing -> unittest.mock).",
+      "outcome": "uv run ruff check on the canonical script and test file returned 'All checks passed!'. uv run python scripts/validation/git_hook_policy.py mypy on the 3 changed files returned 'Success: no issues found' for each."
+    },
+    {
+      "action": "During investigation, an ad hoc `git read-tree <merge-tree-oid>` (run without an isolated GIT_INDEX_FILE, to inspect the merge-tree ratchet's scratch materialization) replaced this worktree's real index, producing ~20 spurious MM/AD entries in `git status` against unrelated upstream files. Caught this before committing by inspecting file content (md5sum matched HEAD) rather than trusting git status, then ran `git reset` (no path, no --hard) to restore the index to HEAD while preserving the real working-tree edit.",
+      "outcome": "Confirmed via `git fsck` (clean) and `git diff --stat` (only tests/skills/doc-accuracy/test_doc_accuracy.py) that the working tree and repository were not damaged; re-ran pytest and ruff to reconfirm green before committing."
+    },
+    {
+      "action": "Committed the post-merge test repair (single file, tests/skills/doc-accuracy/test_doc_accuracy.py), then ran the full uv run python scripts/validation/pre_pr.py --verbose (51 checks).",
+      "outcome": "Before this commit, pre_pr reported 2 failures: Count Ratchets (whole-repo ruff count ratchet regression, 33 > baseline 27 via the merge-tree materialization, reproduced manually with git archive and confirmed the 6 extra violations were the same 6 F821 Any errors) and Session End Validation (QA stale, expected until QA/session evidence is updated). After the commit, Count Ratchets passed (the merge-tree evaluation reads committed history, so committing the Any-import fix cleared it); only Session End Validation remained failing, exactly the expected state pending this QA/session evidence update."
     }
   ],
-  "endingCommit": "aed5d0c14",
+  "endingCommit": "425931199",
   "nextSteps": [
     "None."
   ]

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -39,6 +39,11 @@
         "Complete": true,
         "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md and path-scoped rules for Python, testing, code quality, and canonical source mirroring."
       },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .serena/memories/usage-mandatory.md and used the skill-first convention for repository operations."
+      },
       "memoriesLoaded": {
         "level": "MUST",
         "Complete": true,
@@ -68,53 +73,53 @@
     "sessionEnd": {
       "checklistComplete": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Session start, implementation, validation, memory update, and commit steps are recorded."
       },
       "handoffPreserved": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read only and not modified."
       },
       "serenaMemoryUpdated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "project/doc-accuracy/issue-4948-false-positives written."
       },
       "markdownLintRun": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "No markdown files changed in this fix, so no markdownlint autofix was needed."
       },
       "qaValidation": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/qa/issue-4948-doc-accuracy-false-positives.md"
       },
       "changesCommitted": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Initial fix commit 42c419a68 created; this follow-up session-log commit records the ending SHA."
       },
       "validationPassed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/qa/issue-4948-doc-accuracy-false-positives.md"
       },
       "tasksUpdated": {
         "level": "SHOULD",
         "Complete": false,
-        "Evidence": ""
+        "Evidence": "No follow-up task tracking change was needed for this one-issue fix."
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
         "Complete": false,
-        "Evidence": ""
+        "Evidence": "Not needed for this small scoped fix."
       },
       "reworkWarning": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "rework-warning: none"
       }
     }
   },
@@ -130,12 +135,14 @@
     {
       "action": "Created the external worktree and feature branch.",
       "outcome": "/home/richard/worktrees/ai-agents/issue-4948-2 on fix/4948-doc-accuracy-false-positives."
+    },
+    {
+      "action": "Validated the fix with targeted tests and direct reproduction.",
+      "outcome": "pytest passed, ruff passed, and the issue reproduction returned exit 0 with no findings."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "42c419a68",
   "nextSteps": [
-    "Patch doc_accuracy.py and the matching generated mirror.",
-    "Add regression tests for text, PowerShell, and unmapped claim behavior.",
-    "Run targeted pytest and script validation before committing."
+    "None."
   ]
 }

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits. Resumed in a later session to close the Go/Rust/Java gap: fix commit f507b79f8 replaced the NON_COMPILABLE_LANGUAGES/tuple denylists with a SYMBOL_EXTRACTORS-based allowlist; this commit records that SHA in endingCommit and corrects the QA evidence."
+        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits. Resumed in a later session to close the Go/Rust/Java gap: fix commit f507b79f8 replaced the NON_COMPILABLE_LANGUAGES/tuple denylists with a SYMBOL_EXTRACTORS-based allowlist. Resumed again after a Sol review found the allowlist regressed ```c# fences (fence regex truncated 'c#' to 'c'): fix commit aed5d0c14 broadened the capture group to \\S*; this commit records that SHA in endingCommit and corrects the QA evidence."
       },
       "validationPassed": {
         "level": "MUST",
@@ -151,9 +151,21 @@
     {
       "action": "Ran the full targeted validation loop: uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q, uv run ruff check on the canonical script and the test file, uv run python build/scripts/build_all.py to regenerate the Copilot mirror, a byte-for-byte diff of the canonical script against the regenerated mirror, and uv run python build/scripts/build_all.py --check after committing.",
       "outcome": "96 tests passed (up from 88 before this round), ruff reported no issues, the regenerated mirror was byte-identical to canonical, and --check exited 0 with no staleness once the fix commit (f507b79f8) was in place. Running --check before that commit correctly reports the file as uncommitted drift; that is expected pre-commit behavior, not a defect."
+    },
+    {
+      "action": "Investigated a Sol review finding that the SYMBOL_EXTRACTORS allowlist regresses ```c# fences. Reproduced with re.match(r'^```(\\w*)', '```c#') capturing only 'c', then confirmed _detect_language('c') returns 'c' unchanged (lang_map has 'cs'/'csharp'/'c#' -> 'csharp' but no bare 'c' alias), and 'c' is not a SYMBOL_EXTRACTORS key, so the new Phase 2 allowlist silently dropped every ```c# code example.",
+      "outcome": "Confirmed run_claim_extraction on a markdown fixture with a ```c# fence returned claims: [] before the fix, reproducing the exact regression the reviewer reported."
+    },
+    {
+      "action": "Broadened the fence-detection regex capture group in run_claim_extraction from \\w* to \\S* so the full 'c#' info-string token reaches _detect_language intact (which already tokenizes on whitespace via .split()[0], so this is a no-op for word-only info strings). Left _count_code_blocks's separate \\w* regex untouched: it is a Phase 1 statistics-only counter, not part of the compilability-gating logic the reviewer flagged.",
+      "outcome": "Added TestDetectLanguage.test_c_sharp_hash_alias (pins the pre-existing 'c#' -> 'csharp' lang_map entry), TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence (proves a ```c# fence still produces a code_example claim with language == 'csharp'), and TestRunCompilabilityCheck.test_checks_csharp_hash_alias_end_to_end (chains real run_claim_extraction output for a ```c# fence into run_compilability_check and asserts an unresolved_symbol finding, proving Phase 3 does not skip it either)."
+    },
+    {
+      "action": "Re-ran the full targeted validation loop after the c# fix: uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q, uv run ruff check on the canonical script and the test file, uv run python build/scripts/build_all.py to regenerate the Copilot mirror, a byte-for-byte diff of the canonical script against the regenerated mirror, and uv run python build/scripts/build_all.py --check after committing.",
+      "outcome": "99 tests passed (up from 96 before this round), ruff reported no issues, the regenerated mirror was byte-identical to canonical, and --check exited 0 with no staleness once the fix commit (aed5d0c14) was in place."
     }
   ],
-  "endingCommit": "f507b79f8",
+  "endingCommit": "aed5d0c14",
   "nextSteps": [
     "None."
   ]

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits."
+        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits. Resumed in a later session to close the Go/Rust/Java gap: fix commit f507b79f8 replaced the NON_COMPILABLE_LANGUAGES/tuple denylists with a SYMBOL_EXTRACTORS-based allowlist; this commit records that SHA in endingCommit and corrects the QA evidence."
       },
       "validationPassed": {
         "level": "MUST",
@@ -139,9 +139,21 @@
     {
       "action": "Validated the fix with targeted tests and direct reproduction.",
       "outcome": "pytest passed, ruff passed, and the issue reproduction returned exit 0 with no findings."
+    },
+    {
+      "action": "Resumed the session: audited the NON_COMPILABLE_LANGUAGES denylist and the separate Phase 3 language tuple against SOURCE_EXTENSIONS and found Go, Rust, and Java fences were absent from both, so those languages were still checked for compilability with no symbol extractor to verify against.",
+      "outcome": "Confirmed the gap by reading .claude/skills/doc-accuracy/scripts/doc_accuracy.py: SYMBOL_EXTRACTORS only has csharp, python, javascript, and typescript, but go/rust/java were missing from NON_COMPILABLE_LANGUAGES and from the bash/yaml/json/xml/markdown tuple in run_compilability_check."
+    },
+    {
+      "action": "Replaced both denylist checks in run_claim_extraction (Phase 2) and run_compilability_check (Phase 3) with a single `lang not in SYMBOL_EXTRACTORS` check, and removed the now-unused NON_COMPILABLE_LANGUAGES constant.",
+      "outcome": "Added test_skips_go_fences, test_skips_rust_fences, test_skips_java_fences, test_skips_go_code_examples, test_skips_rust_code_examples, and test_skips_java_code_examples, plus one test_resolves_symbol_extractor_languages per phase parametrized over the live mod.SYMBOL_EXTRACTORS keys. Existing text/mermaid/powershell skip tests kept passing unchanged."
+    },
+    {
+      "action": "Ran the full targeted validation loop: uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q, uv run ruff check on the canonical script and the test file, uv run python build/scripts/build_all.py to regenerate the Copilot mirror, a byte-for-byte diff of the canonical script against the regenerated mirror, and uv run python build/scripts/build_all.py --check after committing.",
+      "outcome": "96 tests passed (up from 88 before this round), ruff reported no issues, the regenerated mirror was byte-identical to canonical, and --check exited 0 with no staleness once the fix commit (f507b79f8) was in place. Running --check before that commit correctly reports the file as uncommitted drift; that is expected pre-commit behavior, not a defect."
     }
   ],
-  "endingCommit": "42c419a68",
+  "endingCommit": "f507b79f8",
   "nextSteps": [
     "None."
   ]

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -89,7 +89,7 @@
       "markdownLintRun": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "No markdown files changed in this fix, so no markdownlint autofix was needed."
+        "Evidence": "npx markdownlint-cli2 .agents/qa/issue-4948-doc-accuracy-false-positives.md returned 0 files because .agents/** is excluded."
       },
       "qaValidation": {
         "level": "MUST",
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Initial fix commit 42c419a68 created; this follow-up session-log commit records the ending SHA."
+        "Evidence": "Initial fix commit 42c419a68 created; session-log metadata was finalized in follow-up commits."
       },
       "validationPassed": {
         "level": "MUST",

--- a/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
+++ b/.agents/sessions/2026-08-14-session-14711-fix-4948-doc-accuracy-false-positives.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14711,
+    "date": "2026-08-14",
+    "branch": "fix/4948-doc-accuracy-false-positives",
+    "startingCommit": "64773a8316d8c033035d7245c0506357f35abb12",
+    "objective": "Fix doc-accuracy false positives for text fences and PowerShell examples"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read Serena instructions manual in this session."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md, CLAUDE.md, .agents/AGENT-INSTRUCTIONS.md, .agents/CLAUDE.md, .agents/HANDOFF.md, and .agents/SESSION-PROTOCOL.md."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md as read-only reference."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/skills/doc-accuracy/SKILL.md."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md and path-scoped rules for Python, testing, code quality, and canonical source mirroring."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No relevant doc-accuracy memory existed in Serena; listed topic lookups returned empty."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4948-doc-accuracy-false-positives"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Worktree branch is fix/4948-doc-accuracy-false-positives, created from origin/main."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Worktree created clean from origin/main before edits."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "64773a8316d8c033035d7245c0506357f35abb12"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Read issue #4948 body and comments.",
+      "outcome": "Confirmed the bug report and the generated PRD comment."
+    },
+    {
+      "action": "Reproduced the false positives with a temporary Markdown fixture.",
+      "outcome": "doc_accuracy.py returned exit 10 with 2 claims and 8 high-severity findings."
+    },
+    {
+      "action": "Created the external worktree and feature branch.",
+      "outcome": "/home/richard/worktrees/ai-agents/issue-4948-2 on fix/4948-doc-accuracy-false-positives."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Patch doc_accuracy.py and the matching generated mirror.",
+    "Add regression tests for text, PowerShell, and unmapped claim behavior.",
+    "Run targeted pytest and script validation before committing."
+  ]
+}

--- a/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -816,8 +816,18 @@ def run_claim_extraction(
         while i < len(lines):
             line = lines[i]
 
-            # Detect fenced code blocks
-            fence_match = re.match(r"^```(\w*)", line)
+            # Detect fenced code blocks. The info string is captured with
+            # \S* rather than \w*: a fence like ```c# has a language token
+            # containing a non-word character, and _detect_language's
+            # lang_map (defined above, in this file) maps that exact token
+            # ("c#") to "csharp". \w* stops before the "#" and passes only
+            # "c", which lang_map does not recognize, so the claim was
+            # silently dropped by the SYMBOL_EXTRACTORS allowlist below.
+            # _detect_language already tokenizes on whitespace via
+            # .split()[0], so widening the capture to non-whitespace does
+            # not change behavior for any fence whose info string was
+            # already all word characters.
+            fence_match = re.match(r"^```(\S*)", line)
             if fence_match:
                 lang = _detect_language(fence_match.group(1))
                 block_start = i + 1

--- a/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -162,26 +162,6 @@ EXCLUDE_DIRS = {
     ".doc-accuracy",
 }
 
-NON_COMPILABLE_LANGUAGES = frozenset({
-    "text",
-    "plaintext",
-    "txt",
-    "ascii",
-    "mermaid",
-    "diff",
-    "log",
-    "output",
-    "console",
-    "csv",
-    "ini",
-    "toml",
-    "conf",
-    "nolang",
-    "powershell",
-    "ps1",
-    "pwsh",
-})
-
 _GIT_TIMEOUT = 60  # seconds, applied to every git subprocess call
 
 # Environment variables that can redirect git to a foreign repository,
@@ -852,7 +832,15 @@ def run_claim_extraction(
                     i += 1
                     continue
 
-                if lang in NON_COMPILABLE_LANGUAGES:
+                # A code_example claim is only useful when Phase 3 can check
+                # its identifiers against real source symbols. Phase 1 only
+                # extracts source_symbols for languages in SYMBOL_EXTRACTORS
+                # (currently csharp, python, javascript, typescript), so any
+                # other normalized language, prose fences (text, mermaid),
+                # shell/config fences (bash, yaml, json), and languages Phase 1
+                # never parses for symbols (go, rust, java) have nothing to
+                # verify against and are skipped here.
+                if lang not in SYMBOL_EXTRACTORS:
                     i += 1
                     continue
 
@@ -966,10 +954,13 @@ def run_compilability_check(
         content = claim_dict["content"]
         lang = claim_dict.get("language", "")
 
-        # Skip non-code languages
-        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", "") or lang in NON_COMPILABLE_LANGUAGES:
-            if claim_dict["type"] == "code_example":
-                continue
+        # A code_example claim can only be checked for compilability when its
+        # normalized language has a symbol extractor (Phase 1 only populates
+        # source_symbols for SYMBOL_EXTRACTORS keys). method_signature claims
+        # carry language="" but are never skipped here: their content came
+        # from prose, not a fence, so there is no fence language to gate on.
+        if lang not in SYMBOL_EXTRACTORS and claim_dict["type"] == "code_example":
+            continue
 
         symbols_ref = claim_dict.get("symbols_referenced", [])
         if not symbols_ref:

--- a/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/.claude/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -162,6 +162,26 @@ EXCLUDE_DIRS = {
     ".doc-accuracy",
 }
 
+NON_COMPILABLE_LANGUAGES = frozenset({
+    "text",
+    "plaintext",
+    "txt",
+    "ascii",
+    "mermaid",
+    "diff",
+    "log",
+    "output",
+    "console",
+    "csv",
+    "ini",
+    "toml",
+    "conf",
+    "nolang",
+    "powershell",
+    "ps1",
+    "pwsh",
+})
+
 _GIT_TIMEOUT = 60  # seconds, applied to every git subprocess call
 
 # Environment variables that can redirect git to a foreign repository,
@@ -832,9 +852,13 @@ def run_claim_extraction(
                     i += 1
                     continue
 
+                if lang in NON_COMPILABLE_LANGUAGES:
+                    i += 1
+                    continue
+
                 identifiers = _extract_identifiers(code_content)
                 # Map identifiers to source files
-                mapped = default_source
+                mapped = ""
                 for ident in identifiers:
                     if ident in symbol_to_source:
                         mapped = symbol_to_source[ident]
@@ -943,7 +967,7 @@ def run_compilability_check(
         lang = claim_dict.get("language", "")
 
         # Skip non-code languages
-        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", ""):
+        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", "") or lang in NON_COMPILABLE_LANGUAGES:
             if claim_dict["type"] == "code_example":
                 continue
 

--- a/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -816,8 +816,18 @@ def run_claim_extraction(
         while i < len(lines):
             line = lines[i]
 
-            # Detect fenced code blocks
-            fence_match = re.match(r"^```(\w*)", line)
+            # Detect fenced code blocks. The info string is captured with
+            # \S* rather than \w*: a fence like ```c# has a language token
+            # containing a non-word character, and _detect_language's
+            # lang_map (defined above, in this file) maps that exact token
+            # ("c#") to "csharp". \w* stops before the "#" and passes only
+            # "c", which lang_map does not recognize, so the claim was
+            # silently dropped by the SYMBOL_EXTRACTORS allowlist below.
+            # _detect_language already tokenizes on whitespace via
+            # .split()[0], so widening the capture to non-whitespace does
+            # not change behavior for any fence whose info string was
+            # already all word characters.
+            fence_match = re.match(r"^```(\S*)", line)
             if fence_match:
                 lang = _detect_language(fence_match.group(1))
                 block_start = i + 1

--- a/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -162,26 +162,6 @@ EXCLUDE_DIRS = {
     ".doc-accuracy",
 }
 
-NON_COMPILABLE_LANGUAGES = frozenset({
-    "text",
-    "plaintext",
-    "txt",
-    "ascii",
-    "mermaid",
-    "diff",
-    "log",
-    "output",
-    "console",
-    "csv",
-    "ini",
-    "toml",
-    "conf",
-    "nolang",
-    "powershell",
-    "ps1",
-    "pwsh",
-})
-
 _GIT_TIMEOUT = 60  # seconds, applied to every git subprocess call
 
 # Environment variables that can redirect git to a foreign repository,
@@ -852,7 +832,15 @@ def run_claim_extraction(
                     i += 1
                     continue
 
-                if lang in NON_COMPILABLE_LANGUAGES:
+                # A code_example claim is only useful when Phase 3 can check
+                # its identifiers against real source symbols. Phase 1 only
+                # extracts source_symbols for languages in SYMBOL_EXTRACTORS
+                # (currently csharp, python, javascript, typescript), so any
+                # other normalized language, prose fences (text, mermaid),
+                # shell/config fences (bash, yaml, json), and languages Phase 1
+                # never parses for symbols (go, rust, java) have nothing to
+                # verify against and are skipped here.
+                if lang not in SYMBOL_EXTRACTORS:
                     i += 1
                     continue
 
@@ -966,10 +954,13 @@ def run_compilability_check(
         content = claim_dict["content"]
         lang = claim_dict.get("language", "")
 
-        # Skip non-code languages
-        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", "") or lang in NON_COMPILABLE_LANGUAGES:
-            if claim_dict["type"] == "code_example":
-                continue
+        # A code_example claim can only be checked for compilability when its
+        # normalized language has a symbol extractor (Phase 1 only populates
+        # source_symbols for SYMBOL_EXTRACTORS keys). method_signature claims
+        # carry language="" but are never skipped here: their content came
+        # from prose, not a fence, so there is no fence language to gate on.
+        if lang not in SYMBOL_EXTRACTORS and claim_dict["type"] == "code_example":
+            continue
 
         symbols_ref = claim_dict.get("symbols_referenced", [])
         if not symbols_ref:

--- a/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
+++ b/src/copilot-cli/skills/doc-accuracy/scripts/doc_accuracy.py
@@ -162,6 +162,26 @@ EXCLUDE_DIRS = {
     ".doc-accuracy",
 }
 
+NON_COMPILABLE_LANGUAGES = frozenset({
+    "text",
+    "plaintext",
+    "txt",
+    "ascii",
+    "mermaid",
+    "diff",
+    "log",
+    "output",
+    "console",
+    "csv",
+    "ini",
+    "toml",
+    "conf",
+    "nolang",
+    "powershell",
+    "ps1",
+    "pwsh",
+})
+
 _GIT_TIMEOUT = 60  # seconds, applied to every git subprocess call
 
 # Environment variables that can redirect git to a foreign repository,
@@ -832,9 +852,13 @@ def run_claim_extraction(
                     i += 1
                     continue
 
+                if lang in NON_COMPILABLE_LANGUAGES:
+                    i += 1
+                    continue
+
                 identifiers = _extract_identifiers(code_content)
                 # Map identifiers to source files
-                mapped = default_source
+                mapped = ""
                 for ident in identifiers:
                     if ident in symbol_to_source:
                         mapped = symbol_to_source[ident]
@@ -943,7 +967,7 @@ def run_compilability_check(
         lang = claim_dict.get("language", "")
 
         # Skip non-code languages
-        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", ""):
+        if lang in ("bash", "shell", "yaml", "yml", "json", "xml", "markdown", "") or lang in NON_COMPILABLE_LANGUAGES:
             if claim_dict["type"] == "code_example":
                 continue
 

--- a/tests/skills/doc-accuracy/test_doc_accuracy.py
+++ b/tests/skills/doc-accuracy/test_doc_accuracy.py
@@ -75,6 +75,18 @@ class TestDetectLanguage:
     def test_cs_alias(self) -> None:
         assert _detect_language("cs") == "csharp"
 
+    def test_c_sharp_hash_alias(self) -> None:
+        """Pin the "c#" -> "csharp" alias that the fence regex depends on.
+
+        _detect_language itself was never the bug (this mapping already
+        existed); the regression was that ```c``` fences never reached this
+        function with the full "c#" token intact (see
+        TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence).
+        This test pins the alias contract so a future edit to lang_map cannot
+        silently reopen that regression from the other end.
+        """
+        assert _detect_language("c#") == "csharp"
+
     def test_empty_string(self) -> None:
         assert _detect_language("") == ""
 
@@ -1401,6 +1413,35 @@ class TestRunClaimExtraction:
             )
             assert code_examples[0]["language"] == lang
 
+    def test_extracts_csharp_from_hash_alias_fence(self, tmp_path: Path) -> None:
+        """Regression test: ```c#``` fences must still produce a claim.
+
+        The fence-detection regex in run_claim_extraction previously captured
+        the info string with \\w*, which stops before the "#" in "c#" and
+        passes only "c" to _detect_language. "c" has no lang_map alias (only
+        "cs"/"csharp"/"c#" map to "csharp"), so it was returned unchanged and,
+        because SYMBOL_EXTRACTORS has no "c" entry, the SYMBOL_EXTRACTORS-based
+        allowlist added for Go/Rust/Java skip support silently dropped every
+        ```c#``` code example. This pins that the full "c#" token reaches
+        _detect_language (which maps it to "csharp", a SYMBOL_EXTRACTORS
+        entry) so the claim survives extraction.
+        """
+        md = "# Doc\n\n```c#\nConsole.WriteLine(42);\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        code_examples = [c for c in result["claims"] if c["type"] == "code_example"]
+        assert len(code_examples) == 1
+        assert code_examples[0]["language"] == "csharp"
+
     def test_leaves_unmapped_code_example_without_source(self, tmp_path: Path) -> None:
         md = "# Doc\n\n```csharp\nConsole.WriteLine(42)\n```\n"
         (tmp_path / "doc.md").write_text(md)
@@ -1568,6 +1609,39 @@ class TestRunCompilabilityCheck:
                 f"expected one finding for language {lang!r}"
             )
             assert result["findings"][0]["category"] == "unresolved_symbol"
+
+    def test_checks_csharp_hash_alias_end_to_end(self, tmp_path: Path) -> None:
+        """Regression test: a ```c#``` fence must still reach unresolved-symbol
+        checking, not just claim extraction.
+
+        Runs the actual run_claim_extraction output (not a hand-built claim
+        dict) through run_compilability_check, so this proves the full
+        pipeline for the reported "c#" regex regression: extraction resolves
+        "c#" to "csharp" (see
+        TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence) and
+        that claim is not skipped in Phase 3 either.
+        """
+        md = "# Doc\n\n```c#\nvar w = TotallyUnresolvedWidget();\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment: dict[str, Any] = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        claims = run_claim_extraction(tmp_path, assessment)
+        code_examples = [c for c in claims["claims"] if c["type"] == "code_example"]
+        assert len(code_examples) == 1
+        assert code_examples[0]["language"] == "csharp"
+
+        result = run_compilability_check(assessment, claims)
+        unresolved = [
+            f for f in result["findings"] if f["category"] == "unresolved_symbol"
+        ]
+        assert len(unresolved) == 1
 
 
 class TestCheckGate:

--- a/tests/skills/doc-accuracy/test_doc_accuracy.py
+++ b/tests/skills/doc-accuracy/test_doc_accuracy.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 TESTS_SKILLS_DIR = str(Path(__file__).resolve().parents[1])
@@ -1589,7 +1590,23 @@ class TestRunCompilabilityCheck:
         assert result["findings"] == []
 
     def test_skips_powershell_code_examples(self) -> None:
-        assessment: dict[str, Any] = {"source_symbols": []}
+        # source_symbols must be non-empty: run_compilability_check now
+        # short-circuits to status="DID_NOT_RUN" when Phase 1 finds no
+        # source symbols (see test_does_not_run_without_source_symbols),
+        # which would make findings == [] trivially true regardless of
+        # whether the powershell skip logic below ran at all. The
+        # placeholder symbol's name never matches a referenced symbol in
+        # this test, so it cannot resolve any claim; asserting
+        # status == "COMPLETED" proves the check actually reached (and
+        # then skipped inside) the per-claim loop.
+        assessment: dict[str, Any] = {
+            "source_symbols": [{
+                "name": "UnrelatedPlaceholder", "kind": "class",
+                "file": "placeholder.py", "line": 1,
+                "signature": "class UnrelatedPlaceholder:",
+                "visibility": "public",
+            }],
+        }
         claims = {
             "claims": [{
                 "id": "claim-0001", "file": "doc.md", "line": 1,
@@ -1600,10 +1617,20 @@ class TestRunCompilabilityCheck:
             }],
         }
         result = run_compilability_check(assessment, claims)
+        assert result["status"] == "COMPLETED"
         assert result["findings"] == []
 
     def test_skips_go_code_examples(self) -> None:
-        assessment: dict[str, Any] = {"source_symbols": []}
+        # See test_skips_powershell_code_examples for why source_symbols
+        # must be non-empty here.
+        assessment: dict[str, Any] = {
+            "source_symbols": [{
+                "name": "UnrelatedPlaceholder", "kind": "class",
+                "file": "placeholder.py", "line": 1,
+                "signature": "class UnrelatedPlaceholder:",
+                "visibility": "public",
+            }],
+        }
         claims = {
             "claims": [{
                 "id": "claim-0001", "file": "doc.md", "line": 1,
@@ -1614,10 +1641,20 @@ class TestRunCompilabilityCheck:
             }],
         }
         result = run_compilability_check(assessment, claims)
+        assert result["status"] == "COMPLETED"
         assert result["findings"] == []
 
     def test_skips_rust_code_examples(self) -> None:
-        assessment: dict[str, Any] = {"source_symbols": []}
+        # See test_skips_powershell_code_examples for why source_symbols
+        # must be non-empty here.
+        assessment: dict[str, Any] = {
+            "source_symbols": [{
+                "name": "UnrelatedPlaceholder", "kind": "class",
+                "file": "placeholder.py", "line": 1,
+                "signature": "class UnrelatedPlaceholder:",
+                "visibility": "public",
+            }],
+        }
         claims = {
             "claims": [{
                 "id": "claim-0001", "file": "doc.md", "line": 1,
@@ -1628,10 +1665,20 @@ class TestRunCompilabilityCheck:
             }],
         }
         result = run_compilability_check(assessment, claims)
+        assert result["status"] == "COMPLETED"
         assert result["findings"] == []
 
     def test_skips_java_code_examples(self) -> None:
-        assessment: dict[str, Any] = {"source_symbols": []}
+        # See test_skips_powershell_code_examples for why source_symbols
+        # must be non-empty here.
+        assessment: dict[str, Any] = {
+            "source_symbols": [{
+                "name": "UnrelatedPlaceholder", "kind": "class",
+                "file": "placeholder.py", "line": 1,
+                "signature": "class UnrelatedPlaceholder:",
+                "visibility": "public",
+            }],
+        }
         claims = {
             "claims": [{
                 "id": "claim-0001", "file": "doc.md", "line": 1,
@@ -1642,6 +1689,7 @@ class TestRunCompilabilityCheck:
             }],
         }
         result = run_compilability_check(assessment, claims)
+        assert result["status"] == "COMPLETED"
         assert result["findings"] == []
 
     def test_resolves_symbol_extractor_languages(self) -> None:
@@ -1655,9 +1703,24 @@ class TestRunCompilabilityCheck:
         checked-but-resolved claim cannot be confused: only "checked and
         unresolved" produces a finding here. Parametrized over the live
         mod.SYMBOL_EXTRACTORS keys.
+
+        source_symbols must be non-empty (see
+        test_skips_powershell_code_examples): with an empty source_symbols
+        list, run_compilability_check now short-circuits to
+        status="DID_NOT_RUN" before the SYMBOL_EXTRACTORS gate ever runs, so
+        len(findings) == 0 would pass for the wrong reason (Phase 3 never
+        ran) instead of the reason this test exists to prove (the symbol was
+        checked and found unresolved).
         """
         for lang in sorted(SYMBOL_EXTRACTORS.keys()):
-            assessment: dict[str, Any] = {"source_symbols": []}
+            assessment: dict[str, Any] = {
+                "source_symbols": [{
+                    "name": "UnrelatedPlaceholder", "kind": "class",
+                    "file": "placeholder.py", "line": 1,
+                    "signature": "class UnrelatedPlaceholder:",
+                    "visibility": "public",
+                }],
+            }
             claims = {
                 "claims": [{
                     "id": "claim-0001", "file": "doc.md", "line": 1,
@@ -1668,6 +1731,9 @@ class TestRunCompilabilityCheck:
                 }],
             }
             result = run_compilability_check(assessment, claims)
+            assert result["status"] == "COMPLETED", (
+                f"expected Phase 3 to run for language {lang!r}"
+            )
             assert len(result["findings"]) == 1, (
                 f"expected one finding for language {lang!r}"
             )
@@ -1683,6 +1749,14 @@ class TestRunCompilabilityCheck:
         "c#" to "csharp" (see
         TestRunClaimExtraction.test_extracts_csharp_from_hash_alias_fence) and
         that claim is not skipped in Phase 3 either.
+
+        source_symbols must be non-empty (see
+        test_skips_powershell_code_examples): run_compilability_check
+        short-circuits to status="DID_NOT_RUN" with an empty source_symbols
+        list, which would make this test pass even if Phase 3 never actually
+        evaluated the extracted claim. "UnrelatedPlaceholder" never matches
+        "TotallyUnresolvedWidget", so it cannot resolve the claim and only
+        exercises the required non-empty precondition.
         """
         md = "# Doc\n\n```c#\nvar w = TotallyUnresolvedWidget();\n```\n"
         (tmp_path / "doc.md").write_text(md)
@@ -1693,7 +1767,12 @@ class TestRunCompilabilityCheck:
                 "mapped_source_files": [],
                 "referenced_symbols": [],
             }],
-            "source_symbols": [],
+            "source_symbols": [{
+                "name": "UnrelatedPlaceholder", "kind": "class",
+                "file": "placeholder.py", "line": 1,
+                "signature": "class UnrelatedPlaceholder:",
+                "visibility": "public",
+            }],
         }
         claims = run_claim_extraction(tmp_path, assessment)
         code_examples = [c for c in claims["claims"] if c["type"] == "code_example"]
@@ -1701,6 +1780,7 @@ class TestRunCompilabilityCheck:
         assert code_examples[0]["language"] == "csharp"
 
         result = run_compilability_check(assessment, claims)
+        assert result["status"] == "COMPLETED"
         unresolved = [
             f for f in result["findings"] if f["category"] == "unresolved_symbol"
         ]

--- a/tests/skills/doc-accuracy/test_doc_accuracy.py
+++ b/tests/skills/doc-accuracy/test_doc_accuracy.py
@@ -1279,6 +1279,67 @@ class TestRunClaimExtraction:
         assert result["claims"][0]["type"] == "code_example"
         assert result["claims"][0]["language"] == "python"
 
+    def test_skips_text_fences(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```text\nP1 P2 P3 Evaluation READY\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_skips_mermaid_fences(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```mermaid\nflowchart TD\nA-->B\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_skips_empty_text_fence(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```text\n   \n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_leaves_unmapped_code_example_without_source(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```csharp\nConsole.WriteLine(42)\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": ["Commit.cs"],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"][0]["type"] == "code_example"
+        assert result["claims"][0]["mapped_source"] == ""
+
     def test_extracts_quantitative_claim(self, tmp_path: Path) -> None:
         md = "Performance is 99.9% uptime.\n"
         (tmp_path / "perf.md").write_text(md)
@@ -1340,6 +1401,20 @@ class TestRunCompilabilityCheck:
                 "type": "method_signature", "language": "",
                 "content": "Returns a List",
                 "symbols_referenced": ["List"],
+                "mapped_source": "",
+            }],
+        }
+        result = run_compilability_check(assessment, claims)
+        assert result["findings"] == []
+
+    def test_skips_powershell_code_examples(self) -> None:
+        assessment: dict[str, Any] = {"source_symbols": []}
+        claims = {
+            "claims": [{
+                "id": "claim-0001", "file": "doc.md", "line": 1,
+                "type": "code_example", "language": "powershell",
+                "content": "Search-WorkItems.ps1 -FailOnTruncation",
+                "symbols_referenced": ["Search-WorkItems", "FailOnTruncation"],
                 "mapped_source": "",
             }],
         }

--- a/tests/skills/doc-accuracy/test_doc_accuracy.py
+++ b/tests/skills/doc-accuracy/test_doc_accuracy.py
@@ -31,6 +31,7 @@ Finding = mod.Finding
 run_assessment = mod.run_assessment
 run_claim_extraction = mod.run_claim_extraction
 run_compilability_check = mod.run_compilability_check
+SYMBOL_EXTRACTORS = mod.SYMBOL_EXTRACTORS
 check_gate = mod.check_gate
 generate_markdown_report = mod.generate_markdown_report
 main = mod.main
@@ -1324,6 +1325,82 @@ class TestRunClaimExtraction:
         result = run_claim_extraction(tmp_path, assessment)
         assert result["claims"] == []
 
+    def test_skips_go_fences(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```go\nfunc UndefinedFunc() {}\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_skips_rust_fences(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```rust\nfn undefined_func() {}\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_skips_java_fences(self, tmp_path: Path) -> None:
+        md = "# Doc\n\n```java\npublic class UndefinedClass {}\n```\n"
+        (tmp_path / "doc.md").write_text(md)
+
+        assessment = {
+            "documentation_files": [{
+                "path": "doc.md",
+                "mapped_source_files": [],
+                "referenced_symbols": [],
+            }],
+            "source_symbols": [],
+        }
+        result = run_claim_extraction(tmp_path, assessment)
+        assert result["claims"] == []
+
+    def test_resolves_symbol_extractor_languages(self, tmp_path: Path) -> None:
+        """Every language with a SYMBOL_EXTRACTORS entry must still be extracted.
+
+        This is the inverse of test_skips_go_fences/test_skips_rust_fences/
+        test_skips_java_fences: the SYMBOL_EXTRACTORS-based skip must not
+        over-fire on a language it is meant to support. Parametrized over the
+        live mod.SYMBOL_EXTRACTORS keys (csharp, python, javascript,
+        typescript today) rather than a hardcoded duplicate list, so this test
+        keeps covering the real allowlist if it ever changes.
+        """
+        for lang in sorted(SYMBOL_EXTRACTORS.keys()):
+            doc_path = tmp_path / f"doc_{lang}.md"
+            doc_path.write_text(f"# Doc\n\n```{lang}\nSomeIdentifier()\n```\n")
+
+            assessment = {
+                "documentation_files": [{
+                    "path": doc_path.name,
+                    "mapped_source_files": [],
+                    "referenced_symbols": [],
+                }],
+                "source_symbols": [],
+            }
+            result = run_claim_extraction(tmp_path, assessment)
+            code_examples = [
+                c for c in result["claims"] if c["type"] == "code_example"
+            ]
+            assert len(code_examples) == 1, (
+                f"expected one code_example claim for language {lang!r}"
+            )
+            assert code_examples[0]["language"] == lang
+
     def test_leaves_unmapped_code_example_without_source(self, tmp_path: Path) -> None:
         md = "# Doc\n\n```csharp\nConsole.WriteLine(42)\n```\n"
         (tmp_path / "doc.md").write_text(md)
@@ -1420,6 +1497,77 @@ class TestRunCompilabilityCheck:
         }
         result = run_compilability_check(assessment, claims)
         assert result["findings"] == []
+
+    def test_skips_go_code_examples(self) -> None:
+        assessment: dict[str, Any] = {"source_symbols": []}
+        claims = {
+            "claims": [{
+                "id": "claim-0001", "file": "doc.md", "line": 1,
+                "type": "code_example", "language": "go",
+                "content": "func UndefinedFunc() {}",
+                "symbols_referenced": ["UndefinedFunc"],
+                "mapped_source": "",
+            }],
+        }
+        result = run_compilability_check(assessment, claims)
+        assert result["findings"] == []
+
+    def test_skips_rust_code_examples(self) -> None:
+        assessment: dict[str, Any] = {"source_symbols": []}
+        claims = {
+            "claims": [{
+                "id": "claim-0001", "file": "doc.md", "line": 1,
+                "type": "code_example", "language": "rust",
+                "content": "struct UndefinedStruct;",
+                "symbols_referenced": ["UndefinedStruct"],
+                "mapped_source": "",
+            }],
+        }
+        result = run_compilability_check(assessment, claims)
+        assert result["findings"] == []
+
+    def test_skips_java_code_examples(self) -> None:
+        assessment: dict[str, Any] = {"source_symbols": []}
+        claims = {
+            "claims": [{
+                "id": "claim-0001", "file": "doc.md", "line": 1,
+                "type": "code_example", "language": "java",
+                "content": "public class UndefinedClass {}",
+                "symbols_referenced": ["UndefinedClass"],
+                "mapped_source": "",
+            }],
+        }
+        result = run_compilability_check(assessment, claims)
+        assert result["findings"] == []
+
+    def test_resolves_symbol_extractor_languages(self) -> None:
+        """Every SYMBOL_EXTRACTORS language must still be checked for findings.
+
+        Inverse of test_skips_go_code_examples/test_skips_rust_code_examples/
+        test_skips_java_code_examples: a code_example claim in a language that
+        DOES have a symbol extractor must reach the unresolved-symbol check
+        rather than being skipped. Uses an unresolvable CamelCase identifier
+        (matching the same shape the skip tests use) so a skipped claim and a
+        checked-but-resolved claim cannot be confused: only "checked and
+        unresolved" produces a finding here. Parametrized over the live
+        mod.SYMBOL_EXTRACTORS keys.
+        """
+        for lang in sorted(SYMBOL_EXTRACTORS.keys()):
+            assessment: dict[str, Any] = {"source_symbols": []}
+            claims = {
+                "claims": [{
+                    "id": "claim-0001", "file": "doc.md", "line": 1,
+                    "type": "code_example", "language": lang,
+                    "content": "TotallyUnresolvedSymbolXyz()",
+                    "symbols_referenced": ["TotallyUnresolvedSymbolXyz"],
+                    "mapped_source": "",
+                }],
+            }
+            result = run_compilability_check(assessment, claims)
+            assert len(result["findings"]) == 1, (
+                f"expected one finding for language {lang!r}"
+            )
+            assert result["findings"][0]["category"] == "unresolved_symbol"
 
 
 class TestCheckGate:


### PR DESCRIPTION
## Summary

Stop `doc-accuracy` from resolving code examples when their normalized language has no symbol extractor.

This removes high-severity false positives from ASCII, PowerShell, Go, Rust, and Java examples while preserving checks for C#, Python, JavaScript, and TypeScript.

## Specification References

| Issue | Relationship |
|---|---|
| #4948 | False-positive reproduction and expected language-aware behavior |

## Type of Change

- [x] Bug fix

## Changes

- Gate code-example extraction and compilability checks on `SYMBOL_EXTRACTORS`.
- Leave unmatched code examples unmapped instead of assigning unrelated source files.
- Capture non-word fence language tokens so `c#` normalizes to `csharp`.
- Add non-vacuous tests for Go, Rust, Java, C#, Python, JavaScript, and TypeScript.
- Regenerate the Copilot CLI skill mirror from the canonical Claude skill.

## Validation

- [x] `uv run pytest tests/skills/doc-accuracy/test_doc_accuracy.py -q`, 105 passed
- [x] `uv run ruff check .claude/skills/doc-accuracy/scripts/doc_accuracy.py tests/skills/doc-accuracy/test_doc_accuracy.py`
- [x] `uv run python build/scripts/build_all.py --check`
- [x] Canonical and Copilot mirror are byte-identical
- [x] `uv run python scripts/validation/pre_pr.py`, 51 of 51 passed
- [x] CWE-78 scan, no findings
- [x] GPT-5.6 Sol review, PASS with no findings

Fixes #4948
