### PR TITLE
fix(hooks): resolve merged-history upstream via a fallback ladder

### DIFF
--- a/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
@@ -208,6 +208,46 @@
       "caused_by": [
         "e017"
       ],
+      "leads_to": [
+        "e025"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e022",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Pushed, opened draft PR #5226 (Fixes #5220), subscribed to its activity",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e023",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Diagnose a second post-push CI failure: Python Security Checks / pip-audit PYSEC-2026-3721 in pinned pip 26.1.2",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e024",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Merge origin/main a second time to pick up the pip-audit pin fix",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e025",
+      "timestamp": "2026-08-21T17:20:04+00:00",
+      "type": "commit",
+      "content": "Commit: f170c11c6013cf565a5e3d553b313e9c8f1240c5",
+      "caused_by": [
+        "e021"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-21-session-5220-session-log-false-positive"
     }
@@ -217,7 +257,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 3,
+    "commits": 4,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
@@ -96,7 +96,77 @@
       "type": "commit",
       "content": "Commit: fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf",
       "caused_by": [
-        "e007"
+        "e007",
+        "e015"
+      ],
+      "leads_to": [
+        "e017"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Run the security agent on the git_hook_policy.py change per .claude/rules/security.md MUST-1 before pushing",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Drop the local-main rung, keeping only origin/HEAD -> origin/main",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Add a negative test proving local main is never trusted, and prove it discriminates",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-run the full suite, ruff, mypy, and pre_pr.py against the final tree",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "test",
+      "content": "865 passed, 1 skipped; ruff and mypy clean; pre_pr.py 57/57",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Unshallow the clone after the first push attempt failed the push-ref-policy hook",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-08-21T16:27:34+00:00",
+      "type": "commit",
+      "content": "Commit: c19f1e73c0786f5af43c67d8c6c14e7362f21d20",
+      "caused_by": [
+        "e010"
       ],
       "leads_to": [],
       "_source_session": "2026-08-21-session-5220-session-log-false-positive"
@@ -107,8 +177,8 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
-    "files_changed": 2
+    "commits": 2,
+    "files_changed": 5
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
@@ -248,6 +248,64 @@
       "caused_by": [
         "e021"
       ],
+      "leads_to": [
+        "e031"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e026",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read the AI spec-coverage and PR-validation bot comments on PR #5226 instead of dismissing them as noise",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e027",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Consolidate both trunk-resolvers onto one shared _resolve_upstream_default (renamed from _merged_history_upstream) and implement the message-differentiation fix",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e028",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix a self-inflicted taste-lints complexity finding (check_branch_context at 11, ceiling 10)",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e029",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Diagnose a third push's single pytest failure in an unrelated lease-renewal test before retrying",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e030",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebind qaCommit/endingCommit a third time after the two code-consolidation commits",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e031",
+      "timestamp": "2026-08-21T17:38:03+00:00",
+      "type": "commit",
+      "content": "Commit: b3c0d7f12c6f770807e2f535ecafc5d5d87707a5",
+      "caused_by": [
+        "e025"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-21-session-5220-session-log-false-positive"
     }
@@ -257,7 +315,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 4,
+    "commits": 5,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
@@ -168,6 +168,46 @@
       "caused_by": [
         "e010"
       ],
+      "leads_to": [
+        "e021"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Diagnose a pre-push python-tests failure on tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e019",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Merge origin/main to pick up the fix rather than patch the test locally",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e020",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebind qaCommit to the merge commit after Session End Validation flagged QA staleness",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e021",
+      "timestamp": "2026-08-21T16:45:32+00:00",
+      "type": "commit",
+      "content": "Commit: 36bfb510b2858c5f22e164cd42342d04921a250a",
+      "caused_by": [
+        "e017"
+      ],
       "leads_to": [],
       "_source_session": "2026-08-21-session-5220-session-log-false-positive"
     }
@@ -177,7 +217,7 @@
     "tool_calls": null,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/memory/episodes/episode-2026-08-21-session-5220-session-log-false-positive.json
@@ -1,0 +1,114 @@
+{
+  "id": "episode-2026-08-21-session-5220-session-log-false-positive",
+  "session": "2026-08-21-session-5220-session-log-false-positive",
+  "timestamp": "2026-08-21T00:00:00+00:00",
+  "causal_order_version": 2,
+  "outcome": "success",
+  "task": "Stop the fresh-checkout mtime-collision false positive in check_branch_context by fixing the root cause in issue #5220, instead of repeating a previous session's workaround of touching an unrelated merged session log or bypassing the hook",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduce the reported false positive locally before trusting the goal directive's framing",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Search open GitHub issues instead of assuming no prior report existed",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirm the specific precondition issue #5220 names: origin/HEAD does not resolve in this checkout",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Implement the fallback ladder in scripts/validation/git_hook_policy.py: extract _merged_history_upstream trying origin/HEAD, then origin/main, then main",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Add a regression test mirroring test_branch_context_fails_open_when_git_is_unavailable's shape",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Run the branch-context test slice, then the full test_lefthook_integration.py suite, ruff, and mypy on changed files",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "test",
+      "content": "21/21 branch-context tests pass including the new one; 864 passed, 1 skipped on the full file; ruff and mypy both clean",
+      "caused_by": [],
+      "leads_to": [
+        "e010"
+      ],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Run scripts/validation/pre_pr.py end to end before pushing",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-08-21T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Create this session log for the current branch rather than touching the unrelated merged log or bypassing the hook",
+      "caused_by": [],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-08-21T16:17:41+00:00",
+      "type": "commit",
+      "content": "Commit: fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [],
+      "_source_session": "2026-08-21-session-5220-session-log-false-positive"
+    }
+  ],
+  "metrics": {
+    "duration_minutes": null,
+    "tool_calls": null,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
+++ b/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
-qaCommit: f170c11c6013cf565a5e3d553b313e9c8f1240c5
+qaCommit: b3c0d7f12c6f770807e2f535ecafc5d5d87707a5
 ---
 
 # QA Report: Issue #5220, check_branch_context hard-blocks after a merge when origin/HEAD is unset
@@ -68,12 +68,14 @@ behavior findings; all confirmed clean by direct read of the affected code.
 
 | Check | Result |
 |-------|--------|
-| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -k "branch_context" -q` | 22 passed |
-| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -q` | 865 passed, 1 skipped |
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -k "branch_context" -q` | 23 passed |
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py tests/test_validate_session_json.py -q` | 1239 passed, 1 skipped |
 | `uv run --frozen ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py` | All checks passed |
 | `uv run --frozen mypy scripts/validation/git_hook_policy.py` | Success: no issues found in 1 source file |
 | `uv run --frozen python scripts/validation/pre_pr.py` | 57 passed, 0 failed, 0 skipped; re-run against the final tree after the SEC-001 fix |
+| `uv run --frozen python scripts/validation/git_hook_policy.py taste scripts/validation/git_hook_policy.py` | `taste-lints: 1 files scanned, no violations found` (post complexity-extraction fix) |
 | Mutation check: reintroduce the local-`main` rung, re-run the new negative test | Fails (`assert 0 == 1`), confirming the test discriminates; reverted and re-confirmed byte-identical to the source file |
+| `AI_AGENTS_PYTEST_WORKER_CAP=4 uv run --frozen python scripts/validation/git_hook_policy.py pytest` (full suite, matches the pre-push job exactly) | 27659 passed, 73 skipped + 24 passed + 46 passed, 9 deselected + 30 passed, across zero errors on a clean tree |
 
 ## Coverage
 
@@ -124,6 +126,51 @@ after this branch's prior merge point. Merged `origin/main` again (merge
 commit `f170c11c6013cf565a5e3d553b313e9c8f1240c5`, no conflicts) rather than
 patching the pin locally, and rebound `qaCommit` to it for the same
 staleness reason as the first merge.
+
+## Automated PR review findings, addressed
+
+The `Validate Spec Coverage` check returned PARTIAL on the PR as first opened,
+correctly identifying two real gaps by direct code reading (not surface
+pattern-matching):
+
+- Issue #5220's second proposed fix ("say which precondition failed") was
+  unimplemented. `check_branch_context` now distinguishes "branch owns a log
+  but no upstream ref resolves at all" from ordinary co-mingling, naming
+  `git remote set-head origin --auto` only in the former case. New tests:
+  `test_branch_context_merged_history_exemption_needs_an_upstream` (extended
+  with a `capsys` assertion) and
+  `test_branch_context_message_stays_generic_without_an_owned_log`.
+- `_read_upstream_default_blob` (a pre-existing, unrelated call site) carried
+  its own duplicate `origin/HEAD` → `origin/main` fallback with looser
+  existence-checking than the new resolver, and neither cited the other.
+  Consolidated onto one shared `_resolve_upstream_default`, which also renamed
+  from `_merged_history_upstream` since it now serves two call sites.
+
+The message-selection branch added for the first finding pushed
+`check_branch_context` to cyclomatic complexity 11 (repo ceiling 10, caught by
+`taste-lints`, self-inflicted). Extracted `_print_branch_context_mismatch` to
+hold it back at 10; no behavior change, re-confirmed by the full branch-context
+suite.
+
+The `Validate PR` check separately flagged the PR description as not matching
+the diff; the description was rewritten to reflect the consolidation and
+message-improvement commits once they landed, rather than describing only the
+original two-rung fix.
+
+## A confirmed-flaky, unrelated local test
+
+A `python-tests` pre-push run failed exactly one test:
+`tests/test_pr_autofix_late_live_state_gate.py::test_fast_exit_reports_lease_loss_after_wait[src/copilot-cli/skills/pr-autofix/SKILL.md]`,
+asserting on a race-sensitive lease-renewal message
+(`LEASE_RENEWAL_INTERVAL_SECONDS=0.05` in the test fixture) under the full
+parallel pre-push job group's resource contention. This file is untouched by
+this PR. Confirmed as a pre-existing flake, not a regression: a standalone
+`AI_AGENTS_PYTEST_WORKER_CAP=4 uv run --frozen python scripts/validation/git_hook_policy.py pytest`
+run against the identical clean tree, immediately before the failing push,
+passed both parametrizations of that exact test along with all 27,659 other
+collected tests. Per `.claude/rules/testing.md`'s flake-handling guidance this
+was the one confirmatory re-run; the push was retried rather than the test
+suite widened.
 
 ## Pre-existing findings, out of scope
 

--- a/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
+++ b/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
-qaCommit: 36bfb510b2858c5f22e164cd42342d04921a250a
+qaCommit: f170c11c6013cf565a5e3d553b313e9c8f1240c5
 ---
 
 # QA Report: Issue #5220, check_branch_context hard-blocks after a merge when origin/HEAD is unset
@@ -111,6 +111,19 @@ the test locally, re-ran the pin test and the branch-context suite to confirm
 both still pass, and rebound `qaCommit` to the merge commit since it now
 carries real, non-evidence-path changes (the ADR-096 and vendor-provenance
 files from `origin/main`) after the prior `qaCommit`.
+
+## Second push attempt and a second base-branch merge
+
+A subsequent push's `Python Security Checks` CI job failed on a newly
+disclosed `pip-audit` finding, `PYSEC-2026-3721` in the pinned `pip==26.1.2`,
+unrelated to this PR's diff. Confirmed via `mcp__github__actions_list`
+(`list_workflow_runs` for `pytest.yml` on `main`) that `main`'s own most
+recent run at the time (`ce4860ea60`) had already fixed this: PR #5225,
+"fix(ci): bump audited pip pin to 26.2 for PYSEC-2026-3721", merged to `main`
+after this branch's prior merge point. Merged `origin/main` again (merge
+commit `f170c11c6013cf565a5e3d553b313e9c8f1240c5`, no conflicts) rather than
+patching the pin locally, and rebound `qaCommit` to it for the same
+staleness reason as the first merge.
 
 ## Pre-existing findings, out of scope
 

--- a/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
+++ b/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
@@ -1,0 +1,68 @@
+---
+qaVerdict: PASS
+qaSessionLog: .agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+qaCommit: fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf
+---
+
+# QA Report: Issue #5220, check_branch_context hard-blocks after a merge when origin/HEAD is unset
+
+## Summary
+
+PASS. `_is_merged_history` now resolves the upstream default branch through a
+fallback ladder (`origin/HEAD`, then `origin/main`, then `main`) instead of
+depending on `origin/HEAD` alone, matching the ladder `resolve_push_update`
+already uses for push-base resolution.
+
+## Root Cause Verified
+
+`_is_merged_history` in `scripts/validation/git_hook_policy.py` asked only
+`git rev-parse --abbrev-ref origin/HEAD` and returned `False` the moment that
+ref failed to resolve. `git clone` sets `origin/HEAD`; a fetch into an
+already-initialised repo, a shallow or filtered clone, and several CI checkout
+actions do not. Reproduced on this checkout before the fix:
+
+```text
+$ git rev-parse --abbrev-ref origin/HEAD
+fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.
+rc=128
+$ git rev-parse --abbrev-ref origin/main
+origin/main
+rc=0
+```
+
+With `origin/HEAD` unresolved, `check_branch_context` blocked with the same
+log names issue #5220 reports (`claude/pr-automerge-goal-eu2soz`,
+`2026-08-21-session-99926-a1b2c3d4e-pr-automerge-goal.json`), confirming this
+checkout hits the exact defect the issue describes.
+
+## Evidence
+
+| Check | Result |
+|-------|--------|
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -k "branch_context" -q` | 21 passed |
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -q` | 864 passed, 1 skipped |
+| `uv run --frozen ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py` | All checks passed |
+| `uv run --frozen mypy scripts/validation/git_hook_policy.py` | Success: no issues found in 1 source file |
+| `uv run --frozen python scripts/validation/pre_pr.py` | 57 passed, 0 failed, 0 skipped |
+
+## Coverage
+
+- **Positive**: `test_branch_context_merged_history_survives_missing_origin_head`
+  proves the exemption still fires when `origin/HEAD` is absent, the winning
+  log is merged history reachable only via `origin/main`, and the branch owns
+  its own log. Negative control inside the same test asserts `origin/HEAD`
+  really is unresolved in the fixture, so the assertion cannot pass for the
+  wrong reason.
+- **Negative** (pre-existing, re-run to confirm no regression):
+  `test_branch_context_blocks_a_newer_log_that_is_not_upstream` and
+  `test_branch_context_merged_history_exemption_needs_an_upstream` still block
+  a genuinely non-upstream newer log and a repo with no upstream ref at all.
+- **Edge** (pre-existing, re-run to confirm no regression):
+  `test_branch_context_survives_a_committed_merge_import` still requires the
+  branch to own its own log before the exemption fires;
+  `test_branch_context_fails_open_when_git_is_unavailable` still fails open
+  when the `git` binary itself is missing.
+
+## Status
+
+QA COMPLETE.

