### PR TITLE
fix(ci): pass --update-if-exists to the PR validation comment poster

### DIFF
--- a/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
+++ b/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
@@ -2,6 +2,25 @@
 
 Date: 2026-08-25
 
+## Failure mode classification
+
+**Class #7: Self-contained agent delegation failure** (partial fit)
+
+The `run_retrospective.py --since "4 hours ago"` script populated its "Work Items"
+section from recent commits rather than this session's actual diff, surfacing
+unrelated pip-audit and setup-uv content. The script lacked context to
+distinguish which commits belonged to this session versus other recent branch
+activity. The partial fit: the script succeeded structurally (returned valid
+markdown) but produced semantically incorrect output due to scope confusion.
+
+## Evidence
+
+- [Issue #5210](https://github.com/rjmurillo/moq.analyzers/issues/5210): Defines the stale-validation-comment bug
+- [PR #5209](https://github.com/rjmurillo/moq.analyzers/pull/5209): Delivery branch for the fix
+- Commit `f3600fdeb`: `fix(ci): pass --update-if-exists to the PR validation comment poster`
+- `.github/workflows/pr-validation.yml`: Workflow file modified to add the flag
+- `tests/ci/test_pr_validation_workflow.py::test_post_pr_comment_step_updates_the_existing_comment_in_place`: Mutation-tested wiring assertion
+
 ## What we did
 
 Fixed the bug in Issue #5210: `pr-validation.yml`'s "Post PR Comment" step called
@@ -76,3 +95,12 @@ Commit: `f3600fdeb` `fix(ci): pass --update-if-exists to the PR validation comme
    items from unrelated recent commits on the branch; do not commit its
    auto-populated "Work Items" section without checking it against the
    actual diff being retrospected.
+
+## Remediation
+
+| Action | Status | Reference |
+|--------|--------|-----------|
+| Add `--update-if-exists` flag to `pr-validation.yml` comment poster step | Applied | Commit `f3600fdeb` |
+| Document `investigation-claim-backstop.yml` write-once decision in YAML comment | Applied | Commit `f3600fdeb` |
+| Add mutation-tested workflow wiring assertion | Applied | `tests/ci/test_pr_validation_workflow.py` |
+| Extend `test_post_issue_comment.py` with body-verification and idempotent-update tests | Applied | PR #5209 |

--- a/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
+++ b/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
@@ -76,3 +76,28 @@ Commit: `f3600fdeb` `fix(ci): pass --update-if-exists to the PR validation comme
    items from unrelated recent commits on the branch; do not commit its
    auto-populated "Work Items" section without checking it against the
    actual diff being retrospected.
+
+## Failure Mode Classification
+
+Matches FM-9, Confident-Incorrectness Recurrence
+(`.agents/governance/FAILURE-MODES.md`): `run_retrospective.py --since "4
+hours ago"` populated the "Work Items" section from partial signal (a
+wall-clock-windowed `git log` scan), and that section named commits unrelated
+to this session's actual diff (a pip-audit pin bump, an unrelated setup-uv
+test fix, from other work on the same branch inside the window). Committing
+that section verbatim, without cross-checking it against `git status` and the
+real diff, would have shipped a retrospective narrating work this session did
+not do. No existing class other than FM-9 fits, so no new class or ADR is
+proposed per `.claude/rules/retros.md` MUST-2.
+
+Caught before commit, not after multi-round correction, so impact is Low: one
+session, one file, corrected pre-push. Evidence is this retrospective's own
+"What went wrong / friction" section above; there is no separate incident
+file because nothing shipped incorrect.
+
+## Remediation
+
+| Action | Status |
+|---|---|
+| Cross-check `run_retrospective.py`'s auto-generated "Work Items" against the actual session diff before committing | Done this session: caught and rewrote by hand before commit |
+| File an issue to scope `run_retrospective.py --since` to the current branch's own commits (or the session's actual diff) instead of a wall-clock window that can span unrelated concurrent work on the same branch | Not filed. Single-session friction with no repeat evidence yet; revisit if this recurs in a future retrospective |

