### PR TITLE
fix(docs): correct stale strict_required_status_checks_policy assertions and add drift check

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-15-session-2-issue-4646.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-2-issue-4646.json
@@ -1,0 +1,114 @@
+{
+  "id": "episode-2026-08-15-session-2-issue-4646",
+  "session": "2026-08-15-session-2-issue-4646",
+  "timestamp": "2026-08-15T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Correct stale strict_required_status_checks_policy assertions and add drift check (issue #4646)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "verify",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "fix",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "fix",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "implement",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "test",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "fix",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "implement",
+      "caused_by": [],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-15T12:13:59+00:00",
+      "type": "commit",
+      "content": "Commit: b24134cd7e542e3681ecb40d7f4aefe15ecb01cb",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003",
+        "e004",
+        "e005",
+        "e006",
+        "e007"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-15-session-2-issue-4646"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/qa/pr-5051-issue-4646-qa.md
+++ b/.agents/qa/pr-5051-issue-4646-qa.md
@@ -1,0 +1,25 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-15-session-2-issue-4646.json
+qaCommit: b24134cd7e542e3681ecb40d7f4aefe15ecb01cb
+---
+
+# QA Report: PR #5051 (Issue #4646)
+
+## Scope
+
+Correct stale `strict_required_status_checks_policy=true` assertions; add drift check.
+
+## Verification
+
+- [x] Live server confirms `false` via `gh api repos/rjmurillo/ai-agents/rulesets/11104075`
+- [x] All 6 memory files corrected with dated annotations
+- [x] `.github/AGENTS.md` section 6.3 rewritten
+- [x] Drift check script handles: no drift, drift, missing gh, auth failure, malformed JSON, extra params
+- [x] 13 tests pass locally
+- [x] Pre-push hooks pass (python-tests, pre-pr-validation)
+- [x] No force push or hook bypass used
+
+## Verdict
+
+PASS

--- a/.agents/sessions/2026-08-15-session-2-issue-4646.json
+++ b/.agents/sessions/2026-08-15-session-2-issue-4646.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2,
+    "date": "2026-08-15",
+    "branch": "fix/4646-ruleset-drift-v3",
+    "startingCommit": "82ea2c54bd",
+    "objective": "Correct stale strict_required_status_checks_policy assertions and add drift check (issue #4646)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Evidence": "serena tools available",
+        "Complete": true
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Evidence": "initial instructions read",
+        "Complete": true
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Evidence": "HANDOFF.md read",
+        "Complete": true
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Evidence": "session log created",
+        "Complete": true
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Evidence": "scripts/validation/ reviewed",
+        "Complete": true
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Evidence": "issue #4646 read",
+        "Complete": true
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Evidence": "AGENTS.md and CLAUDE.md read",
+        "Complete": true
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Evidence": "diagnosing-a-blocked-pr memory loaded",
+        "Complete": true
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Evidence": "fix/4646-ruleset-drift-v3 from origin/main",
+        "Complete": true
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Evidence": "on fix/4646-ruleset-drift-v3",
+        "Complete": true
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Evidence": "all items verified",
+        "Complete": true
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Evidence": "no handoff changes needed",
+        "Complete": true
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Evidence": "memories corrected in commits",
+        "Complete": true
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Evidence": "markdown autofix hook passed",
+        "Complete": true
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Evidence": ".agents/qa/pr-5051-issue-4646-qa.md",
+        "Complete": true
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Evidence": "4 commits pushed",
+        "Complete": true
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Evidence": "pre-push hooks pass",
+        "Complete": true
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "verify",
+      "description": "Confirmed live server: strict=false (reverted 2026-08-10)"
+    },
+    {
+      "action": "fix",
+      "description": "Corrected 6 memory files with dated annotations"
+    },
+    {
+      "action": "fix",
+      "description": "Updated .github/AGENTS.md section 6.3"
+    },
+    {
+      "action": "implement",
+      "description": "Created drift check script with bidirectional detection"
+    },
+    {
+      "action": "test",
+      "description": "Added 13 tests (positive, negative, edge)"
+    },
+    {
+      "action": "fix",
+      "description": "Fixed subprocess encoding violation in consume_pytest_signal.py"
+    },
+    {
+      "action": "implement",
+      "description": "Registered script in reachability test"
+    }
+  ],
+  "endingCommit": "b24134cd7e542e3681ecb40d7f4aefe15ecb01cb",
+  "nextSteps": [
+    "Monitor CI and confirm merge"
+  ]
+}

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -642,20 +642,16 @@ returns exit 0), so the merged tree above is green and concurrent cleanup PRs
 never conflict on the shared line. Arming
 `strict_required_status_checks_policy` on ruleset `11104075` so the second PR
 had to be current before merging is not needed for this race: with the ratchet
