### PR TITLE
fix(pr-autofix): keep completion gate config evaluable

### DIFF
--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -126,7 +126,7 @@ completion_criteria:
     # fetched_pages_complete is a separate data-integrity guard: a truncated
     # GraphQL page can hide a failing required check, so the gate fails closed
     # on partial fetches per the PR #1887 retrospective.
-    pass_when_python: "lambda d: d.get('CanMerge') is True and d.get('CIPassing') is True and d.get('fetched_pages_complete') is True and d.get('UnresolvedThreads') == 0 and d.get('MergeStateStatus') in ('CLEAN', 'UNSTABLE') and len(d.get('UndisposedNonRequiredFailures', ['x'])) == 0"
+    pass_when_python: "lambda d: d.get('CanMerge') is True and d.get('CIPassing') is True and d.get('fetched_pages_complete') is True and d.get('UnresolvedThreads') == 0 and d.get('MergeStateStatus') in ('CLEAN', 'UNSTABLE') and d.get('UndisposedNonRequiredFailures', ['x']) == []"
     fail_open: false
   - name: "PR is not already merged"
     verification: "command"

--- a/src/copilot-cli/commands/pr-review-config.yaml
+++ b/src/copilot-cli/commands/pr-review-config.yaml
@@ -126,7 +126,7 @@ completion_criteria:
     # fetched_pages_complete is a separate data-integrity guard: a truncated
     # GraphQL page can hide a failing required check, so the gate fails closed
     # on partial fetches per the PR #1887 retrospective.
-    pass_when_python: "lambda d: d.get('CanMerge') is True and d.get('CIPassing') is True and d.get('fetched_pages_complete') is True and d.get('UnresolvedThreads') == 0 and d.get('MergeStateStatus') in ('CLEAN', 'UNSTABLE') and len(d.get('UndisposedNonRequiredFailures', ['x'])) == 0"
+    pass_when_python: "lambda d: d.get('CanMerge') is True and d.get('CIPassing') is True and d.get('fetched_pages_complete') is True and d.get('UnresolvedThreads') == 0 and d.get('MergeStateStatus') in ('CLEAN', 'UNSTABLE') and d.get('UndisposedNonRequiredFailures', ['x']) == []"
     fail_open: false
   - name: "PR is not already merged"
     verification: "command"

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -645,6 +645,42 @@ class TestPassWhenDslNegativeBranches:
             )
 
 
