### PR TITLE
fix(hooks): stop injecting stale HANDOFF.md at session start

### DIFF
--- a/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
+++ b/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
@@ -128,7 +128,7 @@ its row and gains a retirement note rather than disappearing.
 
 | Hook | File | Type | Status |
 |------|------|------|--------|
-| **SessionStart: Context Loader** | `SessionStart/invoke_context_loader.py` | SessionStart | Implemented |
+| **SessionStart: Context Loader** | `SessionStart/invoke_context_loader.py` | SessionStart | Implemented, narrowed by #5170 |
 | **PreCompact: Compact Checkpoint** | `PreCompact/invoke_compact_checkpoint.py` | PreCompact | Implemented, trimmed by #3273 |
 | **PreToolUse: False Completion Gate** | `PreToolUse/invoke_false_completion_gate.py` | PreToolUse | Retired by #3184 |
 | **PostToolUse: Plan State Sync** | `PostToolUse/invoke_plan_state_sync.py` | PostToolUse | Retired by #3184 |
@@ -161,14 +161,28 @@ today".
 implemented whose file is absent. Two prior purges left this section stale in
 silence; a third correction with no gate buys one clean read and nothing else.
 
+### Amendment 2026-08-19 (Issue #5168, PR #5170)
+
+The Context Loader hook narrowed: it no longer auto-injects `.agents/HANDOFF.md`
+into session context. That file had carried a "read-only, as of 2025-12-22"
+banner unchanged for eight months, listing pull requests long since resolved;
+ADR-014 already superseded it with per-issue handoffs and Serena memory, and
+the mandatory session-log protocol this hook originally served was itself
+retired as negative-ROI in PR #5135. Injecting the stale file cost roughly
+1,000 tokens per session for no compensating value. The hook still auto-injects
+the latest retrospective and the pending-retro-skeleton reminder; the
+criterion this ADR records ("SessionStart loads context") remains met, on a
+narrower path.
+
 ### Acceptance Criteria Mapping
 
-As accepted in 2026. Rows for retired hooks are kept because they record what
-the decision claimed at the time; the criterion is no longer met by a hook.
+As accepted 2025-12-20. Rows for retired hooks are kept because they record
+what the decision claimed at the time; the criterion is no longer met by a
+hook.
 
 | Criteria | Hook | Evidence | Still met by a hook |
 |----------|------|----------|---------------------|
-| SessionStart loads context | Context Loader | Auto-injects HANDOFF.md + latest retro | Yes |
+| SessionStart loads context | Context Loader | Auto-injects HANDOFF.md + latest retro | Partially, HANDOFF.md dropped by #5168/#5170 |
 | Hook execution logged | All hooks | Audit trail in `.agents/.hook-state/` | Yes, for the survivors |
 | Zero context reading failures | Context Loader | Eliminates manual context loading requirement | Yes |
 | PreToolUse blocks false completion | False Completion Gate | Blocks commit/PR without test evidence | No, retired by #3184 |