--- a/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
+++ b/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
-qaCommit: c19f1e73c0786f5af43c67d8c6c14e7362f21d20
+qaCommit: 36bfb510b2858c5f22e164cd42342d04921a250a
 ---
 
 # QA Report: Issue #5220, check_branch_context hard-blocks after a merge when origin/HEAD is unset
@@ -95,6 +95,22 @@ behavior findings; all confirmed clean by direct read of the affected code.
   branch to own its own log before the exemption fires;
   `test_branch_context_fails_open_when_git_is_unavailable` still fails open
   when the `git` binary itself is missing.
+
+## Push attempts and the base-branch merge
+
+The first two push attempts failed the pre-push suite's `python-tests` job on
+`tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv`,
+which asserted a stale `astral-sh/setup-uv` SHA pin. Confirmed this was not
+caused by this branch: the test passed against `origin/main` directly, and
+`git log 9e1ebd2..origin/main` showed exactly one new commit
+(`a1ee96695`, PR #5219, merged after this branch's own start) that re-pinned
+the same test to the current action SHA. Per the base-branch-recovered
+playbook, merged `origin/main` (merge commit
+`36bfb510b2858c5f22e164cd42342d04921a250a`, no conflicts) instead of patching
+the test locally, re-ran the pin test and the branch-context suite to confirm
+both still pass, and rebound `qaCommit` to the merge commit since it now
+carries real, non-evidence-path changes (the ADR-096 and vendor-provenance
+files from `origin/main`) after the prior `qaCommit`.
 
 ## Pre-existing findings, out of scope
 

--- a/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
+++ b/.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
-qaCommit: fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf
+qaCommit: c19f1e73c0786f5af43c67d8c6c14e7362f21d20
 ---
 
 # QA Report: Issue #5220, check_branch_context hard-blocks after a merge when origin/HEAD is unset
@@ -9,9 +9,11 @@ qaCommit: fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf
 ## Summary
 
 PASS. `_is_merged_history` now resolves the upstream default branch through a
-fallback ladder (`origin/HEAD`, then `origin/main`, then `main`) instead of
-depending on `origin/HEAD` alone, matching the ladder `resolve_push_update`
-already uses for push-base resolution.
+two-rung fallback (`origin/HEAD`, then `origin/main`) instead of depending on
+`origin/HEAD` alone. An initial three-rung version also fell back to local
+`main`, matching `resolve_push_update`'s push-base ladder; a security review
+(2026-08-21, see below) found that rung over-permissive for this call site and
+it was dropped in a follow-up commit.
 
 ## Root Cause Verified
 
@@ -35,15 +37,43 @@ log names issue #5220 reports (`claude/pr-automerge-goal-eu2soz`,
 `2026-08-21-session-99926-a1b2c3d4e-pr-automerge-goal.json`), confirming this
 checkout hits the exact defect the issue describes.
 
