### PR TITLE
fix(validation): detect section reordering in frontmatter bypass

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-15-session-15002-fix-5043-section-reorder.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-15002-fix-5043-section-reorder.json
@@ -1,0 +1,79 @@
+{
+  "id": "episode-2026-08-15-session-15002-fix-5043-section-reorder",
+  "session": "2026-08-15-session-15002-fix-5043-section-reorder",
+  "timestamp": "2026-08-15T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Fix frontmatter bypass missing section reordering (issue #5043)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "implement",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "test",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "verify",
+      "caused_by": [],
+      "leads_to": [
+        "e004"
+      ],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-15T12:25:13+00:00",
+      "type": "commit",
+      "content": "Commit: 5a6ed8716741aa71051fc6e0b108a0aff9d66cbe",
+      "caused_by": [
+        "e001",
+        "e002",
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-15T12:45:40+00:00",
+      "type": "commit",
+      "content": "Commit: 05e717f5b6343ab9e7e635cd5e1fae1be93db3bb",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-08-15-session-15002-fix-5043-section-reorder.json
+++ b/.agents/memory/episodes/episode-2026-08-15-session-15002-fix-5043-section-reorder.json
@@ -63,6 +63,19 @@
       "caused_by": [
         "e004"
       ],
+      "leads_to": [
+        "e006"
+      ],
+      "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-15T12:55:24+00:00",
+      "type": "commit",
+      "content": "Commit: c35be0aff07bf6cc545e8e414ba724f5e1cac1e3",
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-15-session-15002-fix-5043-section-reorder"
     }
@@ -72,7 +85,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 6
   },
   "lessons": []

--- a/.agents/qa/pr-5043-section-reorder-qa.md
+++ b/.agents/qa/pr-5043-section-reorder-qa.md
@@ -1,5 +1,5 @@
 ---
-qaCommit: 05e717f5b6343ab9e7e635cd5e1fae1be93db3bb
+qaCommit: c35be0aff07bf6cc545e8e414ba724f5e1cac1e3
 linkedIssue: 5043
 qaSessionLog: .agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
 qaVerdict: PASS

--- a/.agents/qa/pr-5043-section-reorder-qa.md
+++ b/.agents/qa/pr-5043-section-reorder-qa.md
@@ -1,0 +1,31 @@
+---
+qaCommit: 05e717f5b6343ab9e7e635cd5e1fae1be93db3bb
+linkedIssue: 5043
+qaSessionLog: .agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
+qaVerdict: PASS
+---
+
+# QA Report: Issue #5043 - Section reorder detection
+
+## Test Results
+
+| Suite | Tests | Pass | Fail |
+|-------|-------|------|------|
+| test_install_parity_frontmatter_only.py | 11 | 11 | 0 |
+| test_install_parity_torn_repair.py | 20 | 20 | 0 |
+| tests/build_scripts/ (full) | 1654 | 1654 | 0 |
+
+## Verification
+
+- [x] Positive: section reorder correctly blocks bypass
+- [x] Positive: frontmatter-only change still passes (regression)
+- [x] Negative: body change still blocks
+- [x] Edge: no frontmatter (identical body passes)
+- [x] Edge: unclosed frontmatter treated as body
+- [x] Regression: all existing torn-repair tests pass
+- [x] mypy: 0 errors
+- [x] ruff: clean
+
+## Risk Assessment
+
+Minimal. Change narrows the bypass (more restrictive). Uses same frontmatter-stripping logic as _split_document. Fails closed on any ambiguity.

--- a/.agents/qa/pr-5054-section-reorder-qa.md
+++ b/.agents/qa/pr-5054-section-reorder-qa.md
@@ -1,5 +1,6 @@
 ---
 qaCommit: c35be0aff07bf6cc545e8e414ba724f5e1cac1e3
+linkedPR: 5054
 linkedIssue: 5043
 qaSessionLog: .agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
 qaVerdict: PASS