--- a/.agents/critique/ADR-008-debate-log.md
+++ b/.agents/critique/ADR-008-debate-log.md
@@ -1,0 +1,68 @@
+# ADR Debate Log: ADR-008 Protocol Automation via Lifecycle Hooks
+
+## Summary
+
+- **Scope**: correction only. The Context Loader hook (`invoke_context_loader.py`)
+  stopped auto-injecting `.agents/HANDOFF.md` in PR #5170 (issue #5168); ADR-008's
+  Implementation Status and Acceptance Criteria Mapping tables still claimed the
+  old behavior as currently true. A Copilot review comment on PR #5170 flagged the
+  contradiction. No architecture, policy, or decision content changed.
+- **Rounds**: 1
+- **Outcome**: Consensus (5 Accept, 1 Disagree-and-Commit, reservation incorporated)
+- **Final Status**: accepted (unchanged; this is a correction to an already-accepted ADR, not a status transition)
+
+## Round 1 Summary
+
+### Key Issues Addressed
+
+- The proposed row (first draft) *replaced* the original "as accepted" Evidence
+  text with the narrowed description, which independent-thinker identified as
+  contradicting this table's own stated purpose (rows preserve the original
+  claim; drift is recorded separately). Fixed by restoring the original Evidence
+  text and moving the narrowing note to the status column and a new amendment
+  section, mirroring the existing `#3184`/`#3349` treatment.
+- critic flagged that the Implementation Status table (line 131) would still
+  read bare `Implemented` while the Acceptance Criteria table recorded drift,
+  recreating the two-tables-disagree problem the 2026-07-26 amendment fixed.
+  Fixed by adding `, narrowed by #5170` to that row, matching the sibling row's
+  `Implemented, trimmed by #3273` format.
+- architect and independent-thinker both caught a pre-existing, unrelated typo
+  in the same paragraph being edited ("As accepted in 2026" vs. the ADR's actual
+  2025-12-20 acceptance date). Fixed in the same pass since it sits inside the
+  paragraph under edit.
+
+### Major Changes Made
+
+- `Implementation Status` table, Context Loader row: `Implemented` →
+  `Implemented, narrowed by #5170`.
+- New `### Amendment 2026-08-19 (Issue #5168, PR #5170)` section added, mirroring
+  the existing `### Amendment 2026-07-26 (Issue #3373)` section's role: records
+  what changed and why without rewriting the original decision.
+- `Acceptance Criteria Mapping` table, "SessionStart loads context" row: Evidence
+  restored to the original `Auto-injects HANDOFF.md + latest retro`; status
+  column changed from `Yes` to `Partially, HANDOFF.md dropped by #5168/#5170`.
+- Fixed `As accepted in 2026` → `As accepted 2025-12-20` (pre-existing error,
+  same paragraph).
+
+### Agent Positions
+
+| Agent | Position | Notes |
+|-------|----------|-------|
+| architect | Accept | Confirmed structural compliance with the table's own drift-recording convention; flagged the 2026/2025-12-20 date typo (P2, incorporated) and an Evidence/status symmetry nit (P2, incorporated via the independent-thinker fix) |
+| critic | Accept | Verified hook docstring matches the new claim; flagged Implementation Status row 131 inconsistency (P2, incorporated) and that no test gate checks Evidence-column content (P2, noted as follow-up, not blocking) |
+| independent-thinker | Disagree-and-Commit → resolved | P1: first-draft edit overwrote as-accepted Evidence text against the table's own stated purpose. Restructure proposed (restore Evidence, move drift to status column, add amendment row) was incorporated; would now Accept on the revised text |
+| security | Accept | No security-relevant surface in a documentation-table correction; dropping HANDOFF.md auto-load reduces untrusted-content-in-context surface rather than expanding it |
+| analyst | Accept | Independently verified all four factual claims (hook diff, HANDOFF.md banner/content, ADR-014's existence and purpose, the pre-existing "No, retired by #NNNN" convention) against the actual files rather than trusting the prompt |
+| high-level-advisor | Accept | Judged the six-agent process disproportionate for a one-cell factual correction (P0 priority but trivial cost); recommended a follow-up issue on adr-review triage by severity, separate from this fix |
+
+### Next Steps
+
+- Follow-up issue (not filed as part of this correction): adr-review has no
+  severity triage. A pure factual correction to an existing table cell
+  triggers the same six-agent, Phase-0-through-4 process as a new architectural
+  decision. high-level-advisor's assessment: "This debate cost more than the
+  fix." Worth a lightweight-correction path that still produces an auditable
+  record without the full debate.
+- critic's noted gap (no test asserts Evidence-column content, only
+  hook-file-existence) is a real but separate hardening task, not blocking this
+  correction.

--- a/.claude/hooks/SessionStart/invoke_context_loader.py
+++ b/.claude/hooks/SessionStart/invoke_context_loader.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""Auto-load HANDOFF.md and latest retrospective at session start.
+"""Auto-load the latest retrospective at session start.
 
-Claude Code SessionStart hook that injects critical context files into
-the session to eliminate the 95.8% context reading failure rate documented
-in retrospective analysis.
+Claude Code SessionStart hook that injects the most recent retrospective
+into the session so prior-session findings (recurring bug patterns, gotchas)
+are available without a manual read.
 
-Loads:
-1. .agents/HANDOFF.md (read-only dashboard of project state)
-2. Latest retrospective from .agents/retrospective/ (learnings from prior sessions)
+Loads the latest retrospective from .agents/retrospective/ (learnings from
+prior sessions), truncated to prevent context bloat. Output is printed to
+stdout so Claude Code injects it into the session context.
 
-Both are truncated to prevent context bloat. Output is printed to stdout
-so Claude Code injects it into the session context.
+Does NOT load .agents/HANDOFF.md. That file has been a frozen, read-only
+artifact since 2025-12-22 (superseded by per-issue handoffs and Serena
+memory per ADR-014), and injecting it unconditionally spent roughly 1,000
+tokens per session on a dashboard nobody updates.
 
 Hook Type: SessionStart (non-blocking, fail-open)
 Exit Codes:
@@ -19,7 +21,9 @@ Exit Codes:
 References:
     - Issue #1703 (lifecycle hook infrastructure)
     - Issue #1672 (session-start gate)
+    - Issue #5168 (removed the HANDOFF.md auto-load; stale since 2025-12-22)
     - ADR-008 (protocol automation via lifecycle hooks)
+    - ADR-014 (distributed handoff architecture; supersedes HANDOFF.md)
 """
 
 from __future__ import annotations