+## Security Review
+
+`Task(subagent_type="security")` reviewed the three-rung version (the fix
+before the follow-up commit) and returned three findings:
+
+- **SEC-001 (Low, real, fixed)**: local `main` grants the exemption to a
+  session log that only exists on the developer's own local `main`, the exact
+  issue #682 co-mingling shape. Local `main` is writable by the same actor the
+  check exists to catch, unlike `origin/main`. Fixed by dropping the rung in
+  commit `c19f1e73c0786f5af43c67d8c6c14e7362f21d20`.
+- **SEC-002 (Medium, rule violation, fixed)**: the docstring claimed the
+  three-rung ladder "mirrors" `resolve_push_update` without noting
+  `resolve_push_update`'s local-`main` fallback is conditional
+  (`push_ref.is_new`) while the new one was not, violating
+  `canonical-source-mirror.md`'s divergence-section requirement. Moot after
+  SEC-001's fix removed the rung; the current docstring instead explains why
+  the two-rung version is intentionally *stricter* than
+  `resolve_push_update`.
+- **SEC-003 (Medium, resolved by removal)**: the local-`main` rung had zero
+  test coverage. Resolved by removing the rung rather than adding coverage for
+  behavior that should not exist; a new negative test
+  (`test_branch_context_merged_history_does_not_trust_local_main`) instead
+  pins that local `main` is never trusted.
+
+No injection risk, fail-open contract, or `_commit_ref_exists` peeling
+behavior findings; all confirmed clean by direct read of the affected code.
+
 ## Evidence
 
 | Check | Result |
 |-------|--------|
-| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -k "branch_context" -q` | 21 passed |
-| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -q` | 864 passed, 1 skipped |
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -k "branch_context" -q` | 22 passed |
+| `uv run --frozen python -m pytest tests/test_lefthook_integration.py -q` | 865 passed, 1 skipped |
 | `uv run --frozen ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py` | All checks passed |
 | `uv run --frozen mypy scripts/validation/git_hook_policy.py` | Success: no issues found in 1 source file |
-| `uv run --frozen python scripts/validation/pre_pr.py` | 57 passed, 0 failed, 0 skipped |
+| `uv run --frozen python scripts/validation/pre_pr.py` | 57 passed, 0 failed, 0 skipped; re-run against the final tree after the SEC-001 fix |
+| Mutation check: reintroduce the local-`main` rung, re-run the new negative test | Fails (`assert 0 == 1`), confirming the test discriminates; reverted and re-confirmed byte-identical to the source file |
 
 ## Coverage
 
@@ -53,15 +83,27 @@ checkout hits the exact defect the issue describes.
   its own log. Negative control inside the same test asserts `origin/HEAD`
   really is unresolved in the fixture, so the assertion cannot pass for the
   wrong reason.
-- **Negative** (pre-existing, re-run to confirm no regression):
-  `test_branch_context_blocks_a_newer_log_that_is_not_upstream` and
-  `test_branch_context_merged_history_exemption_needs_an_upstream` still block
-  a genuinely non-upstream newer log and a repo with no upstream ref at all.
+- **Negative**: `test_branch_context_merged_history_does_not_trust_local_main`
+  (added post-security-review) proves a session log present only on local
+  `main`, with no origin remote at all, still blocks; proven to discriminate
+  by mutation. `test_branch_context_blocks_a_newer_log_that_is_not_upstream`
+  and `test_branch_context_merged_history_exemption_needs_an_upstream` (both
+  pre-existing, re-run to confirm no regression) still block a genuinely
+  non-upstream newer log and a repo with no upstream ref at all.
 - **Edge** (pre-existing, re-run to confirm no regression):
   `test_branch_context_survives_a_committed_merge_import` still requires the
   branch to own its own log before the exemption fires;
   `test_branch_context_fails_open_when_git_is_unavailable` still fails open
   when the `git` binary itself is missing.
+
+## Pre-existing findings, out of scope
+
+`taste-lints` (advisory, non-blocking) flags `tests/test_lefthook_integration.py`
+as exceeding 500 lines (11397 lines) and two functions exceeding complexity 10
+(`test_configuration_uses_native_filters_scheduling_and_staging` at line 855,
+`_functions_writing_one_path_two_ways` at line 6320). Both predate this change
+and are unrelated to the branch-context tests added here; not addressed in this
+PR.
 
 ## Status
 

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -189,11 +189,31 @@
     {
       "task": "Merge origin/main a second time to pick up the pip-audit pin fix",
       "outcome": "Clean merge (f170c11c6013cf565a5e3d553b313e9c8f1240c5), no conflicts; branch-context suite re-verified passing; rebound qaCommit/endingCommit again for the same staleness reason"
+    },
+    {
+      "task": "Read the AI spec-coverage and PR-validation bot comments on PR #5226 instead of dismissing them as noise",
+      "outcome": "Spec coverage returned PARTIAL with two evidenced findings: issue #5220's second proposed fix (name the failed precondition) was unimplemented, and _read_upstream_default_blob duplicated the new resolver's fallback logic with looser existence-checking"
+    },
+    {
+      "task": "Consolidate both trunk-resolvers onto one shared _resolve_upstream_default (renamed from _merged_history_upstream) and implement the message-differentiation fix",
+      "outcome": "check_branch_context now names git remote set-head origin --auto only when the branch owns a log and no upstream ref resolves at all; two new tests (capsys-based) pin the two message shapes"
+    },
+    {
+      "task": "Fix a self-inflicted taste-lints complexity finding (check_branch_context at 11, ceiling 10)",
+      "outcome": "Extracted _print_branch_context_mismatch; taste-lints clean, 23/23 branch-context tests still pass"
+    },
+    {
+      "task": "Diagnose a third push's single pytest failure in an unrelated lease-renewal test before retrying",
+      "outcome": "test_pr_autofix_late_live_state_gate.py::test_fast_exit_reports_lease_loss_after_wait, a file this PR never touches, confirmed as a pre-existing timing flake: a standalone full-suite run (27659+ tests) on the identical clean tree passed it cleanly moments earlier; retried the push rather than widening the PR"
+    },
+    {
+      "task": "Rebind qaCommit/endingCommit a third time after the two code-consolidation commits",
+      "outcome": "Updated QA report and this log to point at the final commit"
     }
   ],
-  "endingCommit": "f170c11c6013cf565a5e3d553b313e9c8f1240c5",
+  "endingCommit": "b3c0d7f12c6f770807e2f535ecafc5d5d87707a5",
   "nextSteps": [
-    "Push the merge commit and watch PR #5226's CI settle",
+    "Push the final commit and watch PR #5226's CI settle",
     "Keep the scheduled hourly check-in running until the PR is merged or closed"
   ]
 }

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 5220,
+    "date": "2026-08-21",
+    "branch": "claude/session-log-false-positive-n3s1nn",
+    "startingCommit": "9e1ebd2b8b2d",
+    "objective": "Stop the fresh-checkout mtime-collision false positive in check_branch_context by fixing the root cause in issue #5220, instead of repeating a previous session's workaround of touching an unrelated merged session log or bypassing the hook"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__activate_project is unavailable in this remote execution environment (confirmed via ToolSearch, no match). Used the AGENTS.md-documented fallback instead: read .serena/memories/pr-review/pr-co-mingling-root-cause-2025-12-31.md directly."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP unreachable this session; substituted the fallback memory read above plus the always-on rule context injected at session start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read as the read-only reference it declares itself to be; superseded by session logs and Serena memory per its own 2025-12-22 notice"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used scripts/validate_session_json.py and scripts/validation/pre_pr.py directly rather than an unlisted ad hoc script"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Followed skill-first routing per .claude/rules; no skill covered this task's git-hook-policy code fix, so worked directly per AGENTS.md Autonomy Guardrail (internal, reversible: act)"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read: Python-for-new-scripts and skill-first constraints confirmed already satisfied by this change"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Auto-recalled memory context at session start, plus .serena/memories/pr-review/pr-co-mingling-root-cause-2025-12-31.md read directly for the co-mingling background"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current reported claude/session-log-false-positive-n3s1nn before any commit"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On claude/session-log-false-positive-n3s1nn, 0 commits behind origin/main at session start"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status reported a clean working tree at session start"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "9e1ebd2b8b2d"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items verified above"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not touched"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run python scripts/validation/pre_pr.py includes Markdown Linting; PASS"
+      },
+      "qaValidation": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No new memory needed: this is a code fix for an already-filed, already-documented issue (#5220), not a new pattern to persist"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "See endingCommit and workLog"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pytest tests/test_lefthook_integration.py: 864 passed, 1 skipped; ruff check: All checks passed; mypy scripts/validation/git_hook_policy.py: Success; scripts/validation/pre_pr.py: 57/57 validations passed"
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "rework-warning: none"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Reproduce the reported false positive locally before trusting the goal directive's framing",
+      "outcome": "check_branch_context(repo_root) returned 1 on this fresh checkout: _today_session_log picked an already-merged log (branch claude/pr-automerge-goal-eu2soz) as newest by mtime because every .agents/sessions/*.json file shares a near-identical checkout-time mtime"
+    },
+    {
+      "task": "Search open GitHub issues instead of assuming no prior report existed",
+      "outcome": "Found issue #5220, filed the same day, describing the exact log names this reproduction produced and proposing a fallback-ladder fix for _is_merged_history"
+    },
+    {
+      "task": "Confirm the specific precondition issue #5220 names: origin/HEAD does not resolve in this checkout",
+      "outcome": "git rev-parse --abbrev-ref origin/HEAD exited 128 (ambiguous argument); git rev-parse --abbrev-ref origin/main resolved cleanly, confirming the proposed fallback would work here"
+    },
+    {
+      "task": "Implement the fallback ladder in scripts/validation/git_hook_policy.py: extract _merged_history_upstream trying origin/HEAD, then origin/main, then main",
+      "outcome": "_is_merged_history now uses the extracted resolver instead of asking origin/HEAD alone; mirrors the existing origin/main -> main ladder in resolve_push_update per canonical-source-mirror.md"
+    },
+    {
+      "task": "Add a regression test mirroring test_branch_context_fails_open_when_git_is_unavailable's shape",
+      "outcome": "test_branch_context_merged_history_survives_missing_origin_head in tests/test_lefthook_integration.py, with a new _add_origin_main_without_head_with fixture helper and a negative control proving origin/HEAD is genuinely absent in the fixture"
+    },
+    {
+      "task": "Run the branch-context test slice, then the full test_lefthook_integration.py suite, ruff, and mypy on changed files",
+      "outcome": "21/21 branch-context tests pass including the new one; 864 passed, 1 skipped on the full file; ruff and mypy both clean"
+    },
+    {
+      "task": "Run scripts/validation/pre_pr.py end to end before pushing",
+      "outcome": "57/57 validations passed, 0 failed, 0 skipped"
+    },
+    {
+      "task": "Create this session log for the current branch rather than touching the unrelated merged log or bypassing the hook",
+      "outcome": "check_branch_context now resolves via this branch's own newest-mtime log instead of the stale merged one, independent of the origin/HEAD fix, closing this session's own instance of the false positive"
+    }
+  ],
+  "endingCommit": "fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf",
+  "nextSteps": [
+    "Commit the code fix and test",
+    "Commit this session log with endingCommit set to the code-fix commit, per session-logs.md MUST-2",
+    "Push claude/session-log-false-positive-n3s1nn and open a draft PR that fixes issue #5220",
+    "Subscribe to PR activity and watch CI"
+  ]
+}

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -177,11 +177,23 @@
     {
       "task": "Rebind qaCommit to the merge commit after Session End Validation flagged QA staleness",
       "outcome": "The merge brought in real, non-evidence-path files (ADR-096, tests/ci/test_validate_vendor_provenance.py) after the prior qaCommit; updated the QA report and this log to point at the merge commit"
+    },
+    {
+      "task": "Pushed, opened draft PR #5226 (Fixes #5220), subscribed to its activity",
+      "outcome": "PR opened with full security-review and QA findings in the description; subscribed for CI and review events"
+    },
+    {
+      "task": "Diagnose a second post-push CI failure: Python Security Checks / pip-audit PYSEC-2026-3721 in pinned pip 26.1.2",
+      "outcome": "Unrelated to this PR's diff; confirmed via actions_list that main's own latest pytest.yml run had already fixed it (PR #5225, bump pip pin to 26.2), merged after this branch's prior merge point"
+    },
+    {
+      "task": "Merge origin/main a second time to pick up the pip-audit pin fix",
+      "outcome": "Clean merge (f170c11c6013cf565a5e3d553b313e9c8f1240c5), no conflicts; branch-context suite re-verified passing; rebound qaCommit/endingCommit again for the same staleness reason"
     }
   ],
-  "endingCommit": "36bfb510b2858c5f22e164cd42342d04921a250a",
+  "endingCommit": "f170c11c6013cf565a5e3d553b313e9c8f1240c5",
   "nextSteps": [
-    "Push claude/session-log-false-positive-n3s1nn and open a draft PR that fixes issue #5220",
-    "Subscribe to PR activity and watch CI"
+    "Push the merge commit and watch PR #5226's CI settle",
+    "Keep the scheduled hourly check-in running until the PR is merged or closed"
   ]
 }

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -32,7 +32,7 @@
       "usageMandatoryRead": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Followed skill-first routing per .claude/rules; no skill covered this task's git-hook-policy code fix, so worked directly per AGENTS.md Autonomy Guardrail (internal, reversible: act)"
+        "Evidence": "Followed skill-first routing per .claude/rules; checked security-detection skill whose CRITICAL patterns include scripts/validation/git_hook_policy.py (line 94); security agent was invoked per workLog[9] before pushing"
       },
       "constraintsRead": {
         "level": "MUST",

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -165,9 +165,21 @@
     {
       "task": "Unshallow the clone after the first push attempt failed the push-ref-policy hook",
       "outcome": "git fetch --unshallow origin per the hook's own remediation instruction, then pushed"
+    },
+    {
+      "task": "Diagnose a pre-push python-tests failure on tests/ci/test_validate_vendor_provenance.py::TestWorkflowContract::test_workflow_sets_up_uv",
+      "outcome": "Confirmed pre-existing and unrelated: the test passed against origin/main directly, and one commit landed on main after this branch started (PR #5219, a1ee96695) that re-pinned the same test's expected setup-uv SHA"
+    },
+    {
+      "task": "Merge origin/main to pick up the fix rather than patch the test locally",
+      "outcome": "Clean merge (36bfb510b2858c5f22e164cd42342d04921a250a), no conflicts; the pin test and the full branch-context suite both re-verified passing afterward"
+    },
+    {
+      "task": "Rebind qaCommit to the merge commit after Session End Validation flagged QA staleness",
+      "outcome": "The merge brought in real, non-evidence-path files (ADR-096, tests/ci/test_validate_vendor_provenance.py) after the prior qaCommit; updated the QA report and this log to point at the merge commit"
     }
   ],
-  "endingCommit": "c19f1e73c0786f5af43c67d8c6c14e7362f21d20",
+  "endingCommit": "36bfb510b2858c5f22e164cd42342d04921a250a",
   "nextSteps": [
     "Push claude/session-log-false-positive-n3s1nn and open a draft PR that fixes issue #5220",
     "Subscribe to PR activity and watch CI"

--- a/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
+++ b/.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json
@@ -104,7 +104,7 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "pytest tests/test_lefthook_integration.py: 864 passed, 1 skipped; ruff check: All checks passed; mypy scripts/validation/git_hook_policy.py: Success; scripts/validation/pre_pr.py: 57/57 validations passed"
+        "Evidence": "pytest tests/test_lefthook_integration.py: 865 passed, 1 skipped; ruff check: All checks passed; mypy scripts/validation/git_hook_policy.py: Success; scripts/validation/pre_pr.py: 57/57 validations passed, re-run against the final tree"
       },
       "reworkWarning": {
         "level": "SHOULD",
@@ -145,12 +145,30 @@
     {
       "task": "Create this session log for the current branch rather than touching the unrelated merged log or bypassing the hook",
       "outcome": "check_branch_context now resolves via this branch's own newest-mtime log instead of the stale merged one, independent of the origin/HEAD fix, closing this session's own instance of the false positive"
+    },
+    {
+      "task": "Run the security agent on the git_hook_policy.py change per .claude/rules/security.md MUST-1 before pushing",
+      "outcome": "Found SEC-001: the local-main fallback rung grants the #3343 exemption to a session log that only exists on local main, the exact issue #682 co-mingling shape; also SEC-002 (docstring overclaimed parity with resolve_push_update) and SEC-003 (rung had no test coverage)"
+    },
+    {
+      "task": "Drop the local-main rung, keeping only origin/HEAD -> origin/main",
+      "outcome": "Every scenario issue #5220 cites (fetch into an existing repo, shallow/filtered clone, CI checkout actions) populates origin/main, so the stricter two-rung ladder still fixes the reported bug without the permissive rung"
+    },
+    {
+      "task": "Add a negative test proving local main is never trusted, and prove it discriminates",
+      "outcome": "test_branch_context_merged_history_does_not_trust_local_main added; confirmed it fails (assert 0 == 1) when the local-main rung is temporarily reintroduced, then confirmed the source file was restored byte-identical"
+    },
+    {
+      "task": "Re-run the full suite, ruff, mypy, and pre_pr.py against the final tree",
+      "outcome": "865 passed, 1 skipped; ruff and mypy clean; pre_pr.py 57/57"
+    },
+    {
+      "task": "Unshallow the clone after the first push attempt failed the push-ref-policy hook",
+      "outcome": "git fetch --unshallow origin per the hook's own remediation instruction, then pushed"
     }
   ],
-  "endingCommit": "fb0f0fa15b6dd0d20c1f2d75650dcc991f78ebaf",
+  "endingCommit": "c19f1e73c0786f5af43c67d8c6c14e7362f21d20",
   "nextSteps": [
-    "Commit the code fix and test",
-    "Commit this session log with endingCommit set to the code-fix commit, per session-logs.md MUST-2",
     "Push claude/session-log-false-positive-n3s1nn and open a draft PR that fixes issue #5220",
     "Subscribe to PR activity and watch CI"
   ]

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1822,32 +1822,50 @@ def check_branch_context(repo_root: Path) -> int:
             return 0
         if _is_linked_worktree(repo_root) and _is_committed_here(repo_root, session_log):
             return 0
-        print(
-            "ERROR: branch context mismatch: "
-            f"current='{current_branch}', session='{session_branch}' "
-            f"(log: {session_log.name})",
-            file=sys.stderr,
+        _print_branch_context_mismatch(
+            repo_root, current_branch, session_branch, session_log, branch_owns_a_log
         )
-        if branch_owns_a_log and _resolve_upstream_default(repo_root) is None:
-            print(
-                "  This branch already owns a session log, so the mismatch may be "
-                "unresolvable trunk rather than co-mingling: neither origin/HEAD "
-                "nor origin/main resolves in this checkout. Try: git remote "
-                "set-head origin --auto (or fetch origin main), then re-run. If "
-                "the mismatch persists after that, switch to the expected "
-                "branch, update the session log branch field, or create a new "
-                "session log for the current branch.",
-                file=sys.stderr,
-            )
-        else:
-            print(
-                "  Fix: switch to the expected branch, update the session log branch "
-                "field, or create a new session log for the current branch.",
-                file=sys.stderr,
-            )
         return 1
     except Exception:
         return 0
+
+
+def _print_branch_context_mismatch(
+    repo_root: Path,
+    current_branch: str,
+    session_branch: str,
+    session_log: Path,
+    branch_owns_a_log: bool,
+) -> None:
+    """Print the ``check_branch_context`` block message, picking the right remedy.
+
+    Split out of ``check_branch_context`` to keep that function's cyclomatic
+    complexity at the repo ceiling of 10; this helper carries the branch that
+    chooses between the two remedy messages.
+    """
+    print(
+        "ERROR: branch context mismatch: "
+        f"current='{current_branch}', session='{session_branch}' "
+        f"(log: {session_log.name})",
+        file=sys.stderr,
+    )
+    if branch_owns_a_log and _resolve_upstream_default(repo_root) is None:
+        print(
+            "  This branch already owns a session log, so the mismatch may be "
+            "unresolvable trunk rather than co-mingling: neither origin/HEAD "
+            "nor origin/main resolves in this checkout. Try: git remote "
+            "set-head origin --auto (or fetch origin main), then re-run. If "
+            "the mismatch persists after that, switch to the expected "
+            "branch, update the session log branch field, or create a new "
+            "session log for the current branch.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "  Fix: switch to the expected branch, update the session log branch "
+            "field, or create a new session log for the current branch.",
+            file=sys.stderr,
+        )
 
 
 def check_handoff(paths: Sequence[str], repo_root: Path) -> int:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1059,6 +1059,35 @@ def _session_log_for_branch(sessions_dir: Path, branch: str) -> Path | None:
     return None
 
 
+def _merged_history_upstream(repo_root: Path) -> str | None:
+    """Return the best available name for the upstream default branch.
+
+    ``origin/HEAD`` is the precise answer when it resolves, but only
+    ``git clone`` sets it: a fetch into an already-cloned repo, a shallow or
+    filtered clone, and several CI checkout actions leave it absent, which is
+    exactly the shape a fresh remote-execution container has (issue #5220).
+    Falling back to ``origin/main`` and then local ``main`` mirrors the ladder
+    ``resolve_push_update`` already uses for push-base resolution
+    (``git_hook_policy.py``, the ``base = _merge_base(repo_root, "origin/main",
+    ...)`` / ``_merge_base(repo_root, "main", ...)`` pair): a repo without
+    ``origin/HEAD`` still has a trunk, and refusing to look at it turns a
+    missing convenience ref into a hard block on every subsequent commit.
+
+    Returns ``None`` when no candidate resolves, which keeps
+    ``_is_merged_history`` failing closed for a repo that genuinely cannot
+    name its trunk (no remote, fully isolated clone).
+    """
+    head = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "origin/HEAD"])
+    if head.returncode == 0:
+        candidate = head.stdout.strip()
+        if candidate:
+            return candidate
+    for candidate in ("origin/main", "main"):
+        if _commit_ref_exists(repo_root, candidate):
+            return candidate
+    return None
+
+
 def _is_merged_history(repo_root: Path, path: Path) -> bool:
     """Return True when ``path`` already exists on the upstream default branch.
 
@@ -1074,8 +1103,9 @@ def _is_merged_history(repo_root: Path, path: Path) -> bool:
     the co-mingling case from issue #682 keeps its teeth.
 
     Fails closed on every indeterminate answer it can observe: a path outside
-    the repo, no resolvable ``origin/HEAD``, or a failed probe all return False
-    and the mismatch still blocks.
+    the repo, no resolvable upstream candidate (``_merged_history_upstream``
+    returns ``None``), or a failed probe all return False and the mismatch
+    still blocks.
 
     It cannot fail closed on git being unavailable, and does not claim to.
     ``_run_command`` catches only ``TimeoutExpired``, so a missing git binary
@@ -1090,8 +1120,7 @@ def _is_merged_history(repo_root: Path, path: Path) -> bool:
         relative = path.relative_to(repo_root).as_posix()
     except ValueError:
         return False
-    head = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "origin/HEAD"])
-    upstream = head.stdout.strip() if head.returncode == 0 else ""
+    upstream = _merged_history_upstream(repo_root)
     if not upstream:
         return False
     probe = _run_git(repo_root, ["cat-file", "-e", f"{upstream}:{relative}"])

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1066,25 +1066,34 @@ def _merged_history_upstream(repo_root: Path) -> str | None:
     ``git clone`` sets it: a fetch into an already-cloned repo, a shallow or
     filtered clone, and several CI checkout actions leave it absent, which is
     exactly the shape a fresh remote-execution container has (issue #5220).
-    Falling back to ``origin/main`` and then local ``main`` mirrors the ladder
-    ``resolve_push_update`` already uses for push-base resolution
-    (``git_hook_policy.py``, the ``base = _merge_base(repo_root, "origin/main",
-    ...)`` / ``_merge_base(repo_root, "main", ...)`` pair): a repo without
-    ``origin/HEAD`` still has a trunk, and refusing to look at it turns a
-    missing convenience ref into a hard block on every subsequent commit.
+    Falling back to ``origin/main`` is a genuine equivalent: both name the
+    same remote-tracked trunk, so a log that exists on one exists on the
+    other whenever the local clone has fetched it.
+
+    Stricter than ``resolve_push_update`` on purpose: that function also
+    falls back to local ``main`` (``git_hook_policy.py``, the
+    ``_merge_base(repo_root, "main", ...)`` branch), because there a wrong
+    base only widens a scan and errs conservative. Here the resolved ref
+    feeds a co-mingling exemption (issue #682): a wrong answer grants a
+    bypass instead of widening a scan, so it errs permissive, and local
+    ``main`` is writable by the same developer the exemption would then
+    excuse. A security review of this fix (2026-08-21) confirmed dropping
+    that third rung: every scenario issue #5220 cites, a fetch into an
+    existing repo, a shallow or filtered clone, and CI checkout actions, all
+    populate ``origin/main``, so the stricter two-rung ladder already fixes
+    the reported bug without the permissive rung.
 
     Returns ``None`` when no candidate resolves, which keeps
     ``_is_merged_history`` failing closed for a repo that genuinely cannot
-    name its trunk (no remote, fully isolated clone).
+    name its remote trunk (no remote, fully isolated clone).
     """
     head = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "origin/HEAD"])
     if head.returncode == 0:
         candidate = head.stdout.strip()
         if candidate:
             return candidate
-    for candidate in ("origin/main", "main"):
-        if _commit_ref_exists(repo_root, candidate):
-            return candidate
+    if _commit_ref_exists(repo_root, "origin/main"):
+        return "origin/main"
     return None
 
 

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -925,8 +925,7 @@ def _read_head_blob(repo_root: Path, relative_path: str) -> bytes | None:
 
 
 def _read_upstream_default_blob(repo_root: Path, relative_path: str) -> bytes | None:
-    head = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "origin/HEAD"])
-    upstream = head.stdout.strip() if head.returncode == 0 else "origin/main"
+    upstream = _resolve_upstream_default(repo_root)
     if not upstream:
         return None
     result = _run_git_bytes(repo_root, ["show", f"{upstream}:{relative_path}"])
@@ -1059,7 +1058,7 @@ def _session_log_for_branch(sessions_dir: Path, branch: str) -> Path | None:
     return None
 
 
-def _merged_history_upstream(repo_root: Path) -> str | None:
+def _resolve_upstream_default(repo_root: Path) -> str | None:
     """Return the best available name for the upstream default branch.
 
     ``origin/HEAD`` is the precise answer when it resolves, but only
@@ -1070,22 +1069,33 @@ def _merged_history_upstream(repo_root: Path) -> str | None:
     same remote-tracked trunk, so a log that exists on one exists on the
     other whenever the local clone has fetched it.
 
+    Shared by ``_is_merged_history`` (the co-mingling exemption, issue #682)
+    and ``_read_upstream_default_blob`` (session-content-on-upstream checks).
+    A single resolver keeps their trunk-naming logic from drifting apart the
+    way it briefly did here: an earlier revision of this function lived only
+    under ``_is_merged_history`` while ``_read_upstream_default_blob`` carried
+    its own duplicate, unconditional ``origin/main`` fallback with no
+    existence probe.
+
     Stricter than ``resolve_push_update`` on purpose: that function also
     falls back to local ``main`` (``git_hook_policy.py``, the
     ``_merge_base(repo_root, "main", ...)`` branch), because there a wrong
-    base only widens a scan and errs conservative. Here the resolved ref
-    feeds a co-mingling exemption (issue #682): a wrong answer grants a
-    bypass instead of widening a scan, so it errs permissive, and local
-    ``main`` is writable by the same developer the exemption would then
-    excuse. A security review of this fix (2026-08-21) confirmed dropping
-    that third rung: every scenario issue #5220 cites, a fetch into an
-    existing repo, a shallow or filtered clone, and CI checkout actions, all
-    populate ``origin/main``, so the stricter two-rung ladder already fixes
-    the reported bug without the permissive rung.
+    base only widens a scan and errs conservative. The co-mingling exemption
+    this resolver feeds errs the other way: a wrong answer grants a bypass
+    instead of widening a scan, and local ``main`` is writable by the same
+    developer the exemption would then excuse. A security review of this fix
+    (2026-08-21) confirmed dropping that third rung: every scenario issue
+    #5220 cites, a fetch into an existing repo, a shallow or filtered clone,
+    and CI checkout actions, all populate ``origin/main``, so the stricter
+    two-rung ladder already fixes the reported bug without the permissive
+    rung. ``_read_upstream_default_blob`` has no permissive exemption to
+    weaken, so sharing the stricter resolver only tightens it: it now also
+    probes existence before returning ``origin/main`` instead of trying it
+    unconditionally.
 
-    Returns ``None`` when no candidate resolves, which keeps
-    ``_is_merged_history`` failing closed for a repo that genuinely cannot
-    name its remote trunk (no remote, fully isolated clone).
+    Returns ``None`` when no candidate resolves, which keeps callers failing
+    closed for a repo that genuinely cannot name its remote trunk (no remote,
+    fully isolated clone).
     """
     head = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "origin/HEAD"])
     if head.returncode == 0:
@@ -1112,7 +1122,7 @@ def _is_merged_history(repo_root: Path, path: Path) -> bool:
     the co-mingling case from issue #682 keeps its teeth.
 
     Fails closed on every indeterminate answer it can observe: a path outside
-    the repo, no resolvable upstream candidate (``_merged_history_upstream``
+    the repo, no resolvable upstream candidate (``_resolve_upstream_default``
     returns ``None``), or a failed probe all return False and the mismatch
     still blocks.
 
@@ -1129,7 +1139,7 @@ def _is_merged_history(repo_root: Path, path: Path) -> bool:
         relative = path.relative_to(repo_root).as_posix()
     except ValueError:
         return False
-    upstream = _merged_history_upstream(repo_root)
+    upstream = _resolve_upstream_default(repo_root)
     if not upstream:
         return False
     probe = _run_git(repo_root, ["cat-file", "-e", f"{upstream}:{relative}"])
@@ -1780,6 +1790,15 @@ def check_branch_context(repo_root: Path) -> int:
     The exemption is limited to logs present in the worktree's own ``HEAD``
     (the ``_is_committed_here`` probe): a log that exists only as an untracked
     working-tree file is a live claim, so a real mismatch there still blocks.
+
+    When none of the three exemptions clears the mismatch, the error message
+    is chosen by whether the branch already owns a session log and
+    ``_resolve_upstream_default`` can name a trunk at all. Those two facts
+    together (branch owns a log, trunk unresolvable) mean this checkout
+    cannot even ask whether the winning log is merged history, which is a
+    different failure than genuine co-mingling and points the reader at
+    ``git remote set-head origin --auto`` instead of the three co-mingling
+    remedies (issue #5220's second proposed fix).
     """
     try:
         if _merge_in_progress(repo_root):
@@ -1798,9 +1817,8 @@ def check_branch_context(repo_root: Path) -> int:
             return 0
         if current_branch == session_branch:
             return 0
-        if _session_log_for_branch(sessions_dir, current_branch) is not None and _is_merged_history(
-            repo_root, session_log
-        ):
+        branch_owns_a_log = _session_log_for_branch(sessions_dir, current_branch) is not None
+        if branch_owns_a_log and _is_merged_history(repo_root, session_log):
             return 0
         if _is_linked_worktree(repo_root) and _is_committed_here(repo_root, session_log):
             return 0
@@ -1810,11 +1828,23 @@ def check_branch_context(repo_root: Path) -> int:
             f"(log: {session_log.name})",
             file=sys.stderr,
         )
-        print(
-            "  Fix: switch to the expected branch, update the session log branch "
-            "field, or create a new session log for the current branch.",
-            file=sys.stderr,
-        )
+        if branch_owns_a_log and _resolve_upstream_default(repo_root) is None:
+            print(
+                "  This branch already owns a session log, so the mismatch may be "
+                "unresolvable trunk rather than co-mingling: neither origin/HEAD "
+                "nor origin/main resolves in this checkout. Try: git remote "
+                "set-head origin --auto (or fetch origin main), then re-run. If "
+                "the mismatch persists after that, switch to the expected "
+                "branch, update the session log branch field, or create a new "
+                "session log for the current branch.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "  Fix: switch to the expected branch, update the session log branch "
+                "field, or create a new session log for the current branch.",
+                file=sys.stderr,
+            )
         return 1
     except Exception:
         return 0

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -2004,6 +2004,47 @@ def test_branch_context_merged_history_survives_missing_origin_head(
     assert policy.check_branch_context(repo) == 0
 
 
+def test_branch_context_merged_history_does_not_trust_local_main(tmp_path: Path) -> None:
+    """A file merely present on local ``main`` must not grant the #3343 exemption.
+
+    Issue #682's co-mingling case is a session log landing on the wrong local
+    branch. A fallback to local ``main`` (dropped from ``_merged_history_upstream``
+    after security review of the #5220 fix, 2026-08-21) would treat exactly that
+    shape as settled upstream history: local ``main`` is writable by the same
+    developer the exemption would then excuse, unlike ``origin/main``, which
+    requires a push through review. This builds the file's real presence on a
+    local ``main`` branch via a disposable worktree, so ``_is_merged_history``
+    would find it there if it looked, then writes the same content directly into
+    the primary checkout (untracked) so ``_today_session_log`` still picks it up
+    as the newest-by-mtime candidate, without ever touching feature/x's own
+    branch state.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feature/x")
+    _commit_file(repo, "tracked", "value\n")
+
+    main_worktree = _worktree_on(repo, "main", tmp_path / "wt-main")
+    on_main = _write_session_log(
+        main_worktree, branch="feature/wrong", name="session-on-main", mtime=2_000_000_000.0
+    )
+    relative = on_main.relative_to(main_worktree).as_posix()
+    _git(main_worktree, "add", "--", relative)
+    _git(main_worktree, "commit", "-qm", "test: session log lands on local main")
+    _git(repo, "worktree", "remove", "-f", str(main_worktree))
+
+    _write_session_log(
+        repo, branch="feature/wrong", name="session-on-main", mtime=2_000_000_000.0
+    )
+    _write_session_log(repo, branch="feature/x", name="session-own", mtime=1_000_000_000.0)
+
+    # Negative control: no origin remote exists, so an exemption here could
+    # only come from trusting local main directly, never from resolving an
+    # upstream ref.
+    assert _git(repo, "remote").stdout.strip() == ""
+
+    assert policy.check_branch_context(repo) == 1
+
+
 def test_branch_context_blocks_a_newer_log_that_is_not_upstream(tmp_path: Path) -> None:
     """The issue #682 case must survive the #3343 fix.
 

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -1953,6 +1953,57 @@ def test_branch_context_survives_a_committed_merge_import(tmp_path: Path) -> Non
     assert policy.check_branch_context(repo) == 0
 
 
+def _add_origin_main_without_head_with(repo: Path, tracked: Path) -> None:
+    """Give ``repo`` an ``origin/main`` with no resolvable ``origin/HEAD``.
+
+    Reproduces the common no-``origin/HEAD`` clone shape from issue #5220: a
+    fetch of ``main`` into an already-initialised repo populates
+    ``refs/remotes/origin/main`` without ever creating the symbolic
+    ``refs/remotes/origin/HEAD`` ref, which only ``git clone`` sets up
+    automatically. ``git remote add`` plus ``git fetch`` alone, the shape a
+    fetch-into-existing-repo or some CI checkout actions produce, does not.
+    """
+    relative = tracked.relative_to(repo).as_posix()
+    _git(repo, "add", "--", relative)
+    _git(repo, "commit", "-qm", "test: land session log upstream")
+    remote = repo.parent / "remote.git"
+    _git(repo, "clone", "-q", "--bare", str(repo), str(remote))
+    _git(repo, "remote", "add", "origin", str(remote))
+    default = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    _git(repo, "--git-dir", str(remote), "branch", "-f", "main", default)
+    _git(repo, "fetch", "-q", "origin", "main")
+
+
+def test_branch_context_merged_history_survives_missing_origin_head(
+    tmp_path: Path,
+) -> None:
+    """A missing ``origin/HEAD`` must not defeat the #3343 exemption (issue #5220).
+
+    ``git clone`` sets ``origin/HEAD``; a fetch into an existing repo, a
+    shallow or filtered clone, and several CI checkout actions do not. Before
+    the fix, ``_is_merged_history`` asked only ``origin/HEAD`` and returned
+    False the moment that ref failed to resolve, wedging every commit on a
+    branch that had merged main and owned its own log. The fallback ladder in
+    ``_merged_history_upstream`` must recover via ``origin/main`` here.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feature/x")
+    _commit_file(repo, "tracked", "value\n")
+    imported = _write_session_log(
+        repo, branch="feature/merged", name="session-merged", mtime=2_000_000_000.0
+    )
+    _add_origin_main_without_head_with(repo, imported)
+    os.utime(imported, (2_000_000_000.0, 2_000_000_000.0))
+    _write_session_log(repo, branch="feature/x", name="session-own", mtime=1_000_000_000.0)
+
+    # Negative control: origin/HEAD really is absent in this fixture, so the
+    # assertion below cannot pass just because the fixture set it up anyway.
+    head = _git(repo, "rev-parse", "--abbrev-ref", "origin/HEAD", check=False)
+    assert head.returncode != 0
+
+    assert policy.check_branch_context(repo) == 0
+
+
 def test_branch_context_blocks_a_newer_log_that_is_not_upstream(tmp_path: Path) -> None:
     """The issue #682 case must survive the #3343 fix.
 

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -1984,7 +1984,7 @@ def test_branch_context_merged_history_survives_missing_origin_head(
     the fix, ``_is_merged_history`` asked only ``origin/HEAD`` and returned
     False the moment that ref failed to resolve, wedging every commit on a
     branch that had merged main and owned its own log. The fallback ladder in
-    ``_merged_history_upstream`` must recover via ``origin/main`` here.
+    ``_resolve_upstream_default`` must recover via ``origin/main`` here.
     """
     repo = tmp_path / "repo"
     _init_repo(repo, branch="feature/x")
@@ -2008,7 +2008,7 @@ def test_branch_context_merged_history_does_not_trust_local_main(tmp_path: Path)
     """A file merely present on local ``main`` must not grant the #3343 exemption.
 
     Issue #682's co-mingling case is a session log landing on the wrong local
-    branch. A fallback to local ``main`` (dropped from ``_merged_history_upstream``
+    branch. A fallback to local ``main`` (dropped from ``_resolve_upstream_default``
     after security review of the #5220 fix, 2026-08-21) would treat exactly that
     shape as settled upstream history: local ``main`` is writable by the same
     developer the exemption would then excuse, unlike ``origin/main``, which
@@ -2134,8 +2134,18 @@ def test_a_primary_checkout_is_not_mistaken_for_a_worktree(tmp_path: Path) -> No
     assert policy._is_linked_worktree(worktree) is True
 
 
-def test_branch_context_merged_history_exemption_needs_an_upstream(tmp_path: Path) -> None:
-    """Without a resolvable origin/HEAD the exemption fails closed."""
+def test_branch_context_merged_history_exemption_needs_an_upstream(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without a resolvable origin/HEAD the exemption fails closed.
+
+    The branch owns its own log but has no remote at all, so
+    ``_resolve_upstream_default`` returns None and the mismatch cannot be
+    proven settled history. The message names the real gap
+    (issue #5220's second proposed fix) instead of the generic three
+    co-mingling remedies, which are wrong here: switching branches, editing
+    the log, or writing a new one would not clear an unresolvable trunk.
+    """
     repo = tmp_path / "repo"
     _init_repo(repo, branch="feature/x")
     _commit_file(repo, "tracked", "value\n")
@@ -2143,6 +2153,33 @@ def test_branch_context_merged_history_exemption_needs_an_upstream(tmp_path: Pat
     _write_session_log(repo, branch="feature/other", name="session-new", mtime=2_000_000_000.0)
 
     assert policy.check_branch_context(repo) == 1
+
+    stderr = capsys.readouterr().err
+    assert "git remote set-head origin --auto" in stderr
+    assert "Fix: switch to the expected branch" not in stderr
+
+
+def test_branch_context_message_stays_generic_without_an_owned_log(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A branch with no log of its own gets the original three remedies.
+
+    Same unresolvable-upstream shape as the test above, but the current
+    branch never wrote its own session log, which is the ordinary co-mingling
+    case from issue #682 rather than the #5220 unresolvable-trunk case. The
+    remote-set-head hint would be misleading here: the real problem is a
+    missing log, and fetching origin/main would not fix that.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feature/x")
+    _commit_file(repo, "tracked", "value\n")
+    _write_session_log(repo, branch="feature/other", name="session-new")
+
+    assert policy.check_branch_context(repo) == 1
+
+    stderr = capsys.readouterr().err
+    assert "Fix: switch to the expected branch" in stderr
+    assert "git remote set-head origin --auto" not in stderr
 
 
 def test_branch_context_matches_a_legacy_shaped_owned_log(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### What

`_is_merged_history` in `scripts/validation/git_hook_policy.py` now resolves the upstream default branch through a two-rung fallback (`origin/HEAD`, then `origin/main`) instead of depending on `origin/HEAD` alone, via a shared `_resolve_upstream_default` resolver also used by the pre-existing `_read_upstream_default_blob` (previously a duplicate, looser implementation). `check_branch_context`'s block message now names `git remote set-head origin --auto` specifically when the branch owns a session log but no upstream ref resolves at all, instead of always printing the generic co-mingling remedies.

### Why

`origin/HEAD` is only set by `git clone`. A fetch into an already-initialised repo, a shallow or filtered clone, and several CI checkout actions leave it absent, which is exactly the shape a fresh remote-execution container has. When `origin/HEAD` doesn't resolve, `_is_merged_history` unconditionally returned `False`, so the issue #3343 merged-history exemption in `check_branch_context` could never fire, and a developer who merged `main` and owned their own session log still got permanently blocked on every subsequent commit.

Reproduced on this exact checkout before the fix (`origin/HEAD` unresolved, `origin/main` fine), with the same log names issue #5220 reports.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5220 | check_branch_context hard-blocks every commit after a merge of main when origin/HEAD is unset |

## Changes

- `scripts/validation/git_hook_policy.py`:
  - Extracted `_resolve_upstream_default` (renamed from an earlier `_merged_history_upstream`), resolving `origin/HEAD` then falling back to `origin/main`. Used by both `_is_merged_history` (the co-mingling exemption) and `_read_upstream_default_blob` (a separate, pre-existing session-content-on-upstream check), which previously duplicated this logic with looser existence checking.
  - `check_branch_context`'s block message now distinguishes "branch owns a log but no upstream ref resolves" (unresolvable trunk, issue #5220's second proposed fix) from ordinary co-mingling, via a new `_print_branch_context_mismatch` helper (kept the function's cyclomatic complexity at the repo's ceiling of 10).
- `tests/test_lefthook_integration.py`: added
  - `test_branch_context_merged_history_survives_missing_origin_head` (positive: exemption fires via the `origin/main` fallback)
  - `test_branch_context_merged_history_does_not_trust_local_main` (negative: a session log present only on local `main`, with no origin remote, still blocks; proven to discriminate by temporarily reintroducing that rung and watching the test fail)
  - `capsys` assertions on `test_branch_context_merged_history_exemption_needs_an_upstream` and a new `test_branch_context_message_stays_generic_without_an_owned_log`, pinning the two message shapes
- `.agents/sessions/2026-08-21-session-5220-session-log-false-positive.json`, `.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md`: session log and QA report, including the security review, the two automated spec-coverage findings addressed, and the base-branch merges this branch needed (below).

An initial version of the fix also fell back to local `main` (mirroring `resolve_push_update`'s push-base ladder). Security review (see below) found that rung over-permissive for this call site: it would grant the exemption to a session log that only exists on the developer's own local `main`, exactly the issue #682 co-mingling shape the exemption must never excuse. It was dropped before this PR was opened.

## Acceptance criteria

- [x] `check_branch_context` no longer blocks when `origin/HEAD` is unresolved but `origin/main` is, and the branch owns its own session log
- [x] A session log present only on local `main` still does not grant the exemption (issue #682 case preserved)
- [x] Existing branch-context tests (co-mingling, merge exemption, worktree exemption, fail-open contracts) all still pass
- [x] issue #5220's second proposed fix (name which precondition failed) implemented, with tests pinning both message shapes

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high (git hook / co-mingling guard), no rush

**Focus areas**: whether the two-rung ladder (`origin/HEAD` then `origin/main`) is the right stopping point, whether the new negative tests actually pin the local-`main` exclusion and message differentiation correctly, and whether consolidating `_read_upstream_default_blob` onto the shared resolver is a safe behavioral tightening for that unrelated call site.

## Testing

- [x] Tests added/updated

`uv run --frozen python -m pytest tests/test_lefthook_integration.py tests/test_validate_session_json.py -q` gives 1239 passed, 1 skipped
`uv run --frozen ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py` gives All checks passed
`uv run --frozen mypy scripts/validation/git_hook_policy.py` gives Success
`uv run --frozen python scripts/validation/pre_pr.py` gives 57/57 passed
`AI_AGENTS_PYTEST_WORKER_CAP=4 uv run --frozen python scripts/validation/git_hook_policy.py pytest` (full suite, matches the pre-push job) gives 27659+24+46+30 passed, 0 errors on a clean tree

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes

**Files requiring security review:**

- `scripts/validation/git_hook_policy.py`

`Task(subagent_type="security")` reviewed the three-rung version and found:

- **SEC-001** (Low): local `main` grants the exemption to a log that only exists on local `main`, the exact issue #682 shape. **Fixed**: rung dropped.
- **SEC-002** (Medium, rule violation): the docstring overclaimed parity with `resolve_push_update` without noting its fallback is conditional. **Fixed**: rung removal made the claim moot; current docstring instead explains why the two-rung version is intentionally stricter than `resolve_push_update`.
- **SEC-003** (Medium): the local-`main` rung had no test coverage. **Resolved by removal**, plus a new negative test pinning that local `main` is never trusted.

No injection risk, fail-open contract regression, or ref-peeling issues found. Full findings in the QA report.

### Other Agent Reviews

- [x] QA verified test coverage (`.agents/qa/issue-5220-branch-context-missing-origin-head-test-report.md`)

This PR's own automated review also caught two real, addressed findings: `Validate Spec Coverage` returned PARTIAL, correctly flagging the unimplemented second proposed fix (now implemented) and the duplicate `_read_upstream_default_blob` resolver (now consolidated). Both are in the "Changes" section above. `Validate PR` also caught an em dash in an earlier revision of this description (universal.md MUST NOT entry 5); rewritten to remove it.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (session log + QA report)
- [x] No new warnings introduced

Note: `taste-lints` (advisory, non-blocking) flags `tests/test_lefthook_integration.py` for exceeding 500 lines and two pre-existing functions exceeding complexity 10, both unrelated to this change and not addressed here (see the QA report's "Pre-existing findings" section). A complexity finding this PR itself introduced (`check_branch_context` briefly at 11) was fixed via extraction; `taste-lints` is clean on `scripts/validation/git_hook_policy.py`.

## Notes for Reviewers

This branch merged `origin/main` twice while open, both times to pick up an already-landed, unrelated fix that was blocking this branch's own pre-push suite rather than anything wrong with this diff:

1. `36bfb510`: picked up PR #5219's re-pin of a stale `setup-uv` SHA in a test unrelated to this change.
2. `f170c11c`: picked up PR #5225's pip pin bump for a newly disclosed `pip-audit` finding (`PYSEC-2026-3721`), also unrelated to this change.

Both are recorded with the confirming evidence in the QA report. Neither touched anything this PR's diff depends on.

## Related Issues

Fixes #5220
Refs #3343, #682
