### PR TITLE
feat(rules): voice.md Confusion Protocol carve-out for unattended runs

### DIFF
--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -122,12 +122,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -122,12 +122,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -122,12 +122,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,269 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,269 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,385 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -122,12 +122,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -122,12 +122,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -189,11 +189,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
+Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -189,11 +189,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -195,6 +195,10 @@ Triggering this protocol on routine work wastes the user's time and trains them 
 
 Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, name what you skipped. The user can correct on the next turn.
 
+### Unattended runs
+
+No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+
 ## Ownership: See Something, Say Something
 
 You own everything you touch and everything adjacent to it. Scope is not an excuse. If you walked past a broken thing on the way to the thing you were asked to fix, you saw it. You are on the hook for at least flagging it.

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -189,11 +189,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff or the run's report, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch; continue elsewhere.
 
 ## Ownership: See Something, Say Something
 

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -189,11 +189,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
 Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -160,14 +160,6 @@ Example, coverage-differentiated:
 >
 > Option B: extract a `requireSession` helper and route all four middlewares through it. Completeness: 9/10. Fixes the reported bug plus the three latent ones. Leaves the websocket path (separate auth flow) for a follow-up.
 
-Example, kind-differentiated:
-
-> Note: options differ in kind, not coverage. No completeness score.
->
-> Option A: Redis cache. Cuts auth check to 2ms. Adds a second store to operate.
->
-> Option B: in-process LRU. Cuts auth check to 5ms. No new infra, loses cache on every deploy.
-
 ## Confusion Protocol
 
 For high-stakes ambiguity, **stop and ask**. Do not guess. Do not pick the option that feels right and rationalize it after.