--- a/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
+++ b/.agents/retrospective/2026-08-25-issue-5210-pr-validation-comment-upsert.md
@@ -1,0 +1,78 @@
+# Issue #5210: PR validation comment upsert retrospective
+
+Date: 2026-08-25
+
+## What we did
+
+Fixed the bug in Issue #5210: `pr-validation.yml`'s "Post PR Comment" step called
+`post_issue_comment.py` without `--update-if-exists`, so the script took its
+write-once idempotency path once a `PR-VALIDATION`-marked comment existed. A
+fixed PR kept showing its first failing verdict forever, because every later
+run recomputed the report correctly and then hit the "already exists.
+Skipping." branch. The fix is a one-line workflow change
+(`.github/workflows/pr-validation.yml`) adding the flag, already the documented
+switch to the update path in `post_issue_comment.py` and already used
+identically by `ai-spec-validation.yml`.
+
+The issue also named a second caller of the same script,
+`investigation-claim-backstop.yml`, and required an explicit decision rather
+than a silent default. That step only runs `if: failure()` and never re-posts
+once the PR is fixed, so it has no stale-PASS-shown-as-FAIL failure mode to
+correct; left it write-once and documented the reasoning in a YAML comment
+next to the step.
+
+Commit: `f3600fdeb` `fix(ci): pass --update-if-exists to the PR validation comment poster`
+
+## What went well
+
+- `post_issue_comment.py` already had a correct, fully unit-tested
+  `--update-if-exists` upsert path (`TestMainIdempotency` in
+  `tests/test_post_issue_comment.py`). The defect was purely in wiring, not in
+  the script, which kept the fix to one workflow line.
+- Added a mutation control for the new workflow-wiring test
+  (`tests/ci/test_pr_validation_workflow.py::test_post_pr_comment_step_updates_the_existing_comment_in_place`):
+  reverted only the workflow file with `git stash push --
+  .github/workflows/pr-validation.yml`, confirmed the test fails on the
+  pre-fix workflow, then restored the fix. Confirms the test actually
+  discriminates fixed from broken, per `.claude/rules/testing.md` SHOULD-10.
+- Extended `tests/test_post_issue_comment.py` with two cases the acceptance
+  criteria specifically asked for: one asserting the comment BODY sent to
+  `update_issue_comment` actually changes to the new report (not just that the
+  call returns 0, since the original bug also printed `Success: True`), and one
+  proving a byte-identical re-run still updates in place rather than creating a
+  duplicate comment.
+- `scripts/validation/pre_pr.py` (57/57) and the security agent both cleared
+  the change before push; the security review flagged two pre-existing LOW
+  findings in `post_issue_comment.py`'s marker-matching logic (no comment-author
+  check), out of scope for this fix and not introduced by it.
+
+## What went wrong / friction
+
+- The local clone was shallow (`git fetch --depth=<n>` from an earlier
+  operation), which failed `push-ref-staleness` in the pre-push hook with
+  "push validation requires complete Git history." Fixed with `git fetch
+  --unshallow origin`.
+- The pre-push `retrospective-policy` gate
+  (`scripts/validation/git_hook_policy.py retrospective`) requires either a
+  same-day file under `.agents/retrospective/` or session-log evidence. No
+  session log exists for this session, per `.claude/rules/session-logs.md`
+  ("session log creation is discontinued"), so the only remaining path is this
+  retrospective file. `run_retrospective.py --since "4 hours ago"` populated
+  the auto-generated skeleton's "Work Items" section with unrelated content
+  (a pip-audit pin bump, an unrelated setup-uv test fix) that does not belong
+  to this session's actual diff; rewrote the file by hand instead of trusting
+  the auto-populated section verbatim.
+
+## Learnings
+
+1. When a workflow calls a script that already has a documented idempotency
+   flag, check whether every caller of that script passes it consistently
+   before assuming the bug is in the script.
+2. A wiring-only bug (a missing CLI flag in a workflow YAML step) needs a
+   mutation-tested wiring assertion, not just unit coverage of the script it
+   calls; the unit tests here already existed and did not catch the missing
+   flag because nothing asserted the workflow actually passed it.
+3. `run_retrospective.py`'s `--since` evidence gathering can surface work
+   items from unrelated recent commits on the branch; do not commit its
+   auto-populated "Work Items" section without checking it against the
+   actual diff being retrospected.

--- a/.github/workflows/investigation-claim-backstop.yml
+++ b/.github/workflows/investigation-claim-backstop.yml
@@ -68,24 +68,35 @@ jobs:
             --output-format text
 
       - name: Post Warning on Violations
-        if: failure()
+        # Scoped to the validator's own outcome, not the job-wide failure().
+        # failure() alone also fires when an earlier setup step (checkout,
+        # environment setup, git log for PR commits) fails, which would post
+        # a false "investigation-claim violation" comment for what is really
+        # an infrastructure failure with no violation to report.
+        if: failure() && steps.validate.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         # Intentionally write-once (no --update-if-exists), decided per Issue #5210.
         # Unlike pr-validation.yml, this step only runs on failure and never