-tolerating the drift there is no red `main` to prevent. Note that strict was
-nonetheless armed on 2026-08-04 (ruleset version `45433643`) for a different
-reason, as remediation for the red-`main` incident of that date, so it is on
-today and must stay on. See issue #4646 and
-`.serena/memories/decision-every-merge-invalidates-every-open-pr.md`.
+tolerating the drift there is no red `main` to prevent. Strict was armed on
+2026-08-04 (ruleset version `45433643`) as remediation for the red-`main`
+incident of that date, then reverted to `false` on 2026-08-10 (ruleset last
+updated). The ratchet tolerance alone prevents the race.
 
-**Status note, measured 2026-08-05.** That policy now reads `true` on ruleset
-`11104075`. The paragraph above stays accurate on its own terms: strict checks
-are not what resolves this particular race, and the ratchet tolerance is. Read
-it as a statement about the race, not as a claim about the current setting. Do
-not infer from it that being behind `main` is harmless, because it now blocks
-the merge outright. There is still no merge queue. Issue #4608 records an
-unverified hypothesis about how a future merge group would behave. See issue
-#4646.
+**Status note, measured 2026-08-14.** That policy reads `false` on ruleset
+`11104075`. Being behind `main` does not block merge via the ruleset. The count
+ratchets still enforce practical freshness for PRs touching ratcheted counts.
+There is still no merge queue. Issue #4608 records an unverified hypothesis
+about how a future merge group would behave. See issue #4646.
 
 **Residual cost.** The baseline sits above the true count until someone records
 it, and that gap absorbs one later regression without firing. `--update` closes

--- a/.serena/memories/ci/ci-count-ratchets-require-branch-freshness.md
+++ b/.serena/memories/ci/ci-count-ratchets-require-branch-freshness.md
@@ -1,11 +1,11 @@
-# The count ratchets made "behind main" a real merge blocker before the branch ruleset did too
+# The count ratchets make "behind main" a practical merge blocker even though the ruleset does not
 
 ## Question
 
-`main`'s branch ruleset now sets `strict_required_status_checks_policy: true`, so
-being behind `main` blocks a merge. Before that flip, the count ratchets still
-made stale branches fail in practice. Did branch freshness matter even before
-the ruleset required it?
+`main`'s branch ruleset sets `strict_required_status_checks_policy: false`, so
+being behind `main` does not formally block a merge. Nevertheless the count
+ratchets still make stale branches fail in practice. Does branch freshness
+matter even without the ruleset requiring it?
 
 ## Conventional answer
 

--- a/.serena/memories/ci/monitoring-001-blocked-pr-root-cause.md
+++ b/.serena/memories/ci/monitoring-001-blocked-pr-root-cause.md
@@ -64,10 +64,10 @@ gh pr checks $PR_NUMBER --repo $REPO | grep -E "(pending|fail|skipping)"
 
 The principle above holds. Three of its specifics no longer match the repo:
 
-1. "Needs main merge" is now correct when a PR is behind main. The main ruleset
-   sets `strict_required_status_checks_policy: true`, so being behind main
-   blocks a merge. Refreshing the branch against main is required before the
-   remaining gates can clear.
+1. "Needs main merge" is NOT a valid diagnosis. The main ruleset
+   sets `strict_required_status_checks_policy: false`, so being behind main
+   does not block a merge. Do not refresh the branch unless a status check
+   itself requires current content (e.g. count ratchets).
 2. "Awaiting review" is rarely the answer. `required_approving_review_count`
    is 0. What does block is `required_review_thread_resolution: true`, so an
    unresolved thread, not a missing approval.

--- a/.serena/memories/decision-a-whole-corpus-gate-cannot-be-path-filtered.md
+++ b/.serena/memories/decision-a-whole-corpus-gate-cannot-be-path-filtered.md
@@ -96,9 +96,9 @@ a6c16da8d    #4329   82603   397 bytes headroom
 Each PR was measured against its own base and passed honestly. No two of them
 touch the same file. The ceiling is a sum, so the breach exists only after both
 land. At the time, `strict_required_status_checks_policy: false` on ruleset
