### PR TITLE
docs(adr): supersede stale Copilot CLI compatibility policy

### DIFF
--- a/.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md
+++ b/.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+Status note: The `0.0.397` pin in Decision 1 is historical. `scripts/validation/check_copilot_version_pin.py` is the live authority for acceptable Copilot CLI versions, and it blocks the retired pin via `KNOWN_BAD_VERSIONS: frozenset[str] = frozenset({"0.0.397"})`.
+
 ## Date
 
 2026-02-01
@@ -61,7 +63,7 @@ These warnings appear only with `--log-level all` flag. Default output shows no 
 
 ## Decision
 
-1. **Pin Copilot CLI to 0.0.397** in CI (`npm install -g @github/copilot@0.0.397`) with `--no-auto-update` flag on all invocations. This is the last version before the frontmatter regression.
+1. **Historical pin, now retired**: The `0.0.397` pin is retired. See `scripts/validation/check_copilot_version_pin.py` for the live authority on acceptable Copilot CLI versions.
 2. **Fix `model` field value** from VS Code format (`Claude Opus 4.5 (anthropic)`) to Copilot CLI format (`claude-opus-4.5`). Update `templates/platforms/copilot-cli.yaml` to generate correct values.
 3. **Retain `argument-hint` and `model` fields** in all agent frontmatter. These are valid Copilot CLI fields broken by an upstream regression, not unsupported features.
 4. **Add version verification** to CI. After install, verify `copilot --no-auto-update --version` matches the pinned version and warn if the binary auto-updated.

--- a/.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md
+++ b/.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md
@@ -1,10 +1,21 @@
+---
+id: ADR-044
+status: superseded
+date: 2026-08-15
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: ADR-094
+explainer: null
+implemented: true
+---
+
 # ADR-044: Copilot CLI Frontmatter Compatibility
 
 ## Status
 
-Accepted
+Superseded by ADR-094 (2026-08-15). ADR-094 replaces this record's version-pin and frontmatter policy with current executable sources.
 
-Status note: The `0.0.397` pin in Decision 1 is historical. `scripts/validation/check_copilot_version_pin.py` is the live authority for acceptable Copilot CLI versions, and it blocks the retired pin via `KNOWN_BAD_VERSIONS: frozenset[str] = frozenset({"0.0.397"})`.
+Accepted (2026-02-01). The original decision remains below as historical evidence.
 
 ## Date
 
@@ -63,7 +74,7 @@ These warnings appear only with `--log-level all` flag. Default output shows no 
 
 ## Decision
 
-1. **Historical pin, now retired**: The `0.0.397` pin is retired. See `scripts/validation/check_copilot_version_pin.py` for the live authority on acceptable Copilot CLI versions.
+1. **Pin Copilot CLI to 0.0.397** in CI (`npm install -g @github/copilot@0.0.397`) with `--no-auto-update` flag on all invocations. This is the last version before the frontmatter regression.
 2. **Fix `model` field value** from VS Code format (`Claude Opus 4.5 (anthropic)`) to Copilot CLI format (`claude-opus-4.5`). Update `templates/platforms/copilot-cli.yaml` to generate correct values.
 3. **Retain `argument-hint` and `model` fields** in all agent frontmatter. These are valid Copilot CLI fields broken by an upstream regression, not unsupported features.
 4. **Add version verification** to CI. After install, verify `copilot --no-auto-update --version` matches the pinned version and warn if the binary auto-updated.

--- a/.agents/architecture/ADR-064-commands-to-skills-migration.md
+++ b/.agents/architecture/ADR-064-commands-to-skills-migration.md
@@ -73,8 +73,9 @@ are out of scope here and tracked separately under issue #2139.
     directory clash.
 - Prior art: ADR-030 (skills-pattern-superiority) establishes that skills give
   direct, scoped tool access with lower overhead than subagents. ADR-044
-  (copilot-cli-frontmatter-compatibility) constrains the frontmatter fields
-  Copilot CLI accepts. ADR-012 (skill-catalog-mcp) governs the skill catalog.
+  (copilot-cli-frontmatter-compatibility) originally constrained frontmatter fields
+  Copilot CLI accepted; ADR-094 now governs compatibility via executable
+  owners and smoke verification. ADR-012 (skill-catalog-mcp) governs the skill catalog.
   `DESIGN-REVIEW-vscode-copilot-parity-plan.md` lays out the parity plan.
 
 ### Historical Rationale
@@ -159,8 +160,8 @@ are out of scope here and tracked separately under issue #2139.
    `allowed-tools`, and any `@CLAUDE.md` import. The generated copilot-cli skills
    already model `user-invocable: true` plus `@CLAUDE.md`
    (see `src/copilot-cli/skills/spec/SKILL.md`), so the SKILL.md shape is
-   established. ADR-094 constrains which frontmatter fields Copilot CLI accepts;
-   migration PRs honor that constraint.
+   established. ADR-094 assigns executable owners and requires a real-CLI smoke test;
+   migration PRs pass that verification.
 
 ## Prior Art Investigation
 

--- a/.agents/architecture/ADR-064-commands-to-skills-migration.md
+++ b/.agents/architecture/ADR-064-commands-to-skills-migration.md
@@ -159,7 +159,7 @@ are out of scope here and tracked separately under issue #2139.
    `allowed-tools`, and any `@CLAUDE.md` import. The generated copilot-cli skills
    already model `user-invocable: true` plus `@CLAUDE.md`
    (see `src/copilot-cli/skills/spec/SKILL.md`), so the SKILL.md shape is
-   established. ADR-044 constrains which frontmatter fields Copilot CLI accepts;
+   established. ADR-094 constrains which frontmatter fields Copilot CLI accepts;
    migration PRs honor that constraint.
 
 ## Prior Art Investigation
@@ -271,7 +271,7 @@ skill and reaches Accepted only after consensus.
 ## Related Decisions
 
 - [ADR-030-skills-pattern-superiority.md](ADR-030-skills-pattern-superiority.md). Skills give scoped tool access with lower overhead than subagents.
-- [ADR-044-copilot-cli-frontmatter-compatibility.md](ADR-044-copilot-cli-frontmatter-compatibility.md). Frontmatter fields Copilot CLI accepts.
+- [ADR-094-govern-copilot-cli-compatibility.md](ADR-094-govern-copilot-cli-compatibility.md). Current Copilot CLI compatibility governance.
 - [ADR-012-skill-catalog-mcp.md](ADR-012-skill-catalog-mcp.md). Skill catalog governance.
 - [ADR-040-skill-frontmatter-standardization.md](ADR-040-skill-frontmatter-standardization.md). Skill frontmatter contract.
 - `DESIGN-REVIEW-vscode-copilot-parity-plan.md`. The parity plan this ADR advances.