-        # re-posts once the PR is fixed, so there is no "stale PASS shown as
-        # FAIL" failure mode to correct. The comment is a point-in-time
-        # violation alert, not a recomputed status; the historical record of
-        # what was flagged stays valid documentation even after the offending
-        # commit is amended or removed.
+        # re-posts once the PR is fixed, so the comment can never flip a real
+        # PASS back to a stale FAIL the way pr-validation.yml's bug did. It
+        # can still go stale in a narrower sense: because if: failure() also
+        # skips the successful rerun, the posted text is never cleared or
+        # marked resolved once the PR is fixed. The pinned commit SHA below
+        # (added per PR #5281 review) is what keeps the comment
+        # self-identifying as a point-in-time record instead of reading as
+        # a live, current-tense status.
         run: |
-          cat <<'EOF' > "${RUNNER_TEMP:-.}/comment.md"
-          ## Investigation-Only Claim Violation
-
-          This PR contains session logs claiming `SKIPPED: investigation-only` but the
-          associated commits include files outside the investigation allowlist.
-
+          # The commit SHA line is built with printf, not inside the heredoc
+          # below: the static text after it is full of backticks for markdown
+          # code spans, and an unquoted "<<EOF" heredoc would treat every one
+          # of those as a command-substitution attempt. Keeping the heredoc
+          # quoted ("<<'EOF'") keeps that text fully literal; printf handles
+          # the one line that needs the SHA interpolated.
+          printf '## Investigation-Only Claim Violation\n\nAs of commit `%s`, this PR contained session logs claiming `SKIPPED: investigation-only` while the associated commits included files outside the investigation allowlist. If the PR has since changed, verify the current diff rather than relying on this comment alone; it is not automatically updated or cleared.\n\n' "${HEAD_SHA:0:12}" > "${RUNNER_TEMP:-.}/comment.md"
+          cat <<'EOF' >> "${RUNNER_TEMP:-.}/comment.md"
           **Per ADR-034**, investigation-only sessions may only commit:
           - `.agents/sessions/` (session logs)
           - `.agents/analysis/` (investigation outputs)

--- a/.github/workflows/investigation-claim-backstop.yml
+++ b/.github/workflows/investigation-claim-backstop.yml
@@ -72,6 +72,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Intentionally write-once (no --update-if-exists), decided per Issue #5210.
+        # Unlike pr-validation.yml, this step only runs on failure and never
+        # re-posts once the PR is fixed, so there is no "stale PASS shown as
+        # FAIL" failure mode to correct. The comment is a point-in-time
+        # violation alert, not a recomputed status; the historical record of
+        # what was flagged stays valid documentation even after the offending
+        # commit is amended or removed.
         run: |
           cat <<'EOF' > "${RUNNER_TEMP:-.}/comment.md"
           ## Investigation-Only Claim Violation

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -140,7 +140,8 @@ jobs:
               python3 .github/scripts/post_issue_comment.py \
               --issue "$PR_NUMBER" \
               --body-file "pr-validation-report.md" \
-              --marker "PR-VALIDATION"
+              --marker "PR-VALIDATION" \
+              --update-if-exists
           fi
 
       - name: Set Job Summary

