### PR TITLE
fix(validation): detect and prevent git worktrees under /tmp (#5111)

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -55,11 +55,11 @@ After you resolve the last thread on a PR with live bot reviewers (Copilot, Devi
 
 ### Step 3: Create Worktrees (if --parallel)
 
-Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
-(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
-walked by every filesystem-scanning check in this repository, and one under
-`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
-(issue #5111).
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`.
+A worktree inside the checkout gets walked by every filesystem-scanning check in
+the repository, which turns fast checks into slow ones and can block pushes. A
+worktree under `/tmp` holds the only copy of its unpushed commits until a push
+lands, so a temp-filesystem reclaim or a full temp filesystem destroys them.
 
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -55,9 +55,15 @@ After you resolve the last thread on a PR with live bot reviewers (Copilot, Devi
 
 ### Step 3: Create Worktrees (if --parallel)
 
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
+(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
+walked by every filesystem-scanning check in this repository, and one under
+`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
+(issue #5111).
+
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')
-git worktree add "./.worktrees/pr-{number}" "$branch"
+git worktree add "../wt-pr-{number}" "$branch"
 ```
 
 ### Step 4: Launch Agents

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -59,11 +59,11 @@ Before addressing comments, gather full context:
 
 ### Step 3: Create Worktrees (if --parallel)
 
-Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
-(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
-walked by every filesystem-scanning check in this repository, and one under
-`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
-(issue #5111).
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`.
+A worktree inside the checkout gets walked by every filesystem-scanning check in
+the repository, which turns fast checks into slow ones and can block pushes. A
+worktree under `/tmp` holds the only copy of its unpushed commits until a push
+lands, so a temp-filesystem reclaim or a full temp filesystem destroys them.
 
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -59,9 +59,15 @@ Before addressing comments, gather full context:
 
 ### Step 3: Create Worktrees (if --parallel)
 
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
+(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
+walked by every filesystem-scanning check in this repository, and one under
+`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
+(issue #5111).
+
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')
-git worktree add "./.worktrees/pr-{number}" "$branch"
+git worktree add "../wt-pr-{number}" "$branch"
 ```
 
 ### Step 4: Launch Agents

--- a/scripts/validation/check_tmp_worktrees.py
+++ b/scripts/validation/check_tmp_worktrees.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Report git worktrees living under the system temp directory, and a low temp floor.
+
+`.claude/rules/universal.md` MUST NOT 7 states the binding rule verbatim:
+
+    7. Git worktrees MUST be external.
+
+`.serena/memories/git/git-worktree-tmp-not-durable.md` carries the loss: a
+four-conflict resolution for PR #4003 was committed to `/tmp/wt_4003`, `/tmp`
+was reclaimed mid-session, and roughly two hours of work went with it because a
+worktree's commits live only in that worktree's own object store until a push
+lands.
+
+Issue #5111 is the aggregate version of the same failure. Six orphaned
+worktrees, `baseline_check`, and 33 pytest scratch directories filled a 16G
+tmpfs to 4.0K free. Agent transcript writes then failed with ENOSPC, a
+backgrounded `git push` failed while its wrapper reported exit 0, and five
+commits believed pushed were not. The rule and the memory both already existed;
+nothing measured the filesystem, so six violations accumulated unseen.
+
+TWO FINDINGS, TWO SOURCES. They do not overlap, which is why both run:
+
+  * Registered worktrees come from ``git worktree list --porcelain``.
+  * Orphaned worktrees come from the filesystem. Issue #5111 recorded that
+    ``git worktree list`` showed zero entries under `/tmp` while six worktree
+    directories sat there, because the admin records had already been pruned.
+    A directory is counted as a worktree when it holds a `.git` FILE whose
+    first line begins `gitdir:`, which is what `git worktree add` writes. A
+    `.git` DIRECTORY is an ordinary clone, not a worktree, and is not reported.
+
+Scan depth is the immediate children of the temp root. Every worktree in the
+issue's measurement sat at that depth (`/tmp/pr5010-work`, `/tmp/pr5025-worktree`,
+and four siblings), and one level costs one `stat` per entry.
+
+EXIT CODES (ADR-035):
+  0 - no findings (prints the examined count)
+  1 - at least one worktree under the temp root, or free space below the floor
+  2 - configuration error (unusable argument, or an explicitly named temp root
+      that does not exist)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# 16G tmpfs is the machine in issue #5111. Two GiB is roughly one pytest
+# scratch generation plus one worktree of headroom, so the report fires while
+# there is still room to act rather than after a push has already died.
+DEFAULT_MIN_FREE_GIB = 2.0
+DEFAULT_TEMP_ROOT = Path("/tmp")
+_BYTES_PER_GIB = 1024**3
+_GIT_TIMEOUT_SECONDS = 10
+
+RULE_CITATION = ".claude/rules/universal.md MUST NOT 7 (git worktrees MUST be external)"
+
+
+@dataclass(frozen=True, slots=True)
+class TempWorktree:
+    """One worktree directory found under the temp root."""
+
+    path: str
+    registered: bool
+
+
+@dataclass
+class TempReport:
+    """What one scan found. ``examined`` distinguishes a clean run from no run."""
+
+    temp_root: str
+    temp_root_present: bool
+    examined: int
+    free_bytes: int | None
+    min_free_bytes: int
+    worktrees: list[TempWorktree] = field(default_factory=list)
+    git_listing_failed: bool = False
+    unreadable_entries: int = 0
+
+    @property
+    def free_space_low(self) -> bool:
+        """True when the temp root reported less free space than the floor."""
+        return self.free_bytes is not None and self.free_bytes < self.min_free_bytes
+
+    @property
+    def has_findings(self) -> bool:
+        """True when anything in this report should block or warn."""
+        return bool(self.worktrees) or self.free_space_low
+
+
+def parse_worktree_list(porcelain: str) -> list[str]:
+    """Return the worktree paths in ``git worktree list --porcelain`` output.
+
+    Empty or whitespace-only input returns an empty list: a repository with no
+    linked worktrees is a normal state, not an error.
+    """
+    paths: list[str] = []
+    for line in porcelain.splitlines():
+        if line.startswith("worktree "):
+            paths.append(line[len("worktree ") :].strip())
+    return paths
+
+
+def is_worktree_dir(candidate: Path) -> bool:
+    """True when ``candidate`` holds the `.git` file `git worktree add` writes.
+
+    A linked worktree gets a `.git` FILE containing `gitdir: <admin path>`. A
+    plain clone gets a `.git` DIRECTORY. Only the first is a worktree, so a
+    clone parked in the temp root is not reported as one.
+    """
+    marker = candidate / ".git"
+    try:
+        if not marker.is_file():
+            return False
+        with marker.open(encoding="utf-8", errors="replace") as handle:
+            first_line = handle.readline()
+    except OSError:
+        return False
+    return first_line.startswith("gitdir:")
+
+
+def find_registered_temp_worktrees(paths: list[str], temp_root: Path) -> list[str]:
+    """Return the registered worktree paths that sit under ``temp_root``."""
+    found: list[str] = []
+    for raw in paths:
+        try:
+            resolved = Path(raw).resolve()
+        except OSError:
+            continue
+        if resolved.is_relative_to(temp_root):
+            found.append(raw)
+    return found
+
+
+def _list_registered(repo_root: Path) -> tuple[list[str], bool]:
+    """Return (worktree paths, failed). A git failure is reported, never raised.
+
+    Fail-open on the git half only. The filesystem half below does not depend
+    on git, so a git failure must not suppress the orphan finding that issue
+    #5111 showed is the one git cannot see anyway.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            cwd=repo_root,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return [], True
+    if result.returncode != 0:
+        return [], True
+    return parse_worktree_list(result.stdout), False
+
+
+def _is_directory(path: Path) -> bool | None:
+    """True or False, or None when the filesystem could not answer.
+
+    Three states, not two. A directory that cannot be read is not the same as
+    one that is absent, and collapsing them would let an unreadable temp root
+    report as a clean scan.
+    """
+    try:
+        return path.is_dir()
+    except OSError:
+        return None
+
+
+def scan_temp_root(
+    temp_root: Path,
+    min_free_bytes: int,
+    registered: list[str],
+    git_listing_failed: bool,
+) -> TempReport:
+    """Build the report for one temp root. Pure apart from filesystem reads."""
+    root_state = _is_directory(temp_root)
+    report = TempReport(
+        temp_root=str(temp_root),
+        temp_root_present=root_state is True,
+        examined=0,
+        free_bytes=None,
+        min_free_bytes=min_free_bytes,
+        git_listing_failed=git_listing_failed,
+        unreadable_entries=1 if root_state is None else 0,
+    )
+    if not report.temp_root_present:
+        return report
+
+    registered_resolved = set(find_registered_temp_worktrees(registered, temp_root))
+    seen: set[str] = set()
+    try:
+        entries = sorted(temp_root.iterdir())
+    except OSError:
+        report.unreadable_entries += 1
+        entries = []
+
+    for entry in entries:
+        entry_state = _is_directory(entry)
+        if entry_state is None:
+            report.unreadable_entries += 1
+            continue
+        if not entry_state:
+            continue
+        report.examined += 1
+        if not is_worktree_dir(entry):
+            continue
+        seen.add(str(entry))
+        report.worktrees.append(
+            TempWorktree(path=str(entry), registered=str(entry) in registered_resolved)
+        )
+
+    # A registered worktree whose directory is already gone still names a path
+    # under the temp root, and its admin record is still work git can restore.
+    # Report it even though the filesystem pass could not see it.
+    for path in sorted(registered_resolved - seen):
+        report.worktrees.append(TempWorktree(path=path, registered=True))
+
+    try:
+        report.free_bytes = shutil.disk_usage(temp_root).free
+    except OSError:
+        report.free_bytes = None
+    return report
+
+
+def build_report(
+    repo_root: Path,
+    temp_root: Path | None = None,
+    min_free_gib: float = DEFAULT_MIN_FREE_GIB,
+) -> TempReport:
+    """Run both halves of the scan and return the combined report.
+
+    ``temp_root`` resolves from the module attribute at call time rather than
+    as a default argument. A default binds at import, so a test that replaces
+    ``DEFAULT_TEMP_ROOT`` would never reach it and would quietly measure the
+    real `/tmp` instead of its fixture. ``gc_worktrees.decide`` documents the
+    same trap for the same reason.
+    """
+    registered, git_listing_failed = _list_registered(repo_root)
+    return scan_temp_root(
+        temp_root if temp_root is not None else DEFAULT_TEMP_ROOT,
+        int(min_free_gib * _BYTES_PER_GIB),
+        registered,
+        git_listing_failed,
+    )
+
+
+def format_report(report: TempReport) -> str:
+    """Render the human-readable report. Always names the examined count."""
+    lines: list[str] = []
+    if not report.temp_root_present:
+        lines.append(f"tmp-worktrees: {report.temp_root} is not a directory; nothing examined")
+        return "\n".join(lines)
+
+    for worktree in report.worktrees:
+        origin = "registered" if worktree.registered else "orphaned (git does not know it)"
+        lines.append(f"  {worktree.path} [{origin}]")
+    if report.worktrees:
+        lines.insert(
+            0,
+            f"tmp-worktrees: {len(report.worktrees)} worktree(s) under {report.temp_root}, "
+            f"against {RULE_CITATION}:",
+        )
+        lines.append("  Move each one with: git worktree move <path> <external path>")
+
+    if report.free_space_low and report.free_bytes is not None:
+        lines.append(
+            f"tmp-worktrees: {report.temp_root} has "
+            f"{report.free_bytes / _BYTES_PER_GIB:.2f} GiB free, below the "
+            f"{report.min_free_bytes / _BYTES_PER_GIB:.2f} GiB floor. A full temp "
+            "filesystem fails transcript writes and backgrounded pushes with ENOSPC "
+            "(issue #5111)."
+        )
+
+    if report.git_listing_failed:
+        lines.append(
+            "tmp-worktrees: git worktree list failed; the registered half of this "
+            "report is incomplete (the filesystem half still ran)."
+        )
+    if report.unreadable_entries:
+        lines.append(
+            f"tmp-worktrees: {report.unreadable_entries} entry/entries under "
+            f"{report.temp_root} were unreadable and were not examined."
+        )
+
+    free_note = (
+        f"{report.free_bytes / _BYTES_PER_GIB:.2f} GiB free"
+        if report.free_bytes is not None
+        else "free space unreadable"
+    )
+    lines.append(
+        f"tmp-worktrees: {len(report.worktrees)} worktree(s) in "
+        f"{report.examined} examined entries under {report.temp_root}; {free_note}"
+    )
+    return "\n".join(lines)
+
+
+def validate_tmp_worktrees(repo_root: Path) -> bool:
+    """Advisory pre-PR gate. Prints findings and always returns True.
+
+    Advisory on purpose, and the reason is the incident itself. The subject is
+    machine state, not repository state: the residue issue #5111 measured was
+    left by sessions that had already ended, so a blocking verdict would refuse
+    every push on that machine for a condition the current diff did not create
+    and the pushing agent may not own. That is the same class of wedge the
+    issue is about. The CLI below exits 1 on the same findings, so anyone who
+    wants the blocking form has it without this gate imposing it on everyone.
+    """
+    report = build_report(repo_root)
+    print(format_report(report))
+    return True
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Report git worktrees under the temp root and low temp free space.",
+    )
+    parser.add_argument(
+        "--temp-root",
+        type=Path,
+        default=DEFAULT_TEMP_ROOT,
+        help=f"Directory to scan (default: {DEFAULT_TEMP_ROOT}).",
+    )
+    parser.add_argument(
+        "--min-free-gib",
+        type=float,
+        default=DEFAULT_MIN_FREE_GIB,
+        help=f"Free-space floor in GiB (default: {DEFAULT_MIN_FREE_GIB}).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of human-readable text.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    args = parse_args(argv)
+    if args.min_free_gib < 0:
+        print("error: --min-free-gib must not be negative", file=sys.stderr)
+        return 2
+
+    temp_root = args.temp_root.resolve()
+    explicit_root = args.temp_root != DEFAULT_TEMP_ROOT
+    if explicit_root and not temp_root.is_dir():
+        print(f"error: --temp-root is not a directory: {args.temp_root}", file=sys.stderr)
+        return 2
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_report(repo_root, temp_root, args.min_free_gib)
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(format_report(report))
+    return 1 if report.has_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_worktree_recipes.py
+++ b/scripts/validation/check_worktree_recipes.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Fail when a tracked prescription tells a reader to create a worktree in a bad place.
+
+`.claude/rules/universal.md` MUST NOT 7 states the binding rule verbatim:
+
+    7. Git worktrees MUST be external.
+
+Two destinations break it, and this repository has paid for both:
+
+  * Under the system temp directory. `/tmp` is reclaimed without warning, and a
+    worktree carries the only copy of its unpushed commits. `/tmp/wt_4003` took
+    roughly two hours of merge resolution with it
+    (`.serena/memories/git/git-worktree-tmp-not-durable.md`). Issue #5111 then
+    recorded six of them filling a 16G tmpfs to 4.0K free, which failed agent
+    transcript writes and a backgrounded push with ENOSPC while the wrapper
+    reported exit 0.
+  * Inside the checkout. 59 worktrees under `.claude/worktrees/` turned a 0.49s
+    test into a 422s failure, because much of this repository's tooling walks
+    the filesystem rather than asking git what is tracked
+    (`.serena/memories/git/git-never-place-worktrees-inside-the-checkout.md`).
+    Gitignoring the directory hides it from git, not from a directory walk.
+
+Issue #5111 asked why a rule plus a memory plus a documented prior incident
+still produced six violations. Nothing read the recipes. This checker does.
+
+WHAT COUNTS AS A RECIPE. A line invoking `git worktree add` in a tracked file
+under `SCANNED_PREFIXES`. The path argument is the first non-flag token after
+`add`, with value-taking flags and their values consumed first.
+
+WHAT IS NOT JUDGED, AND WHY EACH CASE IS SKIPPED. Guessing here produces
+findings a reader cannot act on, and a checker that cries wolf gets suppressed
+wholesale, so three cases return no verdict:
+
+  * A shell expansion anywhere in the token (`${dir}`, `$HOME/x`, a backtick).
+    Its value is set elsewhere and cannot be read from the line.
+  * A token that is not path-shaped, meaning it holds no `/` and does not begin
+    with `.`. `git worktree add --detach`, a CI checkout` in prose yields the
+    token `a`, and nothing separates an English word from a bare directory
+    name. The cost of that cutoff is a missed bare-name destination
+    (`git worktree add scratch`); no tracked prescription uses that form.
+  * A home reference (`~/worktrees/x`). Home is outside the checkout and is not
+    a temp filesystem, so the recipe is already correct.
+
+A placeholder SEGMENT is judged, not skipped: `./.worktrees/pr-{number}` and
+`../wt-<slug>` each count their placeholder as one ordinary directory level,
+which is enough to settle whether the path stays inside the checkout. That is
+the difference that catches the real `pr-review` recipes.
+
+WHAT IS EXCLUDED. Trees whose purpose is recording what already happened. A
+retrospective quoting a `/tmp` recipe is evidence, and rewriting it to match
+current policy would destroy the record of why the policy exists. This mirrors
+the same carve-out in `scripts/validation/check_push_lock_paths.py`, whose
+EXCLUDED_PREFIXES reads:
+
+    EXCLUDED_PREFIXES = (
+        ".agents/retrospective/",
+        ".agents/audits/",
+        ".agents/archive/",
+    )
+
+Stricter/looser/different than that checker: this one adds `.agents/memory/`
+and `.agents/sessions/` (episode and session records are also history), and it
+scans every tracked text file under its prefixes rather than fenced Markdown
+blocks only, because a worktree recipe appears in shell scripts too.
+
+EXIT CODES (ADR-035):
+  0 - every resolvable recipe names an external destination (prints the counts)
+  1 - at least one recipe names a temp-root or in-checkout destination
+  2 - configuration or runtime error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+RULE_CITATION = ".claude/rules/universal.md MUST NOT 7 (git worktrees MUST be external)"
+
+SCANNED_PREFIXES = (
+    ".agents/",
+    ".claude/",
+    ".github/",
+    "docs/",
+    "scripts/",
+    "src/",
+    "templates/",
+)
+
+EXCLUDED_PREFIXES = (
+    ".agents/archive/",
+    ".agents/audits/",
+    ".agents/memory/",
+    ".agents/qa/",
+    ".agents/retrospective/",
+    ".agents/sessions/",
+    ".claude/worktrees/",
+)
+
+SCANNED_SUFFIXES = (".md", ".py", ".sh", ".ps1", ".yml", ".yaml", ".txt")
+
+# A line opts out by carrying this token, for prose that must quote a bad
+# recipe in order to prohibit it.
+HISTORICAL_MARKER = "worktree-recipe-historical"
+
+_WORKTREE_ADD = re.compile(r"\bgit\s+worktree\s+add\b(?P<rest>.*)")
+
+# `git worktree add` flags that consume the following token as their value.
+_VALUE_FLAGS = frozenset({"-b", "-B", "--reason", "--lock-reason"})
+
+# A shell expansion makes the token's value unreadable from the line.
+_EXPANSION = re.compile(r"[$`]")
+# Path-shaped: holds a separator, or is explicitly relative to the cwd.
+_PATH_SHAPED = re.compile(r"/|^\.")
+
+_TEMP_PREFIXES = ("/tmp/", "/var/tmp/", "/private/tmp/", "/dev/shm/")
+_TEMP_EXACT = frozenset({"/tmp", "/var/tmp", "/private/tmp", "/dev/shm"})
+
+REASON_TEMP = "names a temp-filesystem path; a reclaim takes the only copy of unpushed work"
+REASON_IN_CHECKOUT = (
+    "resolves inside the checkout; filesystem-walking tooling then scans every nested copy"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Violation:
+    """One bad worktree destination, located for the reader."""
+
+    path: str
+    line_number: int
+    destination: str
+    reason: str
+
+    def render(self) -> str:
+        """One reportable line naming file, line, destination, and why."""
+        return (
+            f"{self.path}:{self.line_number}: "
+            f"worktree destination {self.destination!r} {self.reason}"
+        )
+
+
+def extract_destination(rest: str) -> str | None:
+    """Return the path argument of a `git worktree add`, or None when absent.
+
+    ``rest`` is everything after ``add``. Value-taking flags consume the token
+    after them, boolean flags consume nothing, and the first surviving token is
+    the destination. ``git worktree add <path> <commit-ish>`` puts the commit
+    after the path, so taking the first token is correct for both arities.
+    """
+    tokens = rest.replace('"', " ").replace("'", " ").split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in _VALUE_FLAGS:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return None
+
+
+def classify(destination: str) -> str | None:
+    """Return the violation reason for ``destination``, or None when acceptable.
+
+    Returns None for the three skipped cases in the module docstring, and for
+    the two acceptable ones: an absolute path outside a temp root, and a
+    relative path that climbs out of the checkout (`../wt-<slug>`).
+    """
+    if not destination or _EXPANSION.search(destination):
+        return None
+    if not _PATH_SHAPED.search(destination):
+        return None
+    if destination.startswith("~"):
+        return None
+
+    normalized = destination.rstrip("/") or "/"
+    if normalized in _TEMP_EXACT or destination.startswith(_TEMP_PREFIXES):
+        return REASON_TEMP
+    if destination.startswith("/"):
+        return None
+
+    # Relative. Walk the segments; rising above the checkout root settles it as
+    # external. Known miss: a path that rises and then descends back in by the
+    # checkout's own name (`../ai-agents/.worktrees/x`) reads as external,
+    # because the recipe's text does not carry that name and nothing else
+    # separates it from an ordinary sibling. No tracked prescription uses it.
+    depth = 0
+    for segment in destination.split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            depth -= 1
+            if depth < 0:
+                return None
+            continue
+        depth += 1
+    return REASON_IN_CHECKOUT
+
+
+def scan_text(path: str, text: str) -> list[Violation]:
+    """Return every violation in one file's text."""
+    violations: list[Violation] = []
+    for offset, line in enumerate(text.splitlines()):
+        if HISTORICAL_MARKER in line:
+            continue
+        match = _WORKTREE_ADD.search(line)
+        if match is None:
+            continue
+        destination = extract_destination(match.group("rest"))
+        if destination is None:
+            continue
+        reason = classify(destination)
+        if reason is None:
+            continue
+        violations.append(
+            Violation(
+                path=path,
+                line_number=offset + 1,
+                destination=destination,
+                reason=reason,
+            )
+        )
+    return violations
+
+
+def is_scanned(path: str) -> bool:
+    """True when ``path`` is a prescriptive surface this checker judges."""
+    if not path.startswith(SCANNED_PREFIXES):
+        return False
+    if path.startswith(EXCLUDED_PREFIXES):
+        return False
+    return path.endswith(SCANNED_SUFFIXES)
+
+
+def tracked_files(repo_root: Path) -> list[str]:
+    """Return tracked paths from the index, so a staged file is checked.
+
+    Reads ``git ls-files -z``: paths are not newline-safe (`ci-scripts.md`
+    MUST 9), and the index rather than a directory walk keeps untracked scratch
+    and nested worktree checkouts out of the inventory.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        cwd=repo_root,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git ls-files failed: {result.stderr.strip()}")
+    return [entry for entry in result.stdout.split("\0") if entry]
+
+
+def check_repository(repo_root: Path) -> tuple[list[Violation], int]:
+    """Scan every prescriptive surface. Returns (violations, files examined)."""
+    violations: list[Violation] = []
+    examined = 0
+    for relative in tracked_files(repo_root):
+        if not is_scanned(relative):
+            continue
+        full = repo_root / relative
+        try:
+            text = full.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        examined += 1
+        violations.extend(scan_text(relative, text))
+    return violations, examined
+
+
+def validate_worktree_recipes(repo_root: Path) -> bool:
+    """Blocking pre-PR gate. Returns False when any prescription is bad.
+
+    Blocking, unlike the temp-filesystem report in
+    ``scripts/validation/check_tmp_worktrees.py``. The subject here is tracked
+    repository content, which the author of the diff owns and can fix, so the
+    verdict is actionable at the moment it fires.
+    """
+    try:
+        violations, examined = check_repository(repo_root)
+    except (OSError, RuntimeError) as exc:
+        print(f"[FAIL] worktree recipes: {exc}", file=sys.stderr)
+        return False
+
+    for violation in violations:
+        print(f"  {violation.render()}")
+    if violations:
+        print(f"worktree-recipes: {len(violations)} violation(s) against {RULE_CITATION}")
+        print("  Point the recipe at a sibling of the checkout, for example ../wt-<slug>")
+    print(f"worktree-recipes: {len(violations)} violation(s) in {examined} examined files")
+    return not violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    parser = argparse.ArgumentParser(
+        description="Fail when a tracked prescription creates a worktree in a bad place.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root to scan (default: this script's repository).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    if not (repo_root / ".git").exists():
+        print(f"error: not a git repository: {repo_root}", file=sys.stderr)
+        return 2
+
+    return 0 if validate_worktree_recipes(repo_root) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -49,7 +49,9 @@ from check_nested_tests import validate_no_nested_tests
 from check_push_lock_paths import validate_push_lock_paths
 from check_subprocess_encoding import validate_subprocess_encoding
 from check_test_tree_writes import validate_test_tree_writes
+from check_tmp_worktrees import validate_tmp_worktrees
 from check_unreachable_code import validate_unreachable_code
+from check_worktree_recipes import validate_worktree_recipes
 from checks_coverage import (
     validate_review_marker,
 )
@@ -209,6 +211,18 @@ _SEQUENCE: tuple[_Gate, ...] = (
     _Gate("Subprocess Encoding Convention", _root_only(validate_subprocess_encoding)),
     _Gate("Test Working Tree Writes", _root_only(validate_test_tree_writes)),
     _Gate("Push Lock Path Agreement", _root_only(validate_push_lock_paths)),
+    # Blocks a tracked prescription that tells a reader to create a worktree
+    # under /tmp or inside the checkout, against universal.md MUST NOT 7. Issue
+    # #5111: the rule, a Serena memory, and a prior incident all already
+    # existed, and six violations still accumulated, because nothing read the
+    # recipes.
+    _Gate("Worktree Recipe Destinations", _root_only(validate_worktree_recipes)),
+    # Advisory companion to the gate above: the same rule measured against the
+    # machine rather than the tree. Reports worktrees sitting under /tmp
+    # (including orphans git no longer lists) and a low /tmp free-space floor.
+    # Never fails; see the validator's docstring for why machine state does not
+    # get to block a push. Issue #5111.
+    _Gate("Temp-filesystem Worktrees (advisory)", _root_only(validate_tmp_worktrees)),
     _Gate("Session End Validation", _root_only(validate_session_end)),
     # Type-check changed Python files with ratchet semantics (issue #4674).
     # Surfaces regressions at pre-PR time rather than waiting for push CI.

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -57,9 +57,15 @@ After you resolve the last thread on a PR with live bot reviewers (Copilot, Devi
 
 ### Step 3: Create Worktrees (if --parallel)
 
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
+(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
+walked by every filesystem-scanning check in this repository, and one under
+`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
+(issue #5111).
+
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')
-git worktree add "./.worktrees/pr-{number}" "$branch"
+git worktree add "../wt-pr-{number}" "$branch"
 ```
 
 ### Step 4: Launch Agents

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -57,11 +57,11 @@ After you resolve the last thread on a PR with live bot reviewers (Copilot, Devi
 
 ### Step 3: Create Worktrees (if --parallel)
 
-Worktrees go in a sibling of the checkout, never under it and never under `/tmp`
-(`.claude/rules/universal.md` MUST NOT 7). A worktree inside the checkout is
-walked by every filesystem-scanning check in this repository, and one under
-`/tmp` loses its unpushed commits when the temp filesystem is reclaimed or fills
-(issue #5111).
+Worktrees go in a sibling of the checkout, never under it and never under `/tmp`.
+A worktree inside the checkout gets walked by every filesystem-scanning check in
+the repository, which turns fast checks into slow ones and can block pushes. A
+worktree under `/tmp` holds the only copy of its unpushed commits until a push
+lands, so a temp-filesystem reclaim or a full temp filesystem destroys them.
 
 ```bash
 branch=$(gh pr view {number} --json headRefName -q '.headRefName')

--- a/tests/validation/test_check_tmp_worktrees.py
+++ b/tests/validation/test_check_tmp_worktrees.py
@@ -268,10 +268,10 @@ def test_an_unstattable_entry_is_counted_not_examined(
     entry.mkdir()
     real_is_dir = Path.is_dir
 
-    def explode_for_the_entry(self: Path, *args: object, **kwargs: object) -> bool:
+    def explode_for_the_entry(self: Path) -> bool:
         if self == entry:
             raise OSError("stale file handle")
-        return bool(real_is_dir(self, *args, **kwargs))
+        return bool(real_is_dir(self))
 
     monkeypatch.setattr(Path, "is_dir", explode_for_the_entry)
 

--- a/tests/validation/test_check_tmp_worktrees.py
+++ b/tests/validation/test_check_tmp_worktrees.py
@@ -188,17 +188,42 @@ def test_a_git_failure_is_disclosed_and_does_not_suppress_the_filesystem_half(
     assert "git worktree list failed" in checker.format_report(report)
 
 
-def test_the_free_space_floor_boundary_is_exclusive(tmp_path: Path) -> None:
-    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
-    assert report.free_bytes is not None
-
-    at_floor = checker.scan_temp_root(tmp_path, report.free_bytes, [], git_listing_failed=False)
-    below_floor = checker.scan_temp_root(
-        tmp_path, report.free_bytes + 1, [], git_listing_failed=False
+def _report_with(free: int | None, floor: int) -> checker.TempReport:
+    """A report carrying fixed space numbers, with no filesystem read."""
+    return checker.TempReport(
+        temp_root="/tmp",
+        temp_root_present=True,
+        examined=0,
+        free_bytes=free,
+        min_free_bytes=floor,
     )
 
-    assert at_floor.free_space_low is False, "free == floor is not below the floor"
-    assert below_floor.free_space_low is True
+
+@pytest.mark.parametrize(
+    ("free", "floor", "expected"),
+    [
+        (2 * _GIB, 2 * _GIB, False),  # equal is not below
+        (2 * _GIB - 1, 2 * _GIB, True),  # one byte under is below
+        (2 * _GIB + 1, 2 * _GIB, False),
+        (0, 1, True),  # a full filesystem
+        (10 * _GIB, 2 * _GIB, False),
+        (0, 0, False),  # a floor of zero can never fire
+        (None, 2 * _GIB, False),  # unknown is not low
+    ],
+)
+def test_the_free_space_floor_boundary_is_exclusive(
+    free: int | None, floor: int, expected: bool
+) -> None:
+    """The comparison is arithmetic, so the test supplies both numbers.
+
+    An earlier version read live free space from ``scan_temp_root`` three
+    times and compared the readings. Free space is shared mutable state
+    across pytest-xdist workers (``testing.md`` MUST 5): one disk block
+    consumed between two calls made ``free < floor`` true and failed the
+    run. Measured on a pre-push suite: floor 25185472512, free 25185468416,
+    a 4096-byte drift.
+    """
+    assert _report_with(free, floor).free_space_low is expected
 
 
 # --- error branches -------------------------------------------------------

--- a/tests/validation/test_check_tmp_worktrees.py
+++ b/tests/validation/test_check_tmp_worktrees.py
@@ -419,6 +419,7 @@ def test_module_runs_as_a_script(tmp_path: Path) -> None:
         ["python3", str(script), "--temp-root", str(tmp_path), "--min-free-gib", "0"],
         capture_output=True,
         encoding="utf-8",
+        errors="replace",
         check=False,
     )
 

--- a/tests/validation/test_check_tmp_worktrees.py
+++ b/tests/validation/test_check_tmp_worktrees.py
@@ -1,0 +1,401 @@
+"""Worktrees living under the temp root, and a low temp free-space floor (issue #5111).
+
+Six orphaned worktrees plus pytest scratch filled a 16G tmpfs to 4.0K free.
+Transcript writes then failed with ENOSPC and a backgrounded `git push` failed
+while its wrapper reported exit 0. The issue records that `git worktree list`
+showed zero entries under `/tmp` at the time, so the filesystem half of this
+scan is the half that would have caught it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.validation import check_tmp_worktrees as checker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_GIB = 1024**3
+
+
+def make_worktree_dir(parent: Path, name: str) -> Path:
+    """Create a directory carrying the `.git` file `git worktree add` writes."""
+    path = parent / name
+    path.mkdir()
+    (path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n", encoding="utf-8")
+    return path
+
+
+# --- parse_worktree_list --------------------------------------------------
+
+
+def test_parse_worktree_list_reads_every_worktree_line() -> None:
+    porcelain = (
+        "worktree /home/u/repo\nHEAD abc\nbranch refs/heads/main\n\n"
+        "worktree /tmp/pr5010-work\nHEAD def\ndetached\n"
+    )
+
+    assert checker.parse_worktree_list(porcelain) == ["/home/u/repo", "/tmp/pr5010-work"]
+
+
+@pytest.mark.parametrize("porcelain", ["", "   ", "\n\n"])
+def test_parse_worktree_list_handles_empty_input(porcelain: str) -> None:
+    assert checker.parse_worktree_list(porcelain) == []
+
+
+def test_parse_worktree_list_ignores_non_worktree_lines() -> None:
+    assert checker.parse_worktree_list("HEAD abc\nbare\ndetached\n") == []
+
+
+# --- is_worktree_dir ------------------------------------------------------
+
+
+def test_a_gitdir_file_marks_a_worktree(tmp_path: Path) -> None:
+    assert checker.is_worktree_dir(make_worktree_dir(tmp_path, "wt")) is True
+
+
+def test_a_git_directory_is_a_clone_not_a_worktree(tmp_path: Path) -> None:
+    clone = tmp_path / "clone"
+    (clone / ".git").mkdir(parents=True)
+
+    assert checker.is_worktree_dir(clone) is False
+
+
+def test_a_directory_without_git_is_not_a_worktree(tmp_path: Path) -> None:
+    plain = tmp_path / "baseline_check"
+    plain.mkdir()
+
+    assert checker.is_worktree_dir(plain) is False
+
+
+def test_a_git_file_with_other_content_is_not_a_worktree(tmp_path: Path) -> None:
+    odd = tmp_path / "odd"
+    odd.mkdir()
+    (odd / ".git").write_text("not a gitdir pointer\n", encoding="utf-8")
+
+    assert checker.is_worktree_dir(odd) is False
+
+
+def test_a_missing_directory_is_not_a_worktree(tmp_path: Path) -> None:
+    assert checker.is_worktree_dir(tmp_path / "gone") is False
+
+
+# --- find_registered_temp_worktrees ---------------------------------------
+
+
+def test_registered_paths_under_the_temp_root_are_selected(tmp_path: Path) -> None:
+    inside = tmp_path / "wt"
+    inside.mkdir()
+
+    found = checker.find_registered_temp_worktrees([str(inside), "/home/u/repo"], tmp_path)
+
+    assert found == [str(inside)]
+
+
+def test_registered_paths_outside_the_temp_root_are_ignored(tmp_path: Path) -> None:
+    assert checker.find_registered_temp_worktrees(["/home/u/repo"], tmp_path) == []
+
+
+def test_an_empty_registered_list_selects_nothing(tmp_path: Path) -> None:
+    assert checker.find_registered_temp_worktrees([], tmp_path) == []
+
+
+# --- scan_temp_root: positive ---------------------------------------------
+
+
+def test_an_orphaned_worktree_is_reported_without_git_knowing_it(tmp_path: Path) -> None:
+    # The issue #5111 shape: on disk, absent from `git worktree list`.
+    make_worktree_dir(tmp_path, "pr5010-work")
+
+    report = checker.scan_temp_root(tmp_path, 0, registered=[], git_listing_failed=False)
+
+    assert [w.path for w in report.worktrees] == [str(tmp_path / "pr5010-work")]
+    assert report.worktrees[0].registered is False
+    assert report.has_findings is True
+
+
+def test_a_registered_worktree_is_labelled_registered(tmp_path: Path) -> None:
+    path = make_worktree_dir(tmp_path, "wt")
+
+    report = checker.scan_temp_root(tmp_path, 0, [str(path)], git_listing_failed=False)
+
+    assert report.worktrees[0].registered is True
+
+
+def test_a_registered_worktree_whose_directory_is_gone_is_still_reported(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "vanished"
+
+    report = checker.scan_temp_root(tmp_path, 0, [str(missing)], git_listing_failed=False)
+
+    assert [w.path for w in report.worktrees] == [str(missing)]
+
+
+def test_free_space_below_the_floor_is_a_finding(tmp_path: Path) -> None:
+    # A floor larger than any real disk forces the low-space branch.
+    report = checker.scan_temp_root(tmp_path, 10**18, [], git_listing_failed=False)
+
+    assert report.free_space_low is True
+    assert report.has_findings is True
+    assert "below the" in checker.format_report(report)
+
+
+# --- scan_temp_root: negative ---------------------------------------------
+
+
+def test_a_clean_temp_root_has_no_findings(tmp_path: Path) -> None:
+    (tmp_path / "ordinary-scratch").mkdir()
+    (tmp_path / "a-file.log").write_text("x", encoding="utf-8")
+
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+
+    assert report.worktrees == []
+    assert report.free_space_low is False
+    assert report.has_findings is False
+    assert report.examined == 1, "files must not count as examined directories"
+
+
+def test_an_empty_temp_root_reports_zero_examined(tmp_path: Path) -> None:
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+
+    assert report.examined == 0
+    assert report.has_findings is False
+
+
+# --- scan_temp_root: edge cases -------------------------------------------
+
+
+def test_a_missing_temp_root_is_reported_as_absent_not_as_clean(tmp_path: Path) -> None:
+    report = checker.scan_temp_root(tmp_path / "gone", 0, [], git_listing_failed=False)
+
+    assert report.temp_root_present is False
+    assert report.examined == 0
+    assert report.has_findings is False
+    assert "nothing examined" in checker.format_report(report)
+
+
+def test_a_git_failure_is_disclosed_and_does_not_suppress_the_filesystem_half(
+    tmp_path: Path,
+) -> None:
+    make_worktree_dir(tmp_path, "orphan")
+
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=True)
+
+    assert len(report.worktrees) == 1
+    assert "git worktree list failed" in checker.format_report(report)
+
+
+def test_the_free_space_floor_boundary_is_exclusive(tmp_path: Path) -> None:
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+    assert report.free_bytes is not None
+
+    at_floor = checker.scan_temp_root(tmp_path, report.free_bytes, [], git_listing_failed=False)
+    below_floor = checker.scan_temp_root(
+        tmp_path, report.free_bytes + 1, [], git_listing_failed=False
+    )
+
+    assert at_floor.free_space_low is False, "free == floor is not below the floor"
+    assert below_floor.free_space_low is True
+
+
+# --- error branches -------------------------------------------------------
+
+
+def test_an_unreadable_git_marker_is_not_a_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worktree = make_worktree_dir(tmp_path, "wt")
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", explode)
+
+    assert checker.is_worktree_dir(worktree) is False
+
+
+def test_an_unresolvable_registered_path_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("too many levels of symbolic links")
+
+    monkeypatch.setattr(Path, "resolve", explode)
+
+    assert checker.find_registered_temp_worktrees(["/tmp/wt"], tmp_path) == []
+
+
+def test_a_nonzero_git_exit_is_reported_as_a_listing_failure(tmp_path: Path) -> None:
+    # tmp_path is not a git repository, so `git worktree list` exits non-zero.
+    paths, failed = checker._list_registered(tmp_path)
+
+    assert (paths, failed) == ([], True)
+
+
+def test_a_git_launch_failure_is_reported_as_a_listing_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("git not found")
+
+    monkeypatch.setattr(subprocess, "run", explode)
+
+    assert checker._list_registered(tmp_path) == ([], True)
+
+
+def test_an_unlistable_temp_root_is_counted_and_disclosed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "iterdir", explode)
+
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+
+    assert report.unreadable_entries == 1
+    assert report.examined == 0
+    assert "were unreadable" in checker.format_report(report)
+
+
+def test_an_unstattable_entry_is_counted_not_examined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    entry = tmp_path / "entry"
+    entry.mkdir()
+    real_is_dir = Path.is_dir
+
+    def explode_for_the_entry(self: Path, *args: object, **kwargs: object) -> bool:
+        if self == entry:
+            raise OSError("stale file handle")
+        return bool(real_is_dir(self, *args, **kwargs))
+
+    monkeypatch.setattr(Path, "is_dir", explode_for_the_entry)
+
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+
+    assert report.unreadable_entries == 1
+    assert report.examined == 0
+
+
+def test_an_unreadable_temp_root_is_not_reported_as_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> bool:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "is_dir", explode)
+
+    report = checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False)
+
+    assert report.temp_root_present is False
+    assert report.unreadable_entries == 1, "an unreadable root must not read as absent"
+
+
+def test_unreadable_free_space_is_reported_as_unknown_not_as_low(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("no such device")
+
+    monkeypatch.setattr(checker.shutil, "disk_usage", explode)
+
+    report = checker.scan_temp_root(tmp_path, 10**18, [], git_listing_failed=False)
+
+    assert report.free_bytes is None
+    assert report.free_space_low is False, "unknown free space must not read as low"
+    assert "free space unreadable" in checker.format_report(report)
+
+
+# --- format_report --------------------------------------------------------
+
+
+def test_the_report_always_names_the_examined_count(tmp_path: Path) -> None:
+    (tmp_path / "d").mkdir()
+
+    text = checker.format_report(checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False))
+
+    assert "1 examined entries" in text
+
+
+def test_the_report_cites_the_rule_and_the_repair_command(tmp_path: Path) -> None:
+    make_worktree_dir(tmp_path, "wt")
+
+    text = checker.format_report(checker.scan_temp_root(tmp_path, 0, [], git_listing_failed=False))
+
+    assert "MUST NOT 7" in text
+    assert "git worktree move" in text
+
+
+# --- build_report and the advisory gate -----------------------------------
+
+
+def test_build_report_runs_against_the_real_repository(tmp_path: Path) -> None:
+    report = checker.build_report(REPO_ROOT, temp_root=tmp_path, min_free_gib=0)
+
+    assert report.temp_root == str(tmp_path)
+    assert report.git_listing_failed is False
+
+
+def test_the_advisory_gate_never_fails_even_with_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    make_worktree_dir(tmp_path, "wt")
+    monkeypatch.setattr(checker, "DEFAULT_TEMP_ROOT", tmp_path)
+
+    verdict = checker.validate_tmp_worktrees(REPO_ROOT)
+
+    # The negative control: the gate must have SEEN the planted worktree and
+    # still returned True. Without this assertion the test passes even when
+    # the monkeypatch does not reach the scan, which is the vacuous shape.
+    assert "wt" in capsys.readouterr().out
+    assert verdict is True
+
+
+# --- CLI exit codes -------------------------------------------------------
+
+
+def test_main_exits_zero_on_a_clean_temp_root(tmp_path: Path) -> None:
+    assert checker.main(["--temp-root", str(tmp_path), "--min-free-gib", "0"]) == 0
+
+
+def test_main_exits_one_when_a_worktree_sits_under_the_temp_root(tmp_path: Path) -> None:
+    make_worktree_dir(tmp_path, "pr5025-worktree")
+
+    assert checker.main(["--temp-root", str(tmp_path), "--min-free-gib", "0"]) == 1
+
+
+def test_main_exits_one_when_free_space_is_below_the_floor(tmp_path: Path) -> None:
+    assert checker.main(["--temp-root", str(tmp_path), "--min-free-gib", "1e9"]) == 1
+
+
+def test_main_exits_two_on_a_missing_explicit_temp_root(tmp_path: Path) -> None:
+    assert checker.main(["--temp-root", str(tmp_path / "gone")]) == 2
+
+
+def test_main_exits_two_on_a_negative_floor(tmp_path: Path) -> None:
+    assert checker.main(["--temp-root", str(tmp_path), "--min-free-gib", "-1"]) == 2
+
+
+def test_main_emits_json_when_asked(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    checker.main(["--temp-root", str(tmp_path), "--min-free-gib", "0", "--json"])
+
+    assert '"examined"' in capsys.readouterr().out
+
+
+def test_module_runs_as_a_script(tmp_path: Path) -> None:
+    make_worktree_dir(tmp_path, "wt")
+    script = REPO_ROOT / "scripts" / "validation" / "check_tmp_worktrees.py"
+
+    result = subprocess.run(
+        ["python3", str(script), "--temp-root", str(tmp_path), "--min-free-gib", "0"],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "examined entries" in result.stdout

--- a/tests/validation/test_check_worktree_recipes.py
+++ b/tests/validation/test_check_worktree_recipes.py
@@ -259,6 +259,7 @@ def test_module_runs_as_a_script_and_exits_zero() -> None:
         ["python3", str(REPO_ROOT / "scripts" / "validation" / "check_worktree_recipes.py")],
         capture_output=True,
         encoding="utf-8",
+        errors="replace",
         check=False,
     )
 

--- a/tests/validation/test_check_worktree_recipes.py
+++ b/tests/validation/test_check_worktree_recipes.py
@@ -1,0 +1,266 @@
+"""Worktree destinations in tracked prescriptions (issue #5111).
+
+`.claude/rules/universal.md` MUST NOT 7 says worktrees must be external. The
+rule, a Serena memory, and a documented prior incident all existed while six
+worktrees accumulated under `/tmp` and filled a 16G tmpfs. Nothing read the
+recipes, so nothing caught them.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.validation import check_worktree_recipes as checker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --- extract_destination: which token is the path -------------------------
+
+
+@pytest.mark.parametrize(
+    ("rest", "expected"),
+    [
+        (" ../wt-foo feature/xyz", "../wt-foo"),
+        (" -b feature/xyz ../wt-foo origin/main", "../wt-foo"),
+        (" -B feature/xyz ../wt-foo", "../wt-foo"),
+        (" --detach ../wt-foo origin/main", "../wt-foo"),
+        (" --lock --reason 'holding' ../wt-foo", "../wt-foo"),
+        (' "../wt-foo" "$branch"', "../wt-foo"),
+        (" --force -b b ../wt-foo", "../wt-foo"),
+    ],
+)
+def test_extract_destination_skips_flags_and_their_values(rest: str, expected: str) -> None:
+    assert checker.extract_destination(rest) == expected
+
+
+def test_extract_destination_returns_none_when_only_flags_follow() -> None:
+    assert checker.extract_destination(" --detach") is None
+
+
+def test_extract_destination_returns_none_on_empty_rest() -> None:
+    assert checker.extract_destination("") is None
+
+
+# --- classify: positive (bad destinations) --------------------------------
+
+
+@pytest.mark.parametrize(
+    "destination",
+    ["/tmp/wt_4003", "/tmp", "/tmp/", "/var/tmp/wt", "/private/tmp/wt", "/dev/shm/wt"],
+)
+def test_temp_destinations_are_rejected(destination: str) -> None:
+    assert checker.classify(destination) == checker.REASON_TEMP
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "./.worktrees/pr-1",
+        ".worktrees/pr-1",
+        ".claude/worktrees/agent-a",
+        "sub/dir/wt",
+        "./a/../b",
+    ],
+)
+def test_in_checkout_destinations_are_rejected(destination: str) -> None:
+    assert checker.classify(destination) == checker.REASON_IN_CHECKOUT
+
+
+def test_placeholder_segment_is_counted_not_skipped() -> None:
+    # The real pr-review recipe. The placeholder is one directory level, which
+    # is enough to settle that the path stays inside the checkout.
+    assert checker.classify("./.worktrees/pr-{number}") == checker.REASON_IN_CHECKOUT
+
+
+# --- classify: negative (acceptable destinations) -------------------------
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "../wt-feature-xyz",
+        "../ai-agents-worktrees/pr-1",
+        "../wt-<slug>",
+        "/home/richard/src/GitHub/rjmurillo/ai-agents-slug",
+        "~/worktrees/myapp-hotfix",
+        # Rises above the checkout and descends into a sibling, so it lands
+        # outside even though it holds a descending segment.
+        "../wt/../back-inside",
+    ],
+)
+def test_external_destinations_are_accepted(destination: str) -> None:
+    assert checker.classify(destination) is None
+
+
+def test_reentering_the_checkout_by_name_is_a_known_miss() -> None:
+    """Documents the one in-checkout shape ``classify`` cannot see.
+
+    Once a path rises above the checkout root the checker calls it external,
+    because a recipe's text does not carry the checkout's own directory name
+    and nothing else can tell ``../ai-agents/x`` (back inside) from
+    ``../wt-x`` (a sibling). No tracked prescription uses the re-entering form;
+    this test pins the behavior so a future change to it is deliberate.
+    """
+    assert checker.classify("../ai-agents/.worktrees/pr-1") is None
+
+
+@pytest.mark.parametrize("destination", ["${dir}", "$HOME/wt", "`pwd`/wt", "../$slug"])
+def test_shell_expansions_are_not_judged(destination: str) -> None:
+    assert checker.classify(destination) is None
+
+
+@pytest.mark.parametrize("destination", ["a", "and", "failed", "<path>", "checkout"])
+def test_non_path_shaped_tokens_are_not_judged(destination: str) -> None:
+    assert checker.classify(destination) is None
+
+
+# --- classify: edge cases -------------------------------------------------
+
+
+def test_empty_destination_is_not_judged() -> None:
+    assert checker.classify("") is None
+
+
+def test_bare_slash_is_not_judged_as_temp() -> None:
+    assert checker.classify("/") is None
+
+
+# --- scan_text ------------------------------------------------------------
+
+
+def test_scan_text_reports_file_line_and_destination() -> None:
+    text = "intro\ngit worktree add /tmp/wt_4003 main\ntrailer\n"
+
+    findings = checker.scan_text("docs/x.md", text)
+
+    assert len(findings) == 1
+    assert findings[0].line_number == 2
+    assert findings[0].destination == "/tmp/wt_4003"
+    assert "docs/x.md:2" in findings[0].render()
+
+
+def test_scan_text_returns_empty_for_a_clean_recipe() -> None:
+    assert checker.scan_text("docs/x.md", "git worktree add ../wt-foo main\n") == []
+
+
+def test_scan_text_returns_empty_when_no_recipe_is_present() -> None:
+    assert checker.scan_text("docs/x.md", "no recipes here\n") == []
+
+
+def test_scan_text_handles_empty_input() -> None:
+    assert checker.scan_text("docs/x.md", "") == []
+
+
+def test_historical_marker_opts_a_line_out() -> None:
+    text = f"git worktree add /tmp/wt main  # {checker.HISTORICAL_MARKER}\n"
+
+    assert checker.scan_text("docs/x.md", text) == []
+
+
+def test_a_recipe_with_no_destination_at_all_is_not_a_finding() -> None:
+    # `extract_destination` returns None; the line must be skipped, not guessed.
+    assert checker.scan_text("docs/x.md", "git worktree add --detach\n") == []
+
+
+def test_prose_mentioning_the_command_is_not_a_finding() -> None:
+    # The exact GOTCHAS.md sentence that a naive token scan misreads.
+    text = "The direct cost is that `git bisect`, `git worktree add --detach`, a CI checkout\n"
+
+    assert checker.scan_text(".agents/governance/GOTCHAS.md", text) == []
+
+
+# --- is_scanned -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [".claude/commands/pr-review.md", "scripts/x.py", ".github/prompts/y.prompt.md"],
+)
+def test_prescriptive_surfaces_are_scanned(path: str) -> None:
+    assert checker.is_scanned(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".agents/retrospective/2025-12-24-parallel-pr-review-session.md",
+        ".agents/archive/planning/v0.3.0/PLAN.md",
+        ".agents/sessions/x.json",
+        ".agents/memory/episodes/e.json",
+        ".claude/worktrees/nested/x.md",
+        "README.md",
+        "scripts/x.bin",
+    ],
+)
+def test_history_and_out_of_scope_paths_are_skipped(path: str) -> None:
+    assert checker.is_scanned(path) is False
+
+
+# --- repository-wide gate -------------------------------------------------
+
+
+def test_the_tracked_corpus_has_no_bad_worktree_recipes() -> None:
+    violations, examined = checker.check_repository(REPO_ROOT)
+
+    assert violations == [], "\n".join(v.render() for v in violations)
+    assert examined > 0, "scanned nothing; the inventory or the prefixes are wrong"
+
+
+def test_validate_returns_true_on_the_real_repository() -> None:
+    assert checker.validate_worktree_recipes(REPO_ROOT) is True
+
+
+def test_an_unreadable_tracked_file_is_skipped_not_counted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> str:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", explode)
+
+    violations, examined = checker.check_repository(REPO_ROOT)
+
+    assert violations == []
+    assert examined == 0, "an unreadable file must not count as examined"
+
+
+def test_validate_returns_false_when_the_inventory_cannot_be_read(tmp_path: Path) -> None:
+    # Not a git repository, so git ls-files fails and the gate must fail closed.
+    assert checker.validate_worktree_recipes(tmp_path) is False
+
+
+# --- CLI exit codes -------------------------------------------------------
+
+
+def test_main_exits_zero_on_the_real_repository() -> None:
+    assert checker.main(["--repo-root", str(REPO_ROOT)]) == 0
+
+
+def test_main_exits_two_when_the_root_is_not_a_repository(tmp_path: Path) -> None:
+    assert checker.main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_main_exits_one_when_a_tracked_prescription_is_bad(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    doc = tmp_path / "scripts" / "recipe.md"
+    doc.parent.mkdir()
+    doc.write_text("git worktree add /tmp/wt-bad main\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+
+    assert checker.main(["--repo-root", str(tmp_path)]) == 1
+
+
+def test_module_runs_as_a_script_and_exits_zero() -> None:
+    result = subprocess.run(
+        ["python3", str(REPO_ROOT / "scripts" / "validation" / "check_worktree_recipes.py")],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "examined files" in result.stdout

--- a/tests/validation/test_pre_pr_sequence_registry.py
+++ b/tests/validation/test_pre_pr_sequence_registry.py
@@ -51,6 +51,8 @@ EXPECTED_ORDER: tuple[str, ...] = (
     'Subprocess Encoding Convention',
     'Test Working Tree Writes',
     'Push Lock Path Agreement',
+    'Worktree Recipe Destinations',
+    'Temp-filesystem Worktrees (advisory)',
     'Session End Validation',
     'Mypy Changed Files (ratchet)',
     'Markdown Linting',

--- a/tests/validation/test_pre_pr_worktree_gate_wiring.py
+++ b/tests/validation/test_pre_pr_worktree_gate_wiring.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -46,12 +47,17 @@ def _run_sequence(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
     """Drive the real sequence and return each gate's verdict by name."""
     verdicts: dict[str, bool] = {}
 
-    def record(name: str, state: _State, callback: object, skip: bool = False) -> bool:
+    def record(
+        name: str,
+        state: _State,
+        callback: Callable[[], bool],
+        skip: bool = False,
+    ) -> bool:
         state.total += 1
         if skip:
             state.skipped += 1
             return True
-        result = bool(callback())  # type: ignore[operator]
+        result = bool(callback())
         verdicts[name] = result
         return result
 

--- a/tests/validation/test_pre_pr_worktree_gate_wiring.py
+++ b/tests/validation/test_pre_pr_worktree_gate_wiring.py
@@ -1,0 +1,118 @@
+"""Wiring tests for the two worktree gates in the pre-PR runner (issue #5111).
+
+A gate's own unit tests prove the gate. They cannot prove any call site reached
+it, so a gate can pass every test it owns while `pre_pr` never calls it
+(`.claude/rules/testing.md` SHOULD 6). These tests drive the real sequence and
+fail when either gate is unwired.
+
+Both gates are driven over the same input twice, differing only in the
+condition the gate rejects, so a run that fails for an unrelated reason fails
+its own control too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way the runner does. See the header of
+# tests/validation/test_pre_pr_model_pin_wiring.py for why sys.path is inserted
+# once and deliberately never restored.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_tmp_worktrees
+import check_worktree_recipes
+import pre_pr_sequence
+
+RECIPE_GATE = "Worktree Recipe Destinations"
+TEMP_GATE = "Temp-filesystem Worktrees (advisory)"
+
+
+class _State:
+    """Minimal stand-in for pre_pr.ValidationState."""
+
+    def __init__(self) -> None:
+        self.total = 0
+        self.skipped = 0
+
+
+def _run_sequence(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
+    """Drive the real sequence and return each gate's verdict by name."""
+    verdicts: dict[str, bool] = {}
+
+    def record(name: str, state: _State, callback: object, skip: bool = False) -> bool:
+        state.total += 1
+        if skip:
+            state.skipped += 1
+            return True
+        result = bool(callback())  # type: ignore[operator]
+        verdicts[name] = result
+        return result
+
+    # Every other gate is expensive and irrelevant here, so run only the two
+    # under test. Filtering the real _SEQUENCE (rather than building a fake one)
+    # is what keeps this a wiring test: a gate removed from _SEQUENCE
+    # disappears from the filter and the assertions below fail.
+    wanted = [gate for gate in pre_pr_sequence._SEQUENCE if gate.name in (RECIPE_GATE, TEMP_GATE)]
+    monkeypatch.setattr(pre_pr_sequence, "_SEQUENCE", tuple(wanted))
+
+    args = argparse.Namespace(quick=False, skip_tests=False, verbose=False)
+    pre_pr_sequence.run_all_validations(REPO_ROOT, args, _State(), record)
+    return verdicts
+
+
+def test_both_worktree_gates_are_registered_in_the_sequence() -> None:
+    names = [gate.name for gate in pre_pr_sequence._SEQUENCE]
+
+    assert RECIPE_GATE in names
+    assert TEMP_GATE in names
+
+
+def test_the_sequence_runs_both_gates_and_they_pass_on_the_real_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verdicts = _run_sequence(monkeypatch)
+
+    assert verdicts == {RECIPE_GATE: True, TEMP_GATE: True}
+
+
+def test_the_recipe_gate_fails_the_sequence_when_a_prescription_is_bad(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control for the same run that passed above."""
+    bad = check_worktree_recipes.Violation(
+        path="docs/x.md",
+        line_number=1,
+        destination="/tmp/wt",
+        reason=check_worktree_recipes.REASON_TEMP,
+    )
+    monkeypatch.setattr(
+        check_worktree_recipes,
+        "check_repository",
+        lambda _root: ([bad], 1),
+    )
+
+    verdicts = _run_sequence(monkeypatch)
+
+    assert verdicts[RECIPE_GATE] is False, "pre_pr is not wired to the recipe checker"
+    assert verdicts[TEMP_GATE] is True, "the advisory gate must be unaffected"
+
+
+def test_the_temp_gate_stays_advisory_inside_the_sequence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The advisory gate reports a finding through the sequence without failing it."""
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    monkeypatch.setattr(check_tmp_worktrees, "DEFAULT_TEMP_ROOT", tmp_path)
+
+    verdicts = _run_sequence(monkeypatch)
+
+    assert verdicts[TEMP_GATE] is True


### PR DESCRIPTION
# Pull Request

## Incremental Scope Declaration

This PR delivers Asks #1 and #2 from issue #5111 (detect worktrees under `/tmp` and low `/tmp` free space; prevent it via a blocking recipe-scanner gate, plus the one violating recipe fix it found). Asks #3 (pytest scratch GC / `basetemp` relocation) and #4 (whether agent transcripts belong on tmpfs) are explicitly **not** implemented here and are left for separate follow-up issues. This is a deliberate incremental slice of #5111, not the full issue.

## Summary

### What

Adds two pre-PR validation gates: one detects any git worktree whose path lives under `/tmp` (plus a low-free-space floor check on `/tmp`), the other scans this repo's own tracked commands/docs for `git worktree add` recipes that would create a worktree under `/tmp` or inside the checkout. Also fixes the one violating recipe the new scanner found.

### Why

Issue #5111: on 2026-08-15, six orphaned git worktrees plus pytest scratch filled a 16G `/tmp` tmpfs to 100%, wedging pushes with `ENOSPC`, losing agent transcripts, and causing a background `git push` to report exit 0 while five commits were actually never pushed. `.claude/rules/universal.md` MUST NOT 7 already forbids worktrees under `/tmp` or inside the checkout, and this exact incident recurred (a July 2026 instance is on record), because the rule existed but nothing enforced it.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5111 | Sessions create git worktrees under /tmp, filling the 16G tmpfs and wedging pushes with ENOSPC |

## Changes

- New pre-PR gate (`scripts/validation/check_tmp_worktrees.py`): reports any git worktree, registered or orphaned, whose path sits under the temp root, and flags when `/tmp` free space drops below a 2 GiB floor. **Deliberately advisory, not blocking**, in the wired pre-PR sequence: the subject is machine state left by sessions that already ended, not the current diff, so a blocking verdict would refuse every push on a contaminated machine for a condition the pushing agent may not own, which is the same class of wedge #5111 describes. The standalone CLI (`uv run python scripts/validation/check_tmp_worktrees.py`) exits 1 on the same findings for anyone who wants the blocking form directly. **Scan depth is immediate children of the temp root, not recursive**: the six worktrees issue #5111 measured all sat at that depth (`/tmp/pr5010-work`, `/tmp/pr5025-worktree`, and four siblings), and one level costs one `stat` per entry. A worktree nested more than one level under `/tmp` is not detected.
- New pre-PR gate (`scripts/validation/check_worktree_recipes.py`): scans tracked files for `git worktree add` recipes that resolve under `/tmp` or inside the checkout, and **blocks** the pre-PR sequence on any violation. This one is blocking because the subject is tracked repository content, which the author of the diff owns and can fix at the moment the verdict fires. Known misses, documented rather than solved here: a bare destination argument (`git worktree add scratch`) is skipped as not path-shaped; `git -C <repo> worktree add` and other invocation variants are not parsed; a path that climbs out of the checkout and back in by directory name is not caught.
- Wires both gates into `scripts/validation/pre_pr_sequence.py` (registry-order-guarded via `test_pre_pr_sequence_registry.py`).
- Fixes the one violating recipe the new scanner found: `.claude/commands/pr-review.md`'s parallel-review worktree step used `./.worktrees/pr-{number}`, inside the checkout rather than under `/tmp`, but still the same MUST NOT 7 violation (an in-checkout worktree gets walked by every filesystem-scanning check in the repo, turning fast checks slow and blocking pushes). Changed to `../wt-pr-{number}`, a sibling of the checkout. Mirror regenerated (`src/copilot-cli/skills/pr-review/SKILL.md`, `.github/prompts/pr-review.prompt.md`).

## Acceptance criteria

- [x] A git worktree whose path is an immediate child of `/tmp` is detected and reported (registered and orphaned); the standalone CLI fails on it, the wired pre-PR gate is advisory by design (see Changes)
- [x] `/tmp` free space below the floor is detected and reported the same way
- [x] A repo-internal recipe that would create a worktree under `/tmp` or inside the checkout is detected and **blocks** the pre-PR gate, for the recipe shapes the scanner recognizes (see Changes for documented misses)
- [x] The one existing violating recipe (`pr-review.md`, in-checkout case) is fixed
- [x] Positive, negative, and edge cases covered (unset/empty worktree list, free space at/below floor, shell-expansion and placeholder path segments in recipes)
- [x] Both gates wired into the pre-PR sequence with registry-order coverage
- [ ] Ask #3 (pytest scratch GC / `basetemp` relocation): explicitly out of scope, see Incremental Scope Declaration
- [ ] Ask #4 (agent transcripts on tmpfs): explicitly out of scope, see Incremental Scope Declaration

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush. This is a new push-blocking gate (the recipe scanner) plus an advisory one (the temp-worktree report); false positives on the blocking gate would block every contributor, so its detection logic and tests are the focus.

**Focus areas**: whether the temp-worktree gate's advisory-by-design and immediate-children-only scan choices are the right calls versus a recursive, opt-out-able blocking form; the free-space floor sizing; and whether the recipe scanner's documented misses (bare destinations, `git -C` variants) warrant a follow-up now or later.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

```
$ uv run --frozen python scripts/validation/check_worktree_recipes.py
worktree-recipes: 0 violation(s) in 3159 examined files

$ uv run --frozen pytest tests/validation/test_check_worktree_recipes.py \
    tests/validation/test_check_tmp_worktrees.py \
    tests/validation/test_pre_pr_worktree_gate_wiring.py -q
109 passed in 5.27s
```

`pre_pr.py` passed 56/56 inside the real pre-push hook, including both new gates, on this branch's final commit.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `scripts/validation/pre_pr_sequence.py` (new gate registration)

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

Two self-inflicted test escapes were found and fixed during development: a registry-order test broke when two rows were added to the gate sequence (fixed), and a free-space-boundary test flaked under concurrent load because it read live disk space three times and assumed stability between calls (rewritten to pure arithmetic over supplied numbers, verified with 20 consecutive runs under 8 parallel workers).

Iterated after initial push, in order: a subprocess-encoding ratchet regression (two test-only `subprocess.run` calls used `encoding=` without the required `errors=`), em/en dashes in this description (twice, the second time in the acceptance-criteria checklist itself), an earlier version that overclaimed both gates as blocking when only the recipe scanner actually is, a version that didn't disclose the immediate-children-only scan depth, and this version adding the formal Incremental Scope Declaration for Asks #3/#4.

## Related Issues

Fixes #5111