-11104075 permitted exactly this. With strict now set to true, admission is
-serialized because the second PR must refresh against the merged result before
-it can land.
+11104075 permitted exactly this. With strict reverted to false (2026-08-10), admission is no longer
+serialized by the ruleset; the count ratchets still enforce practical freshness
+for PRs touching ratcheted counts.
 
 Any absolute (non-diff-relative) ceiling has this property. A ratchet that
 compares against `origin/main` does not, which is why the count ratchets caught
@@ -128,8 +128,9 @@ nothing. Verify such a fix against run **jobs** across a burst of merges, never
 against the workflow source.
 
 Running an absolute ceiling at 100.0 percent utilization is still brittle. The
-strict flip weakens the concurrent-admission mechanism because a stale second PR
-must refresh and re-run against the merged result. The capacity answer remains a
+strict flip (when active) weakened the concurrent-admission mechanism because a stale second PR
+had to refresh and re-run against the merged result. With strict now off, the
+concurrent-admission risk returns. The capacity answer remains a
 **reserve band**: fail or warn at PR time when the merged result would leave less
 than a threshold of headroom, so one PR cannot consume the last bytes and leave
 the next routine edit blocked.

--- a/.serena/memories/decision-every-merge-invalidates-every-open-pr.md
+++ b/.serena/memories/decision-every-merge-invalidates-every-open-pr.md
@@ -21,10 +21,8 @@ automatically, and there is still no merge queue to test the combined result:
 grep -rln merge_group .github/workflows/
   -> (nothing)
 ```
-
-**That `false` is a 2026-08-03 reading and is no longer true. Strict is `true`
-today, deliberately, and must stay on. See "Do not correct
-`strict_required_status_checks_policy` back to `false`" below, and issue #4646.
+**Measured 2026-08-14: strict is `false` on ruleset 11104075 (reverted
+2026-08-10). Being behind main does not block merge via the ruleset.
 The `merge_group` half still holds: no workflow answers that event, and a merge
 queue cannot be enabled on this repository anyway.**
 
@@ -34,8 +32,13 @@ clears violations. So **every merge invalidates every other open PR**, and a
 drain of N PRs is not N independent units of work. It is a queue that re-dirties
 itself behind you.
 
-### The strict policy flipped on, which sharpens this rather than fixing it
+### The strict policy flipped on then off (historical, 2026-08-04 to 2026-08-10)
 
+
+> **Current state (2026-08-14):** strict is `false` again. The observations
+> below describe behavior during the armed period. The serialization they
+> document is no longer enforced by the ruleset, though count ratchets still
+> impose practical freshness requirements.
 This memory originally recorded
 `"strict_required_status_checks_policy": false`, and reasoned that no PR was
 ever *required* to be current. That is no longer the configuration. Measured
@@ -161,9 +164,9 @@ repositories for this configuration. The owner must transfer the repository to
 an organization or GitHub must expand eligibility before the ruleset gains a
 `merge_queue` rule.
 
-`strict_required_status_checks_policy` is deliberately `true`. It prevents a
-branch behind main from merging on checks that never saw current main. The
-merge-tree ratchet complements strict checks, it does not replace them.
+`strict_required_status_checks_policy` is `false` (reverted 2026-08-10). A
+branch behind main is not blocked from merging by the ruleset alone. The count
+ratchets still enforce practical freshness for PRs that touch ratcheted counts.
 
 ## Corollary: the merged result can be red even when every input was green
 

--- a/.serena/memories/diagnosing-a-blocked-pr.md
+++ b/.serena/memories/diagnosing-a-blocked-pr.md
@@ -27,13 +27,14 @@ Measured 2026-08-01, that returns: `deletion`, `non_fast_forward`,
 
 | Parameter | Value | Consequence |
 | --- | --- | --- |
-| `strict_required_status_checks_policy` | `true` | Being behind main DOES block. Refresh the branch against main to unblock it. |
+| `strict_required_status_checks_policy` | `false` (measured 2026-08-14; reverted 2026-08-10) | Being behind main does NOT block merge. Do not merge main into a branch solely to unblock it. |
 | `required_review_thread_resolution` | `true` | Any unresolved review thread blocks. This is the dominant real cause. |
 | `required_approving_review_count` | `0` | No human approval needed. |
 | `required_status_checks` | 17 contexts | A required context that is missing blocks. SKIPPED and NEUTRAL do not. |
 
-The ruleset now makes branch freshness a merge gate. When a PR is behind main,
-refresh the branch before diagnosing missing contexts or unresolved threads.
+Branch freshness is not a merge gate (strict is off). When a PR is behind
+main, diagnose missing contexts or unresolved threads directly; do not refresh
+the branch as a first step.
 
 ## The diagnosis that works
 

--- a/.serena/memories/git/git-merging-main-forfeits-the-docs-only-push-bypass.md
+++ b/.serena/memories/git/git-merging-main-forfeits-the-docs-only-push-bypass.md
@@ -129,11 +129,11 @@ as sanctioned.
 Do not re-run the push hoping the refusal was transient. The path set is a
 deterministic property of the push range.
 
-Do not merge main into a docs branch just because GitHub says `behind`. Here it
-does block: `main` carries a **ruleset** with
-`strict_required_status_checks_policy: true`, so an out-of-date head cannot
-merge. `gh pr update-branch` clears that without touching local history.
-
+Do not merge main into a docs branch just because GitHub says `behind`. Here
+it does not block: `main` carries a **ruleset** with
+`strict_required_status_checks_policy: false`, so an out-of-date head can still
+merge. Use `gh pr update-branch` only if a status check itself requires fresh
+content (e.g. count ratchets comparing against the current baseline).
 Do not read a 404 from `gh api repos/{owner}/{repo}/branches/main/protection` as
 "main is unprotected". This repository governs `main` with rulesets, not classic
 branch protection, and the classic endpoint 404s regardless. Ask

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -15,7 +15,7 @@
 
 [GitHub and PR Operations]
 |self-assessment ready-to-push refuted independent review negative control inert: [decision-agent-self-assessment-does-not-survive-review](decision-agent-self-assessment-does-not-survive-review.md) (1149)
-|merge invalidates open PRs stale baseline ratchet strict: [decision-every-merge-invalidates-every-open-pr](decision-every-merge-invalidates-every-open-pr.md) (3568)
+|merge invalidates open PRs stale baseline ratchet strict: [decision-every-merge-invalidates-every-open-pr](decision-every-merge-invalidates-every-open-pr.md) (3635)
 |injected instructions stale snapshot always-on context lags repo: [decision-injected-instructions-lag-the-repo](decision-injected-instructions-lag-the-repo.md) (785)
 |gh graphql rest rate limit budget separate exhaustion: [process/process-gh-graphql-and-rest-budgets-are-separate](process/process-gh-graphql-and-rest-budgets-are-separate.md) (1421)
 |rate limit 403 refusal header X-Ratelimit-Reset Remaining velocity: [ci/github-rate-limit-payload-does-not-predict-service](ci/github-rate-limit-payload-does-not-predict-service.md) (4114)
@@ -39,7 +39,7 @@
 |pr validation gate status check blocker merge: [validation/validation-pr-gates](validation/validation-pr-gates.md) (1245)
 |pr checks read rollup truncation cancelled superseded severity: [pr-review/use-get-pr-checks-not-raw-rollup](pr-review/use-get-pr-checks-not-raw-rollup.md) (1974)
 |adversarial review dispatched model subagent fabricated finding verify: [pr-review/dispatched-model-reviewer-reliability](pr-review/dispatched-model-reviewer-reliability.md) (2569)
-|blocked pr mergeStateStatus ruleset required contexts thread resolution: [diagnosing-a-blocked-pr](diagnosing-a-blocked-pr.md) (885)
+|blocked pr mergeStateStatus ruleset required contexts thread resolution: [diagnosing-a-blocked-pr](diagnosing-a-blocked-pr.md) (919)
 |ruleset required contexts scheduled drift second baseline duplicate source contract: [decision-ruleset-drift-must-not-create-a-second-baseline](decision-ruleset-drift-must-not-create-a-second-baseline.md) (258)
 |pr context statusCheckRollup list null CheckRun StatusContext reviewThreads: [github/pr-context-authoritative-metadata](github/pr-context-authoritative-metadata.md) (195)
 
@@ -101,7 +101,7 @@
 |spec coverage acceptance criteria checkbox observe signal non-blocking: [ci/ci-spec-coverage-acceptance-signal-is-observe-only](ci/ci-spec-coverage-acceptance-signal-is-observe-only.md) (917)
 |mutation harness restore failure truncate empty target sibling: [ci/mutation-harness-restore-failure-safe-writes](ci/mutation-harness-restore-failure-safe-writes.md) (360)
 |BOT_PAT github.token runner token AI review read calls: [ci/ci-ai-review-read-calls-use-runner-token](ci/ci-ai-review-read-calls-use-runner-token.md) (284)
-|count ratchet baseline branch freshness behind main stale: [ci/ci-count-ratchets-require-branch-freshness](ci/ci-count-ratchets-require-branch-freshness.md) (845)
+|count ratchet baseline branch freshness behind main stale: [ci/ci-count-ratchets-require-branch-freshness](ci/ci-count-ratchets-require-branch-freshness.md) (844)
 |taste count ratchet pre-push cost twelve minutes python-tests: [ci/run-count-ratchets-before-the-expensive-pre-push](ci/run-count-ratchets-before-the-expensive-pre-push.md) (714)
 |taste baseline slack MAX_BASELINE_SLACK drift enforced by pytest: [ci/ci-taste-baseline-slack-is-enforced-by-pytest-not-the-ratchet](ci/ci-taste-baseline-slack-is-enforced-by-pytest-not-the-ratchet.md) (839)
 |ratchet declared twice lefthook checks_ratchet parity add/add conflict: [ci/ci-a-ratchet-is-declared-twice-so-drop-it-twice](ci/ci-a-ratchet-is-declared-twice-so-drop-it-twice.md) (704)

--- a/scripts/quality_gate/consume_pytest_signal.py
+++ b/scripts/quality_gate/consume_pytest_signal.py
@@ -185,7 +185,8 @@ def main(argv: list[str] | None = None) -> int:
             result = subprocess.run(
                 ["gh", "api", f"repos/{repo}/pulls/{pr}", "--jq", ".head.sha"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=True,
             )

--- a/scripts/validation/check_ruleset_params_drift.py
+++ b/scripts/validation/check_ruleset_params_drift.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Check recorded ruleset parameters against the live GitHub API.
+
+Compares the values in ruleset_params_baseline.json against the live
+ruleset fetched via `gh api`. Exits non-zero when any parameter drifts.
+
+Usage (local):
+    python scripts/validation/check_ruleset_params_drift.py
+
+Usage (CI, offline / no token):
+    python scripts/validation/check_ruleset_params_drift.py --offline
+
+EXIT CODES (ADR-035):
+    0 - all parameters match or --offline skipped the live check
+    1 - drift detected
+    2 - configuration error (missing baseline, bad JSON)
+    3 - external error (gh CLI unavailable, API failure)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_CONFIG = 2
+EXIT_EXTERNAL = 3
+EXIT_AUTH = 4
+
+BASELINE_PATH = Path(__file__).parent / "ruleset_params_baseline.json"
+REPO = "rjmurillo/ai-agents"
+
+
+def load_baseline() -> dict[str, Any]:
+    """Load the expected parameter baseline."""
+    if not BASELINE_PATH.exists():
+        print(f"ERROR: baseline not found: {BASELINE_PATH}", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
+    try:
+        result: dict[str, Any] = json.loads(
+            BASELINE_PATH.read_text(encoding="utf-8")
+        )
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON in baseline: {exc}", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
+    if "parameters" not in result:
+        print("ERROR: baseline missing 'parameters' key", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
+    return result
+
+
+def fetch_live_params(ruleset_id: int) -> dict[str, Any]:
+    """Fetch live ruleset parameters from GitHub API via gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{REPO}/rulesets/{ruleset_id}"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError:
+        print("ERROR: gh CLI not found on PATH", file=sys.stderr)
+        sys.exit(EXIT_EXTERNAL)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        exit_code = EXIT_AUTH if "auth" in stderr.lower() else EXIT_EXTERNAL
+        print(
+            f"ERROR: gh api failed (exit {result.returncode}): {stderr}",
+            file=sys.stderr,
+        )
+        sys.exit(exit_code)
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON from API: {exc}", file=sys.stderr)
+        sys.exit(EXIT_EXTERNAL)
+
+    params: dict[str, Any] = {}
+    for rule in data.get("rules", []):
+        rule_params = rule.get("parameters", {})
+        if rule_params:
+            params.update(rule_params)
+    return params
+
+
+def check_drift(
+    baseline: dict[str, Any], live: dict[str, Any]
+) -> list[str]:
+    """Compare baseline parameters against live values. Return drift messages."""
+    drifts: list[str] = []
+    baseline_params = baseline.get("parameters", {})
+    for key, expected in baseline_params.items():
+        actual = live.get(key)
+        if actual is None:
+            drifts.append(
+                f"  {key}: expected={expected!r}, not found in live ruleset"
+            )
+        elif actual != expected:
+            drifts.append(f"  {key}: expected={expected!r}, actual={actual!r}")
+    # Detect parameters present live but absent from baseline
+    for key in live:
+        if key not in baseline_params:
+            drifts.append(
+                f"  {key}: unexpected parameter (not in baseline), value={live[key]!r}"
+            )
+    return drifts
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    args = argv if argv is not None else sys.argv[1:]
+
+    if "--offline" in args:
+        print("SKIP: --offline flag set, no live check performed.")
+        return EXIT_OK
+
+    baseline = load_baseline()
+    ruleset_id = baseline.get("ruleset_id")
+    if not ruleset_id:
+        print("ERROR: ruleset_id missing from baseline", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
+
+    live = fetch_live_params(ruleset_id)
+    drifts = check_drift(baseline, live)
+
+    if drifts:
+        print("DRIFT DETECTED between baseline and live ruleset:")
+        print("\n".join(drifts))
+        print(
+            f"\nUpdate {BASELINE_PATH.name} after confirming the change is"
+            " intentional."
+        )
+        return EXIT_DRIFT
+
+    print("OK: all recorded ruleset parameters match live values.")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/ruleset_params_baseline.json
+++ b/scripts/validation/ruleset_params_baseline.json
@@ -1,0 +1,10 @@
+{
+  "ruleset_id": 11104075,
+  "ref": "main",
+  "parameters": {
+    "strict_required_status_checks_policy": false,
+    "required_review_thread_resolution": true,
+    "required_approving_review_count": 0
+  },
+  "measured": "2026-08-14"
+}

--- a/tests/ci/test_validation_scripts_are_reachable.py
+++ b/tests/ci/test_validation_scripts_are_reachable.py
@@ -27,7 +27,7 @@ Workflow, hook, and skill documentation can name an entry point. Once a
 ``SKILL.md`` names a helper script, the graph follows that helper's imports and
 executable string literals.
 
-Under that model the same 89 scripts yield two unreachable, each of which is a
+Under that model the same 89 scripts yield three unreachable, each of which is a
 real decision recorded in ``_NO_CALLER`` below rather than a bulk exemption.
 
 What this does not do: prove the caller is correct, or that the script would
@@ -93,6 +93,11 @@ _NO_CALLER: dict[str, str] = {
         "network and gates nothing in a diff. It is a triage report for #2623, "
         "not a code gate: a PR cannot introduce a duplicate priority label on "
         "an issue. Belongs on a schedule, which does not exist yet."
+    ),
+    "scripts/validation/check_ruleset_params_drift.py": (
+        "Queries the live GitHub API for ruleset parameters, so it needs gh "
+        "auth and network. A PR cannot change a ruleset setting. Designed for "
+        "on-demand and scheduled use to detect server-side drift (#4646)."
     ),
 }
 

--- a/tests/validation/test_check_ruleset_params_drift.py
+++ b/tests/validation/test_check_ruleset_params_drift.py
@@ -1,0 +1,152 @@
+"""Tests for check_ruleset_params_drift.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[2] / "scripts" / "validation")
+)
+import check_ruleset_params_drift as mod
+
+
+class TestCheckDrift:
+    """Unit tests for the drift comparison logic."""
+
+    def test_no_drift(self):
+        baseline = {"parameters": {"strict_required_status_checks_policy": False}}
+        live = {"strict_required_status_checks_policy": False}
+        assert mod.check_drift(baseline, live) == []
+
+    def test_drift_detected(self):
+        baseline = {"parameters": {"strict_required_status_checks_policy": False}}
+        live = {"strict_required_status_checks_policy": True}
+        drifts = mod.check_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "expected=False" in drifts[0]
+        assert "actual=True" in drifts[0]
+
+    def test_missing_key_in_live(self):
+        baseline = {"parameters": {"strict_required_status_checks_policy": False}}
+        live = {}
+        drifts = mod.check_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "not found" in drifts[0]
+
+    def test_multiple_params(self):
+        baseline = {
+            "parameters": {
+                "strict_required_status_checks_policy": False,
+                "required_review_thread_resolution": True,
+            }
+        }
+        live = {
+            "strict_required_status_checks_policy": False,
+            "required_review_thread_resolution": True,
+        }
+        assert mod.check_drift(baseline, live) == []
+
+
+class TestMainOffline:
+    """Test the --offline flag."""
+
+    def test_offline_skips(self, capsys):
+        rc = mod.main(["--offline"])
+        assert rc == 0
+        assert "SKIP" in capsys.readouterr().out
+
+
+class TestMainLive:
+    """Integration-style tests with mocked subprocess."""
+
+    def _mock_gh(self, params: dict):
+        """Return a mock that simulates gh api returning given params."""
+        rules = [{"type": "required_status_checks", "parameters": params}]
+        payload = json.dumps({"rules": rules})
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=payload, stderr=""
+        )
+
+    def test_match_returns_zero(self, capsys):
+        live_params = {
+            "strict_required_status_checks_policy": False,
+            "required_review_thread_resolution": True,
+            "required_approving_review_count": 0,
+        }
+        with patch("subprocess.run", return_value=self._mock_gh(live_params)):
+            rc = mod.main([])
+        assert rc == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_drift_returns_one(self, capsys):
+        live_params = {
+            "strict_required_status_checks_policy": True,
+            "required_review_thread_resolution": True,
+            "required_approving_review_count": 0,
+        }
+        with patch("subprocess.run", return_value=self._mock_gh(live_params)):
+            rc = mod.main([])
+        assert rc == 1
+        assert "DRIFT" in capsys.readouterr().out
+
+    def test_api_failure_exits_auth(self):
+        fail = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="auth failed"
+        )
+        with patch("subprocess.run", return_value=fail):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == 4
+
+    def test_api_failure_exits_external(self):
+        fail = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="network timeout"
+        )
+        with patch("subprocess.run", return_value=fail):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == 3
+
+    def test_gh_not_found_exits_external(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == 3
+
+
+class TestEdgeCases:
+    """Edge cases: malformed baseline, extra live params."""
+
+    def test_malformed_baseline_exits_config(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json{{{", encoding="utf-8")
+        with patch.object(mod, "BASELINE_PATH", bad):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == mod.EXIT_CONFIG
+
+    def test_missing_parameters_key_exits_config(self, tmp_path: Path) -> None:
+        no_params = tmp_path / "no_params.json"
+        no_params.write_text('{"ruleset_id": 1}', encoding="utf-8")
+        with patch.object(mod, "BASELINE_PATH", no_params):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == mod.EXIT_CONFIG
+
+    def test_extra_live_params_reported_as_drift(self) -> None:
+        baseline: dict[str, Any] = {
+            "parameters": {"strict_required_status_checks_policy": False}
+        }
+        live: dict[str, Any] = {
+            "strict_required_status_checks_policy": False,
+            "require_linear_history": True,
+        }
+        drifts = mod.check_drift(baseline, live)
+        assert any("require_linear_history" in d for d in drifts)


### PR DESCRIPTION
## Summary

Corrects all stale `strict_required_status_checks_policy=true` assertions across 6 memory files and `.github/AGENTS.md`. The live server value is `false` (reverted 2026-08-10, measured 2026-08-14).

Adds a durable drift check script (`scripts/validation/check_ruleset_params_drift.py`) with a JSON baseline and 13 tests covering positive, negative, and edge cases.

Also fixes a pre-existing subprocess encoding convention violation in `consume_pytest_signal.py`.

## Changes

- **6 memory files**: Replace `true` with `false`, add dated measurement annotations
- **`.github/AGENTS.md`**: Rewrite section 6.3 with 2026-08-14 measurement
- **New drift check script**: Compares JSON baseline to live API, handles missing `gh` CLI (exit 3), auth failures (exit 4), bidirectional drift detection
- **13 tests**: Positive (no drift), negative (drift detected), edge (malformed JSON, missing key, extra params, FileNotFoundError, auth failure)
- **Reachability test**: Register new script in `_NO_CALLER`
- **Encoding fix**: Pin `encoding="utf-8", errors="replace"` in `consume_pytest_signal.py:185`

Fixes #4646
Replaces #5029 (closed due to memory-index conflict)