--- a/tests/ci/test_investigation_claim_backstop_workflow.py
+++ b/tests/ci/test_investigation_claim_backstop_workflow.py
@@ -1,0 +1,66 @@
+"""Pins the Issue #5210 decision for investigation-claim-backstop.yml.
+
+Issue #5210 found that pr-validation.yml called post_issue_comment.py without
+--update-if-exists, so a fixed PR kept showing its first failing verdict
+forever. The issue named a second caller of the same script,
+investigation-claim-backstop.yml, and required it be "explicitly decided,
+either flagged as intentionally write-once with a comment saying so, or given
+the flag" rather than silently left ambiguous.
+
+This repo decided write-once is correct there: unlike pr-validation.yml,
+the "Post Warning on Violations" step only runs `if: failure()` and never
+re-posts once the PR is fixed, so there is no stale-PASS-shown-as-FAIL
+failure mode to correct. These tests pin that decision so a future edit
+cannot silently drop the explanation or add the flag without updating this
+test to match.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "investigation-claim-backstop.yml"
+
+
+def _post_warning_step() -> dict:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = data["jobs"]["validate-claims"]["steps"]
+    matching = [step for step in steps if step.get("name") == "Post Warning on Violations"]
+    assert len(matching) == 1, "expected exactly one 'Post Warning on Violations' step"
+    return matching[0]
+
+
+def test_the_write_once_decision_is_intentional_not_an_oversight() -> None:
+    """Positive: the step must not silently gain --update-if-exists.
+
+    If a future change adds the flag here, it should be a deliberate
+    decision (with this test updated to match), not a drive-by copy from
+    pr-validation.yml's fix.
+    """
+    run = _post_warning_step().get("run", "")
+    assert "post_issue_comment.py" in run
+    assert "--marker \"INVESTIGATION-CLAIM-BACKSTOP\"" in run
+    assert "--update-if-exists" not in run
+
+
+def test_the_decision_is_documented_next_to_the_step() -> None:
+    """Positive: the rationale must be readable at the call site, not only
+    in the issue tracker, per Issue #5210's acceptance criteria.
+    """
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    assert "Intentionally write-once" in workflow_text
+    assert "#5210" in workflow_text
+
+
+def test_the_step_only_fires_on_failure() -> None:
+    """Edge: the decision's justification depends on this condition holding.
+
+    Write-once is safe here only because the step never re-posts on a
+    passing re-run. If this step ever stops being failure-gated, it inherits
+    the same stale-verdict bug pr-validation.yml had, and the write-once
+    decision above must be revisited.
+    """
+    assert _post_warning_step().get("if") == "failure()"

--- a/tests/ci/test_investigation_claim_backstop_workflow.py
+++ b/tests/ci/test_investigation_claim_backstop_workflow.py
@@ -17,6 +17,7 @@ test to match.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -24,13 +25,42 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "investigation-claim-backstop.yml"
 
+_STEP_NAME = "Post Warning on Violations"
+
 
 def _post_warning_step() -> dict:
     data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = data["jobs"]["validate-claims"]["steps"]
-    matching = [step for step in steps if step.get("name") == "Post Warning on Violations"]
+    matching = [step for step in steps if step.get("name") == _STEP_NAME]
     assert len(matching) == 1, "expected exactly one 'Post Warning on Violations' step"
     return matching[0]
+
+
+def _extract_step_block(text: str, step_name: str) -> str:
+    """Return the raw YAML text spanning only the named list-item step.
+
+    ``yaml.safe_load`` strips comments, so a rationale comment above a step's
+    ``run:`` key is invisible to the parsed structure. This finds the step by
+    its ``- name:`` line and its list-item indentation, then cuts the block
+    off at the next sibling ``- name:`` at the same indentation (or end of
+    text), so a check against the result proves content sits with THIS step
+    and not merely somewhere else in the document.
+    """
+    start_match = re.search(
+        rf"^([ \t]*)- name: {re.escape(step_name)}\s*$", text, flags=re.MULTILINE
+    )
+    assert start_match is not None, f"could not locate the {step_name!r} step"
+    indent = start_match.group(1)
+    next_sibling = re.search(
+        rf"^{re.escape(indent)}- name:", text[start_match.end() :], flags=re.MULTILINE
+    )
+    end = start_match.end() + next_sibling.start() if next_sibling else len(text)
+    return text[start_match.start() : end]
+
+
+def _post_warning_step_raw_block() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return _extract_step_block(text, _STEP_NAME)
 
 
 def test_the_write_once_decision_is_intentional_not_an_oversight() -> None:
@@ -49,10 +79,66 @@ def test_the_write_once_decision_is_intentional_not_an_oversight() -> None:
 def test_the_decision_is_documented_next_to_the_step() -> None:
     """Positive: the rationale must be readable at the call site, not only
     in the issue tracker, per Issue #5210's acceptance criteria.
