### PR TITLE
docs(github-url-intercept): replace PowerShell refs with Python scripts

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-15-session-14711-issue-4994-powershell-refs.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-14711-issue-4994-powershell-refs.json
@@ -1,0 +1,29 @@
+{
+  "id": "episode-2026-08-15-session-14711-issue-4994-powershell-refs",
+  "session": "2026-08-15-session-14711-issue-4994-powershell-refs",
+  "timestamp": "2026-08-15T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Replace stale PowerShell references in github-url-intercept patterns.md",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-15T08:24:45+00:00",
+      "type": "commit",
+      "content": "Commit: 3aa8a2b395",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-15-session-14711-issue-4994-powershell-refs"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-08-15-session-14711-issue-4994-powershell-refs.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-14711-issue-4994-powershell-refs.json
@@ -13,6 +13,19 @@
       "type": "commit",
       "content": "Commit: 3aa8a2b395",
       "caused_by": [],
+      "leads_to": [
+        "e002"
+      ],
+      "_source_session": "2026-08-15-session-14711-issue-4994-powershell-refs"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-15T10:32:52+00:00",
+      "type": "commit",
+      "content": "Commit: 0452c640e7",
+      "caused_by": [
+        "e001"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-15-session-14711-issue-4994-powershell-refs"
     }
@@ -22,8 +35,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
-    "files_changed": 3
+    "commits": 2,
+    "files_changed": 7
   },
   "lessons": []
 }

--- a/.agents/qa/pr-4994-powershell-refs-qa-report.md
+++ b/.agents/qa/pr-4994-powershell-refs-qa-report.md
@@ -1,0 +1,31 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
+qaCommit: 3aa8a2b395ed7901a09034fa664f1b179ffcf52f
+---
+
+# PR 4994 QA Report
+
+## Scope
+
+Validated replacement of stale PowerShell script references in github-url-intercept patterns.md documentation.
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| test_patterns_md_exists | PASS |
+| test_all_referenced_scripts_exist | PASS (all .py scripts resolve to shipped files) |
+| test_no_powershell_references | PASS (zero .ps1 references remain) |
+| Mirror parity | Canonical and Copilot patterns.md match |
+| Pre-push hooks | All passed |
+
+## Test commands
+
+```bash
+uv run pytest tests/skills/github_url_intercept/test_patterns_script_refs.py -v
+```
+
+## Verdict
+
+PASS. Documentation-only change with new validator test confirming no stale references remain.

--- a/.agents/qa/pr-5026-powershell-refs-qa-report.md
+++ b/.agents/qa/pr-5026-powershell-refs-qa-report.md
@@ -4,7 +4,7 @@ qaSessionLog: .agents/sessions/2026-08-15-session-14711-issue-4994-powershell-re
 qaCommit: 3aa8a2b395ed7901a09034fa664f1b179ffcf52f
 ---
 
-# PR 4994 QA Report
+# PR 5026 QA Report
 
 ## Scope
 

--- a/.agents/qa/pr-5026-powershell-refs-qa-report.md
+++ b/.agents/qa/pr-5026-powershell-refs-qa-report.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
-qaCommit: 3aa8a2b395ed7901a09034fa664f1b179ffcf52f
+qaCommit: 0452c640e7c9680465f9c5c83e650c1844026987
 ---
 
 # PR 5026 QA Report

--- a/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
+++ b/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 14711,
+    "date": "2026-08-15",
+    "branch": "fix/4994-remove-powershell-refs",
+    "startingCommit": "790d8024ff",
+    "objective": "Replace stale PowerShell references in github-url-intercept patterns.md"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Not applicable for documentation task"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No handoff file present"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "github skill scripts verified"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/4994-remove-powershell-refs"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/4994-remove-powershell-refs"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All items verified"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No memory updates needed for documentation fix"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Ran via pre-commit hook"
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/pr-4994-powershell-refs-qa-report.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All changes committed"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre-push hooks passed"
+      }
+    }
+  },
+  "workLog": [],
+  "endingCommit": "3aa8a2b395",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
+++ b/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
@@ -99,6 +99,6 @@
     }
   },
   "workLog": [],
-  "endingCommit": "3aa8a2b395",
+  "endingCommit": "0452c640e7",
   "nextSteps": []
 }

--- a/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
+++ b/.agents/sessions/2026-08-15-session-14711-issue-4994-powershell-refs.json
@@ -84,7 +84,7 @@
       "qaValidation": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": ".agents/qa/pr-4994-powershell-refs-qa-report.md"
