### PR TITLE
test(memory): normalize repair fixture date to UTC

### DIFF
--- a/tests/skills/memory/test_repair_episode_causal_links.py
+++ b/tests/skills/memory/test_repair_episode_causal_links.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -189,13 +190,19 @@ class TestFalseEdgeRemoval:
         # the commit so the fixture cannot drift cross-date and turn the
         # pair comparable again.
         sha = _resolvable_sha()
-        commit_date = subprocess.run(
+        commit_timestamp = subprocess.run(
             ["git", "-C", str(REPO_ROOT), "show", "-s", "--format=%cI", sha],
             capture_output=True,
             encoding="utf-8",
             errors="replace",
             check=True,
-        ).stdout.strip()[:10]
+        ).stdout.strip()
+        commit_date = (
+            datetime.fromisoformat(commit_timestamp)
+            .astimezone(timezone.utc)
+            .date()
+            .isoformat()
+        )
         midnight = f"{commit_date}T00:00:00+00:00"
         episode = _flat_episode(sha)
         for evt in episode["events"]:


### PR DESCRIPTION
# Pull Request

## Summary

### What

Normalize the memory-repair regression fixture’s commit timestamp to UTC before deriving its synthetic-midnight date.

### Why

The test claims to create a milestone and commit on the same UTC date, but it sliced the local date from `%cI` and then created a UTC timestamp. For offset commits near midnight, the local and UTC dates differ. Current `main` therefore builds a cross-date fixture, correctly regenerates the edge, and fails the test that expects incomparability.

This is a test-fixture repair only; production memory behavior is unchanged. Rollback is reverting this commit.

## Specification References

| Issue | Relationship |
|---|---|
| #5122 | Removes the duplicate UTC-fixture hunk from the broader hook-health branch |

## Changes

- Parse the complete ISO commit timestamp.
- Convert it to UTC.
- Derive synthetic midnight from the actual UTC date.

## Acceptance criteria

- [x] The false-edge fixture always uses the commit’s UTC date.
- [x] The false-edge removal regression passes.
- [x] The comparable curated-edge control remains passing.
- [x] Production memory code is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted test review, standard scrutiny, blocks every compliant push

**Focus areas**: timezone semantics and preservation of the positive control

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Commands:

- `uv run pytest tests/skills/memory/test_repair_episode_causal_links.py::TestFalseEdgeRemoval -q` — 2 passed.
- `uv run ruff check tests/skills/memory/test_repair_episode_causal_links.py` — passed.
- `timeout 400 env PYTHONPATH=. uv run python scripts/validation/pre_pr.py` — 54/54 passed.
- `git push -u origin fix/memory-repair-utc-fixture` — full pre-push suite passed; remote SHA verified as `7c6f5aabc5c069aac28ca4b4be1e675673d014d8`.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated root cause
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (not applicable)
- [x] No new warnings introduced

## Notes for Reviewers

Reproduction on current `main`: the commit reports Aug 15 in its local offset but Aug 16 UTC. The old fixture creates Aug 15 UTC midnight, accidentally making the pair cross-date.

Refs #5122