+
+    Scoped to this step's own raw text block, not the whole workflow file:
+    a whole-file substring check would still pass if the comment moved to an
+    unrelated job or a stray comment elsewhere, which would not prove the
+    rationale sits next to THIS step as its name and this test's docstring
+    both claim.
     """
-    workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    assert "Intentionally write-once" in workflow_text
-    assert "#5210" in workflow_text
+    step_block = _post_warning_step_raw_block()
+    assert "Intentionally write-once" in step_block
+    assert "#5210" in step_block
+
+
+def test_step_block_extraction_stops_at_the_next_sibling_step() -> None:
+    """Negative control on ``_extract_step_block`` itself, via synthetic YAML.
+
+    ``Post Warning on Violations`` is the last step in the real workflow, so
+    there is no real sibling after it to prove scoping against. Without this
+    control, an unbounded extraction (grabs to end of text) would look
+    identical to a correctly bounded one on the real file, and the positive
+    test above would pass for the wrong reason. This drives the extractor on
+    a two-step fixture where content belongs unambiguously to one step or
+    the other.
+    """
+    text = (
+        "    steps:\n"
+        "      - name: Post Warning on Violations\n"
+        "        # Intentionally write-once, decided per Issue #5210.\n"
+        "        run: echo one\n"
+        "      - name: Set Job Summary\n"
+        "        run: echo two\n"
+    )
+    block = _extract_step_block(text, "Post Warning on Violations")
+    assert "Intentionally write-once" in block
+    assert "#5210" in block
+    assert "Set Job Summary" not in block
+    assert "echo two" not in block
+
+
+def test_step_block_extraction_finds_content_between_two_steps() -> None:
+    """Positive companion to the control above: the middle step is not lost.
+
+    Guards against an over-correction (e.g. stopping at ANY ``- name:``,
+    including one nested inside the target step) that would make the
+    extractor return an empty or truncated block for a step sandwiched
+    between two siblings.
+    """
+    text = (
+        "    steps:\n"
+        "      - name: First\n"
+        "        run: echo first\n"
+        "      - name: Post Warning on Violations\n"
+        "        # Intentionally write-once, decided per Issue #5210.\n"
+        "        run: echo middle\n"
+        "      - name: Set Job Summary\n"
+        "        run: echo last\n"
+    )
+    block = _extract_step_block(text, "Post Warning on Violations")
+    assert "echo middle" in block
+    assert "echo first" not in block
+    assert "echo last" not in block
 
 
 def test_the_step_only_fires_on_failure() -> None:
@@ -63,4 +149,19 @@ def test_the_step_only_fires_on_failure() -> None:
     the same stale-verdict bug pr-validation.yml had, and the write-once
     decision above must be revisited.
     """
-    assert _post_warning_step().get("if") == "failure()"
+    condition = _post_warning_step().get("if")
+    assert condition is not None and "failure()" in condition
+
+
+def test_the_step_does_not_fire_on_an_earlier_setup_failure() -> None:
+    """Edge: a bare `failure()` also fires when checkout or setup fails.
+
+    A job-wide `failure()` posts a false investigation-claim violation
+    comment for what is really an infrastructure failure (checkout, env
+    setup, or the git-log step) with no violation to report. Scoping to the
+    validator step's own outcome is what makes the "point-in-time violation
+    alert" framing in the comment above the step (and in the posted comment
+    body) actually true.
+    """
+    condition = _post_warning_step().get("if")
+    assert condition == "failure() && steps.validate.outcome == 'failure'"

