### PR TITLE
fix(test): raise mutation harness timeout to survive loaded CI (#5102)

### DIFF
--- a/tests/mutation/test_mutate_debate_log_path.py
+++ b/tests/mutation/test_mutate_debate_log_path.py
@@ -34,6 +34,7 @@ is absent (count == 0).
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -54,6 +55,34 @@ _TESTS = [
 _OUTCOME_DEAD = "DEAD"
 _OUTCOME_SURVIVED = "SURVIVED"
 _OUTCOME_DID_NOT_APPLY = "DID-NOT-APPLY"
+
+# Timeout budget (Issue #5102)
+# ---------------------------
+# Two caps bound every mutation test, and their ORDER is the contract:
+#
+#   inner: subprocess.run(timeout=_INNER_SUBPROCESS_TIMEOUT_SECONDS) in
+#          _run_tests_in, bounding the nested pytest process.
+#   outer: @pytest.mark.timeout(_OUTER_TEST_TIMEOUT_SECONDS) on each test that
+#          calls _run_tests_in, overriding the repo-wide --timeout=120 set in
+#          pyproject.toml addopts.
+#
+# The outer cap MUST exceed the inner one. When the outer fires first,
+# pytest-timeout interrupts inside subprocess.communicate and the failure names
+# no command, which is the exact signature reported in Issue #5102:
+#   "Failed: Timeout (>120.0s) from pytest-timeout", raised inside
+#   subprocess.communicate, on a diff that never touched the mutated file.
+# With the inner cap binding instead, the failure is a subprocess.TimeoutExpired
+# naming the pytest command, and _apply_positive_mutant's finally block restores
+# the target bytes.
+#
+# Sizing follows .claude/rules/ci-scripts.md MUST 16: size on a loaded machine,
+# never an idle one. Worst measured single inner run on a contributor machine
+# was 80.69s wall (Issue #5102) for tests/test_lefthook_integration.py alone.
+# _TESTS has since grown tests/validation/test_session_log_optional.py, taking
+# the collected count from 859 to 943 (+9.8%), so that same machine now needs
+# roughly 89s. 120s left under 35s of headroom, which load average 7.63 erased.
+_INNER_SUBPROCESS_TIMEOUT_SECONDS = 300
+_OUTER_TEST_TIMEOUT_SECONDS = 360
 
 
 def _run_tests_in(wt_path: Path) -> subprocess.CompletedProcess[str]:
@@ -84,7 +113,7 @@ def _run_tests_in(wt_path: Path) -> subprocess.CompletedProcess[str]:
             **__import__("os").environ,
             "PYTHONDONTWRITEBYTECODE": "1",
         },
-        timeout=300,
+        timeout=_INNER_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
 
@@ -151,7 +180,94 @@ def test_run_tests_uses_a_bounded_timeout(monkeypatch: pytest.MonkeyPatch, tmp_p
 
     _run_tests_in(tmp_path)
 
-    assert recorded["timeout"] == 300
+    assert recorded["timeout"] == _INNER_SUBPROCESS_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Timeout-budget regression guards (Issue #5102)
+# ---------------------------------------------------------------------------
+
+# Worst single inner-suite wall clock measured on a contributor machine, in
+# seconds. 80.69s was recorded in Issue #5102 against tests/test_lefthook_
+# integration.py alone; _TESTS has since grown a second file that lifts the
+# collected count from 859 to 943 (+9.8%), so the same machine now needs ~89s.
+_MEASURED_WORST_INNER_SECONDS = 89
+
+# A cap this far above the inner bound is no longer a cap. Pins the other side
+# so "raise it until it stops failing" cannot silently disable the budget.
+_OUTER_TIMEOUT_CEILING_SECONDS = 1800
+
+
+def _tests_running_the_inner_suite() -> list[str]:
+    """Names of the top-level tests that create a worktree and run the inner suite.
+
+    Discovered from this module's own source rather than hard-coded, so a fifth
+    mutant added without the timeout marker fails instead of silently
+    inheriting the repo-wide --timeout=120 from pyproject.toml addopts.
+    The `scratch_worktree` fixture is the discriminator: taking it is what makes
+    a test spawn a real nested pytest run through _run_tests_in.
+    """
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    return [
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name.startswith("test_")
+        and any(arg.arg == "scratch_worktree" for arg in node.args.args)
+    ]
+
+
+def _timeout_marker_seconds(test_name: str) -> float | None:
+    """Return the seconds argument of the test's timeout marker, or None."""
+    func = globals()[test_name]
+    for mark in getattr(func, "pytestmark", []):
+        if mark.name == "timeout" and mark.args:
+            return mark.args[0]
+    return None
+
+
+def test_every_inner_suite_test_raises_the_outer_timeout() -> None:
+    names = _tests_running_the_inner_suite()
+
+    # Report the scope alongside the finding: a zero-finding sweep over a
+    # zero-sized scope proves nothing (testing.md MUST 10).
+    assert len(names) == 4, f"Expected 4 inner-suite tests, discovered {len(names)}: {names}"
+
+    unmarked = [name for name in names if _timeout_marker_seconds(name) is None]
+    assert not unmarked, (
+        f"These tests spawn the inner suite but carry no @pytest.mark.timeout, "
+        f"so they inherit the repo-wide --timeout=120 that Issue #5102 blocked "
+        f"pushes on: {unmarked}"
+    )
+
+    too_low = {
+        name: seconds
+        for name in names
+        if (seconds := _timeout_marker_seconds(name)) is not None
+        and seconds < _OUTER_TEST_TIMEOUT_SECONDS
+    }
+    assert not too_low, (
+        f"Timeout lowered below {_OUTER_TEST_TIMEOUT_SECONDS}s: {too_low}. "
+        "See Issue #5102 for the measured budget."
+    )
+
+
+def test_outer_timeout_exceeds_the_inner_subprocess_timeout() -> None:
+    # Ordering invariant. When the outer cap fires first, pytest-timeout
+    # interrupts inside subprocess.communicate and names no command, which is
+    # the unactionable failure Issue #5102 reported. The inner bound must win.
+    assert _OUTER_TEST_TIMEOUT_SECONDS > _INNER_SUBPROCESS_TIMEOUT_SECONDS
+
+
+def test_outer_timeout_clears_twice_the_measured_inner_runtime() -> None:
+    assert _OUTER_TEST_TIMEOUT_SECONDS >= 2 * _MEASURED_WORST_INNER_SECONDS
+
+
+def test_outer_timeout_stays_bounded() -> None:
+    # pytest-timeout reads 0 as "no timeout at all", so removing the bound and
+    # raising it read identically at the marker. Both must fail here.
+    assert isinstance(_OUTER_TEST_TIMEOUT_SECONDS, int)
+    assert 0 < _OUTER_TEST_TIMEOUT_SECONDS <= _OUTER_TIMEOUT_CEILING_SECONDS
 
 
 def test_positive_mutant_restores_target_when_test_run_raises(
@@ -163,7 +279,7 @@ def test_positive_mutant_restores_target_when_test_run_raises(
     target.write_bytes(original)
 
     def raise_timeout(_wt_path: Path) -> subprocess.CompletedProcess[str]:
-        raise subprocess.TimeoutExpired(cmd="pytest", timeout=300)
+        raise subprocess.TimeoutExpired(cmd="pytest", timeout=_INNER_SUBPROCESS_TIMEOUT_SECONDS)
 
     monkeypatch.setattr(sys.modules[__name__], "_run_tests_in", raise_timeout)
 
@@ -212,6 +328,7 @@ _M1_ORIGINAL = b'        path.parent == PurePosixPath(".agents/critique")\n'
 _M1_MUTANT = b'        path.parent == PurePosixPath(".agents/analysis")  # M1 mutant\n'
 
 
+@pytest.mark.timeout(_OUTER_TEST_TIMEOUT_SECONDS)
 def test_m1_directory_name_reverted_is_detected(scratch_worktree: Path) -> None:
     original = (REPO_ROOT / _TARGET_REL).read_bytes()
     outcome = _apply_positive_mutant(
@@ -226,15 +343,12 @@ def test_m1_directory_name_reverted_is_detected(scratch_worktree: Path) -> None:
 # ---------------------------------------------------------------------------
 
 _M2_ORIGINAL = (
-    b'            "ERROR: ADR changes require a debate log staged in '
-    b'.agents/critique",\n'
+    b'            "ERROR: ADR changes require a debate log staged in .agents/critique",\n'
 )
-_M2_MUTANT = (
-    b'            "ERROR: ADR changes require a debate log staged in '
-    b'.agents/wrong-dir",\n'
-)
+_M2_MUTANT = b'            "ERROR: ADR changes require a debate log staged in .agents/wrong-dir",\n'
 
 
+@pytest.mark.timeout(_OUTER_TEST_TIMEOUT_SECONDS)
 def test_m2_error_message_path_changed_is_detected(scratch_worktree: Path) -> None:
     original = (REPO_ROOT / _TARGET_REL).read_bytes()
     outcome = _apply_positive_mutant(
@@ -252,6 +366,7 @@ _M3_ORIGINAL = b"    if not debate_logs:\n"
 _M3_MUTANT = b"    if False:  # M3 mutant: gate removed\n"
 
 
+@pytest.mark.timeout(_OUTER_TEST_TIMEOUT_SECONDS)
 def test_m3_missing_debate_log_gate_removed_is_detected(scratch_worktree: Path) -> None:
     original = (REPO_ROOT / _TARGET_REL).read_bytes()
     outcome = _apply_positive_mutant(
@@ -285,6 +400,7 @@ _IC_MUTANT = (
 )
 
 
+@pytest.mark.timeout(_OUTER_TEST_TIMEOUT_SECONDS)
 def test_ic_comment_only_change_survives(scratch_worktree: Path) -> None:
     """Inverted control: a comment-only mutation must NOT be detected (rc == 0)."""
     original = (REPO_ROOT / _TARGET_REL).read_bytes()


### PR DESCRIPTION
# Pull Request

## Summary

### What

Raises the per-test `pytest-timeout` cap on the four mutation tests in `tests/mutation/test_mutate_debate_log_path.py` from the module's inherited 120s default to 360s, via explicit `@pytest.mark.timeout(360)` markers.

### Why

Issue #5102: each of these tests runs the inner suite `tests/test_lefthook_integration.py` once via `_run_tests_in` (see Correction below), inside a 120s outer pytest-timeout. Under load, that inner run alone can exceed 120s, so `pytest-timeout` fires inside `subprocess.communicate` and the test fails with a timeout that names no command, on a diff that never touched the mutated file (`scripts/validation/git_hook_policy.py`).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5102 | mutation harness nests a 79s suite inside a 120s pytest-timeout and blocks pushes |

## Correction to the issue's diagnosis

The issue states each positive-mutant test runs the inner suite "at least twice (baseline plus mutant)." It does not: `_apply_positive_mutant` calls `_run_tests_in` once per test, and `scripts/testing/mutation_workspace.py` runs no pytest at all. The real mechanism is cap ordering: the outer 120s timeout always beat the inner `subprocess.run(timeout=300)`, so `pytest-timeout` fires first and reports a bare timeout instead of a diagnosable `TimeoutExpired` naming the command.

## Chosen value and arithmetic

Two constraints; the second is binding.

**A, load headroom.** Worst per-node cost measured on this branch: 42.3s (37.89s call + 4.45s setup). Scaled 1.72x for the machine ratio between this box and the original bug report (45.76s vs. the reporter's 78.90s on the issue's own command), that is roughly 73s per node on a loaded box like the one that filed the issue. 360 is 4.9x that.

**B, cap ordering (binding).** The outer cap must exceed the inner `subprocess.run(timeout=300)` plus about 4.5s of worktree setup, so the inner bound wins and produces a diagnosable failure instead of a bare timeout. This rules out the smaller values the issue's own options list suggested (240, 300): 240 keeps the outer cap binding, and 300 races. 360 = 300 + 60.

Scope is the narrowest that works: four per-test markers (`@pytest.mark.timeout(360)`), not a module-level `pytestmark`, not a change to the global `addopts` default in `pyproject.toml`. The module's other, fast unit tests keep the 120s default.

This is Option 1 from the issue (raise the outer cap), chosen over Option 2 (narrow `_TESTS` to the subset that actually exercises the mutated behavior, out of 943 tests in `test_lefthook_integration.py`, since a wrong subset would silently weaken mutation coverage) and Option 3 (move the module to a nightly job, trading a flaky push gate for no gate on every push). Neither is implemented here.

## Acceptance criteria

- [x] The outer timeout on the four mutation tests exceeds the inner suite's loaded wall-clock time by a documented, arithmetic-justified margin
- [x] The inner `subprocess.run(timeout=300)` bound stays binding, so a real hang still produces a diagnosable `TimeoutExpired` naming the command, not a bare pytest-timeout kill
- [x] Only the four mutation tests are affected; the module's other tests keep the 120s default
- [x] A guard test asserts the configured timeout value stays at or above the chosen floor, and that it is not accidentally removed or set unbounded

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush. A push-blocking flake fix; the risk is under-raising the cap (does not fix the flake) or over-raising it (hides a real future hang for longer).

**Focus areas**: whether 360s is the right number given the arithmetic above, and whether the per-test marker scope (versus module-level) is the right call.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

```
$ uv run pytest tests/mutation/test_mutate_debate_log_path.py -q --timeout=600 --durations=6
11 passed in 170.15s

$ uv run ruff check tests/mutation/test_mutate_debate_log_path.py
All checks passed!

$ uv run python scripts/validation/pre_pr.py
RESULT: All validations passed
```

Mutation-tested guard, confirmed to discriminate rather than pass unconditionally:

```
constant 360 -> 120: 2 failed (exceeds_inner, clears_twice), 5 passed
remove @pytest.mark.timeout from test_m1: 1 failed (every_inner_suite_test), 6 passed
control restored: 7 passed
```

Strongest verification: in a real push attempt, all 11 of this module's tests, including all four mutation tests (M1, M2, M3, IC), passed inside the real pre-push `python-tests` job under live contention from three other concurrent agent pushes on the same host. The job issue #5102 reported as red is green for this module on this branch.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

Known cost of this fix, worth stating plainly: raising the per-node cap also raises this module's worst-case contribution to the `python-tests` pre-push job, which itself carries a 30 minute timeout. A genuine inner hang now costs roughly 20 minutes (the inner 300s cap becomes binding) instead of 8. That is the price of stopping the bleeding without touching the cause, and it is the argument for Option 2 as a follow-up: narrow `_TESTS` so the mutation harness does not need 943 tests to kill one mutant.

Advisory-only finding from `taste-lints`, not addressed here: `tests/mutation/test_mutate_debate_log_path.py` is at 461 of a 500-line soft limit. The four new guards were kept in-module because two existing helpers, `_tests_running_the_inner_suite` and `_timeout_marker_seconds`, parse this file's own AST and read its `globals()`; splitting them into a sibling file would need both helpers to follow.

## Related Issues

Fixes #5102

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqkKhvyKa5ycQckzQ5Ajaa)_