+class TestRepositoryConfigContract:
+    """Keep the trusted repository config inside the safe evaluator subset."""
+
+    def test_ready_criterion_expression_is_evaluable(self):
+        # src/copilot-cli/commands/pr-review-config.yaml is the production
+        # contract consumed by /pr-autofix before it enables auto-merge.
+        config_path = (
+            _REPO_ROOT
+            / "src"
+            / "copilot-cli"
+            / "commands"
+            / "pr-review-config.yaml"
+        )
+        config = _dispatcher.yaml.safe_load(
+            config_path.read_text(encoding="utf-8"),
+        )
+        criterion = next(
+            item
+            for item in config["completion_criteria"]
+            if item["name"] == "PR is ready to merge (CI green, no conflicts)"
+        )
+        data = {
+            "CanMerge": True,
+            "CIPassing": True,
+            "fetched_pages_complete": True,
+            "UnresolvedThreads": 0,
+            "MergeStateStatus": "CLEAN",
+            "UndisposedNonRequiredFailures": [],
+        }
+
+        assert _dispatcher._eval_pass_when_python(
+            data,
+            criterion["pass_when_python"],
+        ) is True
+
+
 class TestPassWhenPythonNegativeBranches:
     """Cover the AST-rejection paths in _eval_pass_when_python.
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -648,31 +648,86 @@ class TestPassWhenDslNegativeBranches:
 class TestRepositoryConfigContract:
     """Keep the trusted repository config inside the safe evaluator subset."""
 
-    def test_ready_criterion_expression_is_evaluable(self):
+    def test_ready_criterion_expression_is_evaluable(self, monkeypatch, capsys):
         # .claude/commands/pr-review-config.yaml is the live configuration
-        # consumed by /pr-autofix before it enables auto-merge.
+        # consumed by /pr-autofix before it enables auto-merge. Drive main()
+        # through every production criterion so this contract covers config
+        # loading, dispatch, and the final process verdict, not just the private
+        # expression helper.
         config_path = _REPO_ROOT / ".claude" / "commands" / "pr-review-config.yaml"
-        config = _dispatcher.yaml.safe_load(
-            config_path.read_text(encoding="utf-8"),
+        monkeypatch.setattr(
+            _dispatcher,
+            "_verify_config_trust",
+            lambda *_a, **_k: _dispatcher.TrustCheck(
+                _dispatcher.TRUST_TRUSTED,
+                "",
+            ),
         )
-        criterion = next(
+        responses = [
+            _make_proc(
+                stdout=json.dumps(
+                    {"unresolved_count": 0, "fetched_pages_complete": True},
+                ),
+            ),
+            _make_proc(
+                stdout=json.dumps(
+                    {
+                        "active_suppressed_count": 0,
+                        "unknown_suppressed_count": 0,
+                        "fetched_pages_complete": True,
+                    },
+                ),
+            ),
+            _make_proc(
+                stdout=json.dumps(
+                    {
+                        "unreachable_count": 0,
+                        "invalid_count": 0,
+                        "ambiguous_count": 0,
+                        "fetched_pages_complete": True,
+                    },
+                ),
+            ),
+            _make_proc(
+                stdout=json.dumps(
+                    {
+                        "CanMerge": True,
+                        "CIPassing": True,
+                        "fetched_pages_complete": True,
+                        "UnresolvedThreads": 0,
+                        "MergeStateStatus": "CLEAN",
+                        "UndisposedNonRequiredFailures": [],
+                    },
+                ),
+            ),
+            _make_proc(stdout=json.dumps({"merged": False})),
+        ]
+
+        with patch.object(
+            _dispatcher.subprocess,
+            "run",
+            side_effect=responses,
+        ) as dispatched:
+            rc = _dispatcher.main(
+                [
+                    "--config",
+                    str(config_path),
+                    "--pull-request",
+                    "5147",
+                    "--json",
+                ],
+            )
+
+        assert rc == 0
+        assert dispatched.call_count == len(responses)
+        result = json.loads(capsys.readouterr().out)
+        assert result["all_passed"] is True
+        ready = next(
             item
-            for item in config["completion_criteria"]
+            for item in result["criteria"]
             if item["name"] == "PR is ready to merge (CI green, no conflicts)"
         )
-        data = {
-            "CanMerge": True,
-            "CIPassing": True,
-            "fetched_pages_complete": True,
-            "UnresolvedThreads": 0,
-            "MergeStateStatus": "CLEAN",
-            "UndisposedNonRequiredFailures": [],
-        }
-
-        assert _dispatcher._eval_pass_when_python(
-            data,
-            criterion["pass_when_python"],
-        ) is True
+        assert ready["passed"] is True
 
 
 class TestPassWhenPythonNegativeBranches:

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -649,15 +649,9 @@ class TestRepositoryConfigContract:
     """Keep the trusted repository config inside the safe evaluator subset."""
 
     def test_ready_criterion_expression_is_evaluable(self):
-        # src/copilot-cli/commands/pr-review-config.yaml is the production
-        # contract consumed by /pr-autofix before it enables auto-merge.
-        config_path = (
-            _REPO_ROOT
-            / "src"
-            / "copilot-cli"
-            / "commands"
-            / "pr-review-config.yaml"
-        )
+        # .claude/commands/pr-review-config.yaml is the live configuration
+        # consumed by /pr-autofix before it enables auto-merge.
+        config_path = _REPO_ROOT / ".claude" / "commands" / "pr-review-config.yaml"
         config = _dispatcher.yaml.safe_load(
             config_path.read_text(encoding="utf-8"),
         )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -53,12 +53,10 @@ from __future__ import annotations
 
 import ast
 import codecs
-import math
 import time
 from collections import Counter, deque
 from pathlib import Path
 from typing import NamedTuple
-from unittest import mock
 
 import pytest
 
@@ -5042,121 +5040,46 @@ def test_one_value_reading_many_names_stays_linear() -> None:
     assert elapsed < 3.0, f"chain resolution took {elapsed:.1f}s for {depth} links"
 
 
-def _wide_value_source(width: int) -> str:
-    """One list literal reading ``width`` names that each resolve."""
-    lines = ["import subprocess"]
-    lines += [f"n{index} = subprocess.run" for index in range(width)]
-    lines.append("WIDE = [" + ", ".join(f"n{index}" for index in range(width)) + "]")
-    return "\n".join(lines)
+def test_a_value_reading_many_names_is_walked_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A value node that reads N names is walked once, not once per wake-up.
 
+    The wide list waits on every name it reads, so resolving those names queues
+    the same group thousands of times. Timing that behavior is not a stable
+    proxy for the invariant: under the pre-push hook's concurrent jobs, the
+    4000-name working set contends differently from the 1000-name baseline and
+    has twice exceeded the ratio ceiling while the implementation was correct.
 
-def _best_elapsed(source: str, repeats: int = 3) -> float:
-    """Fastest of several runs. Scheduler noise only ever adds time."""
-    best = float("inf")
-    for _ in range(repeats):
-        started = time.perf_counter()
-        flagged = unpinned_lines(source)
-        best = min(best, time.perf_counter() - started)
-        assert flagged == [], "no call is made, so nothing can decode"
-    assert math.isfinite(best) and best > 0.0, (
-        f"the timer returned {best!r} over {repeats} repeats, so this reading "
-        "carries no duration and any ratio built on it is meaningless. That is "
-        "a measurement failure, not a regression in the code under test. "
-        "Without this check a zero reading reaches the divide below and raises "
-        "ZeroDivisionError, which reads as a crash instead of naming the cause."
-    )
-    return best
-
-
-# Quadrupling the width costs 4x under a linear scan and 16x under the
-# re-queueing one. Measured linear ratios ran 4.24 to 4.97 across three width
-# pairs and eighteen trials, so this sits about 1.6x above the worst linear
-# reading and 2x below what quadratic predicts.
-_LINEAR_SCALING_CEILING = 8.0
-
-_NARROW_WIDTH = 1000
-_WIDE_WIDTH = 4000
-
-
-def test_a_value_reading_many_names_stays_linear() -> None:
-    """A value node that reads N names must be walked once, not once per name.
-
-    The mirror of the wide-unpack shape. One list literal reading ``width``
-    names is re-queued every time one of them resolves, and each pop re-walks
-    the whole node, which is quadratic: 4000 names took 3.26 seconds.
-
-    A group whose names are all settled cannot change an answer, so skipping
-    it before the walk bounds the work. Unlike the wide-unpack case every
-    name here does resolve, which is what drives the re-queue.
-
-    This one is bounded by how the cost grows rather than by a wall clock,
-    which its siblings can afford and this one cannot. Their two regimes sit
-    63x and 110x apart, so a fixed ceiling drops between them with room on
-    both sides. Here they sit about 11x apart: linear measured 0.30 seconds
-    against the docstring's 3.26 for the re-queueing version. The old ceiling
-    of 1.0 second was the midpoint of that narrow gap, which left only 3.6x
-    over linear, and a CI runner about 3.9x slower than a workstation failed
-    it at 1.078 seconds with the implementation behaving correctly. Raising
-    the ceiling instead is not available: any value high enough to stop
-    flaking on that runner sits above the 3.26 seconds quadratic already
-    costs, so the test would stop detecting the regression it exists for.
-
-    A ratio has neither problem. Both readings come off the same machine in
-    the same run, so a slow runner scales them together and cancels out.
+    Count the actual expensive operation instead. ``_settle`` precomputes a
+    group's sources once, before any dependency can wake it. Re-queueing the
+    old implementation moved that walk into the queue and this count rises.
     Refs #4048.
     """
-    narrow = _best_elapsed(_wide_value_source(_NARROW_WIDTH))
-    wide = _best_elapsed(_wide_value_source(_WIDE_WIDTH))
-    ratio = wide / narrow
+    width = 4000
+    wide_value = ast.parse(
+        "[" + ", ".join(f"n{index}" for index in range(width)) + "]",
+        mode="eval",
+    ).body
+    bindings = [("WIDE", wide_value)] + [
+        (f"n{index}", ast.Name(id="subprocess", ctx=ast.Load()))
+        for index in range(width)
+    ]
 
-    assert ratio < _LINEAR_SCALING_CEILING, (
-        f"{_WIDE_WIDTH} names cost {ratio:.2f}x what {_NARROW_WIDTH} did "
-        f"({wide:.3f}s vs {narrow:.3f}s); linear predicts about "
-        f"{_WIDE_WIDTH / _NARROW_WIDTH:.0f}x and quadratic about "
-        f"{(_WIDE_WIDTH / _NARROW_WIDTH) ** 2:.0f}x"
-    )
+    original = _module_sources
+    wide_walks = 0
 
+    def counted_module_sources(value: ast.expr) -> list[str]:
+        nonlocal wide_walks
+        if value is wide_value:
+            wide_walks += 1
+        return original(value)
 
-def test_the_linear_scaling_ceiling_separates_the_two_regimes() -> None:
-    """The bound above proves nothing unless it can fail.
+    monkeypatch.setitem(_settle.__globals__, "_module_sources", counted_module_sources)
+    settled = _settle(bindings, {"subprocess": "subprocess"})
 