@@ -60,7 +64,6 @@ except ImportError:
 
 
 # Maximum characters to inject per file to prevent context bloat
-MAX_HANDOFF_CHARS = 4000
 MAX_RETRO_CHARS = 4000
 
 HOOK_NAME = "context-loader"
@@ -286,7 +289,7 @@ def _emit_utf8(text: str) -> None:
 
 
 def main() -> None:
-    """Load HANDOFF.md and latest retrospective into session context."""
+    """Load the latest retrospective into session context."""
     _drain_stdin()
 
     if skip_if_consumer_repo(HOOK_NAME):
@@ -297,17 +300,7 @@ def main() -> None:
     loaded_files: list[str] = []
     output_parts: list[str] = []
 
-    # 1. Load HANDOFF.md
-    handoff_path = project_path / ".agents" / "HANDOFF.md"
-    handoff_content = _read_file_truncated(handoff_path, MAX_HANDOFF_CHARS)
-    if handoff_content:
-        output_parts.append(
-            "## 📋 Auto-loaded: HANDOFF.md (read-only dashboard)\n\n"
-            f"{handoff_content}"
-        )
-        loaded_files.append("HANDOFF.md")
-
-    # 2. Load latest retrospective
+    # Load latest retrospective
     retro_dir = project_path / ".agents" / "retrospective"
     latest_retro = _find_latest_retrospective(retro_dir)
     if latest_retro:
@@ -319,7 +312,7 @@ def main() -> None:
             )
             loaded_files.append(f"retrospective/{latest_retro.name}")
 
-    # 3. Remind about unfilled retro skeletons (Issue #2079). Surface a count
+    # Remind about unfilled retro skeletons (Issue #2079). Surface a count
     # and the fill command so the next interactive session can complete them.
     pending_count, pending_names = _count_pending_skeletons(retro_dir)
     if pending_count:

--- a/.claude/hooks/dispatch_groups.json
+++ b/.claude/hooks/dispatch_groups.json
@@ -8,7 +8,7 @@
       "shims": [
         {
           "file": "SessionStart/invoke_context_loader.py",
-          "statusMessage": "Auto-loading HANDOFF.md and latest retrospective (#1703)"
+          "statusMessage": "Auto-loading latest retrospective (#1703)"
         }
       ]
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,7 +566,7 @@ and push enforcement runs through Lefthook, `pre_pr.py`, and CI under ADR-084.
 
 | Hook | File | Purpose | Bypass env var |
 |------|------|---------|----------------|
-| SessionStart | `invoke_context_loader.py` | Auto-loads HANDOFF.md + latest retrospective into context | none (fail-open) |
+| SessionStart | `invoke_context_loader.py` | Auto-loads latest retrospective into context | none (fail-open) |
 | PostToolUse | `invoke_observation_sync.py` | Syncs Serena observations to Forgetful | none (fail-open) |
 | PreCompact | `invoke_compact_checkpoint.py` | Snapshots WIP state before context compaction | none (always runs) |
 