@@ -197,7 +189,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+
+Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+
+Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+**always-on corpus is 7 rules, 70,463 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,392 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,587 always-on) because `generate_rules.py`
+116 bytes larger in total (70,579 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,168 bytes is the single biggest
+largest rule either: `voice.md` at 18,160 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,587-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
+70,579-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,463 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,463 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,392 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,579 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,160 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
-70,579-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,463 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,398 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,587 always-on) because `generate_rules.py`
+116 bytes larger in total (70,585 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,168 bytes is the single biggest
+largest rule either: `voice.md` at 18,166 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,587-byte always-on corpus measured at source. `code-quality` and
+70,585-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,398 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,585 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,166 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,585-byte always-on corpus measured at source. `code-quality` and
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,269 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,198 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,385 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 17,966 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
-70,385-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,269 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -281,7 +281,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 8.6x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 8.6x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,166 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,166 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (17,966 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,160 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,160 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,269 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,269 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,385 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff or the run's report, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch; continue elsewhere.
 
 ## Ownership: See Something, Say Something
 

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -194,6 +194,10 @@ Triggering this protocol on routine work wastes the user's time and trains them 
 
 Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, name what you skipped. The user can correct on the next turn.
 
+### Unattended runs
+
+No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+
 ## Ownership: See Something, Say Something
 
 You own everything you touch and everything adjacent to it. Scope is not an excuse. If you walked past a broken thing on the way to the thing you were asked to fix, you saw it. You are on the hook for at least flagging it.

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
 Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -159,14 +159,6 @@ Example, coverage-differentiated:
 >
 > Option B: extract a `requireSession` helper and route all four middlewares through it. Completeness: 9/10. Fixes the reported bug plus the three latent ones. Leaves the websocket path (separate auth flow) for a follow-up.
 
-Example, kind-differentiated:
-
-> Note: options differ in kind, not coverage. No completeness score.
->
-> Option A: Redis cache. Cuts auth check to 2ms. Adds a second store to operate.
->
-> Option B: in-process LRU. Cuts auth check to 5ms. No new infra, loses cache on every deploy.
-
 ## Confusion Protocol
 
 For high-stakes ambiguity, **stop and ask**. Do not guess. Do not pick the option that feels right and rationalize it after.
@@ -196,7 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+
+Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+
+Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
+Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,269 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,269 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,385 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,469 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,463 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,463 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,269 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,269 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,385 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,463 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,463 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,579 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -113,12 +113,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,471 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,471 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,587 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff or the run's report, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch; continue elsewhere.
 
 ## Ownership: See Something, Say Something
 

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -194,6 +194,10 @@ Triggering this protocol on routine work wastes the user's time and trains them 
 
 Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, name what you skipped. The user can correct on the next turn.
 
+### Unattended runs
+
+No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+
 ## Ownership: See Something, Say Something
 
 You own everything you touch and everything adjacent to it. Scope is not an excuse. If you walked past a broken thing on the way to the thing you were asked to fix, you saw it. You are on the hook for at least flagging it.

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (scheduled trigger, fleet worker, headless session). Never end on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
+Instead: record the ambiguity, options with trade-offs, branch taken, and why, to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: halt only that branch, continue independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
+Unattended: no human reads `AskUserQuestion` in the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
 Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
+Ask First items (architecture, new ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -159,14 +159,6 @@ Example, coverage-differentiated:
 >
 > Option B: extract a `requireSession` helper and route all four middlewares through it. Completeness: 9/10. Fixes the reported bug plus the three latent ones. Leaves the websocket path (separate auth flow) for a follow-up.
 
-Example, kind-differentiated:
-
-> Note: options differ in kind, not coverage. No completeness score.
->
-> Option A: Redis cache. Cuts auth check to 2ms. Adds a second store to operate.
->
-> Option B: in-process LRU. Cuts auth check to 5ms. No new infra, loses cache on every deploy.
-
 ## Confusion Protocol
 
 For high-stakes ambiguity, **stop and ask**. Do not guess. Do not pick the option that feels right and rationalize it after.
@@ -196,7 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-No `AskUserQuestion` reader: never stop on a question, it stalls unread. Write the fork to the handoff, take the safest reversible branch. Ask First items still halt, noted there.
+Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+
+Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+
+Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/src/copilot-cli/instructions/voice.instructions.md
+++ b/src/copilot-cli/instructions/voice.instructions.md
@@ -188,11 +188,11 @@ Default for ambiguous-but-low-cost cases: act minimally, flag what you assumed, 
 
 ### Unattended runs
 
-Unattended: no human can read an `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question; unread, it stalls silently.
+Unattended: no human reads `AskUserQuestion` within the run (a scheduled trigger, a fleet worker, a headless session). Never end one on a question: unread, it stalls.
 
-Instead: record the ambiguity, options, and branch taken to the handoff, then take the safest reversible branch and continue.
+Instead: record the ambiguity, options, and branch taken to the per-issue handoff, not `.agents/HANDOFF.md`; take the safest reversible branch and continue.
 
-Ask First items (architecture, ADRs, breaking, security) still get no guess: record it, halt only that branch, keep going on independent work.
+Ask First items (architecture, ADRs, breaking, security) get no guess: record it, halt only that branch, continue on independent work.
 
 ## Ownership: See Something, Say Something
 

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+**always-on corpus is 7 rules, 70,463 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,392 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,587 always-on) because `generate_rules.py`
+116 bytes larger in total (70,579 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,168 bytes is the single biggest
+largest rule either: `voice.md` at 18,160 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,587-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
+70,579-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,463 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,463 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,392 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,579 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,160 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
-70,579-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,463 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,398 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,587 always-on) because `generate_rules.py`
+116 bytes larger in total (70,585 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,168 bytes is the single biggest
+largest rule either: `voice.md` at 18,166 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,587-byte always-on corpus measured at source. `code-quality` and
+70,585-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,398 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,585 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 18,166 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,585-byte always-on corpus measured at source. `code-quality` and
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,269 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,198 bytes
+**always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,400 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,385 always-on) because `generate_rules.py`
+116 bytes larger in total (70,587 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -200,7 +200,7 @@ disagrees by more, the document is stale and the command wins.
 One book rule loads on every file. `pragmatic-programmer.md` was narrowed to
 code files in PR #4424, which recovered 11,225 always-on bytes, the largest
 single reduction this corpus has taken. What remains always-on is not the
-largest rule either: `voice.md` at 17,966 bytes is the single biggest
+largest rule either: `voice.md` at 18,168 bytes is the single biggest
 always-on file.
 
 | Rule | Bytes | Loading | Scenario file | Scored result |
@@ -209,8 +209,8 @@ always-on file.
 | `pragmatic-programmer.md` | 11,375 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
-That leaves 14,152 always-on bytes of book-derived rule, 20.1% of the
-70,385-byte always-on corpus measured at source. `code-quality` and
+That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
+70,587-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,269 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,471 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -281,7 +281,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 8.6x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 8.6x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,166 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,166 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (17,966 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,160 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -454,7 +454,7 @@ The last row is the common case and the easy one to skip. As of 2026-08-04,
 `code-quality.md` (14,152 bytes) already has a scenario file carrying four
 scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. It is the only **book-derived** always-on rule left, rank 2
-in the corpus behind `voice.md` (18,168 bytes). `pragmatic-programmer.md`
+in the corpus behind `voice.md` (18,160 bytes). `pragmatic-programmer.md`
 (11,375 bytes) sits on the same footing with four scenarios of its own, and was
 itself always-on until PR #4424 narrowed its `applyTo` to source files, so it
 now loads on a code edit and not otherwise.


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds an "Unattended runs" subsection to the Confusion Protocol in `.claude/rules/voice.md`, and updates every document that pins the always-on corpus's byte figures to reflect voice.md's new size.

### Why

The Confusion Protocol says "stop and ask" (`AskUserQuestion`) for high-stakes ambiguity. That deadlocks a run nobody is watching: a scheduled trigger, a fleet campaign worker, a headless session. The source retrospective (`.agents/retrospective/2026-08-19-review-and-land-fleet-campaign-prs.md`) records exactly that failure mode: a cycle ended on a question and stalled unread. `AGENTS.md`'s Autonomy Guardrail ("Ambiguous: act minimal, flag rest") never resolved its conflict with the Confusion Protocol, so this closes the gap: never end an unattended run on a question, record the ambiguity/options/branch to the per-issue handoff, take the safest reversible branch, and continue. The AGENTS.md Ask First items (architecture, new ADRs, breaking changes, security) stay hard stops that halt only the affected branch.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5257 | voice.md Confusion Protocol carve-out for unattended runs |

## Changes

- `.claude/rules/voice.md`: add "Unattended runs" subsection to the Confusion Protocol, covering detection (with named examples: scheduled trigger, fleet worker, headless session), the never-ask rule, the write-fork-then-safest-branch procedure (explicitly to the per-issue handoff, not the read-only HANDOFF.md at the repo root, recording the ambiguity, options with trade-offs, branch taken, and why), and the hard-stop carve-out (halts only the affected branch, independent work continues, and names "new ADRs" per AGENTS.md's exact Ask First list rather than a broader "ADRs"). Went through four review-driven revisions after the initial terse version: expanded to cover the issue's four required elements in detail (per the AI spec-coverage gate), disambiguated the handoff target, matched AGENTS.md's exact item names, then added the missing trade-offs/rationale fields (all per Copilot's PR review).
- To fit the `.py` always-on instruction bucket's byte budget (600-byte reserve enforced by the repo's instruction-budget gate), reclaimed space by dropping a redundant "kind-differentiated" completeness-score worked example elsewhere in voice.md; the governing rule for that case is stated in prose two paragraphs above it, and the surviving "coverage-differentiated" example already demonstrates the scoring mechanic.
- Regenerated mirrors: `.github/instructions/voice.instructions.md`, `src/copilot-cli/instructions/voice.instructions.md`.
- Updated the always-on corpus byte pins that voice.md's growth shifted, in every document that states them: `.claude/rules/canonical-source-mirror.md` (+ mirrors), `.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md`, `.claude/skills/context-optimizer/references/model-context-doctrine.md` (+ mirror), and `.claude/skills/context-optimizer/references/rule-audit-procedure.md` (+ mirror).

## Acceptance criteria

- [x] voice.md "Confusion Protocol" ends with an "Unattended runs" subsection covering detection, the never-end-on-a-question rule, the write-the-fork/take-the-safest-branch procedure, and the hard-stop carve-out.
- [x] The interactive behavior of the Confusion Protocol is unchanged (stop and ask remains the rule when a human can answer).
- [x] Both mirrors regenerated and committed in the same change.
- [x] `tests/validation/test_always_on_corpus_claims.py` and `instruction_budget.py` pass with updated figures in `canonical-source-mirror.md`.
- [x] No em dash or en dash anywhere in authored text.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: standard scrutiny, no rush. Additive prose to an always-on rule plus mechanical byte-figure updates across four documents; no code, no behavior change to any script.

**Focus areas**:
- Whether the "Unattended runs" wording now covers the issue's required elements: named unattended contexts, explicit per-issue handoff target, trade-offs/rationale recorded, "new ADRs" matching AGENTS.md exactly, "halt only that branch" (all flagged and fixed across four review rounds).
- Whether dropping the "kind-differentiated" completeness example to make byte-budget room is an acceptable trade, or whether a different cut would be better. See the unresolved review thread for the open question on whether this addition needs a `tests/evals/rule-scenarios/voice.json` scenario under the rule-audit-procedure; I don't think it does (reasoning in the thread), but it's a scope call for @rjmurillo.

## Testing

- [x] Tests added/updated (byte-count pins re-derived from a live measurement, not hand-typed)
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

`uv run --frozen pytest tests/validation/test_always_on_corpus_claims.py tests/validation/test_audit_procedure_claims.py tests/validation/test_instruction_ceiling_ratchet.py -q`: 73 passed.
`uv run python scripts/validation/instruction_budget.py --ci`: PASS, all four extensions within ceiling.
`uv run python scripts/validation/pre_pr.py`: all 57 validations passed on the pushed commit.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious (none added; prose-only change)
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5257
Refs #5259 (also edits voice.md; landing separately, since #5259 was not in scope here)

---

Supersedes #5265 (closed, unmerged; opened by the Copilot coding agent for the same issue, which completed the content but could not land the push after repeated retries).