-    Pins both margins so a later edit cannot quietly widen the ceiling past
-    what quadratic costs, which would leave a bound that always passes, nor
-    tighten it under what linear measured, which is the flake being fixed.
-    """
-    width_factor = _WIDE_WIDTH / _NARROW_WIDTH
-    linear_predicts = width_factor
-    quadratic_predicts = width_factor**2
-    worst_measured_linear_ratio = 4.97
-
-    assert linear_predicts < _LINEAR_SCALING_CEILING < quadratic_predicts
-    assert worst_measured_linear_ratio < _LINEAR_SCALING_CEILING, (
-        "ceiling must clear the slowest linear reading actually observed"
-    )
-
-
-def test_a_zero_duration_reading_is_named_as_a_measurement_failure() -> None:
-    """The zero-reading guard proves nothing unless it can fire.
-
-    A coarse timer handing back two identical stamps yields an elapsed time of
-    zero. That reading reached the divide in the ratio test above and raised
-    ``ZeroDivisionError``, which reads as a crash in the code under test rather
-    than as the measurement failure it is. Guarding at the reading rather than
-    at the one divide covers both readings and every future caller. Refs #4048.
-    """
-    with mock.patch.object(time, "perf_counter", side_effect=[1.0, 1.0]):
-        with pytest.raises(AssertionError, match="carries no duration"):
-            _best_elapsed("x = 1", repeats=1)
-
-
-def test_a_positive_reading_passes_the_zero_duration_guard() -> None:
-    """Negative control for the guard above.
-
-    A guard that rejected every reading would also make the test above pass, so
-    pin that a normal reading survives it.
-    """
-    with mock.patch.object(time, "perf_counter", side_effect=[1.0, 1.25]):
-        assert _best_elapsed("x = 1", repeats=1) == pytest.approx(0.25)
+    assert settled["WIDE"] == "subprocess", "the wide group must actually resolve"
+    assert wide_walks == 1, f"the wide value was walked {wide_walks} times"
 
 
 def test_return_bindings_stay_linear_in_a_deeply_nested_file() -> None:


### PR DESCRIPTION
## Summary

- replace the unsupported `len(...)` call in the trusted completion-gate expression with a safe list comparison
- regenerate the Copilot CLI command mirror
- add a contract test that evaluates the repository's real ready-to-merge criterion through the safe AST evaluator
- replace a load-sensitive performance ratio with a deterministic count of the expensive AST value walk

## Why

`/pr-autofix` classified ready PRs correctly, then failed closed before auto-merge because the trusted config called `len(...)`, while the hardened evaluator permits only the lambda parameter's `.get(...)` calls. This blocked otherwise-ready PRs such as #5137 and #5136.

The normal pre-push hook then failed twice on `test_a_value_reading_many_names_stays_linear` at 9.48x and 9.89x against an 8.0x ceiling. Five isolated runs passed, while a four-process contention probe widened the measured ratio and a re-walking mutant proved the direct walk-count assertion still detects the original regression. The replacement checks the algorithmic invariant rather than using unequal working-set timings as its proxy.

## Validation

- `uv run pytest -q tests/skills/github/test_run_completion_gate.py tests/test_subprocess_text_encoding.py` : 503 passed
- re-walking mutation probe : failed as intended: `the wide value was walked 3 times`
- four-process contention probe : reproduced ratio instability without an implementation change
- `uv run ruff check tests/test_subprocess_text_encoding.py` : passed
- `uv run python scripts/validate_pr_review_config.py` : passed
- `uv run python build/scripts/build_all.py --check` : passed after commit
- `git diff --check` : passed
- two normal pre-push attempts ran 28,134 tests each and failed only on the superseded timing assertion; no hook was bypassed