--- a/tests/test_context_loader.py
+++ b/tests/test_context_loader.py
@@ -2,8 +2,9 @@
 """Tests for SessionStart/invoke_context_loader.py.
 
 Covers:
-- HANDOFF.md loading and truncation
-- Latest retrospective detection and loading
+- Latest retrospective detection, loading, and truncation
+- HANDOFF.md is never loaded (Issue #5168; the file is a frozen, stale
+  artifact and injecting it wasted ~1,000 tokens/session for no benefit)
 - Fail-open on missing files
 - Consumer repo skip
 - Audit trail creation
@@ -26,13 +27,18 @@ import invoke_context_loader
 
 @pytest.fixture
 def project_tree(tmp_path: Path) -> Path:
-    """Create a minimal project directory tree."""
+    """Create a minimal project directory tree.
+
+    Includes a HANDOFF.md even though the hook must never load it: several
+    tests use its presence as a regression guard against the hook starting
+    to read it again.
+    """
     agents = tmp_path / ".agents"
     agents.mkdir()
     (agents / "sessions").mkdir()
     (agents / "retrospective").mkdir()
 
-    # Create HANDOFF.md
+    # Present but must never be loaded (Issue #5168).
     (agents / "HANDOFF.md").write_text(
         "# Handoff\n\nProject state dashboard.\n", encoding="utf-8"
     )
@@ -203,7 +209,7 @@ class TestMain:
                 invoke_context_loader.main()
             assert exc_info.value.code == 0
 
-    def test_loads_handoff_and_retro(
+    def test_loads_retro_and_ignores_handoff(
         self, project_tree: Path, capsys: pytest.CaptureFixture
     ) -> None:
         # Add a retrospective
@@ -218,12 +224,16 @@ class TestMain:
             invoke_context_loader.main()
 
         captured = capsys.readouterr()
-        assert "HANDOFF.md" in captured.out
         assert "Retrospective" in captured.out
+        # Regression guard for Issue #5168: HANDOFF.md exists in project_tree
+        # but must never be read or injected.
+        assert "HANDOFF.md" not in captured.out
 
-    def test_handles_no_retros(
+    def test_ignores_handoff_when_no_retro_present(
         self, project_tree: Path, capsys: pytest.CaptureFixture
     ) -> None:
+        """With only a (stale, unloaded) HANDOFF.md and no retrospective,
+        nothing qualifies for auto-load and the hook reports as much."""
         with patch.object(
             invoke_context_loader, "skip_if_consumer_repo", return_value=False
         ), patch.object(
@@ -232,9 +242,8 @@ class TestMain:
             invoke_context_loader.main()
 
         captured = capsys.readouterr()
-        assert "HANDOFF.md" in captured.out
-        # Should still output something (handoff only)
-        assert "Loaded" in captured.out
+        assert "No context files found" in captured.out
+        assert "HANDOFF.md" not in captured.out
 
     def test_handles_missing_handoff(
         self, tmp_path: Path, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary

### What

`invoke_context_loader.py` (SessionStart hook) no longer auto-loads `.agents/HANDOFF.md`. It still auto-loads the latest retrospective and the pending-retro-skeleton reminder.

### Why

`.agents/HANDOFF.md` has carried a `Status: read-only reference (as of 2025-12-22)` banner unchanged since that date. Its dashboard still lists PRs #222, #212, #147, #89, #94, #95, #76, #93 as active, all resolved months ago. ADR-014 superseded it with per-issue handoffs and Serena memory, and the mandatory session-log protocol this hook's origin ADR-008 was built for was itself retired 2026-08-17 in PR #5135 (explicitly labeled "negative-ROI workflow and session evidence machinery" in that PR's own description). Every session was paying roughly 1,000 tokens to inject an 8-month-stale dashboard nobody updates, with no compensating value.

This was found while auditing session-start/session-end hook ROI: this session's own SessionStart output was the reproduction (the stale dashboard is quoted verbatim in the linked issue). The retrospective half of the same hook is not in question; a same-day retrospective load during that audit surfaced real, current findings.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5168 | Context loader injects stale HANDOFF.md every session |

## Changes

- `invoke_context_loader.py`: drop the HANDOFF.md load, its `MAX_HANDOFF_CHARS` constant, and the docstring claim that it loads HANDOFF.md; document why in its place.
- `tests/test_context_loader.py`: rewrite the two tests that asserted HANDOFF.md loading into regression guards proving it is never loaded (the fixture still creates the file, so a future regression that starts reading it again is caught).
- `.claude/hooks/dispatch_groups.json`: update the `sessionstart-1-context_loader` status message to match (no runtime effect; this field isn't read by the Copilot generator).
- `CONTRIBUTING.md`: update the hooks table row describing this hook.

## Acceptance criteria

- [x] `invoke_context_loader.py` never reads `.agents/HANDOFF.md`
- [x] Retrospective auto-load and pending-skeleton reminder are unchanged
- [x] Tests updated to assert the new behavior, including a regression guard (HANDOFF.md present in the fixture, must not appear in output)
- [x] No remaining doc claims that this hook loads HANDOFF.md

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: confirm the regression-guard tests actually fail if HANDOFF.md loading is reintroduced (they were run against the reverted code to confirm).

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

Executed locally:

- `uv run pytest tests/test_context_loader.py tests/hooks/test_context_loader.py -q`: 33 passed
- `uv run pytest tests/hooks/ tests/build_scripts/test_copilot_dispatcher_artifact.py tests/build_scripts/test_dispatch_expansion.py -q`: 950 passed, 1 skipped
- `uv run ruff check .claude/hooks/SessionStart/invoke_context_loader.py tests/test_context_loader.py`: all checks passed
- `uv run mypy .claude/hooks/SessionStart/invoke_context_loader.py tests/test_context_loader.py`: no issues
- `uv run python scripts/validation/pre_pr.py`: 57/57 validations passed (full run, part of the pre-push hook)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

**Files requiring security review:** None. Removes a file read; adds no new I/O, network, or auth surface.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (`CONTRIBUTING.md`)
- [x] No new warnings introduced

## Related Issues

Fixes #5168


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZoDp7kwVXKc957ZjpuEWW)_