### PR TITLE
fix(ci): bump audited pip pin to 26.2 for PYSEC-2026-3721

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -33,6 +33,59 @@
       "caused_by": [],
       "leads_to": [],
       "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Local pre-push gate's python-tests job failed tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv, unrelated to this branch's diff. Reproduced identically against git show origin/main:.github/workflows/vendor-provenance.yml: the test hardcodes the pre-Renovate-bump astral-sh/setup-uv SHA (ae62891f...) while the workflow file already carries the SHA PR #5215 bumped it to (20cfd1bf..., v10.0.1), a stale assertion pre-existing on main.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the full local pre-push gate to completion after both fixes.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "test",
+      "content": "Ran the full local pre-push gate to completion after both fixes.      python-tests: 27655 passed, 73 skipped, 0 failed. pre-pr-validation: all validations passed once this session log carried the complete required checklist.",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-21T16:00:28+00:00",
+      "type": "commit",
+      "content": "Commit: 8856bea",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-21T16:13:14+00:00",
+      "type": "commit",
+      "content": "Commit: ed791858e3ed9faae9f2538bf4f19c121dae32f4",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
     }
   ],
   "metrics": {
@@ -40,8 +93,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
-    "files_changed": 3
+    "commits": 2,
+    "files_changed": 4
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -84,6 +84,28 @@
       "caused_by": [
         "e007"
       ],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "PR #5225's mergeable_state was dirty against origin/main, which had moved by one commit (PR #5219) since this branch was cut. PR #5219 independently fixed the identical test_workflow_sets_up_uv bug this session also fixed, in parallel, with a more robust implementation (parses the workflow YAML and asserts on the Setup uv step's uses field, per testing.md MUST 9, instead of a raw substring search).",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-21T16:30:14+00:00",
+      "type": "commit",
+      "content": "Commit: 6e3ebfd566c14dfff6a715421c328182bfa2cf41",
+      "caused_by": [
+        "e008"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
     }
@@ -93,8 +115,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
-    "files_changed": 4
+    "commits": 3,
+    "files_changed": 5
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -1,0 +1,47 @@
+{
+  "id": "episode-2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci",
+  "session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci",
+  "timestamp": "2026-08-21T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Resolve CI red on the Python Security Checks job (pip-audit CVE PYSEC-2026-3721 against the pinned pip==26.1.2) per the /goal directive's finding that this is base-branch-wide and unrelated to whatever PR surfaced it, and per issue #5222's already-filed scoped fix.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed the /goal directive's claim against issue #5222, filed the same day: Python Security Checks fails on main because pytest.yml:505 pins pip==26.1.2, which now carries PYSEC-2026-3721 (fixed in 26.2), the same shape as the pin's own origin issue #2438 fixing PYSEC-2026-196 one advisory earlier.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bumped the pinned pip version in pytest.yml's Python Security Checks job from 26.1.2 to 26.2 and updated the three rationale comments naming the old version, per #5222's acceptance criteria.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed the out-of-scope fixture at tests/validation/test_check_ci_dependency_pins.py:254 (a literal pip==26.1.2 string used as negative-test fixture data) was correctly left untouched.",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/qa/session-99927-python-security-checks-ci.md
+++ b/.agents/qa/session-99927-python-security-checks-ci.md
@@ -1,0 +1,65 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+qaCommit: ed791858e3ed9faae9f2538bf4f19c121dae32f4
+---
+
+# Python Security Checks CI Session QA
+
+## Scope
+
+Two source commits this session, both closing issue #5222's Python Security
+Checks CI red:
+
+1. `.github/workflows/pytest.yml`: bumped the audited `pip` pin from
+   `26.1.2` to `26.2` in the `Python Security Checks` job's `Run pip-audit`
+   step, closing `PYSEC-2026-3721`. Updated the three rationale comments
+   that named the old version; kept all three existing `--ignore-vuln`
+   flags unchanged (`CVE-2026-4539`, `CVE-2026-3219`, `CVE-2026-6357`).
+2. `tests/ci/test_validate_vendor_provenance.py`:
+   `TestWorkflowContract.test_workflow_sets_up_uv` hardcoded the
+   pre-Renovate-bump `astral-sh/setup-uv` SHA. Repro'd on `origin/main`
+   before this session touched anything: `git show
+   origin/main:.github/workflows/vendor-provenance.yml` already carries the
+   `v10.0.1` SHA from PR #5215, so the test failed unconditionally on
+   `main`, independent of this branch's diff. Synced the assertion to the
+   current pin. This is a real, non-evidence-path code change discovered
+   while running the local pre-push gate for the item above, not a
+   trivially docs-only or investigation-only change, so no `SKIPPED:`
+   sentinel applies here.
+
+A security-agent review (subagent run, task a396948180a61ec88) covered item
+1 independently: verified `PYSEC-2026-3721` against OSV, confirmed `26.2`
+is the fix version and `26.1.2` is listed as affected, confirmed all three
+retained `--ignore-vuln` flags are still independently justified, and
+confirmed no unrelated pip-audit or workflow logic changed. Verdict:
+approve-with-notes (one pre-existing, out-of-scope finding on the pygments
+ignore's stale rationale, filed separately as issue #5224).
+
+## Test Results
+
+| Command | Result |
+|---|---|
+| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pytest.yml'))"` | OK |
+| `uv run --frozen python -m pytest tests/validation/test_check_ci_dependency_pins.py -q` | 52 passed |
+| `uv run --frozen python -m pytest tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv -q` (before fix, against HEAD) | 1 failed (reproduces the pre-existing bug) |
+| Full `python-tests` pre-push job (after both fixes) | 27655 passed, 73 skipped, 0 failed |
+
+## Pre-Push Gate Evidence
+
+Full `lefthook` pre-push gate suite ran on this commit range before push,
+including `push-ref-policy`, `security-suppression-policy`,
+`retrospective-policy`, `review-axis-drift` (all 12 roles `status=ok`),
+`planning-artifacts`, `python-lint-ratchet`, `type-ignore-count-ratchet`,
+`branch-context-policy`, `memory-index-count-ratchet`,
+`path-normalization`, `taste-count-ratchet`, `python-unreachable-statements`,
+`cli-exit-contract-ratchet`, `merge-tree-ratchet`, `security-scan`, and
+`pre-pr-validation` (57/57 `RESULT: All validations passed`).
+
+## Verdict
+
+VERDICT: PASS
+
+Both fixes are minimal, evidence-backed syncs to already-established facts
+(an advisory's fix version, an already-landed action-pin bump) with no new
+logic, no widened `--ignore-vuln` scope, and no unrelated files touched.

--- a/.agents/qa/session-99927-python-security-checks-ci.md
+++ b/.agents/qa/session-99927-python-security-checks-ci.md
@@ -1,12 +1,25 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
-qaCommit: ed791858e3ed9faae9f2538bf4f19c121dae32f4
+qaCommit: 6e3ebfd566c14dfff6a715421c328182bfa2cf41
 ---
 
 # Python Security Checks CI Session QA
 
 ## Scope
+
+`qaCommit` is rebound past its original commit (`ed791858e`, the
+vendor-provenance test fix) to `6e3ebfd56`, the merge of `origin/main` into
+this branch. Between those two commits, `origin/main` had independently
+landed the identical `test_workflow_sets_up_uv` fix (PR #5219, in parallel
+with this session) with a more robust implementation (parses the workflow
+YAML and asserts on the `Setup uv` step's `uses` field, rather than a raw
+substring search, per `testing.md` MUST 9). The merge conflicted on that
+one test; resolved by taking `origin/main`'s version in full (confirmed
+byte-identical to `origin/main`'s copy of the file post-merge). No other
+source file changed in the merge; the rest of the diff between the two
+`qaCommit` values is `origin/main`'s own unrelated ADR-096 frontmatter fix
+and its session/QA evidence files.
 
 Two source commits this session, both closing issue #5222's Python Security
 Checks CI red:

--- a/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 99927,
+    "date": "2026-08-21",
+    "branch": "claude/python-security-checks-ci-dnffqh",
+    "startingCommit": "9e1ebd2b8b2de2ef1887001631fa7dfbfa10de39",
+    "objective": "Resolve CI red on the Python Security Checks job (pip-audit CVE PYSEC-2026-3721 against the pinned pip==26.1.2) per the /goal directive's finding that this is base-branch-wide and unrelated to whatever PR surfaced it, and per issue #5222's already-filed scoped fix."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "memoriesLoaded": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Session-start and prompt-submit hooks auto-injected Serena memory context (json-api-type-annotations, install-script-ci-verification-workflow, skills-gemini-index)."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, created after branch-context-policy flagged a stale mtime-tied session log (2026-08-21-session-99926-a1b2c3d4e-pr-automerge-goal.json, from an already-merged, unrelated prior session) as a false-positive branch mismatch on a fresh checkout where every file in .agents/sessions/ shares one checkout mtime."
+      },
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git status confirmed HEAD on claude/python-security-checks-ci-dnffqh, clean working tree, 0 commits ahead of origin/main at session start."
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is claude/python-security-checks-ci-dnffqh, not main."
+      },
+      "usageMandatoryRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "AGENTS.md and CLAUDE.md were auto-injected as system-reminder context at session start."
+      }
+    },
+    "sessionEnd": {
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md was not touched this session (read-only per ADR-014)."
+      },
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This checklist, completed at session end."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "One-file fix to .github/workflows/pytest.yml, committed with Fixes #5222."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "uv run --frozen python scripts/validation/pre_pr.py reported RESULT: All validations passed (57/57) before push; tests/validation/test_check_ci_dependency_pins.py (52 tests) passed unchanged."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Confirmed the /goal directive's claim against issue #5222, filed the same day: Python Security Checks fails on main because pytest.yml:505 pins pip==26.1.2, which now carries PYSEC-2026-3721 (fixed in 26.2), the same shape as the pin's own origin issue #2438 fixing PYSEC-2026-196 one advisory earlier.",
+      "result": "Verified no open PR yet addressed #5222, and this session's designated branch name matches the issue's topic, confirming the scoped fix belongs here."
+    },
+    {
+      "action": "Bumped the pinned pip version in pytest.yml's Python Security Checks job from 26.1.2 to 26.2 and updated the three rationale comments naming the old version, per #5222's acceptance criteria.",
+      "result": "All three existing --ignore-vuln flags (CVE-2026-4539 pygments, CVE-2026-3219 and CVE-2026-6357 historical pip 26.0.x findings) were kept unchanged; their re-check condition now reads 26.2 instead of 26.1.2."
+    },
+    {
+      "action": "Confirmed the out-of-scope fixture at tests/validation/test_check_ci_dependency_pins.py:254 (a literal pip==26.1.2 string used as negative-test fixture data) was correctly left untouched.",
+      "result": "grep across the repo for 26.1.2 showed only uv.lock (unrelated dev dependency), the new historical-rationale comment, the fixture, and two closed historical session logs."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push the branch and open the PR with Fixes #5222.",
+    "Watch CI: Python Security Checks should go green on this PR now that pip 26.2 has no known vulnerabilities against the three retained ignores."
+  ]
+}

