### PR TITLE
docs(agents): stop agents stalling on merge-blocked/conflicted PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 **Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|No manifest version (ADR-092)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact|Report PR "blocked"/"has conflicts"/awaiting user w/o first running the merge-blocked or merge-resolver flow above
+**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact|Report PR blocked/conflicted w/o fix
 
 ## Context
 
@@ -32,10 +32,9 @@ Knowledge -> context. Actions -> skills.
 
 ## Skill-First
 
-|PRs: GitHub|Reviews: pr-comment-responder|Conflicts: merge-resolver agent|Push: /push-pr
+|PRs: GitHub|Reviews: pr-comment-responder|Push: /push-pr
 |Security: security-detection|Quality: analyze|Learn: reflect|Lifecycle: /spec /plan /build /test /review /ship
-|Merge "blocked"/"conversation must be resolved": never stop and ask the user; run `github` skill's `why_pr_blocked.py` to diagnose, then `resolve_pr_review_thread.py --pull-request N --all` (covers outdated-but-unresolved threads too), then re-check before reporting status
-|Merge "has conflicts"/"must be resolved before continuing": never stop and ask the user; invoke merge-resolver agent to merge base into the PR branch and resolve, then push and re-check mergeability
+|Merge blocked/conflicted: don't ask; github skill (why_pr_blocked+resolve) or merge-resolver agent; re-check
 |CI-feedback sub-loop: cluster, ladder build->test->review->ship. See `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
 |ADR-078: no skill -> autoplan; multi-step/cross-cutting -> orchestrator; no return loop
 |New capability: buy-vs-build Quick BEFORE /spec+baseline; >13wk no baseline = prune. Skip: bug/doc/refactor/approved-cap-extension

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 **Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|No manifest version (ADR-092)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact
+**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact|Report PR "blocked"/awaiting user w/o first running the merge-blocked skill flow above
 
 ## Context
 
@@ -34,6 +34,7 @@ Knowledge -> context. Actions -> skills.
 
 |PRs: GitHub|Reviews: pr-comment-responder|Conflicts: merge-resolver agent|Push: /push-pr
 |Security: security-detection|Quality: analyze|Learn: reflect|Lifecycle: /spec /plan /build /test /review /ship
+|Merge "blocked"/"conversation must be resolved": never stop and ask the user; run `github` skill's `why_pr_blocked.py` to diagnose, then `resolve_pr_review_thread.py --pull-request N --all` (covers outdated-but-unresolved threads too), then re-check before reporting status
 |CI-feedback sub-loop: cluster, ladder build->test->review->ship. See `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
 |ADR-078: no skill -> autoplan; multi-step/cross-cutting -> orchestrator; no return loop
 |New capability: buy-vs-build Quick BEFORE /spec+baseline; >13wk no baseline = prune. Skip: bug/doc/refactor/approved-cap-extension

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 **Always**: Python (ADR-042)|Verify branch|Check skills|Assign issues|PR template|Atomic commits <=5 files|Scoped lint|Pin Actions SHA|Run changed workflows pre-push|No manifest version (ADR-092)
 **Ask First**: Architecture|New ADRs|Breaking|Security
 **Autonomy Guardrail**: Internal+reversible: act|External/irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact|Report PR "blocked"/awaiting user w/o first running the merge-blocked skill flow above
+**Never**: Commit secrets|Edit HANDOFF.md|New bash scripts|Logic in YAML (ADR-006)|Raw gh if skill exists|Force push|Skip hooks|Internal refs in src|Scratch in tree|Resolve security threads w/o fix|Ship unrun gen artifact|Report PR "blocked"/"has conflicts"/awaiting user w/o first running the merge-blocked or merge-resolver flow above
 
 ## Context
 
@@ -35,6 +35,7 @@ Knowledge -> context. Actions -> skills.
 |PRs: GitHub|Reviews: pr-comment-responder|Conflicts: merge-resolver agent|Push: /push-pr
 |Security: security-detection|Quality: analyze|Learn: reflect|Lifecycle: /spec /plan /build /test /review /ship
 |Merge "blocked"/"conversation must be resolved": never stop and ask the user; run `github` skill's `why_pr_blocked.py` to diagnose, then `resolve_pr_review_thread.py --pull-request N --all` (covers outdated-but-unresolved threads too), then re-check before reporting status
+|Merge "has conflicts"/"must be resolved before continuing": never stop and ask the user; invoke merge-resolver agent to merge base into the PR branch and resolve, then push and re-check mergeability
 |CI-feedback sub-loop: cluster, ladder build->test->review->ship. See `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
 |ADR-078: no skill -> autoplan; multi-step/cross-cutting -> orchestrator; no return loop
 |New capability: buy-vs-build Quick BEFORE /spec+baseline; >13wk no baseline = prune. Skip: bug/doc/refactor/approved-cap-extension


### PR DESCRIPTION
## Summary

### What

Adds explicit `AGENTS.md` guidance so agents resolve a "merge blocked" / "conversation must be resolved" or "has conflicts" GitHub state themselves instead of surfacing the raw platform message and stopping to wait on the user.

### Why

Both messages already have a scripted resolution path in this repo (the `github` skill's `why_pr_blocked.py` + `resolve_pr_review_thread.py --all` for unresolved/outdated review threads, and the `merge-resolver` agent for base-branch conflicts), but nothing in `AGENTS.md` told an agent to run them before reporting status. The default behavior fell back to echoing GitHub's own wording and pausing for input, which is the exact anti-pattern `AGENTS.md`'s `Autonomy Guardrail` line ("Internal+reversible: act") already argues against for this class of state.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5240 | AGENTS.md: agents stall reporting "merge blocked" instead of resolving via the github skill |

## Changes

- Added a `Skill-First` entry naming the diagnose-then-resolve flow for both a blocked merge and a conflicted branch.
- Added a matching `Never` boundary: never report PR blocked/conflicted without first running that flow.
- Removed the now-redundant `Conflicts: merge-resolver agent` pointer on the `PRs` line (superseded by the new, more explicit line).
- Kept `AGENTS.md` under the repo's 3,000-byte per-file workspace budget; landed at 2,963 bytes with headroom (see Testing section below for the validator commands).

## Acceptance criteria

- [x] `AGENTS.md` tells an agent to run `why_pr_blocked.py` + `resolve_pr_review_thread.py --all` (or the `merge-resolver` agent for conflicts) before reporting a blocked/conflicted PR to the user
- [x] `AGENTS.md` stays within the 3,000-byte per-file workspace budget

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

**Focus areas**: whether the terse wording (matching `AGENTS.md`'s existing pipe-delimited style) is still clear enough to act on.

## Testing

- [x] No testing required (documentation only)

Ran locally and all passed: the workspace-budget validator, the two targeted pytest files covering the per-file and repo-wide workspace budget, the always-on instruction-budget check, and the full pre-push validation suite (`scripts/validation/pre_pr.py` plus the repo's pytest suite).

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5240
