### PR TITLE
docs(retro): withdraw a rule citation that says something else

### DIFF
--- a/.agents/qa/session-99923-pr-autofix-tier-field-contract.md
+++ b/.agents/qa/session-99923-pr-autofix-tier-field-contract.md
@@ -44,14 +44,26 @@ rather than the list, which is not.
 Most of the tree is a support module paired with the cases that drive it:
 `pr_autofix_field_parser.py` for the jq reads and the guards on that checker,
 `pr_autofix_tier_parser.py` for the tier set, and `pr_autofix_dispatch_harness.py`
-for the runtime behavior. One module inverts that relationship rather than
-standing outside it: `test_pr_autofix_harness_isolation.py` imports the dispatch
-harness like every other case module, but its subject is the harness's own
-environment rather than the command block the harness runs, so it verifies its
-collaborator instead of being driven by it. An earlier wording here said it
-"stands alone", which reads as importing nothing and is false. Grepping that
-module for `^from tests.commands` returns the dispatch-harness import, same as
-every sibling.
+for the runtime behavior. Three case modules import the dispatch harness and call
+`run_dispatch`: `test_pr_autofix_tier_dispatch_runtime.py`,
+`test_pr_autofix_earned_t1_exemption.py`, and
+`test_pr_autofix_harness_isolation.py`. The other three import parser helpers
+instead. What separates the isolation module from its two harness siblings is the
+**subject under test**, not the dependency: they assert what the extracted command
+block does with a given tier, completeness flag, and auto-merge state, while it
+asserts what the harness itself puts into the subprocess environment. That is why
+the allowlist's own definition cannot stand in for it.
+
+Two earlier wordings of this paragraph were wrong, in the document whose subject
+is claims narrower than the evidence behind them. The first said the module
+"stands alone", which reads as importing nothing. The replacement said it "imports
+the dispatch harness like every other case module" and "verifies its collaborator
+instead of being driven by it": the first half overcounts, since only three of six
+do, and the second half is false, because it calls `run_dispatch` at lines 54 and
+88 and therefore drives the harness exactly as its two siblings do. Copilot found
+both. Re-derive the membership with
+`grep -ln "pr_autofix_dispatch_harness" tests/commands/test_pr_autofix_*.py`
+rather than trusting this list.
 
 This section has now gone stale three times, and each repair was narrower than
 the failure. First it described the one-line fix and three modules, so the PASS

--- a/.agents/qa/session-99923-pr-autofix-tier-field-contract.md
+++ b/.agents/qa/session-99923-pr-autofix-tier-field-contract.md
@@ -44,9 +44,14 @@ rather than the list, which is not.
 Most of the tree is a support module paired with the cases that drive it:
 `pr_autofix_field_parser.py` for the jq reads and the guards on that checker,
 `pr_autofix_tier_parser.py` for the tier set, and `pr_autofix_dispatch_harness.py`
-for the runtime behavior. One module stands alone,
-`test_pr_autofix_harness_isolation.py`, because its subject is the harness's own
-environment rather than anything the harness runs.
+for the runtime behavior. One module inverts that relationship rather than
+standing outside it: `test_pr_autofix_harness_isolation.py` imports the dispatch
+harness like every other case module, but its subject is the harness's own
+environment rather than the command block the harness runs, so it verifies its
+collaborator instead of being driven by it. An earlier wording here said it
+"stands alone", which reads as importing nothing and is false. Grepping that
+module for `^from tests.commands` returns the dispatch-harness import, same as
+every sibling.
 
 This section has now gone stale three times, and each repair was narrower than
 the failure. First it described the one-line fix and three modules, so the PASS

--- a/.agents/retrospective/2026-08-21-pr-5176-fixing-silent-failures-silently.md
+++ b/.agents/retrospective/2026-08-21-pr-5176-fixing-silent-failures-silently.md
@@ -278,12 +278,32 @@ against the session objective, the compliance evidence, and the episode; it was
 corrected there in `0b81de54f` and in PR #5206 in `dc99b4502`.
 
 **Why nothing caught it.** No gate in this repository checks that a cited rule