--- a/.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md
+++ b/.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md
@@ -1,0 +1,153 @@
+---
+id: ADR-094
+status: accepted
+date: 2026-08-15
+decision-makers: [rjmurillo]
+supersedes: [ADR-044]
+superseded-by: null
+explainer: null
+implemented: true
+---
+
+# ADR-094: Govern Copilot CLI Compatibility Through Executable Surfaces
+
+## Status
+
+Accepted (2026-08-15). Six of six ADR reviewers accepted Round 2 after the first draft was blocked. Review evidence: `.agents/critique/ADR-094-debate-log.md`.
+
+## Date
+
+2026-08-15
+
+## Context
+
+ADR-044 combined three concerns:
+
+1. A temporary Copilot CLI pin for a frontmatter regression.
+2. Frontmatter field and model-value policy.
+3. Runtime version verification.
+
+The decision shipped on 2026-02-01. Later work changed each concern:
+
+- `.github/actions/ai-review/action.yml` now configures `COPILOT_VERSION="1.0.63"`.
+- `.github/workflows/nightly-cli-smoke.yml` independently configures a Renovate-managed smoke version.
+- `scripts/validation/check_copilot_version_pin.py` blocks `0.0.397` as known bad.
+- ADR-080 now governs model pins and requires evidence for versioned model identifiers.
+- Session 2586 on 2026-06-17 verified agent loading on Copilot CLI 1.0.63 with `argument-hint` present and no unsupported-field warning.
+
+ADR-044 still told contributors to install `0.0.397`, and its model and agent-count claims no longer matched the repository. The record was implemented, so the project ADR mutability rule requires a superseding ADR instead of an in-place decision rewrite.
+
+## Decision
+
+1. **Supersede ADR-044 in full.** Keep ADR-044 unchanged except for lifecycle metadata and its supersession notice.
+2. **Treat executable configuration as the version record.**
+   - `.github/actions/ai-review/action.yml` owns the required review path's `COPILOT_VERSION`.
+   - `.github/workflows/nightly-cli-smoke.yml` owns its independent, Renovate-managed smoke version.
+   - These versions may differ because the nightly workflow validates newer runtime behavior before the required review path adopts it.
+3. **Treat `check_copilot_version_pin.py` as a known-bad guard, not an allowlist.** It validates the required review pin in `action.yml`. A passing result means the configured value is parseable and not denylisted. It does not prove compatibility, and it does not govern the nightly smoke pin.
+4. **Retire `0.0.397` immediately.** Keep it in `KNOWN_BAD_VERSIONS` as historical evidence. Documentation and runbooks must not recommend installing it.
+5. **Keep runtime drift detection warn-only.** `scripts/ci/install_copilot_cli.py` warns when the installed binary differs from the configured version. This ADR does not claim that mismatch blocks CI.
+6. **Defer model and frontmatter policy to current owners.**
+   - ADR-080 governs model pins and evidence.
+   - `templates/platforms/*.yaml` and the agent generators own platform output shape.
+   - Runtime compatibility requires a real-CLI smoke with the fields under test. ADR prose does not freeze model identifiers or agent counts.
+7. **Use this upgrade procedure for the required review pin.**
+   - Reproduce the target version locally.
+   - Load an agent carrying the relevant frontmatter fields with debug logging.
+   - Update `COPILOT_VERSION` in `action.yml` and the fallback in `scripts/ci/install_copilot_cli.py` together.
+   - Run the known-bad validator, its tests, and the workflow dry run.
+   - Update an ADR only when this policy changes, not for routine version bumps.
+
+## Prior Art Investigation
+
+### What Currently Exists
+
+- **Structure being changed**: ADR-044's combined pin, frontmatter, and runtime-verification decision.
+- **When introduced**: commit `03f6d858d7`, PR #1024, 2026-02-01.
+- **Original context**: Copilot CLI 0.0.398 through 0.0.400 silently rejected custom-agent frontmatter, breaking six review jobs.
+
+### Historical Rationale
+
+The 0.0.397 pin restored review jobs while preserving `argument-hint` and `model`. `--no-auto-update` limited binary self-update risk. The workaround was rational while the regression remained active.
+
+### Why Change Now
+
+- The required review path has run 1.0.63 since issue #2630.
+- Local evidence recorded on 2026-06-17 showed 1.0.63 loaded an agent with `argument-hint` and emitted no unsupported-field warning.
+- `0.0.397` is npm-deprecated and blocked by the repository's known-bad guard.
+- ADR-080 replaced ADR-044's model-pin assumptions.
+- Leaving ADR-044 Accepted directs contributors to a version the repository rejects.
+
+The main risk is replacing one stale source with another. This decision limits durable prose to ownership and verification policy. Executable files retain the actual version values.
+
+## Rationale
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not Chosen |
+|-------------|------|------|----------------|
+| Amend ADR-044 in place | One file; preserves inbound links | Rewrites an implemented decision; leaves unrelated stale claims mixed with current policy | Violates the adopted bounded mutability rule |
+| Keep ADR-044 Accepted with a status note | Preserves surviving decisions | No partial-supersession lifecycle; readers still treat stale model and pin text as current | The whole record has drifted |
+| Make the validator the version authority | Executable and testable | It is a one-target denylist, not the source of the configured version or proof of compatibility | Misstates the validator contract |
+| Centralize every Copilot version in one new config file | One literal for all callers | Removes deliberate nightly-versus-required-path variation and expands this governance fix into runtime refactoring | Not required to resolve the contradiction |
+| Supersede ADR-044 and name executable owners | Preserves history; matches current code; separates policy from values | Multiple executable owners remain and need clear scope | Chosen |
+
+### Trade-offs
+
+The decision gives up one prose location containing every current value. In exchange, routine version updates no longer require an ADR edit, and a dated ADR cannot override executable configuration.
+
+The required review and nightly smoke paths may run different versions. That difference is intentional but increases review cost. The known-bad validator covers only the required review path today.
+
+## Consequences
+
+### Positive
+
+- Contributors no longer receive instructions to install blocked version `0.0.397`.
+- ADR-044 remains intact as evidence for the original incident and response.
+- Version values live beside the code that consumes them.
+- Model policy has one current owner, ADR-080.
+- The known-bad guard's scope and limits are explicit.
+
+### Negative
+
+- The required review action, installer fallback, and nightly smoke retain multiple version literals.
+- Runtime version mismatch remains warn-only.
+- The known-bad guard does not cover the nightly smoke pin.
+- Compatibility still requires a real-CLI smoke. Static validation cannot prove vendor behavior.
+
+### Neutral
+
+- Routine Copilot CLI version bumps do not change this ADR.
+- `--no-auto-update` remains part of Copilot CLI invocations.
+
+## Impact on Dependent Components
+
+| Component | Dependency Type | Required Update | Risk |
+|-----------|----------------|-----------------|------|
+| ADR-044 | Direct | Mark superseded by ADR-094; preserve original decision text | Low |
+| `CONTRIBUTING.md` | Direct | Remove 0.0.397 and stale model literals; point to executable owners | Medium |
+| Copilot frontmatter regression runbook | Direct | Replace reinstall guidance with current diagnostic and upgrade procedure | Medium |
+| ADR-080 | Indirect | Remains the model-pin authority | Low |
+| `action.yml` and installer fallback | Direct | Continue changing together for required review pin bumps | Medium |
+| Nightly CLI smoke workflow | Direct | Remains independently Renovate-managed | Low |
+| Known-bad validator | Direct | Remains a required-review-path denylist guard | Low |
+
+## Implementation Notes
+
+This change updates governance and contributor guidance only. It does not change runtime pins, validator scope, or warn-only runtime drift behavior.
+
+## Related Decisions
+
+- ADR-044: original Copilot CLI frontmatter compatibility decision, superseded by this record.
+- ADR-080: model-pin justification policy.
+- ADR-093: red checks require equivalent verification evidence.
+
+## References
+
+- Issue #4939.
+- Issue #2630.
+- Session `.agents/sessions/2026-06-17-session-2586-fix-2630-bump-pinned-githubcopilot.json`.
+- `scripts/validation/check_copilot_version_pin.py`.
+- `.github/actions/ai-review/action.yml`.
+- `.github/workflows/nightly-cli-smoke.yml`.
+- `.claude/skills/adr-generator/references/adr-best-practices.md`.