--- a/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -33,6 +33,31 @@
         "complete": true,
         "level": "SHOULD",
         "evidence": "AGENTS.md and CLAUDE.md were auto-injected as system-reminder context at session start."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "mcp__serena__activate_project was not called; work was read/write via git, GitHub MCP tools, Grep, and Read, with no symbol-level code navigation needed for a one-line workflow value and its comments."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "mcp__serena__initial_instructions was not called; see serenaActivated."
+      },
+      "handoffRead": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": ".agents/HANDOFF.md was not read this session; the /goal directive scoped work to a single already-filed issue (#5222) with its own acceptance criteria rather than continuing prior in-flight work."
+      },
+      "skillScriptsListed": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not run. Session began directly under the /goal directive naming the exact finding and file/line to act on."
+      },
+      "constraintsRead": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": ".agents/governance/PROJECT-CONSTRAINTS.md was not explicitly opened; the fix's scope and acceptance criteria were fully specified by issue #5222."
       }
     },
     "sessionEnd": {
@@ -49,12 +74,27 @@
       "changesCommitted": {
         "complete": true,
         "level": "MUST",
-        "evidence": "One-file fix to .github/workflows/pytest.yml, committed with Fixes #5222."
+        "evidence": "Two commits: 8856bea (.github/workflows/pytest.yml pip pin bump, Fixes #5222) and ed791858e (tests/ci/test_validate_vendor_provenance.py stale-SHA repair, Refs #5222), plus this session log and its QA report."
       },
       "validationPassed": {
         "complete": true,
         "level": "MUST",
-        "evidence": "uv run --frozen python scripts/validation/pre_pr.py reported RESULT: All validations passed (57/57) before push; tests/validation/test_check_ci_dependency_pins.py (52 tests) passed unchanged."
+        "evidence": "uv run --frozen python scripts/validation/pre_pr.py reported RESULT: All validations passed (57/57); the full pre-push gate (including python-tests, 27655 passed) ran clean before push."
+      },
+      "qaValidation": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/qa/session-99927-python-security-checks-ci.md"
+      },
+      "markdownLintRun": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not run; no markdown was added or edited this session (a YAML workflow, a Python test assertion, and this JSON session log)."
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "No durable cross-session knowledge identified beyond what is captured in this log and PR/issue #5222 and #5224."
       }
     }
   },
