### PR TITLE
fix(tests): tolerate a pre-deleted git blob in the corrupt-object-store test

### DIFF
--- a/tests/validation/test_portability_baseline_predecessor.py
+++ b/tests/validation/test_portability_baseline_predecessor.py
@@ -302,7 +302,7 @@ class TestALookupThatFailsIsNotAnAbsentFloor:
         objects = root / ".git" / "objects"
         for blob in objects.rglob("*"):
             if blob.is_file() and blob.parent.name != "info":
-                blob.unlink()
+                blob.unlink(missing_ok=True)
 
         previous, problem = read_previous_sections(root, path)
 


### PR DESCRIPTION
## Summary

`test_a_corrupt_object_store_is_refused` in `tests/validation/test_portability_baseline_predecessor.py` deletes every blob under `.git/objects` with `Path.unlink()` to simulate a corrupt object store. This races git's background `maintenance.lock`, which can delete the same blob first, making `unlink()` raise `FileNotFoundError` and the test flaky.

Fix: `blob.unlink(missing_ok=True)`. The test's assertions are unchanged, it still needs at least one blob gone to trigger the corrupt-store code path, which `_commit_baseline` guarantees by construction.

This was flagged as a real, pre-existing, out-of-scope defect in PR #5176's "Notes for Reviewers": "An unrelated test is flaky and can redden this PR... One-word fix is `blob.unlink(missing_ok=True)`. Not this PR's code, so not fixed here." Fixing it here as an independent, unrelated-scope change so it stops reddening other PRs' CI.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **PR** | Refs #5176 | Flagged the defect in its "Notes for Reviewers"; out of scope there |

## Changes

- `tests/validation/test_portability_baseline_predecessor.py`: `blob.unlink()` to `blob.unlink(missing_ok=True)` in `test_a_corrupt_object_store_is_refused`, tolerating a blob git's background maintenance already deleted.

## Testing

- [x] `uv run pytest tests/validation/test_portability_baseline_predecessor.py -q`, 26 passed

## Type of Change

- [x] Bug fix (non-breaking change fixing a flaky test)

## Author Pre-flight

- [x] Pre-PR validation passed (full `push-ref-policy` pre-push gate suite green, including `python-tests` and `pre-pr-validation`)
- [x] No new warnings introduced
- [x] Single-file, single-line change