--- a/.agents/critique/ADR-094-debate-log.md
+++ b/.agents/critique/ADR-094-debate-log.md
@@ -60,3 +60,26 @@ None. All Round 1 blocking findings were resolved.
 ## Final Decision
 
 ADR-094 is accepted. ADR-044 is superseded and retained as historical evidence.
+
+## Round 3: Cross-Reference Correction
+
+### Change
+
+Update ADR-064 references from superseded ADR-044 to current ADR-094.
+
+### Rationale
+
+ADR-064 lines 162 and 274 referenced ADR-044 for Copilot CLI frontmatter constraints.
+Since ADR-094 supersedes ADR-044, readers following these references would land on
+retired guidance. Correcting the pointers is a mechanical cross-reference fix.
+
+### Agent Positions
+
+| Agent | Position |
+|-------|----------|
+| implementer | Accept (reference-only change) |
+
+### Outcome
+
+Accepted. No decision change in ADR-064; only link targets updated.
+

--- a/.agents/critique/ADR-094-debate-log.md
+++ b/.agents/critique/ADR-094-debate-log.md
@@ -1,0 +1,62 @@
+# ADR Debate Log: Govern Copilot CLI Compatibility Through Executable Surfaces
+
+## Summary
+
+- **Rounds**: 2
+- **Outcome**: Consensus
+- **Final Status**: accepted
+- **ADR**: `.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md`
+
+## Round 1 Summary
+
+### Key Issues Addressed
+
+- The first draft rewrote an implemented ADR in place.
+- The validator was described as an allowlist and version authority, but it is a one-target known-bad guard.
+- Runtime version mismatch was described as blocking, but the installer reports a warning.
+- `CONTRIBUTING.md` and the Serena runbook still recommended blocked version `0.0.397`.
+- ADR-044 carried stale model identifiers, agent counts, and frontmatter claims.
+
+### Agent Positions
+
+| Agent | Position |
+|-------|----------|
+| architect | Block |
+| critic | Block |
+| independent-thinker | Block |
+| security | Disagree-and-Commit |
+| analyst | Block |
+| high-level-advisor | Block |
+
+### Resolution
+
+The in-place rewrite was discarded. A new ADR was created to supersede ADR-044. ADR-044's original decision text was restored. The new ADR assigns version ownership to executable surfaces, narrows the validator contract, records warn-only runtime drift, defers model policy to ADR-080, and retires `0.0.397`. Contributor guidance and the regression runbook were corrected in the same change.
+
+## Round 2 Summary
+
+### Key Issues Addressed
+
+- ADR-044 and ADR-094 now form a bidirectional supersession pair.
+- The required review and nightly smoke versions have separate, explicit owners.
+- Validator scope and limitations match the current Python implementation.
+- Current 1.0.63 compatibility evidence cites session 2586.
+- Historical model and agent-count claims remain only in the superseded record.
+
+### Agent Positions
+
+| Agent | Position |
+|-------|----------|
+| architect | Accept |
+| critic | Accept |
+| independent-thinker | Accept |
+| security | Accept |
+| analyst | Accept |
+| high-level-advisor | Accept |
+
+### Dissent Record
+
+None. All Round 1 blocking findings were resolved.
+
+## Final Decision
+
+ADR-094 is accepted. ADR-044 is superseded and retained as historical evidence.

--- a/.agents/critique/ADR-094-debate-log.md
+++ b/.agents/critique/ADR-094-debate-log.md
@@ -61,7 +61,7 @@ None. All Round 1 blocking findings were resolved.
 
 ADR-094 is accepted. ADR-044 is superseded and retained as historical evidence.
 
-## Round 3: Cross-Reference Correction
+## Post-Review Correction: Cross-Reference Update
 
 ### Change
 

--- a/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -120,7 +120,32 @@
         "e006",
         "e007",
         "e008",