-item says what the citation claims it says. `.claude/rules/knowledge-persistence.md`
-MUST NOT 3 names exactly this shape and requires grepping the rule tree and
-citing file and item number, or dropping the attribution; it is guidance a
-reviewer enforces, not a check. That makes this an instance of Finding 5's
-theme one level up: the durable record carried a claim that was never measured,
-and every restatement of it looked like corroboration.
+item says what the citation claims it says. The rule that does name this shape is
+`.claude/rules/canonical-source-mirror.md`, in "Behavioral claims: read the body,
+not the name":
+
+> A function's name is not evidence of its behavior. Neither is its call site, a
+> prior PR description, or your memory of it. Open the file and read the body.
+
+It closes by widening past the word "mirrors": "This section binds any assertion
+about another component's behavior, whatever words carry it. The trigger is not a
+phrase like 'mirrors'; the trigger is that you told the reader what some other
+code does." A rule item is such a component, and the failure here was reading its
+name and number rather than its body. Guidance a reviewer enforces, not a check.
+
+**This paragraph first cited the wrong rule, and the wrongness is the same one.**
+It named `knowledge-persistence.md` MUST NOT 3. That item is about a different
+failure: presenting an *operator preference* as a repository rule, where the
+remedy is to "grep the rule tree for X and cite the file and item number, or drop
+the attribution". Here a real repository rule was misread, and the original
+paragraph already cited the correct file and the correct item number, so MUST NOT
+3's remedy would have passed it. Citing a rule for a shape it does not name,
+inside a correction about citing a rule for something it does not say, is the
+same error one level further down. Copilot found it on PR #5212.
+
+That makes this an instance of Finding 5's theme one level up: the durable record
+carried a claim that was never measured, and every restatement of it looked like
+corroboration.
 
 **Appended rather than edited in place**, per `.claude/rules/retros.md` MUST NOT
 1: corrections to a landed retro append a new section with a date and rationale.

--- a/.agents/retrospective/2026-08-21-pr-5176-fixing-silent-failures-silently.md
+++ b/.agents/retrospective/2026-08-21-pr-5176-fixing-silent-failures-silently.md
@@ -247,6 +247,49 @@ gone a fourth round of the same staleness before #5208 was filed: five actions
 had landed and none had a row, so the record understated the work exactly as the
 scope line above overstated its own precision.
 
+## Corrections
+
+### 2026-08-21: the Remediation section cited a rule that does not say what it was cited for
+
+The Remediation section states that the two rule follow-ups cannot ride on PR
+#5176 because `.claude/rules/claude-agents.md` MUST NOT 2 "forbids bundling with
+code". That is wrong. The item reads, verbatim:
+
+> MUST NOT bundle skill code changes with memory changes in the same PR
+> (separate concerns).
+
+Different pairing on both sides. Neither follow-up touches a Serena memory, and
+PR #5176 changed command and test code rather than skill code. The item does not
+reach the decision at all.
+
+**The decision itself stands, on a fact rather than a rule.** PR #5176 carried
+the `needs-split` label at 17 changed files, so adding two rule items would have
+grown a diff a reviewer had already asked to shrink. The citation is withdrawn
+rather than swapped for a different one, because reaching for a rule to justify
+a decision already made is how the wrong one got cited in the first place.
+
+**Blast radius, because this is the interesting part.** The same misreading
+reached three PR bodies, two session logs, two extracted episodes, this
+retrospective, several review-thread replies, and a spec validator that echoed
+it back as a verified requirement, which is what made it feel settled rather
+than assumed. The correct reading was already in-tree, in a 2026-07-26 session
+log, before any of it was written. Copilot filed it three times on PR #5204,
+against the session objective, the compliance evidence, and the episode; it was
+corrected there in `0b81de54f` and in PR #5206 in `dc99b4502`.
+
+**Why nothing caught it.** No gate in this repository checks that a cited rule
+item says what the citation claims it says. `.claude/rules/knowledge-persistence.md`
+MUST NOT 3 names exactly this shape and requires grepping the rule tree and
+citing file and item number, or dropping the attribution; it is guidance a
+reviewer enforces, not a check. That makes this an instance of Finding 5's
+theme one level up: the durable record carried a claim that was never measured,
+and every restatement of it looked like corroboration.
+
+**Appended rather than edited in place**, per `.claude/rules/retros.md` MUST NOT
+1: corrections to a landed retro append a new section with a date and rationale.
+The original paragraph is left standing above so a reader can see what was
+believed and what replaced it.
+
 ## References
 
 - PR #5176, issue #5094.


### PR DESCRIPTION
# Pull Request

## Summary

### What

Corrections to records PR #5176 landed on `main`. Every one is a claim about another component written without opening it, and every one was found by a reviewer rather than by a gate.

1. The retrospective cites `claude-agents.md` MUST NOT 2 as forbidding a rule change bundled with code. That item says something else.
2. The QA report says one test module "stands alone". It imports the dispatch harness.
3. **Both of my first corrections were themselves wrong**, and Copilot caught both on this PR. See "Corrections to the corrections" below.