+        "Evidence": ".agents/qa/pr-5026-powershell-refs-qa-report.md"
       },
       "changesCommitted": {
         "level": "MUST",

--- a/.claude/skills/github-url-intercept/references/patterns.md
+++ b/.claude/skills/github-url-intercept/references/patterns.md
@@ -129,7 +129,7 @@ Raw gist content:
 | Need | Script | Why |
 |------|--------|-----|
 | PR overview | get_pr_context.py | Structured JSON, proper error handling |
-| Review comments | Get-PRReviewComments.ps1 (legacy) | Pagination handled, threading preserved |
+| Review comments | get_pr_review_comments.py | Pagination handled, threading preserved |
 | Review threads | get_pr_review_threads.py | Full thread context |
 | CI status | get_pr_checks.py | Can wait for completion, structured output |
 | Issue overview | get_issue_context.py | Structured JSON, proper error handling |

--- a/.claude/skills/github-url-intercept/references/patterns.md
+++ b/.claude/skills/github-url-intercept/references/patterns.md
@@ -161,8 +161,8 @@ Raw gist content:
 ### When Size Matters Most
 
 1. **Large PRs** (100+ files, 1000+ lines)
-   - Use `-DiffStat` instead of full diff
-   - Use `-IncludeChangedFiles` without `-IncludeDiff`
+   - Use `--diff-stat` instead of full diff
+   - Use `--include-changed-files` without `--include-diff`
 
 2. **Busy issues** (50+ comments)
    - Get issue context first

--- a/src/copilot-cli/skills/github-url-intercept/references/patterns.md
+++ b/src/copilot-cli/skills/github-url-intercept/references/patterns.md
@@ -129,7 +129,7 @@ Raw gist content:
 | Need | Script | Why |
 |------|--------|-----|
 | PR overview | get_pr_context.py | Structured JSON, proper error handling |
-| Review comments | Get-PRReviewComments.ps1 (legacy) | Pagination handled, threading preserved |
+| Review comments | get_pr_review_comments.py | Pagination handled, threading preserved |
 | Review threads | get_pr_review_threads.py | Full thread context |
 | CI status | get_pr_checks.py | Can wait for completion, structured output |
 | Issue overview | get_issue_context.py | Structured JSON, proper error handling |

--- a/src/copilot-cli/skills/github-url-intercept/references/patterns.md
+++ b/src/copilot-cli/skills/github-url-intercept/references/patterns.md
@@ -161,8 +161,8 @@ Raw gist content:
 ### When Size Matters Most
 
 1. **Large PRs** (100+ files, 1000+ lines)
-   - Use `-DiffStat` instead of full diff
-   - Use `-IncludeChangedFiles` without `-IncludeDiff`
+   - Use `--diff-stat` instead of full diff
+   - Use `--include-changed-files` without `--include-diff`
 
 2. **Busy issues** (50+ comments)
    - Get issue context first

--- a/tests/skills/github_url_intercept/test_patterns_script_refs.py
+++ b/tests/skills/github_url_intercept/test_patterns_script_refs.py
@@ -1,0 +1,65 @@
+"""Validate that script names in patterns.md resolve to shipped files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[3]
+PATTERNS_MD = (
+    REPO_ROOT
+    / ".claude"
+    / "skills"
+    / "github-url-intercept"
+    / "references"
+    / "patterns.md"
+)
+GITHUB_SCRIPTS_DIR = REPO_ROOT / ".claude" / "skills" / "github" / "scripts"
+
+
+def _extract_script_names(text: str) -> list[str]:
+    """Extract Python script names referenced as commands in patterns.md.
+
+    Matches scripts after arrow indicators or in table Script columns,
+    excluding example file paths in URLs.
+    """
+    # Scripts after → arrows (e.g., "→ get_pr_context.py --pull-request 123")
+    arrow_refs = re.findall(r"→\s+([\w-]+\.py)", text)
+    # Scripts in table cells (column after |)
+    table_refs = re.findall(r"\|\s+([\w-]+\.py)\b", text)
+    return arrow_refs + table_refs
+
+
+def _find_script(name: str) -> Path | None:
+    """Locate a script anywhere under the github skills scripts directory."""
+    for path in GITHUB_SCRIPTS_DIR.rglob(name):
+        return path
+    return None
+
+
+@pytest.fixture()
+def pattern_scripts() -> list[str]:
+    content = PATTERNS_MD.read_text()
+    return _extract_script_names(content)
+
+
+def test_patterns_md_exists() -> None:
+    assert PATTERNS_MD.is_file(), f"Missing: {PATTERNS_MD}"
+
+
+def test_all_referenced_scripts_exist(pattern_scripts: list[str]) -> None:
+    """Every .py script named in patterns.md must exist in the github skill."""
+    missing: list[str] = []
+    for name in set(pattern_scripts):
+        if _find_script(name) is None:
+            missing.append(name)
+    assert not missing, f"Scripts referenced in patterns.md but not found: {missing}"
+
+
+def test_no_powershell_references() -> None:
+    """No .ps1 references should remain in patterns.md."""
+    content = PATTERNS_MD.read_text()
+    ps1_refs = re.findall(r"\b[\w-]+\.ps1\b", content)
+    assert not ps1_refs, f"PowerShell references remain: {ps1_refs}"


### PR DESCRIPTION
## Summary

Replace the stale PowerShell reference in the URL routing patterns documentation with the current Python script name.

Fixes #4994

## Changes

- Replace `Get-PRReviewComments.ps1 (legacy)` with the Python equivalent in `patterns.md`
- Regenerate the Copilot CLI mirror
- Add `test_patterns_script_refs.py` validator that:
  - Asserts all script names in patterns.md resolve to shipped files
  - Asserts no `.ps1` references remain

## Testing

```bash
uv run pytest tests/skills/github_url_intercept/test_patterns_script_refs.py -v
```

## Check state

- Local hooks pass (pre-commit, pre-push)
- 3 new tests pass
- Documentation-only change to patterns.md (no executable behavior change)