--- a/tests/ci/test_investigation_claim_backstop_workflow.py
+++ b/tests/ci/test_investigation_claim_backstop_workflow.py
@@ -165,3 +165,58 @@ def test_the_step_does_not_fire_on_an_earlier_setup_failure() -> None:
     """
     condition = _post_warning_step().get("if")
     assert condition == "failure() && steps.validate.outcome == 'failure'"
+
+
+def test_the_step_exports_the_pr_head_sha() -> None:
+    """Positive: the posted comment needs the triggering commit available.
+
+    Without `HEAD_SHA` in the step's `env:`, the `printf` call below has
+    nothing to interpolate and the "As of commit ..." wording (pinned by
+    ``test_the_comment_self_identifies_as_a_point_in_time_record`` below)
+    could not exist.
+    """
+    env = _post_warning_step().get("env", {})
+    assert env.get("HEAD_SHA") == "${{ github.event.pull_request.head.sha }}"
+
+
+def test_the_comment_self_identifies_as_a_point_in_time_record() -> None:
+    """Positive: pins the fix for the present-tense-staleness review finding.
+
+    Reverting the `printf`/`HEAD_SHA` hunk while keeping the surrounding
+    heredoc would leave this suite green on every other test here (the
+    write-once decision, the failure-scoping, and the rationale comment all
+    still hold), silently reintroducing the exact defect a reviewer flagged:
+    a warning that reads as current status long after the PR was fixed. This
+    test is what actually breaks if that hunk disappears.
+    """
+    step_block = _post_warning_step_raw_block()
+    assert 'HEAD_SHA:0:12' in step_block
+    assert "As of commit `%s`, this PR contained" in step_block
+    # The old present-tense claim, unqualified by a commit reference, must
+    # not survive: that exact phrasing is what made the comment read as a
+    # live status instead of a point-in-time record.
+    assert "This PR contains session logs" not in step_block
+
+
+def test_the_sha_interpolation_uses_printf_not_the_heredoc() -> None:
+    """Edge: pins the shell-injection fix, not just its visible symptom.
+
+    The vulnerable shape (`cat <<EOF`, unquoted, with `$HEAD_SHA` inside a
+    markdown body full of backticks) would satisfy the two tests above too,
+    since the rendered text can look identical until the shell actually
+    tries to expand it. Assert on the mechanism: the interpolation happens
+    in a `printf` call, and the static markdown heredoc stays quoted.
+    """
+    step_block = _post_warning_step_raw_block()
+    assert re.search(r"printf\s+'[^']*%s[^']*'\s+\"\$\{HEAD_SHA:0:12\}\"", step_block)
+    # Every actual heredoc redirect must be the quoted form. An unquoted
+    # `<<EOF` would shell-expand the markdown body, including every
+    # backtick-wrapped code span in it. Scanned line-by-line, skipping `#`
+    # comment lines: this rationale comment's own prose mentions the bare
+    # `<<EOF` syntax in quotes, which would otherwise false-positive.
+    code_lines = [
+        line for line in step_block.splitlines() if not line.strip().startswith("#")
+    ]
+    heredoc_redirects = re.findall(r"<<-?'?\"?EOF'?\"?", "\n".join(code_lines))
+    assert heredoc_redirects, "expected at least one heredoc redirect in the step"
+    assert all(redirect in ("<<'EOF'", '<<"EOF"') for redirect in heredoc_redirects)

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -422,6 +422,29 @@ def test_workflow_delegates_all_pr_validation_blocks():
     assert "Write-Error \"PR has $env:COMMIT_COUNT commits" not in workflow
 
 
+def test_post_pr_comment_step_updates_the_existing_comment_in_place() -> None:
+    """Issue #5210: a re-run must overwrite the prior verdict, not skip it.
+
+    ``post_issue_comment.py`` takes a write-once path by default: once a
+    comment carrying the ``PR-VALIDATION`` marker exists, every later run
+    printed "already exists. Skipping." and left the first run's verdict
+    showing forever, even after the underlying checks started passing.
+    ``--update-if-exists`` is the documented switch to the upsert path; this
+    pins it onto the step so a regression here is caught by a wiring test,
+    not discovered by a stale FAIL on a fixed PR (as PR #5209 was).
+    """
+    matching = [
+        step
+        for step in _pr_validation_steps()
+        if step.get("name") == "Post PR Comment"
+    ]
+    assert len(matching) == 1, "expected exactly one 'Post PR Comment' step"
+    run = matching[0].get("run", "")
+    assert "post_issue_comment.py" in run
+    assert "--marker \"PR-VALIDATION\"" in run
+    assert "--update-if-exists" in run
+
+
 
 
 class TestModelPinEnforcementIsWiredIntoCI:

--- a/tests/test_post_issue_comment.py
+++ b/tests/test_post_issue_comment.py
@@ -328,11 +328,14 @@ class TestMainIdempotency:
         update_mock.assert_called_once_with("o", "r", 99, existing_body)
         # subprocess.run is only exercised for the auth check on this path;
         # no "gh api ... -X POST ... comments" call means no duplicate was
-        # created.
+        # created. The create-comment call splits "comments" (in the URL
+        # argument) and "POST" (in a separate "-X POST" argument) across two
+        # list elements, so each must be checked across the whole call_args
+        # list rather than within a single argument.
         assert not any(
-            "comments" in str(arg) and "POST" in str(arg)
+            any("comments" in str(arg) for arg in call_args)
+            and any("POST" in str(arg) for arg in call_args)
             for call_args in run_calls
-            for arg in call_args
         )
 
     def test_marker_not_found_posts_new(self, tmp_path, monkeypatch):

--- a/tests/test_post_issue_comment.py
+++ b/tests/test_post_issue_comment.py
@@ -245,6 +245,96 @@ class TestMainIdempotency:
         outputs = _read_outputs(output_file)
         assert outputs["updated"] == "true"
 
+    def test_update_replaces_stale_body_with_the_new_report(self, tmp_path, monkeypatch):
+        """Issue #5210: prove the comment CONTENT changes, not just the exit code.
+
+        The original bug exited 0 and printed "Success: True" on the
+        write-once skip path too, so a passing return code cannot
+        distinguish a report that actually updated from one that silently
+        kept showing the first run's stale verdict. Assert on what was
+        actually sent to ``update_issue_comment``.
+        """
+        _setup_output(tmp_path, monkeypatch)
+        existing_comments = [
+            {"id": 99, "body": "<!-- test-marker -->\nOLD REPORT: FAIL"}
+        ]
+        captured: dict[str, str] = {}
+
+        def fake_update(owner, repo, comment_id, body):
+            captured["body"] = body
+            return {"id": comment_id, "html_url": "https://ex.com", "updated_at": "now"}
+
+        with patch("subprocess.run", return_value=_completed(rc=0)), patch(
+            f"{_MODULE_NAME}.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            f"{_MODULE_NAME}.get_issue_comments",
+            return_value=existing_comments,
+        ), patch(
+            f"{_MODULE_NAME}.update_issue_comment",
+            side_effect=fake_update,
+        ):
+            rc = main([
+                "--issue", "1",
+                "--body", "NEW REPORT: PASS",
+                "--marker", "test-marker",
+                "--update-if-exists",
+            ])
+
+        assert rc == 0
+        assert "NEW REPORT: PASS" in captured["body"]
+        assert "OLD REPORT: FAIL" not in captured["body"]
+
+    def test_byte_identical_rerun_updates_in_place_not_a_duplicate(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative/edge: an unchanged report must not create a second comment.
+
+        A re-run whose recomputed report is byte-identical to the existing
+        comment still takes the update path (same comment id, same body) and
+        never falls through to the create-new-comment POST branch.
+        """
+        _setup_output(tmp_path, monkeypatch)
+        existing_body = "<!-- test-marker -->\n\nSAME REPORT: PASS"
+        existing_comments = [{"id": 99, "body": existing_body}]
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            run_calls.append(args)
+            return _completed(rc=0)
+
+        def fake_update(owner, repo, comment_id, body):
+            return {"id": comment_id, "html_url": "https://ex.com", "updated_at": "now"}
+
+        with patch("subprocess.run", side_effect=fake_run), patch(
+            f"{_MODULE_NAME}.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            f"{_MODULE_NAME}.get_issue_comments",
+            return_value=existing_comments,
+        ), patch(
+            f"{_MODULE_NAME}.update_issue_comment",
+            side_effect=fake_update,
+        ) as update_mock:
+            rc = main([
+                "--issue", "1",
+                "--body", "SAME REPORT: PASS",
+                "--marker", "test-marker",
+                "--update-if-exists",
+            ])
+
+        assert rc == 0
+        update_mock.assert_called_once_with("o", "r", 99, existing_body)
+        # subprocess.run is only exercised for the auth check on this path;
+        # no "gh api ... -X POST ... comments" call means no duplicate was
+        # created.
+        assert not any(
+            "comments" in str(arg) and "POST" in str(arg)
+            for call_args in run_calls
+            for arg in call_args
+        )
+
     def test_marker_not_found_posts_new(self, tmp_path, monkeypatch):
         output_file = _setup_output(tmp_path, monkeypatch)
         response = json.dumps({


### PR DESCRIPTION
## Summary

### What

`pr-validation.yml`'s "Post PR Comment" step now passes `--update-if-exists` to post_issue_comment.py, so a re-run overwrites the existing `PR-VALIDATION` comment with the freshly computed report instead of skipping the update. `investigation-claim-backstop.yml`'s call to the same script is left write-once on purpose, with the reasoning documented in a comment next to the step and pinned by a wiring test.

Review also surfaced two related defects in `investigation-claim-backstop.yml`'s "Post Warning on Violations" step, fixed in the same PR: its `if: failure()` condition fired on an unrelated setup failure (checkout, env setup, the git-log step) and posted a false violation comment with nothing to report; and the posted comment read in the present tense ("This PR contains...") with no reference to a specific commit, so it kept reading as a live status long after the PR that triggered it was fixed.

### Why

post_issue_comment.py has a write-once idempotency default: once a comment carrying a given marker exists, a later run without `--update-if-exists` prints "already exists. Skipping." and exits 0. `pr-validation.yml` never passed the flag, so once a PR posted a failing verdict, every later re-run recomputed the report correctly and then discarded it. The comment kept showing the first run's stale `FAIL`/`WARN` forever, even after the PR was fixed. PR #5209 reproduced this live: the report scored `PASS 4/4` on a later run while the visible comment still read `WARN 0/4`.

The backstop workflow's condition and wording issues are a narrower version of the same class of problem: a comment that can be technically correct at post time but goes stale or misfires once the triggering PR state changes, with nothing scoping it to the commit or the failure it actually describes.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5210 | The PR Validation comment can never update, so a fixed PR keeps showing its first failing verdict forever |

## Changes

- `.github/workflows/pr-validation.yml`: add `--update-if-exists` to the comment-posting step's post_issue_comment.py invocation.
- `.github/workflows/investigation-claim-backstop.yml`:
  - Document (via a YAML comment next to the "Post Warning on Violations" step) the decision to leave this caller write-once. That step only runs `if: failure()` and never re-posts once the PR is fixed, so it has no stale-verdict failure mode to correct.
  - Scope the step's `if:` condition to `failure() && steps.validate.outcome == 'failure'` instead of a bare `failure()`, so an earlier setup-step failure (checkout, environment setup, the PR-commits git log) no longer posts a false investigation-claim-violation comment.
  - Export `HEAD_SHA` and interpolate it into the posted comment via `printf` (not inside the heredoc, which stays quoted to avoid shell-expanding the markdown body's backticks), so the comment reads "As of commit `<sha>`, this PR contained..." instead of an unqualified present-tense claim.
- `tests/ci/test_pr_validation_workflow.py`: add a wiring test asserting the "Post PR Comment" step passes `--update-if-exists`.
- `tests/ci/test_investigation_claim_backstop_workflow.py` (new): pin the write-once decision for the backstop workflow (flag absent, rationale documented, step still failure-gated), the narrowed `if:` condition, the `HEAD_SHA` export and point-in-time wording, and the printf/quoted-heredoc shape of the SHA interpolation, so a future edit can't silently drift on any of these.
- `tests/test_post_issue_comment.py`: extend `TestMainIdempotency` with two cases the issue's acceptance criteria asked for. First, a re-run with `--update-if-exists` sends the *new* report body to `update_issue_comment`, not just a `0` exit code, since the original bug also exited 0 and printed `Success: True`. Second, a byte-identical re-run still goes through the update path (same comment id) rather than creating a duplicate via a new `POST`.

## Acceptance criteria

- [x] `pr-validation.yml` passes `--update-if-exists`.
- [x] A test proves a second run with a different report body replaces the comment. Asserts on the comment body content sent to `update_issue_comment`, not just the exit code.
- [x] Negative test: a run whose report is byte-identical to the existing comment does not create a duplicate.
- [x] `investigation-claim-backstop.yml` is explicitly decided: flagged as intentionally write-once with a comment explaining why, not given the flag.
- [x] Positive, negative, and edge tests added per `.agents/governance/TESTING-RIGOR.md`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny (workflow YAML + CI script), no rush.

**Focus areas**: whether leaving `investigation-claim-backstop.yml` write-once (rather than adding the flag) is the right call, and whether the `HEAD_SHA`/printf interpolation added to that same step is shell-injection safe. The reasoning is in the workflow comments and in `tests/ci/test_investigation_claim_backstop_workflow.py`.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only) : N/A, tests added instead

New/changed tests run clean: `tests/test_post_issue_comment.py`, `tests/ci/test_pr_validation_workflow.py`, `tests/ci/test_investigation_claim_backstop_workflow.py` (76 passed). The wiring tests were verified against mutation controls: reverting only the corresponding workflow fix (keeping the test) makes the relevant test fail, and restoring the fix makes it pass again.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [x] Security agent reviewed infrastructure changes

**Verdict**: APPROVE WITH NOTES (0 blocking). Two pre-existing LOW findings noted in post_issue_comment.py's marker-matching logic (no comment-author check when selecting the existing marked comment to update), out of scope for this change and not introduced by it. Net posture improves, since the pre-fix write-once-skip path was strictly worse for the same edge case. A second, later review specifically covered the `HEAD_SHA`/printf change and confirmed the quoted-heredoc plus printf-interpolation split avoids shell command substitution from the markdown body's backticks.

**Files requiring security review:**

- `.github/workflows/pr-validation.yml`
- `.github/workflows/investigation-claim-backstop.yml`

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`, 57/57)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable) : N/A, no user-facing docs affected
- [x] No new warnings introduced

## Related Issues

Fixes #5210