No code, no test, no workflow, no rule.

### Why

`.claude/rules/claude-agents.md` MUST NOT 2 reads, verbatim:

> MUST NOT bundle skill code changes with memory changes in the same PR (separate concerns).

Different pairing on both sides. Neither rule follow-up (#5187, #5188) touches a Serena memory, and PR #5176 changed command and test code rather than skill code. The item does not reach the decision it was cited for.

The decision itself stands, on a fact rather than a rule: #5176 carried the `needs-split` label at 17 changed files, so adding two rule items would have grown a diff a reviewer had already asked to shrink. The citation is **withdrawn rather than swapped for a different one**, because reaching for a rule to justify a decision already made is how the wrong one got cited in the first place.

A retrospective is not a static document. The `reflect` skill mines `.agents/retrospective/` as institutional knowledge, so a false policy claim there gets retrieved by a later session as prior knowledge and cited as established. That is not hypothetical for this one: the same misreading had already reached three PR bodies, two session logs, two extracted episodes, several review-thread replies, and a spec validator that echoed it back as a verified requirement. The correct reading was in-tree the whole time, in a 2026-07-26 session log.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5094 | The issue PR #5176 fixed; these correct records that PR merged |

`Refs`, not `Fixes`: #5094 is closed and was closed correctly. This corrects artifacts, not the fix.

## Changes

- `.agents/retrospective/2026-08-21-pr-5176-fixing-silent-failures-silently.md`: appends a dated `## Corrections` section withdrawing the citation.
- `.agents/qa/session-99923-pr-autofix-tier-field-contract.md`: replaces "stands alone" with what the module actually does.

## Evidence

**The retrospective correction is appended, not edited in place.** `.claude/rules/retros.md` MUST NOT 1 reads: "MUST NOT delete or edit landed retros to soften criticism. Corrections append a new section with a date and rationale." My first attempt rewrote the Remediation paragraph directly. That would not have softened anything, but the rule prescribes the form as well as the direction, so it was reverted and redone as an appended section. The original paragraph stands above it.

**The sweep, so this is not another single-probe claim.** `git grep -n "forbids bundling with code\|forbids bundling a rule change with code\|MUST NOT 2, no bundling with code"` returns exactly one hit, the retrospective line fixed here.

Re-run against two refs rather than one, because the first ref went stale while this PR sat open:

| Ref | What it is | Hits |
|---|---|---|
| `15f95d2b6` | `main` when this PR was opened | 1, the line fixed here |
| `63bca8796` | `main` now, after #5206 and #5204 merged | 1, the same line |

The second row is the one that matters. The two sibling PRs added rule text and QA prose to `main` between the first sweep and now, so a sweep pinned to the old ref could not speak for the tree this PR merges into. Neither merge reintroduced the phrase.

The other instances were corrected before their PRs merged: PR #5204 in `0b81de54f` and PR #5206 in `dc99b4502`.

**Why no gate caught any of it.** Nothing in this repository checks that a cited rule item says what the citation claims. The rule that names the shape is `.claude/rules/canonical-source-mirror.md`, "Behavioral claims: read the body, not the name":

> A function's name is not evidence of its behavior. Neither is its call site, a prior PR description, or your memory of it. Open the file and read the body.

It closes by widening past the word "mirrors": "This section binds any assertion about another component's behavior, whatever words carry it." A rule item is such a component. Guidance a reviewer enforces, not a check.

### Corrections to the corrections

Both of my first fixes were wrong, and the way each was wrong is the point.

**The retrospective correction cited the wrong rule.** It named `knowledge-persistence.md` MUST NOT 3. That item is about presenting an *operator preference* as a repository rule, and its remedy is to "grep the rule tree for X and cite the file and item number, or drop the attribution". Here a real repository rule was misread, and the original paragraph already cited the correct file and the correct item number, so that remedy would have passed it. Grepping and citing was exactly what I did; reading the body was what I skipped. Citing a rule for a shape it does not name, inside a correction about citing a rule for something it does not say, is the same error one level further down. Sharper still: I cited the correct `canonical-source-mirror.md` section in a QA report on #5206 earlier the same day, then reached for the wrong rule here.

**The QA correction was wrong twice over.** The replacement said the isolation module "imports the dispatch harness like every other case module" and "verifies its collaborator instead of being driven by it". Measured:

```
$ grep -ln "pr_autofix_dispatch_harness" tests/commands/test_pr_autofix_*.py | wc -l
3
$ grep -n "run_dispatch(" tests/commands/test_pr_autofix_harness_isolation.py
54:    run = run_dispatch(
88:    run = run_dispatch(
```

Three of six modules import the harness, not all six; the other three import parser helpers. And the module calls `run_dispatch` twice, so it drives the harness exactly as its two siblings do. I invented a dependency inversion to explain a difference that is not about dependencies.

The real distinction is the **subject under test**. `test_pr_autofix_tier_dispatch_runtime.py` and `test_pr_autofix_earned_t1_exemption.py` assert what the extracted command block does with a given tier, completeness flag, and auto-merge state; `test_pr_autofix_harness_isolation.py` asserts what the harness itself puts into the subprocess environment. Same collaborator, same call, different question. That is also why the allowlist's own definition cannot stand in for it.

The paragraph now carries the membership grep rather than a list of three names, because a list is a measurement of a moment and this paragraph has already gone stale three times on exactly that.

## Acceptance criteria

- [x] The withdrawn citation quotes what `claude-agents.md` MUST NOT 2 actually says
- [x] No replacement rule is cited in its place; the decision rests on the label and the file count
- [x] The retrospective correction is appended with a date and rationale, per `retros.md` MUST NOT 1
- [x] The original paragraph is left standing rather than deleted
- [x] A repository-wide grep confirms no other instance of the claim remains on `main`, re-run against **current** `main` (`63bca8796`) and not only against the ref this PR opened on (`15f95d2b6`), because both sibling PRs merged in between
- [x] Every rule cited as naming a failure shape was checked against that rule's body, not its name and number. One was not, and is recorded above with its correction rather than silently swapped
- [x] Every claim about the test tree's structure is backed by a command whose output is quoted, and the artifact carries the command so the next reader re-derives it
- [x] No code, test, workflow, or rule changes ride along

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, light scrutiny, no rush.

**Focus areas**:

1. **Whether withdrawing beats replacing** for the `claude-agents.md` citation. I deliberately did not go looking for another rule that would justify the split. The argument is that the search itself is the failure mode, and the round recorded above is what happens when I do reach for a replacement.
2. **Whether the appended-section form is right** for a correction that sharpens rather than softens. `retros.md` MUST NOT 1 prescribes it for the softening case; I read it as prescribing the form for all corrections, which is the conservative reading.
3. **Whether the corrections-to-corrections section earns its length.** It could be cut to the fixed text. I kept the record because two rounds of the same error in the same paragraph is the finding, not a distraction from it.

## Testing

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

Two markdown files under `.agents/`, which markdownlint excludes by configuration. The full pre-push gate ran on this branch with no bypass on every push: `pre-pr-validation` and `python-tests` both green, along with every ratchet and advisory job.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Prose in two records. No auth, secrets, CI, hook, or execution surface.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

1. **This branch reuses a merged PR's name.** `claude/pr-5175-review-v21yk2` was #5176's head and was deleted on merge. This is a fresh branch cut from `main` at `15f95d2b6`, not a continuation. Nothing from the merged history is restacked.
2. **No `--no-verify` here.** #5176 needed it for the 40-commit ceiling. A two-commit branch clears the ceiling, so the full gate ran.
3. **The two sibling PRs have merged**, both on 2026-08-21: #5206 as `e3087603f` and #5204 as `63bca8796`. They are the rule follow-ups whose split this citation was wrongly used to justify, and each carried its own correction of the same misreading. Neither ever depended on this PR, and this PR still merges clean against the `main` they produced: `git merge-tree --write-tree origin/claude/pr-5175-review-v21yk2 origin/main` reports no conflict.
4. **Two related deferrals are filed**: **#5211** for the duplicate MUST ordinals in `ci-scripts.md` and `testing.md`, with the warning that the sweep cannot be done by matching an ordinal alone; and **#5213** for two `extract_session_episode.py --preserve` defects found while repairing an episode on #5206.
5. **One imperfection shipped in #5206** and is recorded here because it is no longer fixable there: its QA report cites `.agents/steering/README.md:19` for a sentence on `:21`. The branch was at the 40-commit ceiling and `push-ref-policy` verifies the bypass label through `gh`, which was HTTP 403 for that session, so the fix could not be pushed. The patch is in a comment on #5206 if anyone wants to land it separately.

## Related Issues

Refs #5094

---
_Generated by [Claude Code](https://claude.ai/code/session_01PH6TA7Xub3gnMHBUURe5Aa)_