--- a/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
+++ b/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
@@ -25,7 +25,7 @@
       "checklistComplete": {"complete": true, "level": "MUST", "evidence": "All items recorded"},
       "handoffPreserved": {"complete": true, "level": "MUST", "evidence": "No handoff changes"},
       "markdownLintRun": {"complete": true, "level": "MUST", "evidence": "No markdown in code commit"},
-      "qaValidation": {"complete": true, "level": "MUST", "evidence": ".agents/qa/pr-5043-section-reorder-qa.md"},
+      "qaValidation": {"complete": true, "level": "MUST", "evidence": ".agents/qa/pr-5054-section-reorder-qa.md"},
       "changesCommitted": {"complete": true, "level": "MUST", "evidence": "All changes committed and pushed"},
       "validationPassed": {"complete": true, "level": "MUST", "evidence": "1654 tests passed, mypy clean, ruff clean"},
       "serenaMemoryUpdated": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"}

--- a/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
+++ b/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 15002,
+    "date": "2026-08-15",
+    "branch": "fix/5043-frontmatter-section-reorder",
+    "startingCommit": "b97dabfd3dcfb3fa19dfefe47c3250bac4addc3a",
+    "objective": "Fix frontmatter bypass missing section reordering (issue #5043)"
+  },
+  "endingCommit": "05e717f5b6343ab9e7e635cd5e1fae1be93db3bb",
+  "protocolCompliance": {
+    "sessionStart": {
+      "handoffRead": {"complete": true, "level": "MUST", "evidence": "Read issue #5043 and PR #5030 review"},
+      "sessionLogCreated": {"complete": true, "level": "MUST", "evidence": "This file"},
+      "branchVerified": {"complete": true, "level": "MUST", "evidence": "fix/5043-frontmatter-section-reorder"},
+      "notOnMain": {"complete": true, "level": "MUST", "evidence": "On fix/5043-frontmatter-section-reorder"},
+      "usageMandatoryRead": {"complete": true, "level": "MUST", "evidence": "Read AGENTS.md"},
+      "constraintsRead": {"complete": true, "level": "MUST", "evidence": "Read project constraints"},
+      "memoriesLoaded": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"},
+      "serenaInstructions": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"},
+      "serenaActivated": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"},
+      "skillScriptsListed": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"}
+    },
+    "sessionEnd": {
+      "checklistComplete": {"complete": true, "level": "MUST", "evidence": "All items recorded"},
+      "handoffPreserved": {"complete": true, "level": "MUST", "evidence": "No handoff changes"},
+      "markdownLintRun": {"complete": true, "level": "MUST", "evidence": "No markdown in code commit"},
+      "qaValidation": {"complete": true, "level": "MUST", "evidence": ".agents/qa/pr-5043-section-reorder-qa.md"},
+      "changesCommitted": {"complete": true, "level": "MUST", "evidence": "All changes committed and pushed"},
+      "validationPassed": {"complete": true, "level": "MUST", "evidence": "1654 tests passed, mypy clean, ruff clean"},
+      "serenaMemoryUpdated": {"complete": false, "level": "SHOULD", "evidence": "SHOULD: implementer session; not applicable"}
+    }
+  },
+  "workLog": [
+    {"action": "implement", "description": "Replaced dict comparison with raw body-text comparison via _strip_frontmatter helper"},
+    {"action": "test", "description": "Added 4 tests: reorder blocks, identical passes, no-frontmatter, unclosed frontmatter"},
+    {"action": "verify", "description": "All 1654 build_scripts tests pass, mypy clean, ruff clean"}
+  ],
+  "nextSteps": [],
+  "outcome": {
+    "status": "success",
+    "summary": "Section reordering now correctly detected as body change in frontmatter bypass",
+    "filesChanged": ["build/scripts/validate_install_parity.py", "tests/build_scripts/test_install_parity_frontmatter_only.py"],
+    "testsAdded": 4,
+    "testsTotal": 1654,
+    "testsPassed": true
+  }
+}

--- a/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
+++ b/.agents/sessions/2026-08-15-session-15002-fix-5043-section-reorder.json
@@ -7,7 +7,7 @@
     "startingCommit": "b97dabfd3dcfb3fa19dfefe47c3250bac4addc3a",
     "objective": "Fix frontmatter bypass missing section reordering (issue #5043)"
   },