-        "e009"
+        "e009",
+        "e011"
+      ],
+      "leads_to": [
+        "e012"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Addressed PR #5024 review threads: corrected ADR-064 cross-references, completed handoff inventory, added debate log correction entry.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-15T13:16:08+00:00",
+      "type": "commit",
+      "content": "Commit: b66a37b977f7ce93013dcfea6ba4ea0dde8590de",
+      "caused_by": [
+        "e010"
       ],
       "leads_to": [],
       "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
@@ -131,8 +156,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
-    "files_changed": 9
+    "commits": 2,
+    "files_changed": 11
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -147,6 +147,19 @@
       "caused_by": [
         "e010"
       ],
+      "leads_to": [
+        "e013"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-15T14:19:37+00:00",
+      "type": "commit",
+      "content": "Commit: 4f1bdb2a118facd8656d2b07274d63e83c5359eb",
+      "caused_by": [
+        "e012"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
     }
@@ -156,7 +169,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 11
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -1,0 +1,138 @@
+{
+  "id": "episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version",
+  "session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version",
+  "timestamp": "2026-08-15T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Process issue 4939 ADR-044 version pin conflict",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rechecked issue 4939 context, existing PR state, and claim state.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduced the contradiction with the validator.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Amended ADR-044 to point readers at the live validator.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Recorded session state, QA evidence, and the per-issue handoff.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran ADR-044 amendment review Round 1 with architect, critic, independent-thinker, security, analyst, and high-level-advisor.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replaced the in-place amendment with ADR-094 and corrected dependent guidance.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran ADR review Round 2 against the revised artifacts.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran targeted validation.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "test",
+      "content": "Ran targeted validation.      15 validator tests passed; repository pin 1.0.63 passed; ADR numbers were unique; CONTRIBUTING markdown passed; diff check and stale-guidance searches passed.",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-15T07:42:31+00:00",
+      "type": "commit",
+      "content": "Commit: 66eea82edc2bc82639ea5d513c149a27e6f47cd0",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007",
+        "e008",
+        "e009"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 9
+  },
+  "lessons": []
+}

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
-qaCommit: b66a37b977f7ce93013dcfea6ba4ea0dde8590de
+qaCommit: 4f1bdb2a118facd8656d2b07274d63e83c5359eb
 ---
 
 # QA Report, issue 4939

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,0 +1,25 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+qaCommit: 3f8fa69466ab2761b0e76307bf067659c97b986a
+---
+
+# QA Report, issue 4939
+
+**Branch**: fix/4939-adr044-version-pin-conflict
+**Worktree**: /home/richard/worktrees/ai-agents/issue-4939-2
+
+## Scope
+
+ADR-044 note for the retired `0.0.397` Copilot CLI pin.
+
+## Validation
+
+- Positive: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-ok.yml>` returned `COPILOT_VERSION pin OK: 1.0.79`.
+- Negative: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-bad.yml>` rejected `0.0.397` with exit 1.
+- Edge: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-missing.yml>` rejected a missing pin with exit 1.
+- Markdown: `npx markdownlint-cli2 .agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md .agents/sessions/handoffs/2026-08-15-4939-handoff.md` passed.
+
+## Result
+
+PASS

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
-qaCommit: e0962301a3ad12dfae638308fa59e6dbb110d030
+qaCommit: 66eea82edc2bc82639ea5d513c149a27e6f47cd0
 ---
 
 # QA Report, issue 4939
@@ -22,6 +22,7 @@ ADR-094 supersession policy, ADR-044 lifecycle update, contributor guidance, and
 - Diff integrity: `git diff --check` passed.
 - Stale guidance search: no live contributor or runbook instruction still recommends `0.0.397`.
 - ADR review: Round 1 blocked 5 to 1. Round 2 accepted 6 to 0 after ADR-094 replaced the in-place amendment.
+- Full gate: `uv run python scripts/validation/pre_pr.py` passed all 51 validations.
 
 ## Result
 

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
-qaCommit: 66eea82edc2bc82639ea5d513c149a27e6f47cd0
+qaCommit: b66a37b977f7ce93013dcfea6ba4ea0dde8590de
 ---
 
 # QA Report, issue 4939

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
-qaCommit: 3f8fa69466ab2761b0e76307bf067659c97b986a
+qaCommit: 1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3
 ---
 
 # QA Report, issue 4939
@@ -11,14 +11,17 @@ qaCommit: 3f8fa69466ab2761b0e76307bf067659c97b986a
 
 ## Scope
 
-ADR-044 note for the retired `0.0.397` Copilot CLI pin.
+ADR-094 supersession policy, ADR-044 lifecycle update, contributor guidance, and the Copilot CLI regression runbook.
 
 ## Validation
 
-- Positive: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-ok.yml>` returned `COPILOT_VERSION pin OK: 1.0.79`.
-- Negative: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-bad.yml>` rejected `0.0.397` with exit 1.
-- Edge: `uv run python scripts/validation/check_copilot_version_pin.py --action <temp-missing.yml>` rejected a missing pin with exit 1.
-- Markdown: `npx markdownlint-cli2 .agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md .agents/sessions/handoffs/2026-08-15-4939-handoff.md` passed.
+- Validator tests: `uv run pytest tests/test_check_copilot_version_pin.py -q` passed 15 tests.
+- Repository pin: `uv run python scripts/validation/check_copilot_version_pin.py` returned `COPILOT_VERSION pin OK: 1.0.63`.
+- ADR numbering: `python3 scripts/validation/check_adr_uniqueness.py` passed and reported 095 as the next free number.
+- Markdown: `npx markdownlint-cli2 CONTRIBUTING.md` passed with zero errors.
+- Diff integrity: `git diff --check` passed.
+- Stale guidance search: no live contributor or runbook instruction still recommends `0.0.397`.
+- ADR review: Round 1 blocked 5 to 1. Round 2 accepted 6 to 0 after ADR-094 replaced the in-place amendment.
 
 ## Result
 

--- a/.agents/qa/session-14710-issue-4939-qa.md
+++ b/.agents/qa/session-14710-issue-4939-qa.md
@@ -1,13 +1,13 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
-qaCommit: 1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3
+qaCommit: e0962301a3ad12dfae638308fa59e6dbb110d030
 ---
 
 # QA Report, issue 4939
 
 **Branch**: fix/4939-adr044-version-pin-conflict
-**Worktree**: /home/richard/worktrees/ai-agents/issue-4939-2
+**Worktree**: external worktree `issue-4939-2`
 
 ## Scope
 

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "3f8fa69466ab2761b0e76307bf067659c97b986a"
+        "Evidence": "ecd19db2798332ad188d1ccac1a008d78ec9cb63"
       },
       "validationPassed": {
         "level": "MUST",
@@ -146,11 +146,43 @@
         ".agents/qa/session-14710-issue-4939-qa.md",
         ".agents/sessions/handoffs/2026-08-15-4939-handoff.md"
       ]
+    },
+    {
+      "action": "Ran ADR-044 amendment review Round 1 with architect, critic, independent-thinker, security, analyst, and high-level-advisor.",
+      "result": "Five reviewers blocked and one disagreed-and-committed. Shared blockers: an implemented ADR cannot be rewritten, the validator is not the version authority, runtime drift is warn-only, and live contributor guidance still recommended 0.0.397.",
+      "files": [
+        ".agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md"
+      ]
+    },
+    {
+      "action": "Replaced the in-place amendment with ADR-094 and corrected dependent guidance.",
+      "result": "ADR-044 preserves its original decision and points to ADR-094. ADR-094 assigns executable owners, scopes the known-bad guard, records immediate retirement, and defers model policy to ADR-080.",
+      "files": [
+        ".agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md",
+        ".agents/architecture/ADR-094-govern-copilot-cli-compatibility.md",
+        "CONTRIBUTING.md",
+        ".serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md"
+      ]
+    },
+    {
+      "action": "Ran ADR review Round 2 against the revised artifacts.",
+      "result": "All six reviewers accepted. The debate log records both rounds and the resolved findings.",
+      "files": [
+        ".agents/critique/ADR-094-debate-log.md"
+      ]
+    },
+    {
+      "action": "Ran targeted validation.",
+      "result": "15 validator tests passed; repository pin 1.0.63 passed; ADR numbers were unique; CONTRIBUTING markdown passed; diff check and stale-guidance searches passed.",
+      "files": [
+        ".agents/qa/session-14710-issue-4939-qa.md"
+      ]
     }
   ],
-  "endingCommit": "3f8fa69466ab2761b0e76307bf067659c97b986a",
+  "endingCommit": "ecd19db2798332ad188d1ccac1a008d78ec9cb63",
   "nextSteps": [
-    "Open a PR when campaign timing allows.",
-    "Re-run the validator and markdownlint if the ADR text changes again."
+    "Commit the accepted ADR and companion guidance.",
+    "Run the full pre-PR gate.",
+    "Open one PR for issue #4939."
   ]
 }

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "ecd19db2798332ad188d1ccac1a008d78ec9cb63"
+        "Evidence": "1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3"
       },
       "validationPassed": {
         "level": "MUST",
@@ -179,9 +179,8 @@
       ]
     }
   ],
-  "endingCommit": "ecd19db2798332ad188d1ccac1a008d78ec9cb63",
+  "endingCommit": "1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3",
   "nextSteps": [
-    "Commit the accepted ADR and companion guidance.",
     "Run the full pre-PR gate.",
     "Open one PR for issue #4939."
   ]

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -188,7 +188,7 @@
       ]
     }
   ],
-  "endingCommit": "b66a37b977f7ce93013dcfea6ba4ea0dde8590de",
+  "endingCommit": "4f1bdb2a118facd8656d2b07274d63e83c5359eb",
   "nextSteps": [
     "Obtain explicit human-maintainer APPROVED review on PR #5024.",
     "Merge PR #5024 after approval."

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -177,6 +177,10 @@
       "files": [
         ".agents/qa/session-14710-issue-4939-qa.md"
       ]
+    },
+    {
+      "phase": "review-fix",
+      "description": "Address PR #5024 review threads: update ADR-064 refs, fix handoff inventory"
     }
   ],
   "endingCommit": "66eea82edc2bc82639ea5d513c149a27e6f47cd0",

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -3,26 +3,26 @@
   "session": {
     "number": 14710,
     "date": "2026-08-15",
-    "branch": "main",
-    "startingCommit": "639eebc0f",
+    "branch": "fix/4939-adr044-version-pin-conflict",
+    "startingCommit": "64773a8316d8c033035d7245c0506357f35abb12",
     "objective": "Process issue 4939 ADR-044 version pin conflict"
   },
   "protocolCompliance": {
     "sessionStart": {
       "serenaActivated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Serena init tool output present in transcript"
       },
       "serenaInstructions": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Serena instructions output present in transcript"
       },
       "handoffRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md and .agents/sessions/handoffs/README.md"
       },
       "sessionLogCreated": {
         "level": "MUST",
@@ -31,80 +31,80 @@
       },
       "skillScriptsListed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Listed .claude/skills/github/scripts/*.py"
       },
       "usageMandatoryRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Read memory usage-mandatory"
       },
       "constraintsRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md"
       },
       "memoriesLoaded": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Loaded github/github-cli-issue-operations and github/github-cli-pr-operations"
       },
       "branchVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "main"
+        "Evidence": "fix/4939-adr044-version-pin-conflict"
       },
       "notOnMain": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": "On main"
+        "Complete": true,
+        "Evidence": "Work moved to external feature branch"
       },
       "gitStatusVerified": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "git status checked in repo and worktree"
       },
       "startingCommitNoted": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "639eebc0f"
+        "Evidence": "64773a8316d8c033035d7245c0506357f35abb12"
       }
     },
     "sessionEnd": {
       "checklistComplete": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Completed local validation and atomic commits"
       },
       "handoffPreserved": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/sessions/handoffs/2026-08-15-4939-handoff.md"
       },
       "serenaMemoryUpdated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "issues/4939-adr044-version-pin-conflict"
       },
       "markdownLintRun": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 .agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md .agents/sessions/handoffs/2026-08-15-4939-handoff.md"
       },
       "qaValidation": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".agents/qa/session-14710-issue-4939-qa.md"
       },
       "changesCommitted": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "3f8fa69466ab2761b0e76307bf067659c97b986a"
       },
       "validationPassed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "scripts/validate_session_json.py passed after updating workLog and QA evidence"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -118,7 +118,39 @@
       }
     }
   },
-  "workLog": [],
-  "endingCommit": "",
-  "nextSteps": []
+  "workLog": [
+    {
+      "action": "Rechecked issue 4939 context, existing PR state, and claim state.",
+      "result": "Confirmed no open PR and a fresh claim on rjmurillo.",
+      "files": []
+    },
+    {
+      "action": "Reproduced the contradiction with the validator.",
+      "result": "Confirmed 1.0.79 passes, 0.0.397 fails, and a missing pin fails.",
+      "files": [
+        "scripts/validation/check_copilot_version_pin.py"
+      ]
+    },
+    {
+      "action": "Amended ADR-044 to point readers at the live validator.",
+      "result": "The retired pin now reads as historical context instead of active guidance.",
+      "files": [
+        ".agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md"
+      ]
+    },
+    {
+      "action": "Recorded session state, QA evidence, and the per-issue handoff.",
+      "result": "Session log validates and the handoff captures the current branch state.",
+      "files": [
+        ".agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json",
+        ".agents/qa/session-14710-issue-4939-qa.md",
+        ".agents/sessions/handoffs/2026-08-15-4939-handoff.md"
+      ]
+    }
+  ],
+  "endingCommit": "3f8fa69466ab2761b0e76307bf067659c97b986a",
+  "nextSteps": [
+    "Open a PR when campaign timing allows.",
+    "Re-run the validator and markdownlint if the ADR text changes again."
+  ]
 }

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -179,13 +179,18 @@
       ]
     },
     {
-      "phase": "review-fix",
-      "description": "Address PR #5024 review threads: update ADR-064 refs, fix handoff inventory"
+      "action": "Addressed PR #5024 review threads: corrected ADR-064 cross-references, completed handoff inventory, added debate log correction entry.",
+      "result": "All three unresolved threads fixed and resolved. CI green.",
+      "files": [
+        ".agents/architecture/ADR-064-commands-to-skills-migration.md",
+        ".agents/critique/ADR-094-debate-log.md",
+        ".agents/sessions/handoffs/2026-08-15-4939-handoff.md"
+      ]
     }
   ],
-  "endingCommit": "66eea82edc2bc82639ea5d513c149a27e6f47cd0",
+  "endingCommit": "b66a37b977f7ce93013dcfea6ba4ea0dde8590de",
   "nextSteps": [
-    "Run the full pre-PR gate.",
-    "Open one PR for issue #4939."
+    "Obtain explicit human-maintainer APPROVED review on PR #5024.",
+    "Merge PR #5024 after approval."
   ]
 }

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -99,7 +99,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3"
+        "Evidence": "e0962301a3ad12dfae638308fa59e6dbb110d030"
       },
       "validationPassed": {
         "level": "MUST",
@@ -179,7 +179,7 @@
       ]
     }
   ],
-  "endingCommit": "1cbbbbfc3f315a5ba6ca4be861c9ca51bfad5ef3",
+  "endingCommit": "e0962301a3ad12dfae638308fa59e6dbb110d030",
   "nextSteps": [
     "Run the full pre-PR gate.",
     "Open one PR for issue #4939."

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14710,
+    "date": "2026-08-15",
+    "branch": "main",
+    "startingCommit": "639eebc0f",
+    "objective": "Process issue 4939 ADR-044 version pin conflict"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "main"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": "On main"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "639eebc0f"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
+++ b/.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json
@@ -99,12 +99,12 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "e0962301a3ad12dfae638308fa59e6dbb110d030"
+        "Evidence": "66eea82edc2bc82639ea5d513c149a27e6f47cd0"
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "scripts/validate_session_json.py passed after updating workLog and QA evidence"
+        "Evidence": "uv run python scripts/validation/pre_pr.py passed all 51 validations"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -179,7 +179,7 @@
       ]
     }
   ],
-  "endingCommit": "e0962301a3ad12dfae638308fa59e6dbb110d030",
+  "endingCommit": "66eea82edc2bc82639ea5d513c149a27e6f47cd0",
   "nextSteps": [
     "Run the full pre-PR gate.",
     "Open one PR for issue #4939."

--- a/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
+++ b/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
@@ -4,21 +4,26 @@
 
 - **Issue**: #4939, ADR-044 version pin conflict
 - **Branch**: fix/4939-adr044-version-pin-conflict
-- **Task**: Retire the stale 0.0.397 guidance and point ADR-044 at the live validator
-- **Phase**: reviewing
-- **Progress**: 100 percent, local fix and validation complete
+- **Task**: Supersede stale ADR-044 guidance with current Copilot CLI compatibility governance
+- **Phase**: validating
+- **Progress**: 100 percent, ADR consensus and local validation complete
 
 ## Files Modified
 
-- `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md` - Retired the live pin guidance and added a validator note.
+- `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md` - Preserved original decisions and marked the record superseded.
+- `.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md` - Added current ownership, retirement, and verification policy.
+- `.agents/critique/ADR-094-debate-log.md` - Recorded two review rounds and final 6 of 6 consensus.
+- `CONTRIBUTING.md` - Removed stale version and model guidance.
+- `.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md` - Replaced the retired reinstall procedure.
 - `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json` - Session record with validation state.
 - `.agents/sessions/handoffs/2026-08-15-4939-handoff.md` - This handoff.
 
 ## Decisions Made
 
-- **Keep ADR-044 Accepted, but mark the 0.0.397 pin as historical**: The live rule stays in `scripts/validation/check_copilot_version_pin.py`.
-  - Alternatives considered: change ADR status to Superseded, modify the validator instead.
-  - Reference: issue 4939, `scripts/validation/check_copilot_version_pin.py`, ADR-044.
+- **Supersede ADR-044 with ADR-094**: ADR-044 was implemented, so the bounded mutability rule forbids rewriting its decisions.
+- **Use executable owners**: `action.yml` owns the required review pin. The nightly workflow owns its independent smoke pin.
+- **Scope the validator accurately**: It blocks known-bad required-review pins. It is not an allowlist or compatibility proof.
+- **Retire 0.0.397 immediately**: Keep it only as known-bad historical evidence.
 
 ## Blocked Items
 
@@ -26,13 +31,14 @@
 
 ## Next Steps
 
-1. Open a PR when campaign timing allows.
-2. Re-run the validator and markdownlint if the ADR text changes again.
-3. Let review decide whether the Accepted status should remain or be superseded later.
+1. Run the full pre-PR gate.
+2. Open one PR for issue #4939.
 
 ## Context for Next Session
 
-- The validator still blocks `0.0.397` via `KNOWN_BAD_VERSIONS`. The ADR note points readers there.
+- ADR-094 was accepted after two debate rounds.
+- The validator still blocks `0.0.397` via `KNOWN_BAD_VERSIONS`.
+- Runtime version mismatch remains warn-only.
 - The worktree branch is external and separate from the main repo worktree.
 
 ## Verification on Resume

--- a/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
+++ b/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
@@ -16,6 +16,8 @@
 - `CONTRIBUTING.md` - Removed stale version and model guidance.
 - `.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md` - Replaced the retired reinstall procedure.
 - `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json` - Session record with validation state.
+- `.agents/qa/session-14710-issue-4939-qa.md` - QA report for session.
+- `.serena/memories/memory-index.md` - Updated memory index.
 - `.agents/sessions/handoffs/2026-08-15-4939-handoff.md` - This handoff.
 
 ## Decisions Made

--- a/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
+++ b/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
@@ -4,20 +4,23 @@
 
 - **Issue**: #4939, ADR-044 version pin conflict
 - **Branch**: fix/4939-adr044-version-pin-conflict
+- **PR**: #5024
 - **Task**: Supersede stale ADR-044 guidance with current Copilot CLI compatibility governance
-- **Phase**: validating
-- **Progress**: 100 percent, ADR consensus and local validation complete
+- **Phase**: awaiting human approval
+- **Progress**: 100 percent, all technical gates pass
 
 ## Files Modified
 
 - `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md` - Preserved original decisions and marked the record superseded.
+- `.agents/architecture/ADR-064-commands-to-skills-migration.md` - Updated cross-references from retired ADR-044 to current ADR-094.
 - `.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md` - Added current ownership, retirement, and verification policy.
-- `.agents/critique/ADR-094-debate-log.md` - Recorded two review rounds and final 6 of 6 consensus.
+- `.agents/critique/ADR-094-debate-log.md` - Recorded two review rounds, final 6 of 6 consensus, and post-review correction.
 - `CONTRIBUTING.md` - Removed stale version and model guidance.
 - `.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md` - Replaced the retired reinstall procedure.
 - `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json` - Session record with validation state.
 - `.agents/qa/session-14710-issue-4939-qa.md` - QA report for session.
 - `.serena/memories/memory-index.md` - Updated memory index.
+- `.agents/memory/episodes/episode-2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json` - Generated session episode.
 - `.agents/sessions/handoffs/2026-08-15-4939-handoff.md` - This handoff.
 
 ## Decisions Made
@@ -29,12 +32,12 @@
 
 ## Blocked Items
 
-- None.
+- Human-maintainer APPROVED review required on PR #5024 (governance material).
 
 ## Next Steps
 
-1. Run the full pre-PR gate.
-2. Open one PR for issue #4939.
+1. Obtain explicit human-maintainer APPROVED review on PR #5024.
+2. Merge after approval and confirm issue #4939 closure.
 
 ## Context for Next Session
 
@@ -42,15 +45,17 @@
 - The validator still blocks `0.0.397` via `KNOWN_BAD_VERSIONS`.
 - Runtime version mismatch remains warn-only.
 - The worktree branch is external and separate from the main repo worktree.
+- All three Copilot review threads resolved with commit evidence.
+- CI is green (107 checks).
 
 ## Verification on Resume
 
 - [ ] `git status` matches **Files Modified**
 - [ ] Branch matches `fix/4939-adr044-version-pin-conflict`
-- [ ] Blocked items still blocked
-- [ ] Next step #1 is still correct
+- [ ] PR #5024 is still OPEN and awaiting approval
+- [ ] No new unresolved review threads
 
 ## Related
 
 - Session log: `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json`
-- PR: none yet
+- PR: #5024

--- a/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
+++ b/.agents/sessions/handoffs/2026-08-15-4939-handoff.md
@@ -1,0 +1,48 @@
+# Session Handoff, 2026-08-15T03:44:00Z
+
+## Status
+
+- **Issue**: #4939, ADR-044 version pin conflict
+- **Branch**: fix/4939-adr044-version-pin-conflict
+- **Task**: Retire the stale 0.0.397 guidance and point ADR-044 at the live validator
+- **Phase**: reviewing
+- **Progress**: 100 percent, local fix and validation complete
+
+## Files Modified
+
+- `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md` - Retired the live pin guidance and added a validator note.
+- `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json` - Session record with validation state.
+- `.agents/sessions/handoffs/2026-08-15-4939-handoff.md` - This handoff.
+
+## Decisions Made
+
+- **Keep ADR-044 Accepted, but mark the 0.0.397 pin as historical**: The live rule stays in `scripts/validation/check_copilot_version_pin.py`.
+  - Alternatives considered: change ADR status to Superseded, modify the validator instead.
+  - Reference: issue 4939, `scripts/validation/check_copilot_version_pin.py`, ADR-044.
+
+## Blocked Items
+
+- None.
+
+## Next Steps
+
+1. Open a PR when campaign timing allows.
+2. Re-run the validator and markdownlint if the ADR text changes again.
+3. Let review decide whether the Accepted status should remain or be superseded later.
+
+## Context for Next Session
+
+- The validator still blocks `0.0.397` via `KNOWN_BAD_VERSIONS`. The ADR note points readers there.
+- The worktree branch is external and separate from the main repo worktree.
+
+## Verification on Resume
+
+- [ ] `git status` matches **Files Modified**
+- [ ] Branch matches `fix/4939-adr044-version-pin-conflict`
+- [ ] Blocked items still blocked
+- [ ] Next step #1 is still correct
+
+## Related
+
+- Session log: `.agents/sessions/2026-08-15-session-14710-b0d6e4079-process-issue-4939-adr-044-version.json`
+- PR: none yet

--- a/.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md
+++ b/.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md
@@ -1,10 +1,10 @@
 # Copilot CLI Frontmatter Regression Runbook
 
-**Statement**: Pin Copilot CLI version and validate agent frontmatter when CLI updates break agent loading.
+**Statement**: Diagnose Copilot CLI agent-loading regressions against the configured executable version and validate affected frontmatter before changing a pin.
 
 **Context**: When Copilot CLI updates cause "No such agent" errors, the root cause is likely frontmatter field validation regression. This runbook documents the investigation and resolution process from the 0.0.398+ regression (github/copilot-cli#1195).
 
-**Evidence**: ADR-044, PR #1024, tested on 0.0.397 vs 0.0.400 (2026-02-01).
+**Evidence**: ADR-044 records the 0.0.397 workaround. ADR-094 supersedes that policy. Issue #2630 and session 2586 verified 1.0.63 on 2026-06-17.
 
 **Atomicity**: 95% | **Impact**: 9
 
@@ -22,7 +22,12 @@
 copilot --no-auto-update --version
 ```
 
-Compare with known good version (currently 0.0.397). The binary may auto-update independently of npm version.
+Compare with the version configured by the failing surface:
+
+- Required reviews: `COPILOT_VERSION` in `.github/actions/ai-review/action.yml`
+- Nightly smoke: `COPILOT_CLI_VERSION` in `.github/workflows/nightly-cli-smoke.yml`
+
+The binary may auto-update independently of the npm package.
 
 ### Step 2: Test Agent Loading with Debug Logs
 
@@ -50,13 +55,13 @@ Monitor: https://github.com/github/copilot-cli/issues/1195
 
 ## Resolution Pattern
 
-### Pin to Last Known Good Version
+### Validate a Candidate Version
 
 ```bash
-npm install -g @github/copilot@0.0.397
+npm install -g @github/copilot@X.Y.Z
 ```
 
-Always use `--no-auto-update` on all invocations to prevent binary self-update.
+Always use `--no-auto-update` during validation.
 
 ### Version Verification
 
@@ -64,7 +69,7 @@ After install, verify the binary matches:
 
 ```bash
 VERSION=$(copilot --no-auto-update --version 2>&1 | head -1)
-echo "$VERSION"  # Should match pinned version
+echo "$VERSION"
 ```
 
 ### Validate Agent Loading
@@ -79,28 +84,28 @@ done
 
 ## Key Findings
 
-### Model Field Behavior
+### Historical Model Field Behavior
 
-The frontmatter `model` field is accepted by 0.0.397 without warnings but does NOT control runtime model selection. Model must be passed via `--model` CLI flag.
+On 0.0.397, the frontmatter `model` field was accepted without warnings but did not control runtime model selection. Do not generalize that result to current versions. ADR-080 governs model pins.
 
 | Invocation | Model Used |
 |------------|-----------|
 | No `--model` flag | `claude-sonnet-4.5` (CLI default) |
 | `--model claude-opus-4.5` | `claude-opus-4.5` |
 
-CI handles this via `copilot-model` action input (default: `claude-opus-4.5`).
+Read the current action input and platform configuration before diagnosing model selection.
 
 ### Auto-Update Bypass
 
 npm-loader.js delegates to a platform-specific binary that auto-updates independently. `npm list -g` may show 0.0.382 while `copilot --version` reports 0.0.400. npm version pinning alone is insufficient; `--no-auto-update` is required.
 
-### Platform-Specific Model Values
+### Platform-Specific Model Owners
 
-| Platform | Model Value | Config File |
-|----------|------------|-------------|
-| Copilot CLI | `claude-opus-4.5` | `templates/platforms/copilot-cli.yaml` |
-| VS Code | `Claude Opus 4.5 (copilot)` | `templates/platforms/vscode.yaml` |
-| Claude Code | `opus` | Hardcoded in `.claude/agents/` |
+| Platform | Source |
+|----------|--------|
+| Copilot CLI | `templates/platforms/copilot-cli.yaml` |
+| VS Code | `templates/platforms/vscode.yaml` |
+| Claude Code | Agent frontmatter and harness defaults |
 
 ### Valid Frontmatter Fields by Platform
 
@@ -112,7 +117,8 @@ npm-loader.js delegates to a platform-specific binary that auto-updates independ
 
 ## Related Files
 
-- ADR: `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md`
+- Current policy: `.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md`
+- Historical decision: `.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md`
 - CI action: `.github/actions/ai-review/action.yml`
 - Platform configs: `templates/platforms/copilot-cli.yaml`, `templates/platforms/vscode.yaml`
 - Build system: `build/Generate-Agents.Common.psm1`

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -33,7 +33,7 @@
 |jq json parse filter select map array object: [skills-jq-index](skills-jq-index.md) (356)
 |pr autofix lease bare checkout wrong branch local: [pr-autofix/bare-root-requires-pr-worktree-for-sha-audit](pr-autofix/bare-root-requires-pr-worktree-for-sha-audit.md) (299)
 |gh extension notify combine metrics milestone webhook grep: [skills-gh-extensions-index](skills-gh-extensions-index.md) (346)
-|copilot review false-positive triage response cli agent frontmatter: [skills-copilot-index](skills-copilot-index.md) (497), [copilot/copilot-cli-frontmatter-regression-runbook](copilot/copilot-cli-frontmatter-regression-runbook.md) (1875)
+|copilot review false-positive triage response cli agent frontmatter: [skills-copilot-index](skills-copilot-index.md) (497), [copilot/copilot-cli-frontmatter-regression-runbook](copilot/copilot-cli-frontmatter-regression-runbook.md) (1903)
 |triage stale closure verify history bot superseded duplicate: [pr-review/triage-001-verify-before-stale-closure](pr-review/triage-001-verify-before-stale-closure.md) (435), [pr-review/triage-002-bot-closure-verification](pr-review/triage-002-bot-closure-verification.md) (452)
 |pr validation gate status check blocker merge: [validation/validation-pr-gates](validation/validation-pr-gates.md) (1245)
 |pr checks read rollup truncation cancelled superseded severity: [pr-review/use-get-pr-checks-not-raw-rollup](pr-review/use-get-pr-checks-not-raw-rollup.md) (1974)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -424,7 +424,7 @@ outputDir: src/vs-code-agents
 fileExtension: .agent.md
 
 frontmatter:
-  model: "Claude Opus 4.5 (copilot)"
+  model: "Claude Opus 4.6 (copilot)"
   includeNameField: false
 
 handoffSyntax: "#runSubagent"
@@ -439,7 +439,7 @@ fileExtension: .agent.md
 
 frontmatter:
   # Copilot CLI model: use CLI model identifiers (not VS Code display names)
-  model: "claude-opus-4.5"
+  model: "claude-opus-4.6"
   includeNameField: true
 
 handoffSyntax: "/agent"
@@ -449,13 +449,13 @@ handoffSyntax: "/agent"
 
 | Feature | VS Code | Copilot CLI |
 |---------|---------|-------------|
-| Model field | `Claude Opus 4.5 (copilot)` | `claude-opus-4.5` |
+| Model field | `Claude Opus 4.6 (copilot)` | `claude-opus-4.6` |
 | Name field | Not included | Required |
 | Handoff syntax | `#runSubagent` | `/agent` |
 | Tools prefix | `tools_vscode` | `tools_copilot` |
 | `argument-hint` | Included | Included |
 
-> **Note:** The Copilot CLI `model` frontmatter field is accepted but does not control runtime model selection on version 0.0.397. The `--model` CLI flag is required. See ADR-044 for details.
+> **Note:** These model values reflect the current platform configuration, not durable policy. ADR-080 governs model-pin evidence. Runtime model selection follows the current Copilot CLI contract and action inputs.
 
 ## Important: Do Not Edit Generated Files
 
@@ -749,7 +749,9 @@ The CI pipeline uses GitHub Copilot CLI to run agent reviews. The CLI version is
 
 ### Current Pin
 
-The CI action (`.github/actions/ai-review/action.yml`) pins `@github/copilot@0.0.397` with `--no-auto-update` on all invocations. This is documented in [ADR-044](.agents/architecture/ADR-044-copilot-cli-frontmatter-compatibility.md).
+The required review path reads `COPILOT_VERSION` from `.github/actions/ai-review/action.yml`. The fallback in `scripts/ci/install_copilot_cli.py` must match it. The nightly smoke workflow carries an independent, Renovate-managed version.
+
+`scripts/validation/check_copilot_version_pin.py` rejects known-bad required-review pins. It is a denylist guard, not the version source or proof of runtime compatibility. See [ADR-094](.agents/architecture/ADR-094-govern-copilot-cli-compatibility.md).
 
 ### Why Version Pinning
 
@@ -798,17 +800,18 @@ gh act pull_request \
 
 **Known limitation:** PowerShell composite action steps fail with "Exec format error" in `act`. This is a known `act` limitation, not a workflow bug. The Copilot CLI install and agent invocation steps run correctly.
 
-### Upgrading the Copilot CLI Pin
+### Upgrading the Required Review Pin
 
-When the upstream regression ([github/copilot-cli#1195](https://github.com/github/copilot-cli/issues/1195)) is fixed:
+When changing the required review path's Copilot CLI version:
 
 1. Install the new version locally: `npm install -g @github/copilot@X.Y.Z`
 2. Run the agent validation loop above
-3. Update the version in `.github/actions/ai-review/action.yml`
+3. Update `.github/actions/ai-review/action.yml` and `scripts/ci/install_copilot_cli.py` together
 4. Run `gh act` dry-run to validate workflow structure
-5. Update ADR-044 with the new version and test results
+5. Run `uv run pytest tests/test_check_copilot_version_pin.py`
+6. Run `uv run python scripts/validation/check_copilot_version_pin.py`
 
-See `.serena/memories/copilot-cli-frontmatter-regression-runbook.md` for the full diagnostic runbook.
+Routine version bumps do not require an ADR edit. See `.serena/memories/copilot/copilot-cli-frontmatter-regression-runbook.md` for the diagnostic runbook.
 
 ## ADR-to-Protocol Sync Process
 


### PR DESCRIPTION
## Summary

Supersede ADR-044 instead of rewriting its implemented decisions.

ADR-094 now defines current Copilot CLI compatibility governance. Executable files own their version values, the validator remains a known-bad guard, runtime drift remains warn-only, and blocked version `0.0.397` is historical evidence only.

## Specification References

| Issue | Relationship |
|---|---|
| #4939 | Accepted ADR guidance contradicted the enforced version guard |

## Type of Change

- [x] Governance and documentation correction

## Changes

- Preserve ADR-044's original decision and mark it superseded.
- Add accepted ADR-094 with current version, validator, frontmatter, and sunset policy.
- Record two ADR review rounds and final 6 of 6 consensus.
- Remove stale `0.0.397` and model guidance from `CONTRIBUTING.md`.
- Update the Serena regression runbook to validate candidate versions instead of reinstalling 0.0.397.

## Validation

- [x] `uv run pytest tests/test_check_copilot_version_pin.py -q`, 15 passed
- [x] `uv run python scripts/validation/check_copilot_version_pin.py`, pin 1.0.63 accepted
- [x] `python3 scripts/validation/check_adr_uniqueness.py`, next free ADR 095
- [x] ADR review Round 2, 6 of 6 accepted
- [x] `npx markdownlint-cli2 CONTRIBUTING.md`
- [x] `uv run python scripts/validation/pre_pr.py`, 51 of 51 passed

Fixes #4939