@@ -70,9 +110,17 @@
     {
       "action": "Confirmed the out-of-scope fixture at tests/validation/test_check_ci_dependency_pins.py:254 (a literal pip==26.1.2 string used as negative-test fixture data) was correctly left untouched.",
       "result": "grep across the repo for 26.1.2 showed only uv.lock (unrelated dev dependency), the new historical-rationale comment, the fixture, and two closed historical session logs."
+    },
+    {
+      "action": "Local pre-push gate's python-tests job failed tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv, unrelated to this branch's diff. Reproduced identically against git show origin/main:.github/workflows/vendor-provenance.yml: the test hardcodes the pre-Renovate-bump astral-sh/setup-uv SHA (ae62891f...) while the workflow file already carries the SHA PR #5215 bumped it to (20cfd1bf..., v10.0.1), a stale assertion pre-existing on main.",
+      "result": "Fixed the one-line stale assertion in a separate commit (ed791858e, Refs #5222, universal.md forbids bypassing the local pre-push hook, and the fix is a minimal sync to already-landed reality, not new logic); confirmed no other reference to the old SHA exists in tests/ or workflows/."
+    },
+    {
+      "action": "Ran the full local pre-push gate to completion after both fixes.",
+      "result": "python-tests: 27655 passed, 73 skipped, 0 failed. pre-pr-validation: all validations passed once this session log carried the complete required checklist."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "ed791858e3ed9faae9f2538bf4f19c121dae32f4",
   "nextSteps": [
     "Push the branch and open the PR with Fixes #5222.",
     "Watch CI: Python Security Checks should go green on this PR now that pip 26.2 has no known vulnerabilities against the three retained ignores."

--- a/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
+++ b/.agents/sessions/2026-08-21-session-99927-9e1ebd2b8-python-security-checks-ci.json
@@ -74,7 +74,7 @@
       "changesCommitted": {
         "complete": true,
         "level": "MUST",
-        "evidence": "Two commits: 8856bea (.github/workflows/pytest.yml pip pin bump, Fixes #5222) and ed791858e (tests/ci/test_validate_vendor_provenance.py stale-SHA repair, Refs #5222), plus this session log and its QA report."
+        "evidence": "Three commits: 8856bea (.github/workflows/pytest.yml pip pin bump, Fixes #5222), ed791858e (tests/ci/test_validate_vendor_provenance.py stale-SHA repair, Refs #5222), and this session log's own commit; plus a merge commit (6e3ebfd56) resolving a conflict against a concurrently-landed fix on origin/main (PR #5219)."
       },
       "validationPassed": {
         "complete": true,
@@ -118,9 +118,13 @@
     {
       "action": "Ran the full local pre-push gate to completion after both fixes.",
       "result": "python-tests: 27655 passed, 73 skipped, 0 failed. pre-pr-validation: all validations passed once this session log carried the complete required checklist."
+    },
+    {
+      "action": "PR #5225's mergeable_state was dirty against origin/main, which had moved by one commit (PR #5219) since this branch was cut. PR #5219 independently fixed the identical test_workflow_sets_up_uv bug this session also fixed, in parallel, with a more robust implementation (parses the workflow YAML and asserts on the Setup uv step's uses field, per testing.md MUST 9, instead of a raw substring search).",
+      "result": "Merged origin/main (6e3ebfd56); resolved the single conflict by taking origin/main's version of the test in full, confirmed byte-identical post-merge. Rebound this QA report's qaCommit and this log's endingCommit past the merge, per the same rebind pattern PR #5219's own session used and per session-logs.md rule 3 (re-point endingCommit after history-changing operations)."
     }
   ],
-  "endingCommit": "ed791858e3ed9faae9f2538bf4f19c121dae32f4",
+  "endingCommit": "6e3ebfd566c14dfff6a715421c328182bfa2cf41",
   "nextSteps": [
     "Push the branch and open the PR with Fixes #5222.",
     "Watch CI: Python Security Checks should go green on this PR now that pip 26.2 has no known vulnerabilities against the three retained ignores."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -490,19 +490,20 @@ jobs:
       - name: Run pip-audit
         run: |
           # Keep the audited environment on the first fixed pip release for
-          # PYSEC-2026-196. CI hit pip 26.1.1 after setup-code-env installed
-          # dependencies, and pip-audit reports the fixed version as 26.1.2.
+          # PYSEC-2026-3721 (fixed in 26.2; issue #5222). Pip 26.1.2 was the
+          # prior fix for PYSEC-2026-196 (issue #2438) and has since become
+          # the vulnerable version for PYSEC-2026-3721 itself.
 
           # Ignored CVEs (re-evaluate when upstream releases a fix):
           #   CVE-2026-4539: pygments 2.19.2, no fix available.
           #   CVE-2026-3219: historical pip 26.0/26.0.1 finding for
           #     concatenated tar/ZIP archives. The runner is upgraded to pip
-          #     26.1.2 below; keep this ignore only while pip-audit still
+          #     26.2 below; keep this ignore only while pip-audit still
           #     reports stale transitive runner metadata after that upgrade.
           #   CVE-2026-6357: historical pip 26.0.x finding in the same
           #     local-only class as CVE-2026-3219. Remove this ignore when
-          #     pip-audit no longer reports it after the pip 26.1.2 upgrade.
-          python -m pip install --upgrade "pip==26.1.2"
+          #     pip-audit no longer reports it after the pip 26.2 upgrade.
+          python -m pip install --upgrade "pip==26.2"
           pip-audit \
             --ignore-vuln CVE-2026-4539 \
             --ignore-vuln CVE-2026-3219 \

--- a/tests/ci/test_validate_vendor_provenance.py
+++ b/tests/ci/test_validate_vendor_provenance.py
@@ -994,7 +994,7 @@ class TestWorkflowContract:
     def test_workflow_sets_up_uv(self) -> None:
         """vendor-provenance.yml must install uv before validation."""
         wf = Path(".github/workflows/vendor-provenance.yml").read_text()
-        assert "astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d" in wf
+        assert "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d" in wf
 
     def test_required_check_context_matches_job_name(self) -> None:
         """The documented required-check context must be the emitted context.


### PR DESCRIPTION
## Summary

`Python Security Checks` fails on `main` and therefore on every open PR. `.github/workflows/pytest.yml`'s `Run pip-audit` step pinned `pip==26.1.2` to escape `PYSEC-2026-196` (issue #2438), and that same version now carries `PYSEC-2026-3721`, fixed in `26.2`. Same shape as its predecessor.

## Changes

- `.github/workflows/pytest.yml`: bump the audited `pip` pin from `26.1.2` to `26.2`; update the three rationale comments that named the old version so none describe a version the workflow no longer installs. All three existing `--ignore-vuln` flags (`CVE-2026-4539` pygments, `CVE-2026-3219` and `CVE-2026-6357` historical pip 26.0.x findings) are unchanged, with their re-check condition now tied to `26.2`.
- `.agents/sessions/` and `.agents/qa/`: this session's log and QA report.

## Context: a second, unrelated bug hit and merged out

While driving this PR to green, the local pre-push gate failed `tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv`. It hardcoded the `astral-sh/setup-uv` SHA from before PR #5215's Renovate bump, and reproduced identically on a fresh `origin/main`, independent of this PR's diff. This branch fixed it locally, then `origin/main` moved (PR #5219) and had independently landed the identical fix with a more robust implementation (parses the workflow YAML and asserts on the `Setup uv` step's `uses` field, per `testing.md` MUST 9, instead of a raw substring match). Merging `origin/main` into this branch and taking its version in full removed that file from this PR's own diff entirely, since it now matches base exactly. Not a change this PR carries; noted here only so CI history makes sense.

## Evidence

Security-agent review (independent subagent run) verified `PYSEC-2026-3721` against OSV directly: `26.1.2` is listed as affected, `26.2` is the fix version, and an OSV query against `26.2` returns no known vulnerabilities. All three retained `--ignore-vuln` flags are still independently justified after the bump. Verdict: approve-with-notes. Full write-up in `.agents/qa/session-99927-python-security-checks-ci.md`.

Local pre-push gate ran clean end to end on this branch: `pre-pr-validation` (57/57), `python-tests` (27655 passed, 73 skipped, 0 failed), `merge-tree-ratchet`, `security-scan`, `review-axis-drift` (12/12 roles ok). All check suites report `success` on the merge-resolved head.

## Out of scope

- Retiring the `--ignore-vuln` flags (#1778).
- The pygments `CVE-2026-4539` ignore comment says "no fix available", which the security review flagged as stale (2.20.0 now fixes it). Filed separately as #5224 rather than bundled here.

## Acceptance criteria (from #5222)

- [x] `pytest.yml:505` installs `pip==26.2`
- [x] The three rationale comments naming `26.1.2` are updated to match, with no stale version left behind
- [x] All three `--ignore-vuln` flags are retained, and the comment states the re-check is now conditioned on `26.2`
- [x] `Python Security Checks` is green on this PR

## Related Issues

Fixes #5222