-  "endingCommit": "05e717f5b6343ab9e7e635cd5e1fae1be93db3bb",
+  "endingCommit": "c35be0aff07bf6cc545e8e414ba724f5e1cac1e3",
   "protocolCompliance": {
     "sessionStart": {
       "handoffRead": {"complete": true, "level": "MUST", "evidence": "Read issue #5043 and PR #5030 review"},

--- a/build/scripts/validate_install_parity.py
+++ b/build/scripts/validate_install_parity.py
@@ -421,15 +421,18 @@ def _diff_is_frontmatter_only(root: Path, base: str, members: Iterable[str]) -> 
     """True when every member's diff touches only YAML frontmatter.
 
     The invariant this validator protects is H2 body-section agreement.
-    When every touched file's preamble and H2 sections are identical
-    between base and HEAD, the diff can only have changed YAML frontmatter
-    (the block stripped by _split_document). Frontmatter parity was never
-    an invariant -- sibling copies legitimately carry different name/model
+    When every touched file's body text (everything after the YAML
+    frontmatter block) is identical between base and HEAD, the diff can
+    only have changed YAML frontmatter. Frontmatter parity was never an
+    invariant -- sibling copies legitimately carry different name/model
     keys -- so co-change is the wrong requirement for this diff shape.
 
+    Compares the raw body text (not parsed dicts) so that section
+    reordering is correctly detected as a body change.
+
     Returns False whenever the answer cannot be established (file missing,
-    unreadable, unparseable, or has a body change), so the gate fails
-    closed. Issue #4922.
+    unreadable, or has a body change), so the gate fails closed.
+    Issue #4922, #5043.
     """
     for member in members:
         try:
@@ -439,17 +442,21 @@ def _diff_is_frontmatter_only(root: Path, base: str, members: Iterable[str]) -> 
         before_text = _git_show(base, member, root)
         if before_text is None:
             return False
-        before_doc = _split_document(before_text)
-        after_doc = _split_document(after_text)
-        if before_doc is None or after_doc is None:
-            return False
-        before_preamble, before_sections = before_doc
-        after_preamble, after_sections = after_doc
-        if before_preamble != after_preamble:
-            return False
-        if before_sections != after_sections:
+        # Strip frontmatter and compare remaining body text directly.
+        # Using _split_document's dict would miss section reordering
+        # because Python dict equality ignores insertion order.
+        if _strip_frontmatter(before_text) != _strip_frontmatter(after_text):
             return False
     return True
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Remove YAML frontmatter block, return remaining body text."""
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end != -1:
+            return text[end + 5:]
+    return text
 
 # --- Path normalization -------------------------------------------------
 

--- a/scripts/quality_gate/consume_pytest_signal.py
+++ b/scripts/quality_gate/consume_pytest_signal.py
@@ -186,6 +186,8 @@ def main(argv: list[str] | None = None) -> int:
                 ["gh", "api", f"repos/{repo}/pulls/{pr}", "--jq", ".head.sha"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=True,
             )

--- a/tests/build_scripts/test_install_parity_frontmatter_only.py
+++ b/tests/build_scripts/test_install_parity_frontmatter_only.py
@@ -256,3 +256,120 @@ class TestFrontmatterOnlyFailsClosed:
             _GENERATED_TOUCHED, repo_root=parity_repo, base="HEAD"
         )
         assert len(violations) == 1
+
+
+class TestSectionReorderDetection:
+    """Verify that section reordering is NOT classified as frontmatter-only.
+
+    Issue #5043: dict equality ignores insertion order, so reordering H2
+    sections was incorrectly classified as frontmatter-only.
+    """
+
+    def test_section_reorder_blocks_bypass(self, parity_repo: Path) -> None:
+        """Reordering H2 sections is a body change, not frontmatter-only."""
+        reordered = """\
+---
+name: critic
+description: Review critic agent
+model: claude-sonnet-4.6
+---
+
+Preamble text.
+
+## Workflow
+
+Step 1. Review.
+
+## Core Identity
+
+You are a constructive reviewer.
+"""
+        for rel in _GENERATED_TOUCHED:
+            (parity_repo / rel).write_text(reordered)
+        _run_git(parity_repo, "add", "-A")
+
+        violations = vip.find_violations(
+            _GENERATED_TOUCHED, repo_root=parity_repo, base="HEAD"
+        )
+        assert violations != [], "Section reorder must be detected as body change"
+
+    def test_identical_body_different_frontmatter_still_passes(
+        self, parity_repo: Path
+    ) -> None:
+        """Frontmatter-only change with unchanged body order still passes."""
+        for rel in _GENERATED_TOUCHED:
+            (parity_repo / rel).write_text(FRONTMATTER_WITHOUT_MODEL)
+        _run_git(parity_repo, "add", "-A")
+
+        violations = vip.find_violations(
+            _GENERATED_TOUCHED, repo_root=parity_repo, base="HEAD"
+        )
+        assert violations == []
+
+    def test_no_frontmatter_body_unchanged_passes(
+        self, parity_repo: Path
+    ) -> None:
+        """File without frontmatter: identical body is still frontmatter-only."""
+        no_fm = """\
+Preamble text.
+
+## Core Identity
+
+You are a constructive reviewer.
+
+## Workflow
+
+Step 1. Review.
+"""
+        # Set base to no-frontmatter version
+        for rel in _GENERATED_TOUCHED:
+            (parity_repo / rel).write_text(no_fm)
+        _run_git(parity_repo, "add", "-A")
+        _run_git(parity_repo, "commit", "-m", "no-fm base")
+
+        # Working tree is identical - no violation
+        violations = vip.find_violations(
+            _GENERATED_TOUCHED, repo_root=parity_repo, base="HEAD"
+        )
+        assert violations == []
+
+    def test_unclosed_frontmatter_treated_as_body(
+        self, parity_repo: Path
+    ) -> None:
+        """Unclosed frontmatter (no closing ---) is treated as body text."""
+        unclosed_before = """\
+---
+name: critic
+model: old
+
+Preamble text.
+
+## Core Identity
+
+You are a constructive reviewer.
+"""
+        unclosed_after = """\
+---
+name: critic
+model: new
+
+Preamble text.
+
+## Core Identity
+
+You are a constructive reviewer.
+"""
+        for rel in _GENERATED_TOUCHED:
+            (parity_repo / rel).write_text(unclosed_before)
+        _run_git(parity_repo, "add", "-A")
+        _run_git(parity_repo, "commit", "-m", "unclosed fm base")
+
+        for rel in _GENERATED_TOUCHED:
+            (parity_repo / rel).write_text(unclosed_after)
+        _run_git(parity_repo, "add", "-A")
+
+        violations = vip.find_violations(
+            _GENERATED_TOUCHED, repo_root=parity_repo, base="HEAD"
+        )
+        # Unclosed frontmatter means entire text is "body", so a change blocks
+        assert violations != []


### PR DESCRIPTION
## Summary

The frontmatter-only bypass (PR #5030) used `_split_document()` dict comparison. Python dict equality ignores insertion order, so reordering H2 sections was incorrectly classified as frontmatter-only and bypassed the parity gate.

## Changes

- **`build/scripts/validate_install_parity.py`**: Replace dict comparison with raw body-text comparison via new `_strip_frontmatter()` helper. Compares the text after removing YAML frontmatter so any body change (including reordering) is detected.
- **`tests/build_scripts/test_install_parity_frontmatter_only.py`**: Add 4 tests covering section reorder (blocks), identical body (passes), no-frontmatter edge case, unclosed frontmatter edge case.
- **`scripts/quality_gate/consume_pytest_signal.py`**: Drive-by fix for pre-existing subprocess encoding violation (issue #4261).

## Approach

Uses the same frontmatter-stripping logic as `_split_document` (find opening/closing `---` delimiters) but returns raw text instead of a parsed dict. This preserves ordering naturally without adding a new parser.

Fixes #5043