### PR TITLE
feat(adr): ADR-073 lifecycle frontmatter across 67 ADRs, plus five status decisions

### DIFF
--- a/.agents/architecture/ADR-001-markdown-linting.md
+++ b/.agents/architecture/ADR-001-markdown-linting.md
@@ -1,3 +1,14 @@
+---
+id: ADR-001
+status: accepted
+date: 2025-12-13
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-001: Markdown Linting Configuration
 
 ## Status

--- a/.agents/architecture/ADR-002-agent-model-selection-optimization.md
+++ b/.agents/architecture/ADR-002-agent-model-selection-optimization.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-002
 status: deprecated
-date: 2025-12-16
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-002-agent-model-selection-optimization.md
+++ b/.agents/architecture/ADR-002-agent-model-selection-optimization.md
@@ -1,8 +1,64 @@
+---
+id: ADR-002
+status: deprecated
+date: 2025-12-16
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-002: Agent Model Selection Optimization
 
 ## Status
 
-Provisionally Superseded by ADR-039 (2026-01-03 to 2026-01-17)
+Deprecated (2026-08-25).
+
+### Resolution of the provisional supersession (2026-08-25)
+
+The two notes below are retained as written, because they are the record of what
+was believed at the time. Both are now resolved, and this section is the
+resolution.
+
+**The ADR-039 supersession did not hold.** ADR-039's provisional window
+(2026-01-03 to 2026-01-17) expired without its validation ever being performed,
+and its downgrades were reverted. Verified against the live tree: `model:` in the
+agent frontmatter for orchestrator, architect, independent-thinker, roadmap,
+high-level-advisor, and security all read `opus`, which is this ADR's assignment,
+not ADR-039's downgrade. ADR-039 is deprecated in the same change for that
+reason.
+
+**That does not revive this ADR as `accepted`,** and the status here is
+`deprecated` rather than a restoration, for two independent reasons.
+
+First, this ADR's own table does not describe the live tree either. It assigns
+`critic` and `qa` to Sonnet; both are `opus` today. It opens by scoping itself to
+"All 18 agents in the ai-agents repository"; there are 33 agent files under
+`.claude/agents/` now. A table that matches neither the tree nor its own stated
+scope is not a live decision, whatever happened to the ADR that tried to replace
+it.
+
+Second, the question this ADR answers has been re-answered on better grounds.
+ADR-080 (accepted, 2026-07-11) governs model pins now, and it supersedes this
+ADR's method rather than its numbers. Its Context section rejects exactly the
+reasoning ADR-002 used: "The pins encode a guess, not a measurement." Where this
+ADR scored agents across five dimensions and derived assignments from the scores,
+ADR-080 requires a pin to justify itself against the harness-inherited default or
+not exist. `scripts/validation/check_model_pins.py` enforces that.
+
+`superseded-by` is deliberately left `null`. Naming ADR-080 there would require
+the reciprocal `supersedes: [ADR-002]` on ADR-080, and editing an accepted ADR is
+outside the scope of this backfill. The relationship is recorded in prose here
+until someone makes it on both sides at once.
+
+`scripts/validation/model_pin_baseline.json` is the artifact that tracks the
+remaining pins. Read its own description before citing it: "Draining ratchet:
+this count must never grow and should shrink each release until empty." It is a
+debt register, not an endorsement of the assignments it contains, and it is not
+evidence that this ADR's table is frozen or blessed.
+
+### Original notes (2025-12-16 to 2026-01-03), retained
 
 **Note**: ADR-039 is in 2-week provisional status pending validation. If validation fails, ADR-002 assignments will be restored.
 

--- a/.agents/architecture/ADR-003-agent-tool-selection-criteria.md
+++ b/.agents/architecture/ADR-003-agent-tool-selection-criteria.md
@@ -1,9 +1,18 @@
 ---
+id: ADR-003
 status: accepted
 date: 2025-12-16
-decision-makers: ["architect", "orchestrator"]
-consulted: ["implementer", "analyst", "devops"]
-informed: ["all agents"]
+decision-makers: [architect, orchestrator]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+consulted:
+- implementer
+- analyst
+- devops
+informed:
+- all agents
 ---
 
 # ADR-003: Role-Specific Tool Allocation for Multi-Agent System

--- a/.agents/architecture/ADR-005-powershell-only-scripting.md
+++ b/.agents/architecture/ADR-005-powershell-only-scripting.md
@@ -1,3 +1,14 @@
+---
+id: ADR-005
+status: superseded
+date: 2025-12-18
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: ADR-042
+explainer: null
+implemented: true
+---
+
 # ADR-005: PowerShell-Only Scripting Standard
 
 **Status**: Superseded by [ADR-042](./ADR-042-python-migration-strategy.md)

--- a/.agents/architecture/ADR-005-powershell-only-scripting.md
+++ b/.agents/architecture/ADR-005-powershell-only-scripting.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-005
 status: superseded
-date: 2025-12-18
+date: 2026-01-17
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: ADR-042

--- a/.agents/architecture/ADR-006-thin-workflows-testable-modules.md
+++ b/.agents/architecture/ADR-006-thin-workflows-testable-modules.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-006
 status: accepted
-date: 2025-12-18
+date: 2026-04-29
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-006-thin-workflows-testable-modules.md
+++ b/.agents/architecture/ADR-006-thin-workflows-testable-modules.md
@@ -1,3 +1,14 @@
+---
+id: ADR-006
+status: accepted
+date: 2025-12-18
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-006: Thin Workflows, Testable Modules
 
 **Status**: Accepted

--- a/.agents/architecture/ADR-007-memory-first-architecture.md
+++ b/.agents/architecture/ADR-007-memory-first-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-007
+status: accepted
+date: 2026-01-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-007: Memory-First Architecture
 
 ## Status

--- a/.agents/architecture/ADR-007-memory-first-architecture.md
+++ b/.agents/architecture/ADR-007-memory-first-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-007
 status: accepted
-date: 2026-01-01
+date: 2026-08-16
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
+++ b/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
@@ -1,3 +1,14 @@
+---
+id: ADR-008
+status: accepted
+date: 2025-12-20
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-008: Protocol Automation via Lifecycle Hooks
 
 ## Status

--- a/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
+++ b/.agents/architecture/ADR-008-protocol-automation-lifecycle-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-008
 status: accepted
-date: 2025-12-20
+date: 2026-08-19
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-009-parallel-safe-multi-agent-design.md
+++ b/.agents/architecture/ADR-009-parallel-safe-multi-agent-design.md
@@ -1,3 +1,14 @@
+---
+id: ADR-009
+status: accepted
+date: 2025-12-20
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-009: Parallel-Safe Multi-Agent Design
 
 ## Status

--- a/.agents/architecture/ADR-010-quality-gates-evaluator-optimizer.md
+++ b/.agents/architecture/ADR-010-quality-gates-evaluator-optimizer.md
@@ -1,3 +1,14 @@
+---
+id: ADR-010
+status: accepted
+date: 2025-12-20
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-010: Quality Gates with Evaluator-Optimizer Pattern
 
 ## Status

--- a/.agents/architecture/ADR-011-session-state-mcp.md
+++ b/.agents/architecture/ADR-011-session-state-mcp.md
@@ -1,3 +1,14 @@
+---
+id: ADR-011
+status: proposed
+date: 2025-12-21
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-011: Session State MCP
 
 ## Status

--- a/.agents/architecture/ADR-012-skill-catalog-mcp.md
+++ b/.agents/architecture/ADR-012-skill-catalog-mcp.md
@@ -1,3 +1,14 @@
+---
+id: ADR-012
+status: proposed
+date: 2025-12-21
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-012: Skill Catalog MCP
 
 ## Status

--- a/.agents/architecture/ADR-013-agent-orchestration-mcp.md
+++ b/.agents/architecture/ADR-013-agent-orchestration-mcp.md
@@ -6,7 +6,7 @@ decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null
 explainer: null
-implemented: true
+implemented: false
 ---
 
 # ADR-013: Agent Orchestration MCP

--- a/.agents/architecture/ADR-013-agent-orchestration-mcp.md
+++ b/.agents/architecture/ADR-013-agent-orchestration-mcp.md
@@ -1,3 +1,14 @@
+---
+id: ADR-013
+status: proposed
+date: 2025-12-21
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-013: Agent Orchestration MCP
 
 ## Status

--- a/.agents/architecture/ADR-014-distributed-handoff-architecture.md
+++ b/.agents/architecture/ADR-014-distributed-handoff-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-014
 status: accepted
-date: 2025-12-22
+date: 2026-08-16
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-014-distributed-handoff-architecture.md
+++ b/.agents/architecture/ADR-014-distributed-handoff-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-014
+status: accepted
+date: 2025-12-22
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-014: Distributed Handoff Architecture
 
 ## Status

--- a/.agents/architecture/ADR-015-artifact-storage-minimization.md
+++ b/.agents/architecture/ADR-015-artifact-storage-minimization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-015
+status: accepted
+date: 2025-12-22
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-015: Artifact Storage Minimization Strategy
 
 ## Status

--- a/.agents/architecture/ADR-016-workflow-execution-optimization.md
+++ b/.agents/architecture/ADR-016-workflow-execution-optimization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-016
+status: accepted
+date: 2025-12-22
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-016: Workflow Execution Optimization Strategy
 
 ## Status

--- a/.agents/architecture/ADR-017-tiered-memory-index-architecture.md
+++ b/.agents/architecture/ADR-017-tiered-memory-index-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-017
+status: accepted
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-017: Tiered Memory Index Architecture
 
 **Status**: Accepted

--- a/.agents/architecture/ADR-017-tiered-memory-index-architecture.md
+++ b/.agents/architecture/ADR-017-tiered-memory-index-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-017
 status: accepted
-date: 2025-12-23
+date: 2025-12-28
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-018-cache-invalidation-strategy.md
+++ b/.agents/architecture/ADR-018-cache-invalidation-strategy.md
@@ -1,3 +1,14 @@
+---
+id: ADR-018
+status: accepted
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-018: Cache Invalidation Strategy for GitHub Data
 
 **Status**: Accepted

--- a/.agents/architecture/ADR-019-script-organization.md
+++ b/.agents/architecture/ADR-019-script-organization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-019
+status: accepted
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-019: Script Organization and Usage Patterns
 
 ## Status

--- a/.agents/architecture/ADR-020-feature-request-review-step.md
+++ b/.agents/architecture/ADR-020-feature-request-review-step.md
@@ -1,9 +1,18 @@
 ---
+id: ADR-020
 status: proposed
 date: 2025-12-19
-decision-makers: ["architect", "user"]
-consulted: ["analyst", "roadmap"]
-informed: ["implementer", "devops"]
+decision-makers: [architect, user]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+consulted:
+- analyst
+- roadmap
+informed:
+- implementer
+- devops
 ---
 
 # ADR-020: Feature Request Review Step in Issue Triage Workflow

--- a/.agents/architecture/ADR-020-feature-request-review-step.md
+++ b/.agents/architecture/ADR-020-feature-request-review-step.md
@@ -15,6 +15,8 @@ informed:
 - devops
 ---
 
+<!-- # taste-lint: ignore file-size (long-form prose ADR at 502 lines; the 500-line limit targets code cohesion and does not apply to a decision record, cf. ADR-035 which carries the same exemption) -->
+
 # ADR-020: Feature Request Review Step in Issue Triage Workflow
 
 ## Context and Problem Statement

--- a/.agents/architecture/ADR-021-model-routing-strategy.md
+++ b/.agents/architecture/ADR-021-model-routing-strategy.md
@@ -1,3 +1,14 @@
+---
+id: ADR-021
+status: accepted
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-021: AI Review Model Routing Strategy
 
 ## Status
@@ -135,7 +146,7 @@ All three components (routing + evidence rules + escalation) are required.
 
 ### Negative
 
-1. **More false WARN**: By design—conservative stance shifts false PASS to false WARN
+1. **More false WARN**: By design: conservative stance shifts false PASS to false WARN
 2. **Higher cost for escalations**: Escalation to Opus increases cost/latency for borderline cases
 3. **PR resizing pressure**: Some PRs may require resizing to get PASS verdict
 4. **Operational complexity**: Routing logic, escalation triggers, fallback handling add complexity

--- a/.agents/architecture/ADR-022-architecture-governance-split-criteria.md
+++ b/.agents/architecture/ADR-022-architecture-governance-split-criteria.md
@@ -1,3 +1,14 @@
+---
+id: ADR-022
+status: proposed
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-022: Architecture vs Governance Decision Split Criteria
 
 ## Status

--- a/.agents/architecture/ADR-023-quality-gate-prompt-testing.md
+++ b/.agents/architecture/ADR-023-quality-gate-prompt-testing.md
@@ -1,9 +1,22 @@
 ---
+id: ADR-023
 status: accepted
 date: 2025-12-26
-decision-makers: ["architect", "user"]
-consulted: ["qa", "devops", "security", "critic", "independent-thinker", "high-level-advisor"]
-informed: ["implementer", "analyst"]
+decision-makers: [architect, user]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+consulted:
+- qa
+- devops
+- security
+- critic
+- independent-thinker
+- high-level-advisor
+informed:
+- implementer
+- analyst
 ---
 
 # ADR-023: Quality Gate Prompt Structural Validation

--- a/.agents/architecture/ADR-026-pr-automation-concurrency-and-safety.md
+++ b/.agents/architecture/ADR-026-pr-automation-concurrency-and-safety.md
@@ -127,7 +127,7 @@ function Test-SafeBranchName {
 **Rejected Alternative**: Deploy live immediately
 - **Why rejected**: Automation bugs could close valid PRs or corrupt data; reversible after confidence established
 
-**Update (2024-12-24)**: Dry run flag removed entirely after successful validation period.
+**Update (2025-12-24)**: Dry run flag removed entirely after successful validation period.
 - **Reason**: Bug in dry run flag parsing caused scheduled runs to incorrectly operate in dry run mode (empty string evaluated as true)
 - **Solution**: Simplified by removing the flag - workflow now always performs actual operations
 - **Impact**: Net reduction of 76 lines of code, simpler maintainability

--- a/.agents/architecture/ADR-026-pr-automation-concurrency-and-safety.md
+++ b/.agents/architecture/ADR-026-pr-automation-concurrency-and-safety.md
@@ -1,3 +1,14 @@
+---
+id: ADR-026
+status: accepted
+date: 2026-07-27
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-026: PR Automation Concurrency and Safety Controls
 
 ## Status

--- a/.agents/architecture/ADR-027-github-mcp-agent-isolation.md
+++ b/.agents/architecture/ADR-027-github-mcp-agent-isolation.md
@@ -1,7 +1,12 @@
 ---
+id: ADR-027
 status: proposed
 date: 2025-12-23
-decision-makers: User, Architect Agent
+decision-makers: [User, Architect Agent]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
 consulted: Analyst (Session 80), Independent-Thinker
 informed: Implementer, DevOps, Orchestrator
 ---

--- a/.agents/architecture/ADR-028-powershell-output-schema-consistency.md
+++ b/.agents/architecture/ADR-028-powershell-output-schema-consistency.md
@@ -1,3 +1,14 @@
+---
+id: ADR-028
+status: accepted
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-028: PowerShell Output Schema Consistency
 
 ## Status

--- a/.agents/architecture/ADR-029-skill-file-line-ending-normalization.md
+++ b/.agents/architecture/ADR-029-skill-file-line-ending-normalization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-029
+status: accepted
+date: 2025-12-27
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-029: Skill File Line Ending Normalization
 
 ## Status

--- a/.agents/architecture/ADR-030-skills-pattern-superiority.md
+++ b/.agents/architecture/ADR-030-skills-pattern-superiority.md
@@ -12,7 +12,7 @@ implemented: false
 # ADR-030: Skills Pattern Superiority
 
 **Date**: 2025-12-23
-**Status**: Critical Update - Changes Recommendation
+**Status**: Rejected (historically recorded as "Critical Update - Changes Recommendation"; see the record note below)
 
 > **Record note (2026-08-25).** This is an amendment memo to ADR-027 (GitHub MCP
 > Server with Agent Isolation Pattern, same date, still `proposed`), proposing

--- a/.agents/architecture/ADR-030-skills-pattern-superiority.md
+++ b/.agents/architecture/ADR-030-skills-pattern-superiority.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-030
 status: rejected
-date: 2025-12-23
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-030-skills-pattern-superiority.md
+++ b/.agents/architecture/ADR-030-skills-pattern-superiority.md
@@ -1,7 +1,24 @@
+---
+id: ADR-030
+status: rejected
+date: 2025-12-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-030: Skills Pattern Superiority
 
 **Date**: 2025-12-23
 **Status**: Critical Update - Changes Recommendation
+
+> **Record note (2026-08-25).** This is an amendment memo to ADR-027 (GitHub MCP
+> Server with Agent Isolation Pattern, same date, still `proposed`), proposing
+> "Option E" (GitHub skill plus direct MCP access). Option E as specified was not
+> built: `.claude/skills/github/SKILL.md` wraps Python scripts rather than
+> declaring `allowed-tools: mcp__github__*`.
 
 ---
 

--- a/.agents/architecture/ADR-031-hybrid-powershell-architecture.md
+++ b/.agents/architecture/ADR-031-hybrid-powershell-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-031
+status: proposed
+date: 2025-12-29
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-031: Hybrid PowerShell Architecture for Claude Code Performance
 
 ## Status

--- a/.agents/architecture/ADR-032-ears-requirements-syntax.md
+++ b/.agents/architecture/ADR-032-ears-requirements-syntax.md
@@ -1,3 +1,14 @@
+---
+id: ADR-032
+status: accepted
+date: 2025-12-30
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-032: EARS Requirements Syntax Standard
 
 ## Status
@@ -118,7 +129,7 @@ EARS was developed by Alistair Mavin et al. at Rolls-Royce and has been validate
 
 **Exit criteria**: EARS patterns prove insufficient OR overhead exceeds benefit.
 
-**Rollback path**: Revert to natural language requirements. No migration required—delete template and write informal prose. Lock-in level: **None** (EARS is a syntax convention, not infrastructure).
+**Rollback path**: Revert to natural language requirements. No migration required: delete template and write informal prose. Lock-in level: **None** (EARS is a syntax convention, not infrastructure).
 
 ## Implementation Notes
 

--- a/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
+++ b/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-033
 status: accepted
-date: 2025-12-30
+date: 2026-08-16
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
+++ b/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
@@ -1,3 +1,14 @@
+---
+id: ADR-033
+status: accepted
+date: 2025-12-30
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-033: Routing-Level Enforcement Gates
 
 ## Status

--- a/.agents/architecture/ADR-034-investigation-session-qa-exemption.md
+++ b/.agents/architecture/ADR-034-investigation-session-qa-exemption.md
@@ -1,15 +1,19 @@
 ---
+id: ADR-034
 status: accepted
-date: 2025-12-30
-decision-makers:
-  - orchestrator
+date: 2026-07-08
+decision-makers: [orchestrator]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
 consulted:
-  - analyst
-  - architect
-  - security
-  - critic
-  - independent-thinker
-  - high-level-advisor
+- analyst
+- architect
+- security
+- critic
+- independent-thinker
+- high-level-advisor
 informed: []
 ---
 

--- a/.agents/architecture/ADR-035-exit-code-standardization.md
+++ b/.agents/architecture/ADR-035-exit-code-standardization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-035
+status: accepted
+date: 2025-12-30
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-035: Exit Code Standardization
 
 <!-- # taste-lint: ignore file-size (long-form ADR; the 500-line code-cohesion limit does not apply to prose ADRs, cf. ADR-013 at 597, ADR-022 at 604, ADR-037 at 593, all accepted over the limit) -->

--- a/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
+++ b/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-036
 status: accepted
-date: 2026-01-01
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
+++ b/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
@@ -13,7 +13,9 @@ implemented: true
 
 ## Status
 
-Accepted
+Accepted. (Updated 2026-08-25: two stale `Generate-Agents.ps1` references
+repointed to `build/generate_agents.py`, which this record already named
+correctly elsewhere. The decision itself is unchanged.)
 
 ## Date
 

--- a/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
+++ b/.agents/architecture/ADR-036-two-source-agent-template-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-036
+status: accepted
+date: 2026-01-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-036: Two-Source Agent Template Architecture
 
 ## Status
@@ -50,7 +61,7 @@ Adopt a **two-source architecture**:
 - **Maintenance**: Manual edits, auto-generates outputs
 - **Content**: Shared prompts applicable to both Copilot platforms
 - **Files**: 18 template files
-- **Generates**: `src/copilot-cli/*.agent.md` and `src/vs-code-agents/*.md` via `build/Generate-Agents.ps1`
+- **Generates**: `src/copilot-cli/*.agent.md` and `src/vs-code-agents/*.md` via `build/generate_agents.py`
 
 ### Synchronization Requirement
 
@@ -98,7 +109,7 @@ The pre-commit hook handles generation but NOT content synchronization between s
 ### Neutral
 
 - Total agent count unchanged (18 agents x 3 platforms = 54 outputs)
-- Build complexity localized to `Generate-Agents.ps1`
+- Build complexity localized to `generate_agents.py`
 
 ## Implementation Notes
 

--- a/.agents/architecture/ADR-037-memory-router-architecture.md
+++ b/.agents/architecture/ADR-037-memory-router-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-037
+status: accepted
+date: 2026-07-20
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-037: Memory Router Architecture
 
 **Status**: Accepted

--- a/.agents/architecture/ADR-038-reflexion-memory-schema.md
+++ b/.agents/architecture/ADR-038-reflexion-memory-schema.md
@@ -1,3 +1,14 @@
+---
+id: ADR-038
+status: proposed
+date: 2026-01-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-038: Reflexion Memory Schema
 
 ## Status

--- a/.agents/architecture/ADR-039-agent-model-cost-optimization.md
+++ b/.agents/architecture/ADR-039-agent-model-cost-optimization.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-039
 status: deprecated
-date: 2026-01-03
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-039-agent-model-cost-optimization.md
+++ b/.agents/architecture/ADR-039-agent-model-cost-optimization.md
@@ -1,6 +1,61 @@
+---
+id: ADR-039
+status: deprecated
+date: 2026-01-03
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-039: Agent Model Cost Optimization
 
 ## Status
+
+Deprecated (2026-08-25). The provisional window below closed without
+validation, and the changes it made were reverted.
+
+### How the provisional window actually ended (recorded 2026-08-25)
+
+The original status is retained verbatim below. This section records what
+happened to it, because for seven months the record said "provisional pending
+validation" for a window that had already expired.
+
+**Zero of the four Final Acceptance Criteria were ever measured.** The criteria
+listed below call for monitoring data on error rates, missed security issues,
+architecture-decision quality, and user satisfaction.
+`.agents/governance/model-pin-evidence.json`, the sidecar that would hold such
+evidence, contains `"pins": []`. No validation verdict, pass or fail, was ever
+recorded anywhere.
+
+**The downgrades were reverted, but not through this ADR's rollback
+procedure.** The per-agent rollback documented in this record's Implementation
+section was never executed. The assignments were reverted incidentally on
+2026-02-07, three weeks after the window closed, as a side effect of commit
+`568af6775` (PR #1046, "migrate agent prompts from cloudmcp-manager to Memory
+Router (ADR-037)"), which rewrote 41 agent prompt files for an unrelated reason.
+That commit does not mention ADR-039 at all. Verified against the live tree: the
+six agents this ADR downgraded all read `model: opus` today, which is ADR-002's
+assignment.
+
+**`supersedes` is `[]`, deliberately.** This ADR claims to supersede ADR-002
+"pending validation". The validation never happened and the assignments were
+undone, so the supersession never took effect. Recording it in the frontmatter
+would assert a relationship that does not hold. ADR-002 is deprecated in the same
+change, on its own separate grounds.
+
+**Why `deprecated` and not `rejected`.** This repository uses `rejected` for a
+proposal declined before it was ever in force: ADR-095 ("Recorded so the proposal
+is findable and does not return") and ADR-061 (withdrawn before acceptance). That
+is not this record. ADR-039's changes were implemented and ran in production for
+roughly five weeks, from 2026-01-03 until the incidental revert. `deprecated`
+means "was in force, no longer is", which is what happened here. `implemented` is
+`true` for the same reason, and it stays true despite the revert: the field gates
+amend-versus-supersede, and a decision whose code shipped must not be silently
+amended even after that code is gone.
+
+### Original status (2026-01-03), retained
 
 **PROVISIONAL** (2026-01-03 to 2026-01-17)
 

--- a/.agents/architecture/ADR-039-agent-model-cost-optimization.md
+++ b/.agents/architecture/ADR-039-agent-model-cost-optimization.md
@@ -273,7 +273,10 @@ git revert f101c06 d81f237 651205a
 
 ## Related Decisions
 
-- [ADR-002: Agent Model Selection Optimization](ADR-002-agent-model-selection-optimization.md) - Superseded
+- [ADR-002: Agent Model Selection Optimization](ADR-002-agent-model-selection-optimization.md)
+  - The supersession this record originally claimed never took effect, so
+    `supersedes` is `[]`. See the 2026-08-25 status resolution above. ADR-002 is
+    deprecated on its own separate grounds.
 - ADR-007: Memory-First Architecture - Memory agent performance (reference only)
 
 ## References

--- a/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
+++ b/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-040
 status: accepted
-date: 2026-01-03
+date: 2026-07-11
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
+++ b/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-040
 status: accepted
-date: 2026-07-11
+date: 2026-08-14
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
+++ b/.agents/architecture/ADR-040-skill-frontmatter-standardization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-040
+status: accepted
+date: 2026-01-03
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-040: Skill Frontmatter Standardization and Model Identifier Strategy
 
 ## Status

--- a/.agents/architecture/ADR-041-codeql-integration.md
+++ b/.agents/architecture/ADR-041-codeql-integration.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-041
 status: accepted
-date: 2026-01-16
+date: 2026-07-21
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-041-codeql-integration.md
+++ b/.agents/architecture/ADR-041-codeql-integration.md
@@ -1,3 +1,14 @@
+---
+id: ADR-041
+status: accepted
+date: 2026-01-16
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-041: CodeQL Integration Multi-Tier Strategy
 
 **Status**: Accepted as amended (adr-review consensus 2026-07-21: 6/6 Accept, comprising 5 clean Accept and 1 Accept-with-changes whose two required changes are applied below). Originally Accepted 2026-01-16; amended 2026-07-21 to retire Tier 3 (automatic PostToolUse quick scan) and simplify to a two-tier strategy, per this ADR's own 6-month re-evaluation clause. See the Amendment section below.

--- a/.agents/architecture/ADR-042-python-migration-strategy.md
+++ b/.agents/architecture/ADR-042-python-migration-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-042
 status: accepted
-date: 2026-01-17
+date: 2026-04-13
 decision-makers: [rjmurillo]
 supersedes: [ADR-005]
 superseded-by: null

--- a/.agents/architecture/ADR-042-python-migration-strategy.md
+++ b/.agents/architecture/ADR-042-python-migration-strategy.md
@@ -1,3 +1,14 @@
+---
+id: ADR-042
+status: accepted
+date: 2026-01-17
+decision-makers: [rjmurillo]
+supersedes: [ADR-005]
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-042: Python Migration Strategy
 
 ## Status

--- a/.agents/architecture/ADR-043-scoped-tool-execution.md
+++ b/.agents/architecture/ADR-043-scoped-tool-execution.md
@@ -1,3 +1,14 @@
+---
+id: ADR-043
+status: accepted
+date: 2026-01-21
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-043: Scoped Tool Execution
 
 ## Status

--- a/.agents/architecture/ADR-045-framework-extraction-via-plugin-marketplace.md
+++ b/.agents/architecture/ADR-045-framework-extraction-via-plugin-marketplace.md
@@ -1,3 +1,14 @@
+---
+id: ADR-045
+status: accepted
+date: 2026-02-07
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-045: Framework Extraction via Plugin Marketplace
 
 ## Status

--- a/.agents/architecture/ADR-046-planning-agent-rename.md
+++ b/.agents/architecture/ADR-046-planning-agent-rename.md
@@ -1,3 +1,14 @@
+---
+id: ADR-046
+status: accepted
+date: 2026-02-08
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-046: Planning Agent Rename for Role Clarity
 
 ## Status

--- a/.agents/architecture/ADR-047-plugin-mode-hook-behavior.md
+++ b/.agents/architecture/ADR-047-plugin-mode-hook-behavior.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-047
 status: accepted
-date: 2026-02-16
+date: 2026-04-29
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-047-plugin-mode-hook-behavior.md
+++ b/.agents/architecture/ADR-047-plugin-mode-hook-behavior.md
@@ -1,3 +1,14 @@
+---
+id: ADR-047
+status: accepted
+date: 2026-02-16
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-047: Plugin-Mode Hook Behavior
 
 ## Status

--- a/.agents/architecture/ADR-048-mcp-tool-ecosystem-expansion.md
+++ b/.agents/architecture/ADR-048-mcp-tool-ecosystem-expansion.md
@@ -1,3 +1,14 @@
+---
+id: ADR-048
+status: proposed
+date: 2026-02-23
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-048: MCP Tool Ecosystem Expansion
 
 ## Status

--- a/.agents/architecture/ADR-049-pre-pr-validation-gates.md
+++ b/.agents/architecture/ADR-049-pre-pr-validation-gates.md
@@ -1,3 +1,14 @@
+---
+id: ADR-049
+status: proposed
+date: 2026-02-24
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-049: Pre-PR Validation Gates
 
 ## Status

--- a/.agents/architecture/ADR-050-adr-protocol-sync.md
+++ b/.agents/architecture/ADR-050-adr-protocol-sync.md
@@ -1,3 +1,14 @@
+---
+id: ADR-050
+status: accepted
+date: 2026-02-21
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-050: ADR-to-Protocol Sync Process
 
 ## Status

--- a/.agents/architecture/ADR-051-synthesis-panel-frontmatter-standard.md
+++ b/.agents/architecture/ADR-051-synthesis-panel-frontmatter-standard.md
@@ -1,3 +1,14 @@
+---
+id: ADR-051
+status: accepted
+date: 2026-03-07
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-051: Synthesis Panel Frontmatter Standard
 
 ## Status

--- a/.agents/architecture/ADR-052-template-strategy.md
+++ b/.agents/architecture/ADR-052-template-strategy.md
@@ -1,6 +1,6 @@
 ---
 id: ADR-052
-status: proposed
+status: rejected
 date: 2026-03-01
 decision-makers: [rjmurillo]
 supersedes: []
@@ -13,7 +13,39 @@ implemented: false
 
 ## Status
 
-Proposed. Supersedes ADR-036.
+Rejected (2026-08-25).
+
+The supersession of ADR-036 that this line used to claim is withdrawn, and the
+frontmatter carries `supersedes: []`. The proposal below never took effect, so
+there is nothing for it to have superseded. ADR-036 remains the live, operative
+architecture.
+
+### Rejection rationale (2026-08-25)
+
+This ADR proposed eliminating `templates/` in favour of generating platform
+variants from `src/claude/` (its "Option B"). More than five months on, none of
+that was built and the pattern it proposed to replace is still what runs:
+
+- `build/scripts/generate_platform_agents.py`, the generator this ADR specifies,
+  does not exist. Neither does `platform-overrides/`.
+- `templates/agents/*.shared.md` is still the live mechanism. There are 31 such
+  files, and `build/generate_agents.py` reads them on every build.
+
+The central evidence was also already answered before this ADR was written. It
+rests on a 2 to 13 percent similarity measurement between the templates and the
+Claude agents, presented as sync failure. ADR-036 had addressed exactly that
+measurement: "Claude agents contain Claude-specific sections (MCP tool
+references, Serena memory protocols, handoff instructions) that have no
+equivalent on other platforms. Similarity metrics comparing Claude to templates
+measure divergence that is **BY DESIGN**, not sync failure." This ADR does not
+engage that rebuttal anywhere.
+
+Issue #124 (the standing question of whether the two-source template pattern
+should continue, referenced in ADR-036) remains open and unresolved. This
+rejection closes ADR-052's specific proposal, not the underlying question.
+
+`implemented` is `false`, which is accurate: nothing this ADR proposed ever
+merged.
 
 ## Author
 

--- a/.agents/architecture/ADR-052-template-strategy.md
+++ b/.agents/architecture/ADR-052-template-strategy.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-052
 status: rejected
-date: 2026-03-01
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-052-template-strategy.md
+++ b/.agents/architecture/ADR-052-template-strategy.md
@@ -1,3 +1,14 @@
+---
+id: ADR-052
+status: proposed
+date: 2026-03-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-052: Template Strategy for Multi-Platform Agent Distribution
 
 ## Status

--- a/.agents/architecture/ADR-053-adr-exception-criteria.md
+++ b/.agents/architecture/ADR-053-adr-exception-criteria.md
@@ -1,3 +1,14 @@
+---
+id: ADR-053
+status: accepted
+date: 2026-03-07
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-053: ADR Exception Criteria (Chesterton's Fence)
 
 ## Status
@@ -29,9 +40,9 @@ The broader issue is that ADR exceptions are structurally easier to create than 
 
 The analysis MUST answer three questions:
 
-1. **Why does the rule exist?** — Quote the original ADR rationale. Paraphrase is not acceptable.
-2. **Impact if removed?** — Document what breaks, degrades, or sets problematic precedent.
-3. **Alternatives tried?** — List at least two compliance attempts and their outcomes.
+1. **Why does the rule exist?**: Quote the original ADR rationale. Paraphrase is not acceptable.
+2. **Impact if removed?**: Document what breaks, degrades, or sets problematic precedent.
+3. **Alternatives tried?**: List at least two compliance attempts and their outcomes.
 
 Exceptions that do not include this analysis are rejected by the architect agent.
 
@@ -75,14 +86,14 @@ The analysis template and rejection criteria are documented in `.agents/governan
 
 ## Implementation Notes
 
-1. `.agents/governance/ADR-EXCEPTION-CRITERIA.md` — criteria document and exception template (this PR).
-2. `src/claude/architect.md` — exception validation checklist added to ADR Review section (this PR).
+1. `.agents/governance/ADR-EXCEPTION-CRITERIA.md`: criteria document and exception template (this PR).
+2. `src/claude/architect.md`: exception validation checklist added to ADR Review section (this PR).
 3. Existing ADR-005 exceptions remain valid; no retroactive revocation.
 
 ## Related Decisions
 
-- [ADR-005](./ADR-005-powershell-only-scripting.md) — Motivating case (PR #908 (2026-01-14) exception)
-- [ADR-022](./ADR-022-architecture-governance-split-criteria.md) — Governance split criteria
+- [ADR-005](./ADR-005-powershell-only-scripting.md): Motivating case (PR #908 (2026-01-14) exception)
+- [ADR-022](./ADR-022-architecture-governance-split-criteria.md): Governance split criteria
 
 ## Confirmation
 

--- a/.agents/architecture/ADR-054-local-security-scanning.md
+++ b/.agents/architecture/ADR-054-local-security-scanning.md
@@ -1,3 +1,14 @@
+---
+id: ADR-054
+status: accepted
+date: 2026-07-20
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-054: Local Security Scanning
 
 **Status**: Accepted (amended 2026-05-02)

--- a/.agents/architecture/ADR-055-github-actions-runner-selection.md
+++ b/.agents/architecture/ADR-055-github-actions-runner-selection.md
@@ -1,3 +1,14 @@
+---
+id: ADR-055
+status: accepted
+date: 2025-12-29
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-055: GitHub Actions Runner Selection
 
 **Status**: Accepted (supersedes ADR-024, ADR-025)

--- a/.agents/architecture/ADR-055-github-actions-runner-selection.md
+++ b/.agents/architecture/ADR-055-github-actions-runner-selection.md
@@ -18,7 +18,7 @@ implemented: true
 > ADR-073 frontmatter yet, so claiming the relationship here would leave a
 > one-sided reference with no reciprocal `superseded-by` on the other end. Issue
 > #5192 owns both targets and owes the reciprocal edit; the claim returns to this
-> record when it can be made from both sides at once.
+> record when it can be made from both sides at once. (Struck 2026-08-25.)
 
 **Date**: 2025-12-29
 **Authors**: DevOps Agent

--- a/.agents/architecture/ADR-055-github-actions-runner-selection.md
+++ b/.agents/architecture/ADR-055-github-actions-runner-selection.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-055
 status: accepted
-date: 2025-12-29
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null
@@ -19,6 +19,7 @@ implemented: true
 > one-sided reference with no reciprocal `superseded-by` on the other end. Issue
 > #5192 owns both targets and owes the reciprocal edit; the claim returns to this
 > record when it can be made from both sides at once.
+
 **Date**: 2025-12-29
 **Authors**: DevOps Agent
 **Related**: Issue #197

--- a/.agents/architecture/ADR-055-github-actions-runner-selection.md
+++ b/.agents/architecture/ADR-055-github-actions-runner-selection.md
@@ -11,7 +11,14 @@ implemented: true
 
 # ADR-055: GitHub Actions Runner Selection
 
-**Status**: Accepted (supersedes ADR-024, ADR-025)
+**Status**: Accepted
+
+> The supersession of ADR-024 and ADR-025 that this line used to assert is not
+> recorded in the frontmatter, which carries `supersedes: []`. Neither target has
+> ADR-073 frontmatter yet, so claiming the relationship here would leave a
+> one-sided reference with no reciprocal `superseded-by` on the other end. Issue
+> #5192 owns both targets and owes the reciprocal edit; the claim returns to this
+> record when it can be made from both sides at once.
 **Date**: 2025-12-29
 **Authors**: DevOps Agent
 **Related**: Issue #197

--- a/.agents/architecture/ADR-056-skill-output-format-standardization.md
+++ b/.agents/architecture/ADR-056-skill-output-format-standardization.md
@@ -1,3 +1,14 @@
+---
+id: ADR-056
+status: accepted
+date: 2026-03-08
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-056: Skill Output Format Standardization
 
 ## Status
@@ -23,7 +34,7 @@ ADR-028 established that all properties should be included in output objects. AD
 1. **All skill scripts MUST wrap output in a standard envelope** with `Success`, `Data`, `Error`, and `Metadata` fields
 2. **Scripts MUST accept `-OutputFormat`** parameter with values `JSON`, `Human`, `Auto` (default: `Auto`)
 3. **`Auto` resolves to `JSON`** when stdout is redirected or in CI; `Human` when interactive
-4. **JSON mode emits only valid JSON** to the success output stream — no `Write-Host`
+4. **JSON mode emits only valid JSON** to the success output stream, no `Write-Host`
 5. **Human mode writes a compact summary** to the host with color-coded status
 6. **Error responses use a standard envelope** with `ErrorCode` enum values aligned to ADR-035 exit codes
 7. **Exit codes continue to follow ADR-035**

--- a/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
+++ b/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
@@ -1,9 +1,20 @@
 ---
+id: ADR-057
 status: accepted
-date: 2026-04-19
-decision-makers: ["architect", "user"]
-consulted: ["qa", "security", "critic"]
-informed: ["implementer", "analyst", "devops"]
+date: 2026-07-22
+decision-makers: [architect, user]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+consulted:
+- qa
+- security
+- critic
+informed:
+- implementer
+- analyst
+- devops
 ---
 
 # ADR-057: Prompt Behavioral Evaluation Methodology

--- a/.agents/architecture/ADR-058-agent-eval-discipline.md
+++ b/.agents/architecture/ADR-058-agent-eval-discipline.md
@@ -1,9 +1,21 @@
 ---
+id: ADR-058
 status: proposed
 date: 2026-05-03
-decision-makers: ["architect", "user"]
-consulted: ["qa", "security", "critic", "analyst", "implementer"]
-informed: ["devops", "memory"]
+decision-makers: [architect, user]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+consulted:
+- qa
+- security
+- critic
+- analyst
+- implementer
+informed:
+- devops
+- memory
 ---
 
 # ADR-058: Agent Eval Discipline (Agent-vs-Baseline Efficacy)

--- a/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
+++ b/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
@@ -1,3 +1,14 @@
+---
+id: ADR-059
+status: proposed
+date: 2026-05-08
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-059: /pr-review Completion Gate Dispatcher and pass_when DSL
 
 ## Status

--- a/.agents/architecture/ADR-060-rework-warning-session-log-persistence.md
+++ b/.agents/architecture/ADR-060-rework-warning-session-log-persistence.md
@@ -1,3 +1,14 @@
+---
+id: ADR-060
+status: accepted
+date: 2026-05-25
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-060: Rework Warning Evidence Persistence in Session Log JSON
 
 ## Status

--- a/.agents/architecture/ADR-060-rework-warning-session-log-persistence.md
+++ b/.agents/architecture/ADR-060-rework-warning-session-log-persistence.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-060
 status: accepted
-date: 2026-05-25
+date: 2026-07-27
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
+++ b/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
@@ -25,7 +25,7 @@ the frontmatter agree on their first token as ADR-073 requires. `rejected` is th
 value this repository already uses for a proposal declined before acceptance and
 retained so it stays findable: see ADR-095, whose prose reads "Rejected. Recorded
 so the proposal is findable and does not return." The parenthetical carries the
-nuance the enum cannot.
+nuance the enum cannot. (Prose reconciled 2026-08-25.)
 
 ## Date
 

--- a/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
+++ b/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-061
 status: rejected
-date: 2026-05-27
+date: 2026-07-27
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null
@@ -13,15 +13,19 @@ implemented: false
 
 ## Status
 
-Withdrawn (2026-05-27, before acceptance, based on 6-agent debate verdict)
+Rejected (withdrawn 2026-05-27, before acceptance, based on 6-agent debate
+verdict).
 
-The ADR-073 lifecycle frontmatter on this record carries `status: rejected`. The
-schema enum is `proposed | accepted | rejected | deprecated | superseded` and has
-no `withdrawn` member. `rejected` is the enum value this repository already uses
-for a proposal that was declined before acceptance and is retained so it stays
-findable: see ADR-095, whose prose reads "Rejected. Recorded so the proposal is
-findable and does not return." The prose above remains the accurate account of
-what happened; the enum is the machine-readable approximation of it.
+The word used at the time was "withdrawn", and it is the accurate account of
+what happened: the author pulled the proposal rather than a reviewer declining
+it. The ADR-073 enum is `proposed | accepted | rejected | deprecated |
+superseded` and has no `withdrawn` member, so this record carries
+`status: rejected`, and the leading word here is `Rejected` so that the prose and
+the frontmatter agree on their first token as ADR-073 requires. `rejected` is the
+value this repository already uses for a proposal declined before acceptance and
+retained so it stays findable: see ADR-095, whose prose reads "Rejected. Recorded
+so the proposal is findable and does not return." The parenthetical carries the
+nuance the enum cannot.
 
 ## Date
 

--- a/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
+++ b/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-061
 status: rejected
-date: 2026-07-27
+date: 2026-08-25
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
+++ b/.agents/architecture/ADR-061-hook-matcher-shims-delegate-pattern.md
@@ -1,8 +1,27 @@
+---
+id: ADR-061
+status: rejected
+date: 2026-05-27
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-061: Hook Matcher Shims Delegate to Canonical Body
 
 ## Status
 
 Withdrawn (2026-05-27, before acceptance, based on 6-agent debate verdict)
+
+The ADR-073 lifecycle frontmatter on this record carries `status: rejected`. The
+schema enum is `proposed | accepted | rejected | deprecated | superseded` and has
+no `withdrawn` member. `rejected` is the enum value this repository already uses
+for a proposal that was declined before acceptance and is retained so it stays
+findable: see ADR-095, whose prose reads "Rejected. Recorded so the proposal is
+findable and does not return." The prose above remains the accurate account of
+what happened; the enum is the machine-readable approximation of it.
 
 ## Date
 

--- a/.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md
+++ b/.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md
@@ -1,3 +1,14 @@
+---
+id: ADR-062
+status: accepted
+date: 2026-05-31
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-062: Conditional LSP-First Navigation Enforcement
 
 ## Status

--- a/.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md
+++ b/.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-062
 status: accepted
-date: 2026-05-31
+date: 2026-07-27
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-063-memory-skill-decomposition.md
+++ b/.agents/architecture/ADR-063-memory-skill-decomposition.md
@@ -20,8 +20,6 @@ adr-review gate for this status flip; this acceptance records the human decision
 and does not append a fabricated debate log. Architect-review record:
 `.agents/critique/ADR-063-debate-log.md`.
 
-status: accepted
-
 ## Date
 
 2026-06-01

--- a/.agents/architecture/ADR-063-memory-skill-decomposition.md
+++ b/.agents/architecture/ADR-063-memory-skill-decomposition.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-063
 status: accepted
-date: 2026-06-01
+date: 2026-07-27
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-063-memory-skill-decomposition.md
+++ b/.agents/architecture/ADR-063-memory-skill-decomposition.md
@@ -1,3 +1,14 @@
+---
+id: ADR-063
+status: accepted
+date: 2026-06-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-063: Decompose the Memory Skill Into Focused Sub-Skills
 
 ## Status

--- a/.agents/architecture/ADR-064-commands-to-skills-migration.md
+++ b/.agents/architecture/ADR-064-commands-to-skills-migration.md
@@ -15,8 +15,6 @@ implemented: false
 
 Proposed
 
-status: proposed
-
 ## Date
 
 2026-06-01

--- a/.agents/architecture/ADR-064-commands-to-skills-migration.md
+++ b/.agents/architecture/ADR-064-commands-to-skills-migration.md
@@ -1,3 +1,14 @@
+---
+id: ADR-064
+status: proposed
+date: 2026-06-01
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-064: Retire `.claude/commands/` as a Canonical Authoring Surface; Skills Are the Single User-Invocable Surface
 
 ## Status

--- a/.agents/architecture/ADR-065-orchestrator-as-router.md
+++ b/.agents/architecture/ADR-065-orchestrator-as-router.md
@@ -1,3 +1,14 @@
+---
+id: ADR-065
+status: proposed
+date: 2026-05-29
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-065: Orchestrator Is a Deterministic Router and Retry Policy, Not a Supervisor
 
 ## Status

--- a/.agents/architecture/ADR-066-hook-fail-open-reconciliation.md
+++ b/.agents/architecture/ADR-066-hook-fail-open-reconciliation.md
@@ -1,9 +1,22 @@
 ---
-status: "accepted"
-date: 2026-06-02
+id: ADR-066
+status: accepted
+date: 2026-07-19
 decision-makers: [architect]
-consulted: [analyst, critic, independent-thinker, security, high-level-advisor]
-informed: [implementer, qa, devops]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+consulted:
+- analyst
+- critic
+- independent-thinker
+- security
+- high-level-advisor
+informed:
+- implementer
+- qa
+- devops
 ---
 
 # ADR-066: Hook Fail-Open Reconciliation (Prevention-First, Fail-Closed-and-Loud)

--- a/.agents/architecture/ADR-067-validate-pr-change-claim-context.md
+++ b/.agents/architecture/ADR-067-validate-pr-change-claim-context.md
@@ -1,3 +1,14 @@
+---
+id: ADR-067
+status: proposed
+date: 2026-06-02
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-067: validate-pr Check 1 default-flip - change-claim context required
 
 ## Status

--- a/.agents/architecture/ADR-069-context-corpus-is-the-product.md
+++ b/.agents/architecture/ADR-069-context-corpus-is-the-product.md
@@ -1,9 +1,21 @@
 ---
+id: ADR-069
 status: proposed
 date: 2026-05-02
-decision-makers: ["architect", "user"]
-consulted: ["analyst", "critic", "qa"]
-informed: ["implementer", "devops", "security", "roadmap"]
+decision-makers: [architect, user]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+consulted:
+- analyst
+- critic
+- qa
+informed:
+- implementer
+- devops
+- security
+- roadmap
 ---
 
 # ADR-069: The Curated Context Corpus IS the Product, Orchestration Is Plumbing

--- a/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
+++ b/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-070
 status: proposed
-date: 2026-05-31
+date: 2026-07-27
 decision-makers: [rjmurillo]
 supersedes: []
 superseded-by: null

--- a/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
+++ b/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
@@ -1,3 +1,14 @@
+---
+id: ADR-070
+status: proposed
+date: 2026-05-31
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
+---
+
 # ADR-070: Memory-First Gate Is a BLOCKING Step in the Spec Pipeline
 
 ## Status

--- a/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
+++ b/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
@@ -1,5 +1,12 @@
 ---
+id: ADR-071
 status: accepted
+date: 2026-08-19
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: true
 ---
 
 # ADR-071: Plugin Hook Runtime-Contract Verification

--- a/.agents/architecture/ADR-072-jtbd-plugin-architecture.md
+++ b/.agents/architecture/ADR-072-jtbd-plugin-architecture.md
@@ -1,3 +1,14 @@
+---
+id: ADR-072
+status: proposed
+date: 2026-06-09
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
 # ADR-072: JTBD-Based Plugin Architecture with Per-Harness Emission
 
 ## Status

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -386,3 +386,4 @@ the batch here as it lands.
 | 3 | ADR-012, ADR-013, ADR-014, ADR-015 |
 | 4 | ADR-016, ADR-017, ADR-018, ADR-019 |
 | 5 | ADR-021, ADR-022, ADR-026, ADR-028 |
+| 6 | ADR-029, ADR-031, ADR-032, ADR-033 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -1,3 +1,5 @@
+<!-- # taste-lint: ignore file-size (review record covering 67 ADRs; the 500-line code-cohesion limit does not apply to a review log, and splitting it would break the adr-policy gate, which needs one staged debate log per ADR commit) -->
+
 # ADR-073 Phase 2 backfill: review and debate log
 
 Subject: ADR-073 lifecycle frontmatter across 68 records. Issues #5190 and

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -52,20 +52,58 @@ check `git rev-parse --is-shallow-repository` first.
 `accepted`; the nuance stays in prose. No prose was rewritten to fit the enum,
 with one deliberate exception recorded under ADR-061 below.
 
-**`date`.** The most recent date the record states in a date-bearing field: the
-`## Date` section (its last value when it lists several) or an inline `**Date**:`
-or `**Revised**:` line. Where no such field exists, and only there, the value is
-`git log --follow -1 --format=%ad --date=short`. Two records needed the git
-fallback: ADR-001 (2025-12-13) and ADR-026 (2026-07-27).
+**`date`.** ADR-073 line 54 comments the field `# last updated`, so the value is
+the latest date the record states about *itself* anywhere in the file, not the
+first date field found. A date counts when it appears in a self-referential
+update context:
 
-Amendment dates appearing only inside `## Status` prose are deliberately not
-used. This is a real trade and it is recorded rather than hidden: ADR-040's
-prose records a partial supersession dated 2026-07-11 while its frontmatter
-`date` reads 2026-01-03, and ADR-062 and ADR-063 have the same shape. The rule
-was kept because the issue's acceptance criterion names the `## Date` section as
-the source, and because a rule that scrapes narrative prose for dates is exactly
-the brittleness ADR-073 exists to remove. The cost is that `date` means "last
-dated field", not "last touched".
+- a `## Date` section value (every value, when it lists several);
+- any `**Date**:`, `**Revised**:`, or `**Updated**:` field, **all** of them, not
+  just the first;
+- an amendment or revision heading (`## Amendment 2026-07-21`,
+  `### Current-State Amendment (2026-08-16)`);
+- a dated amendment, acceptance, supersession, or withdrawal statement inside
+  `## Status`.
+
+Dates in evidence tables, cited incidents, PR references, and measurement rows
+are excluded: those are dates the record mentions, not dates the record was
+changed.
+
+Where no such context exists, and only there, the value is
+`git log --follow -1 --format=%ad --date=short origin/main -- <path>`. Two
+records need that fallback: ADR-001 (2025-12-13) and ADR-026 (2026-07-27). The
+ref matters. Reading `HEAD` instead of `origin/main` returns this branch's own
+backfill commit, so every record would be dated the day the backfill ran, which
+is circular.
+
+**This rule replaced an earlier, narrower one, and the correction changed 13 of
+the 53 records.** The first version read only formal date fields and deliberately
+ignored amendment dates carried in headings or `## Status` prose. That was
+disclosed as a trade at the time, but it was wrong on ADR-073's own terms,
+because `# last updated` does not mean "last formal Date field". Copilot's
+automated review on PR #5291 raised it and the objection is correct.
+
+The narrow rule was also buggy independent of the policy question. It matched
+`**Date**:` with a single `re.search`, which returns the first hit, so ADR-006's
+second formal `**Date**: 2026-04-28` field (belonging to its 2026-04-28
+amendment) was never seen. That record was wrong under the old rule's own stated
+terms, not merely under the new one.
+
+Corrected records, with the context that supplied the new value:
+
+| ADR | was | now | source |
+|-----|-----|-----|--------|
+| ADR-006 | 2025-12-18 | 2026-04-29 | `## Round 3 amendment-of-amendment (2026-04-29)` |
+| ADR-007 | 2026-01-01 | 2026-08-16 | `### Current-State Amendment (2026-08-16)` |
+| ADR-008 | 2025-12-20 | 2026-08-19 | `### Amendment 2026-08-19 (Issue #5168, PR #5170)` |
+| ADR-014 | 2025-12-22 | 2026-08-16 | `### Current-State Amendment (2026-08-16)` |
+| ADR-033 | 2025-12-30 | 2026-08-16 | `### Current-State Amendment (2026-08-16)` |
+| ADR-040 | 2026-01-03 | 2026-07-11 | dated supersession statement in `## Status` |
+| ADR-041 | 2026-01-16 | 2026-07-21 | `## Amendment 2026-07-21: Retire Tier 3` |
+| ADR-047 | 2026-02-16 | 2026-04-29 | dated amendment statement in `## Status` |
+| ADR-060, ADR-061, ADR-062, ADR-063, ADR-070 | various | 2026-07-27 | `## Amendment 2026-07-27`, the ADR-088 citation repoint that touched all five |
+
+ADR-001 and ADR-026 were re-derived and confirmed unchanged.
 
 **`decision-makers`.** `[rjmurillo]` on all 53. This follows ADR-073's own
 frontmatter, which lists only `rjmurillo` even though its acceptance rested on a
@@ -150,15 +188,26 @@ nowhere in the tree), ADR-072.
 
 ### Records carrying a status/implementation mismatch, deliberately
 
-Four records are `proposed` with `implemented: true`: ADR-038, ADR-049, ADR-059,
-ADR-067, plus ADR-070. This is not an error. It is the field behaving as ADR-073
-specifies, and it surfaces a real governance gap the schema was built to make
-visible: decisions that shipped without ever being formally accepted. ADR-070 is
-the clearest case, since its own Implementation Notes read "It documents an
-already-landed gate; it does not change the gate."
+**Eight records, counted against the final frontmatter state rather than against
+an earlier draft of this paragraph.**
 
-Three records are `accepted` with `implemented: false`: ADR-010, ADR-018,
-ADR-028. These are the mirror image, decisions accepted and never built.
+Five are `proposed` with `implemented: true`: ADR-038, ADR-049, ADR-059, ADR-067,
+ADR-070. This is not an error. It is the field behaving as ADR-073 specifies, and
+it surfaces a real governance gap the schema was built to make visible: decisions
+that shipped without ever being formally accepted. ADR-070 is the clearest case,
+since its own Implementation Notes read "It documents an already-landed gate; it
+does not change the gate."
+
+Three are `accepted` with `implemented: false`: ADR-010, ADR-018, ADR-028. The
+mirror image, decisions accepted and never built.
+
+An earlier version of this paragraph said "four records" while listing five, and
+a sixth record (ADR-013) was in the group because its `implemented` value was
+wrong. Copilot's automated review on PR #5291 caught both. ADR-013 is an Agent
+Orchestration MCP that was never built: there is no `mcp/` tree, and its three
+sibling MCP proposals (ADR-011, ADR-012, ADR-048) all carry `implemented: false`
+for exactly that reason. It was corrected to `false`, which removes it from this
+group. The count above is now generated from the files rather than transcribed.
 
 Both groups are worth a follow-up triage issue. Neither is fixed here, because
 changing a status is a governance act and this PR is a metadata backfill.
@@ -304,7 +353,8 @@ much they should weigh on a reviewer:
 3. `decision-makers` is uniformly `[rjmurillo]`, discarding `**Deciders**` lines
    that name other parties.
 4. ADR-052 and ADR-055 carry deliberately empty `supersedes` pending #5192.
-5. `date` tracks the last dated field, not the last amendment recorded in prose.
+5. `date` now tracks the latest self-referential update date anywhere in the
+   record, including amendment headings. This corrected 13 of the 53.
 
 ## Status mapping for all 53 records reviewed
 
@@ -312,15 +362,15 @@ much they should weigh on a reviewer:
 |-----|--------|------|------------|---------------|-------------|
 | ADR-001 | accepted | 2025-12-13 | [] | null | true |
 | ADR-005 | superseded | 2025-12-18 | [] | ADR-042 | true |
-| ADR-006 | accepted | 2025-12-18 | [] | null | true |
-| ADR-007 | accepted | 2026-01-01 | [] | null | true |
-| ADR-008 | accepted | 2025-12-20 | [] | null | true |
+| ADR-006 | accepted | 2026-04-29 | [] | null | true |
+| ADR-007 | accepted | 2026-08-16 | [] | null | true |
+| ADR-008 | accepted | 2026-08-19 | [] | null | true |
 | ADR-009 | accepted | 2025-12-20 | [] | null | true |
 | ADR-010 | accepted | 2025-12-20 | [] | null | false |
 | ADR-011 | proposed | 2025-12-21 | [] | null | false |
 | ADR-012 | proposed | 2025-12-21 | [] | null | false |
-| ADR-013 | proposed | 2025-12-21 | [] | null | true |
-| ADR-014 | accepted | 2025-12-22 | [] | null | true |
+| ADR-013 | proposed | 2025-12-21 | [] | null | false |
+| ADR-014 | accepted | 2026-08-16 | [] | null | true |
 | ADR-015 | accepted | 2025-12-22 | [] | null | true |
 | ADR-016 | accepted | 2025-12-22 | [] | null | true |
 | ADR-017 | accepted | 2025-12-23 | [] | null | true |
@@ -333,17 +383,17 @@ much they should weigh on a reviewer:
 | ADR-029 | accepted | 2025-12-27 | [] | null | true |
 | ADR-031 | proposed | 2025-12-29 | [] | null | false |
 | ADR-032 | accepted | 2025-12-30 | [] | null | true |
-| ADR-033 | accepted | 2025-12-30 | [] | null | true |
+| ADR-033 | accepted | 2026-08-16 | [] | null | true |
 | ADR-035 | accepted | 2025-12-30 | [] | null | true |
 | ADR-037 | accepted | 2026-07-20 | [] | null | true |
 | ADR-038 | proposed | 2026-01-01 | [] | null | true |
-| ADR-040 | accepted | 2026-01-03 | [] | null | true |
-| ADR-041 | accepted | 2026-01-16 | [] | null | true |
+| ADR-040 | accepted | 2026-07-11 | [] | null | true |
+| ADR-041 | accepted | 2026-07-21 | [] | null | true |
 | ADR-042 | accepted | 2026-01-17 | [ADR-005] | null | true |
 | ADR-043 | accepted | 2026-01-21 | [] | null | true |
 | ADR-045 | accepted | 2026-02-07 | [] | null | true |
 | ADR-046 | accepted | 2026-02-08 | [] | null | true |
-| ADR-047 | accepted | 2026-02-16 | [] | null | true |
+| ADR-047 | accepted | 2026-04-29 | [] | null | true |
 | ADR-048 | proposed | 2026-02-23 | [] | null | false |
 | ADR-049 | proposed | 2026-02-24 | [] | null | true |
 | ADR-050 | accepted | 2026-02-21 | [] | null | true |
@@ -354,14 +404,14 @@ much they should weigh on a reviewer:
 | ADR-055 | accepted | 2025-12-29 | [] | null | true |
 | ADR-056 | accepted | 2026-03-08 | [] | null | true |
 | ADR-059 | proposed | 2026-05-08 | [] | null | true |
-| ADR-060 | accepted | 2026-05-25 | [] | null | true |
-| ADR-061 | rejected | 2026-05-27 | [] | null | false |
-| ADR-062 | accepted | 2026-05-31 | [] | null | true |
-| ADR-063 | accepted | 2026-06-01 | [] | null | true |
+| ADR-060 | accepted | 2026-07-27 | [] | null | true |
+| ADR-061 | rejected | 2026-07-27 | [] | null | false |
+| ADR-062 | accepted | 2026-07-27 | [] | null | true |
+| ADR-063 | accepted | 2026-07-27 | [] | null | true |
 | ADR-064 | proposed | 2026-06-01 | [] | null | false |
 | ADR-065 | proposed | 2026-05-29 | [] | null | false |
 | ADR-067 | proposed | 2026-06-02 | [] | null | true |
-| ADR-070 | proposed | 2026-05-31 | [] | null | true |
+| ADR-070 | proposed | 2026-07-27 | [] | null | true |
 | ADR-072 | proposed | 2026-06-09 | [] | null | false |
 
 ## Records excluded from this change
@@ -373,7 +423,7 @@ needs a decision that belongs to another open issue:
 |-----|--------|--------------|
 | ADR-002, ADR-039 | Status is a "provisional" window that expired 2026-01-17. No enum member represents it. | #5193 |
 | ADR-030 | Not a decision record. Skill documentation carrying a "Critical Update" status. Its fate is being decided elsewhere. | #5195 |
-| ADR-024, ADR-025, ADR-036 | Prose-marked Accepted but actually superseded. The reciprocal `superseded-by` fix belongs with the other dangling supersessions. | #5192 |
+| ADR-024, ADR-025 | Prose-marked Accepted but actually superseded. The reciprocal `superseded-by` fix belongs with the other dangling supersessions. | #5192 |
 
 Because these six are excluded, issue #5190's acceptance criterion that every
 `ADR-[0-9]*.md` carry frontmatter is not fully met by this change. It is

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -387,3 +387,4 @@ the batch here as it lands.
 | 4 | ADR-016, ADR-017, ADR-018, ADR-019 |
 | 5 | ADR-021, ADR-022, ADR-026, ADR-028 |
 | 6 | ADR-029, ADR-031, ADR-032, ADR-033 |
+| 7 | ADR-035, ADR-037, ADR-038, ADR-040 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -384,3 +384,4 @@ the batch here as it lands.
 | 1 | ADR-001, ADR-005, ADR-006, ADR-007 |
 | 2 | ADR-008, ADR-009, ADR-010, ADR-011 |
 | 3 | ADR-012, ADR-013, ADR-014, ADR-015 |
+| 4 | ADR-016, ADR-017, ADR-018, ADR-019 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -472,3 +472,4 @@ the batch here as it lands.
 | 14 | ADR-072 |
 | 15 | ADR-014, ADR-033, ADR-040, ADR-041 |
 | 16 | ADR-047, ADR-060, ADR-061, ADR-062 |
+| 17 | ADR-063, ADR-070 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -389,3 +389,4 @@ the batch here as it lands.
 | 6 | ADR-029, ADR-031, ADR-032, ADR-033 |
 | 7 | ADR-035, ADR-037, ADR-038, ADR-040 |
 | 8 | ADR-041, ADR-042, ADR-043, ADR-045 |
+| 9 | ADR-046, ADR-047, ADR-048, ADR-049 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -419,3 +419,4 @@ the batch here as it lands.
 | 11 | ADR-054, ADR-055, ADR-056, ADR-059 |
 | 12 | ADR-060, ADR-061, ADR-062, ADR-063 |
 | 13 | ADR-064, ADR-065, ADR-067, ADR-070 |
+| 14 | ADR-072 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -22,18 +22,20 @@ are the derivation rules behind it sound?
 **Read this section before treating this document as consensus evidence. Two
 different review standards apply to different parts of this PR.**
 
-| Records | Review standard |
-|---|---|
-| **5 status decisions**: ADR-002, ADR-030, ADR-036, ADR-039, ADR-052 | A real six-agent adr-review debate (architect, critic, independent-thinker, security, analyst, high-level-advisor), convened by the repository owner outside the authoring session. |
-| The **62 mechanical records**: 52 of the original 53, plus the 10 from issue #5290 | Single-reviewer structured review, described below. |
+**Two six-agent rounds ran, and both are recorded in this document.**
 
-The five status decisions are the ones that carry governance weight: each is a
-real transition with prose changes, not a transcription of an existing status.
-Those got the full roster. The 62 mechanical records did not.
+| Round | Scope | Verdict |
+|---|---|---|
+| First | The 5 status decisions | DISAGREE-AND-COMMIT. Two of the five statuses were overturned by the debate. |
+| Second (final) | **All 67 records** | 3 ACCEPT, 2 DISAGREE-AND-COMMIT, 1 BLOCK, cleared by two named fixes. |
 
-A further six-agent round covering the **full final state** (all 67 touched
-records at once) is planned by the owner after this pass lands, to reach a single
-verdict for the whole PR. Until that round completes, the paragraphs below stand.
+The second round is what covers the 62 mechanical records, and it is the
+authoritative review for the whole batch. Neither round was unanimous, and the
+dissents in both are recorded rather than summarised away.
+
+The single-reviewer account below is retained as history. It describes the state
+before either round ran, and it is why this document exists in the shape it does;
+it is no longer the review standard for any part of this PR.
 
 ### The single-reviewer standard, for the 62 mechanical records
 
@@ -52,14 +54,11 @@ review of the PR, not on a consensus that did not happen.
 The review was not a formality. It changed six of the fifty-three records before
 they were written. Those corrections are recorded under "Findings" below.
 
-**For these 62 mechanical records, the reviewer must choose one of two paths
-before merge, and the choice belongs to the repository owner, not to a
-default.** Either (a) cover them in the planned full-state six-agent round and
-merge on that consensus, or (b) decide that single-reviewer structured review is
-sufficient evidence for a mechanical metadata backfill against an
-already-accepted schema, and record that decision. Do not merge these 62 on the
-assumption that a six-agent debate covered them; as of this writing it covered
-only the five status decisions.
+**That gap is now closed.** The choice this paragraph used to put to the
+reviewer, cover the 62 in a full-state round or accept narrower evidence, was
+resolved by running the round. It found seven wrong dates that the single
+reviewer and every bot round had missed, which is the concrete answer to whether
+the extra pass was worth its cost.
 
 The repository was un-shallowed (`git fetch --unshallow`, 2630 commits) before
 any date or implementation claim was made. The session began with a 50-commit

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -857,3 +857,4 @@ the batch here as it lands.
 | 25 | ADR-030, ADR-036, ADR-055, ADR-061 |
 | 26 | ADR-005, ADR-017, ADR-026, ADR-036 |
 | 27 | ADR-039, ADR-040, ADR-042, ADR-055 |
+| 28 | ADR-061 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -520,3 +520,4 @@ the batch here as it lands.
 | 17 | ADR-063, ADR-070 |
 | 18 | ADR-055 |
 | 19 | ADR-002, ADR-030, ADR-036, ADR-039 |
+| 20 | ADR-052 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -471,3 +471,4 @@ the batch here as it lands.
 | 13 | ADR-064, ADR-065, ADR-067, ADR-070 |
 | 14 | ADR-072 |
 | 15 | ADR-014, ADR-033, ADR-040, ADR-041 |
+| 16 | ADR-047, ADR-060, ADR-061, ADR-062 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -382,3 +382,4 @@ the batch here as it lands.
 | Batch | ADRs |
 |-------|------|
 | 1 | ADR-001, ADR-005, ADR-006, ADR-007 |
+| 2 | ADR-008, ADR-009, ADR-010, ADR-011 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -856,3 +856,4 @@ the batch here as it lands.
 | 24 | ADR-002, ADR-030, ADR-039, ADR-052 |
 | 25 | ADR-030, ADR-036, ADR-055, ADR-061 |
 | 26 | ADR-005, ADR-017, ADR-026, ADR-036 |
+| 27 | ADR-039, ADR-040, ADR-042, ADR-055 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -523,3 +523,4 @@ the batch here as it lands.
 | 20 | ADR-052 |
 | 21 | ADR-003, ADR-020, ADR-023, ADR-027 |
 | 22 | ADR-034, ADR-057, ADR-058, ADR-066 |
+| 23 | ADR-069, ADR-071 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -134,6 +134,51 @@ The value finally used is the artifact test: does the thing the ADR decided
 exist in the working tree now, or did it provably exist and merge before being
 removed? Every `implemented` value below was settled that way, by path.
 
+#### Deviation from ADR-073's literal text, and why
+
+This is a deliberate departure from the governing text, recorded here rather
+than applied quietly.
+
+**What the literal text says.** ADR-073's Implementation Notes, Phase 2, read:
+"`implemented` is derived from whether a merged change references the ADR."
+Issue #5190 repeats the same formulation. Read strictly, that is a
+reference-count rule: find a merged commit citing `ADR-NNN`, set the field true.
+
+**What was actually done.** Artifact verification. The field is true when the
+thing the decision called for demonstrably exists, or provably existed and was
+merged before later removal, established by opening the path rather than by
+counting citations.
+
+**Why the literal rule is wrong.** A reference-count rule produces answers that
+are wrong in both directions, and the errors do not cancel:
+
+- **It over-reports.** Commit messages cite neighbouring ADRs freely. The commit
+  implementing ADR-033 mentions ADR-032; the commit implementing ADR-017 mentions
+  ADR-018. A counting rule credits all four.
+- **It under-reports.** ADR-041 and ADR-046 have zero live id-references while
+  their artifacts (`codeql-analysis.yml`, the `codeql-scan` skill,
+  `milestone-planner.md`) plainly exist.
+- **It cannot express a reversion, which is the decisive case.** ADR-039's
+  assignments were merged and then reverted. A reference-count rule marks it
+  `implemented: true` permanently, because the merged references never
+  disappear. That is precisely backwards for a field whose stated job is gating
+  amend-versus-supersede: the record's decision is no longer in force, and
+  treating it as implemented would tell a future author to supersede where an
+  amendment is correct. ADR-039 is handled in this PR (see the status-decision
+  section) and is the counterexample that settles the question.
+
+**Why not recalculate to the literal rule.** Doing so would knowingly reintroduce
+answers already shown to be wrong, in order to match wording rather than intent.
+ADR-073 line 54 states the field's purpose in the schema itself,
+`# flips true at first merged change; gates amend-vs-supersede`. Artifact
+verification serves that purpose; citation counting only approximates it, and
+approximates it badly on the reversion case.
+
+**What a reviewer should do with this.** If the maintainer prefers the literal
+reading, the fix is to amend ADR-073's Phase 2 wording rather than to recompute
+53 records into known-wrong values. Either way the deviation is now on the
+record instead of buried in a script.
+
 **`supersedes` / `superseded-by`.** Populated only where both ends are in scope,
 so no one-sided reference is created. Exactly one pair qualifies.
 
@@ -473,3 +518,4 @@ the batch here as it lands.
 | 15 | ADR-014, ADR-033, ADR-040, ADR-041 |
 | 16 | ADR-047, ADR-060, ADR-061, ADR-062 |
 | 17 | ADR-063, ADR-070 |
+| 18 | ADR-055 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -521,3 +521,4 @@ the batch here as it lands.
 | 18 | ADR-055 |
 | 19 | ADR-002, ADR-030, ADR-036, ADR-039 |
 | 20 | ADR-052 |
+| 21 | ADR-003, ADR-020, ADR-023, ADR-027 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -385,3 +385,4 @@ the batch here as it lands.
 | 2 | ADR-008, ADR-009, ADR-010, ADR-011 |
 | 3 | ADR-012, ADR-013, ADR-014, ADR-015 |
 | 4 | ADR-016, ADR-017, ADR-018, ADR-019 |
+| 5 | ADR-021, ADR-022, ADR-026, ADR-028 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -1,21 +1,44 @@
 # ADR-073 Phase 2 backfill: review and debate log
 
-Subject: adding ADR-073 lifecycle frontmatter to 53 existing ADRs that carry no
-frontmatter block. Issue #5190. Branch `claude/autoplan-goal-vd6pmg`.
+Subject: ADR-073 lifecycle frontmatter across 68 records. Issues #5190 and
+#5290. Branch `claude/autoplan-goal-vd6pmg`.
+
+Scope: **67 distinct ADR files**, 70 files in the PR. That is 53 records which
+carried no frontmatter, 10 which carried a partial block (#5290), and 4 further
+records added for status decisions (ADR-002, ADR-030, ADR-036, ADR-039). A fifth
+status decision, ADR-052, was already among the 53, so counting the status
+decisions as five and the rest as 63 would double-count it: 62 records are
+mechanical, 5 are decisions, 67 in total.
 
 ADR-073 (`.agents/architecture/ADR-073-adr-lifecycle-frontmatter.md`) is Accepted
 (2026-06-19) and is not reopened here. Its schema is taken as given. This review
-covers one question only: is the prose-to-enum mapping proposed for each of the
-53 records correct, and are the derivation rules behind it sound?
+covers two questions: is the prose-to-enum mapping right for each record, and
+are the derivation rules behind it sound?
 
 ## How this review was conducted
 
-**Read this section before treating this document as consensus evidence.**
+**Read this section before treating this document as consensus evidence. Two
+different review standards apply to different parts of this PR.**
+
+| Records | Review standard |
+|---|---|
+| **5 status decisions**: ADR-002, ADR-030, ADR-036, ADR-039, ADR-052 | A real six-agent adr-review debate (architect, critic, independent-thinker, security, analyst, high-level-advisor), convened by the repository owner outside the authoring session. |
+| The **62 mechanical records**: 52 of the original 53, plus the 10 from issue #5290 | Single-reviewer structured review, described below. |
+
+The five status decisions are the ones that carry governance weight: each is a
+real transition with prose changes, not a transcription of an existing status.
+Those got the full roster. The 62 mechanical records did not.
+
+A further six-agent round covering the **full final state** (all 67 touched
+records at once) is planned by the owner after this pass lands, to reach a single
+verdict for the whole PR. Until that round completes, the paragraphs below stand.
+
+### The single-reviewer standard, for the 62 mechanical records
 
 The `adr-review` skill specifies a six-agent debate (architect, critic,
 independent-thinker, security, analyst, high-level-advisor). That roster could
-not be convened: sub-agent delegation was unavailable in the session that
-produced this change, so no agent other than the authoring one participated.
+not be convened for these: sub-agent delegation was unavailable in the session
+that produced this change, so no agent other than the authoring one participated.
 
 What this document is instead: a single-reviewer structured review worked
 through the six adr-review axes in sequence, in which every factual claim was
@@ -27,13 +50,14 @@ review of the PR, not on a consensus that did not happen.
 The review was not a formality. It changed six of the fifty-three records before
 they were written. Those corrections are recorded under "Findings" below.
 
-**The reviewer of this PR must choose one of two paths before merge, and the
-choice belongs to the repository owner, not to a default.** Either (a) convene
-the real six-agent adr-review debate in a session where sub-agent delegation
-works, and merge on that consensus, or (b) decide that single-reviewer
-structured review is sufficient evidence for a mechanical metadata backfill
-against an already-accepted schema, and record that decision. Do not merge on
-the assumption that a six-agent debate happened, because it did not.
+**For these 62 mechanical records, the reviewer must choose one of two paths
+before merge, and the choice belongs to the repository owner, not to a
+default.** Either (a) cover them in the planned full-state six-agent round and
+merge on that consensus, or (b) decide that single-reviewer structured review is
+sufficient evidence for a mechanical metadata backfill against an
+already-accepted schema, and record that decision. Do not merge these 62 on the
+assumption that a six-agent debate covered them; as of this writing it covered
+only the five status decisions.
 
 The repository was un-shallowed (`git fetch --unshallow`, 2630 commits) before
 any date or implementation claim was made. The session began with a 50-commit
@@ -459,21 +483,156 @@ much they should weigh on a reviewer:
 | ADR-070 | proposed | 2026-07-27 | [] | null | true |
 | ADR-072 | proposed | 2026-06-09 | [] | null | false |
 
+## The five status decisions (six-agent debate)
+
+These five were deferred from the original backfill because each needed a
+decision rather than a transcription. The owner convened the full adr-review
+roster on them. Summary of what the debate settled and the evidence each rests
+on, all verified against the live tree before writing:
+
+### ADR-002, ADR-039: both `deprecated`
+
+The pair was one question. ADR-039 claimed to supersede ADR-002 "pending
+validation" during a provisional window (2026-01-03 to 2026-01-17).
+
+The window closed with **zero of its four acceptance criteria measured**.
+`.agents/governance/model-pin-evidence.json` holds `"pins": []`. No validation
+verdict, pass or fail, was recorded anywhere. The downgrades were reverted, but
+not through ADR-039's own documented rollback procedure: they went incidentally
+on 2026-02-07, three weeks after the window closed, inside commit `568af6775`
+(PR #1046, "migrate agent prompts from cloudmcp-manager to Memory Router"), which
+rewrote 41 agent files for an unrelated reason and does not mention ADR-039 at
+all. Verified: `model:` for orchestrator, architect, independent-thinker,
+roadmap, high-level-advisor, and security all read `opus` today, which is
+ADR-002's assignment.
+
+So ADR-039's `supersedes` is `[]`: the supersession never took effect.
+
+**ADR-002 is not revived to `accepted`** on the strength of that. Its own table
+is also wrong about the tree: it assigns `critic` and `qa` to Sonnet where both
+are `opus`, and it scopes itself to "All 18 agents" where 33 exist under
+`.claude/agents/`. And the question has been re-answered on better grounds by
+ADR-080 (accepted, 2026-07-11), whose Context section rejects ADR-002's method
+directly: "The pins encode a guess, not a measurement."
+
+`superseded-by` stays `null` on ADR-002. Naming ADR-080 needs the reciprocal
+`supersedes: [ADR-002]` on an accepted ADR, which is outside this PR.
+
+**Why `deprecated` and not `rejected`.** Both shipped and ran in production,
+ADR-039 for roughly five weeks. This repository uses `rejected` for a proposal
+declined *before* it was ever in force (ADR-095, ADR-061). `deprecated` means
+"was in force, no longer is". Both carry `implemented: true`, which stays true
+despite the revert, for the reason given in the deviation note above.
+
+The pair follows the ADR-098 and ADR-093 precedent for status handling: ADR-098's
+own Status section states that "the acceptance of a governance ADR is a maintainer
+act", which is why both of those ship `proposed` against `implemented: true`
+rather than self-asserting acceptance.
+
+### ADR-030: `rejected`, body untouched
+
+Not a decision record. It is a same-day amendment memo to ADR-027 (still
+`proposed`), and its own header reads `**Status**: Critical Update - Changes
+Recommendation`, which is not an enum member. Its "Option E" was not built:
+`.claude/skills/github/SKILL.md` wraps Python scripts and contains zero
+`mcp__github` references, so it never declared `allowed-tools: mcp__github__*`.
+
+**The body is deliberately left alone.** It is the only record of what was argued
+on 2025-12-23, and rewriting it would fabricate a decision that was never made.
+The record gets frontmatter and a five-line note, nothing else.
+
+Six live sites still cite ADR-030 as binding authority, including
+`scripts/validation/check_agent_skill_discriminator.py`, which hardcodes its
+path. Two more cite `ADR-030 line 31`, a line number this PR shifts by roughly
+16. Filed as issue #5293, which also carries the real open question: the
+skill-first principle is still live practice and now has no written home.
+
+### ADR-036: `accepted`, and NOT superseded
+
+**This corrects an error in an earlier version of this document**, which grouped
+ADR-036 with ADR-024 and ADR-025 as "actually superseded, deferred to #5192".
+That characterization was wrong.
+
+ADR-036 is the live, operative architecture. Verified: 31 `templates/agents/*.shared.md`
+files exist and `build/generate_agents.py` reads them on every build. ADR-052,
+the rival proposal that claimed to supersede it, was never implemented. ADR-036
+has nothing to do with the ADR-024/ADR-025 dangling-supersession problem and
+ships here as an ordinary `accepted` transcription.
+
+Two stale `Generate-Agents.ps1` references (lines 53 and 101) are repointed to
+`build/generate_agents.py`. This is an internal inconsistency, not a new claim:
+the same file already names `generate_agents.py` correctly at line 231. Stale
+agent-count figures elsewhere in the record are left alone as out of scope.
+
+### ADR-052: `rejected`
+
+Proposed eliminating `templates/` in favour of generating platform variants from
+`src/claude/` ("Option B"). Five months on, none of it exists:
+`build/scripts/generate_platform_agents.py` and `platform-overrides/` are both
+absent, while `templates/agents/*.shared.md` remains what the build reads.
+
+Its central evidence, a 2 to 13 percent template-vs-Claude drift measurement
+presented as sync failure, had already been answered by ADR-036 before ADR-052
+was written: "Similarity metrics comparing Claude to templates measure divergence
+that is **BY DESIGN**, not sync failure." ADR-052 never engages that rebuttal.
+
+The prose claim "Supersedes ADR-036." is struck, matching the frontmatter's
+`supersedes: []`.
+
+**Issue #124 (the standing question of whether the two-source template pattern
+should continue, referenced in ADR-036) remains open and unresolved. This
+rejection closes ADR-052's specific proposal, not the underlying question.**
+
+## The ten records from issue #5290
+
+These carried `status`, `date`, and `decision-makers` but none of `id`,
+`supersedes`, `superseded-by`, `explainer`, or `implemented`, so they fell
+between issue #5190's two categories and nothing owned them. ADR-071 had no
+`date` either; its `## Date` section supplies 2026-08-19.
+
+**Existing recorded values are preserved, not overwritten.** This is a deliberate
+divergence from the `decision-makers: [rjmurillo]` rule applied to the 53. Those
+53 recorded no decision-makers at all, so a value had to be chosen. These ten
+name their own, so overwriting them would destroy recorded information for the
+sake of uniformity, which is the exact objection raised against the uniform rule.
+Their `consulted` and `informed` keys are kept as well. Two shape fixes only:
+ADR-027's `decision-makers` was a bare scalar and is normalized to a list, and
+ADR-066's quoted `status` is unquoted.
+
+| ADR | status | date | implemented | Basis |
+|-----|--------|------|-------------|-------|
+| ADR-003 | accepted | 2025-12-16 | true | `build/scripts/validate_agent_matrix_refs.py`, `git_hook_policy.py` |
+| ADR-020 | proposed | 2025-12-19 | false | Zero references anywhere |
+| ADR-023 | accepted | 2025-12-26 | true | `scripts/eval/eval-suite.py` |
+| ADR-027 | proposed | 2025-12-23 | false | Zero references; ADR-030's parent |
+| ADR-034 | accepted | 2026-07-08 | true | `validate_investigation_claims.py` plus its workflow. Date from `## Amendment (2026-07-08)` |
+| ADR-057 | accepted | 2026-07-22 | true | 11 executable references. Date from `## Amendment 2026-07-22 (Issue #3185)` |
+| ADR-058 | proposed | 2026-05-03 | true | `scripts/eval/_eval_agent_types.py:28` implements its fourth verdict outcome |
+| ADR-066 | accepted | 2026-07-19 | true | `.claude/lib/hook_dispatch.py`, `generate_dispatcher.py`. Date from a dated `## Status` statement |
+| ADR-069 | proposed | 2026-05-02 | false | Its only executable references are renumbering-history strings in the uniqueness allowlist, not implementation |
+| ADR-071 | accepted | 2026-08-19 | true | `nightly-cli-smoke.yml`, runtime-contract tests |
+
+ADR-058 is a sixth `proposed`-but-implemented record, on top of the five in the
+53. It is the same governance gap, not a new one.
+
 ## Records excluded from this change
 
-Six of the 59 frontmatter-free ADRs are deliberately not touched, because each
-needs a decision that belongs to another open issue:
+Two of the 59 frontmatter-free ADRs remain untouched. Four that were previously
+deferred (ADR-002, ADR-030, ADR-036, ADR-039) are resolved above and now ship in
+this PR:
 
 | ADR | Reason | Owning issue |
 |-----|--------|--------------|
-| ADR-002, ADR-039 | Status is a "provisional" window that expired 2026-01-17. No enum member represents it. | #5193 |
-| ADR-030 | Not a decision record. Skill documentation carrying a "Critical Update" status. Its fate is being decided elsewhere. | #5195 |
-| ADR-024, ADR-025 | Prose-marked Accepted but actually superseded. The reciprocal `superseded-by` fix belongs with the other dangling supersessions. | #5192 |
+| ADR-024, ADR-025 | Prose-marked Accepted but actually superseded. The reciprocal `superseded-by` fix belongs with the other dangling supersessions, which PR #5209 handles. | #5192 |
 
-Because these six are excluded, issue #5190's acceptance criterion that every
-`ADR-[0-9]*.md` carry frontmatter is not fully met by this change. It is
-therefore referenced with `Refs`, not `Fixes`. A follow-up after #5192, #5193,
-and #5195 land can pick up the remaining six, plus the ten partial-frontmatter
+Resolved and now shipping here, previously deferred: ADR-002 and ADR-039 (#5193)
+are `deprecated`, ADR-030 (#5195) is `rejected`, and ADR-036 was never part of
+the #5192 problem at all.
+
+Because ADR-024 and ADR-025 are excluded, issue #5190's acceptance criterion that
+every `ADR-[0-9]*.md` carry frontmatter is not fully met by this change. It is
+therefore referenced with `Refs`, not `Fixes`. A follow-up after #5192 lands can
+pick up the remaining two
 records listed under "Verification performed", and close it.
 
 ## Scope-gate note

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -522,3 +522,4 @@ the batch here as it lands.
 | 19 | ADR-002, ADR-030, ADR-036, ADR-039 |
 | 20 | ADR-052 |
 | 21 | ADR-003, ADR-020, ADR-023, ADR-027 |
+| 22 | ADR-034, ADR-057, ADR-058, ADR-066 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -392,3 +392,4 @@ the batch here as it lands.
 | 9 | ADR-046, ADR-047, ADR-048, ADR-049 |
 | 10 | ADR-050, ADR-051, ADR-052, ADR-053 |
 | 11 | ADR-054, ADR-055, ADR-056, ADR-059 |
+| 12 | ADR-060, ADR-061, ADR-062, ADR-063 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -97,17 +97,35 @@ this list, and their absence was not cosmetic: the five status decisions in this
 PR are exactly the records whose new prose reads "Deprecated (2026-08-25)" or
 "Rejected (2026-08-25)", so the rule as first written did not recognise the
 statements it had just caused to be written. Cursor Bugbot caught the
-consequence. Four records now carry `date: 2026-08-25`, the day their status
-actually changed: **ADR-002, ADR-030, ADR-039, ADR-052**.
+consequence.
 
-**ADR-036 deliberately keeps `date: 2026-01-01`.** It is the fifth status
-decision, but its status did not change: it was `accepted` in prose and is
-`accepted` in frontmatter. The only edit was repointing two stale
-`Generate-Agents.ps1` references, which is a citation repair, not a decision
-change. This is the line the rule draws: `date` tracks when the decision content
-last changed as the record itself states it, not when the file was last touched.
-Were it the latter, all 67 records would read 2026-08-25 and the field would
-carry no information at all.
+**Seven records now carry `date: 2026-08-25`**, every record whose *body content*
+this PR changed:
+
+| ADR | What changed in the body |
+|---|---|
+| ADR-002, ADR-039 | Status changed to `deprecated`, with a resolution section |
+| ADR-030 | Status changed to `rejected`, with a record note |
+| ADR-052 | Status changed to `rejected`, supersession claim struck |
+| ADR-036 | Two stale `Generate-Agents.ps1` references repointed |
+| ADR-055 | Supersession claim struck from the `**Status**:` line |
+| ADR-061 | Status prose reconciled to open with `Rejected` |
+
+The line the rule draws is **content, not touch**. ADR-036, ADR-055, and ADR-061
+did not change status, but each had a factual claim in its body corrected or
+removed, which is a change to what the record says. An earlier version of this
+document argued ADR-036 should keep `2026-01-01` because a citation repair is not
+a decision change; that line was too fine, and it left three records asserting
+prose they had not asserted the day before while claiming an older last-updated
+date.
+
+What does **not** advance the date, and why the field still carries information:
+the 60 records that received only a frontmatter block keep their original dates,
+as do ADR-021, ADR-032, ADR-053, and ADR-056, whose only edits were replacing
+prohibited em dashes with commas and colons, and ADR-020, which gained a
+lint-suppression comment. Metadata and punctuation are not content. Were every
+touched file dated today, all 67 would read 2026-08-25 and the field would carry
+nothing.
 
 Dates in evidence tables, cited incidents, PR references, and measurement rows
 are excluded: those are dates the record mentions, not dates the record was
@@ -373,7 +391,9 @@ the enum; `id` matches the filename number; `date` matches `YYYY-MM-DD`;
 `implemented` is a bool; `supersedes` is a list; the prose `## Status` first word
 agrees with the enum; and every supersession is reciprocal.
 
-Result on the 53 records this PR touches: zero errors.
+Result, re-run against **all 67 records this PR touches**, not the original 53:
+**zero errors**. The earlier version of this line claimed only the 53 and was
+stale once the five status decisions and the ten #5290 records landed.
 
 The same pass reports pre-existing problems in records this PR does not touch,
 recorded here because they were seen and should not be lost:
@@ -488,14 +508,14 @@ much they should weigh on a reviewer:
 | ADR-049 | proposed | 2026-02-24 | [] | null | true |
 | ADR-050 | accepted | 2026-02-21 | [] | null | true |
 | ADR-051 | accepted | 2026-03-07 | [] | null | true |
-| ADR-052 | proposed | 2026-08-25 | [] | null | false |
+| ADR-052 | rejected | 2026-08-25 | [] | null | false |
 | ADR-053 | accepted | 2026-03-07 | [] | null | true |
 | ADR-054 | accepted | 2026-07-20 | [] | null | true |
-| ADR-055 | accepted | 2025-12-29 | [] | null | true |
+| ADR-055 | accepted | 2026-08-25 | [] | null | true |
 | ADR-056 | accepted | 2026-03-08 | [] | null | true |
 | ADR-059 | proposed | 2026-05-08 | [] | null | true |
 | ADR-060 | accepted | 2026-07-27 | [] | null | true |
-| ADR-061 | rejected | 2026-07-27 | [] | null | false |
+| ADR-061 | rejected | 2026-08-25 | [] | null | false |
 | ADR-062 | accepted | 2026-07-27 | [] | null | true |
 | ADR-063 | accepted | 2026-07-27 | [] | null | true |
 | ADR-064 | proposed | 2026-06-01 | [] | null | false |
@@ -503,6 +523,53 @@ much they should weigh on a reviewer:
 | ADR-067 | proposed | 2026-06-02 | [] | null | true |
 | ADR-070 | proposed | 2026-07-27 | [] | null | true |
 | ADR-072 | proposed | 2026-06-09 | [] | null | false |
+
+## The six-agent debate: per-role verdicts
+
+The roster below reviewed the five status decisions. **Consensus was
+DISAGREE-AND-COMMIT, not unanimous ACCEPT**, and the disagreement was
+substantive: two reviewers argued against the originally proposed status for two
+records, and security registered a narrow BLOCK. The originally proposed pattern
+was `accepted` for ADR-002 and `rejected` for ADR-039. **Both were overturned by
+the debate.** What shipped is the synthesis, not the proposal.
+
+| Role | Verdict | Position |
+|---|---|---|
+| **architect** | ACCEPT | Confirmed all five as originally proposed. Wanted `implemented: true` on ADR-002 with the debate log cited for its acceptance; `supersedes: []` on ADR-039; judged a `superseded` framing wrong for ADR-030 because ADR-027 predates it. **Caught the ADR-036 mischaracterization in the backfill log** and required an Issue #124 pointer in ADR-052's rejection prose. |
+| **critic** | DISAGREE-AND-COMMIT | Found ADR-002's cited evidence argues the **opposite** of the claim made from it: `model_pin_baseline.json` is a draining ratchet toward zero, not a freeze or endorsement. Found `rejected` wrong for ADR-039 because it shipped and ran, where this repo's `rejected` precedent means declined-before-acceptance; recommended `deprecated`. Flagged ADR-030's six live citations as making a full status flip risky. Recommended ADR-052 to `rejected`. Warned that **all five would end with frontmatter and prose disagreeing** unless prose was explicitly reconciled. |
+| **independent-thinker** | DISAGREE-AND-COMMIT | Independently verified evidence rather than accepting it: found `.claude/agents/critic.md` and `qa.md` are `opus`, contradicting ADR-002's own table. Recommended `deprecated` over `accepted` for ADR-002, citing ADR-080 as methodologically superseding it and ADR-073's debate-log binding on any `accepted` transition. Recommended `deprecated` over `rejected` for ADR-039, and found the revert story factually incomplete: it happened incidentally via PR #1046 / commit `568af6775`, three weeks late, not through ADR-039's own rollback procedure. **Blocked rewriting ADR-030's body** as fabricating a decision never made. Reached `rejected` for ADR-052 via a footgun argument: leaving it `proposed` risks an agent literally executing "remove `templates/agents/`". |
+| **security** | **BLOCK**, narrowly, on ADR-002 only | Found ADR-098 and ADR-093 directly on point: both ship `status: proposed` against `implemented: true` precisely because "the acceptance of a governance ADR is a maintainer act". Flipping ADR-002 to `accepted` here would be **the exact self-asserted-approval pattern ADR-073 line 61 exists to prevent**. Cleared ADR-039, ADR-036, and the ADR-052 supersession strike as ACCEPT, being transcription and drift-fix rather than new transitions. Recommended `deprecated` over `rejected` for ADR-030, since `rejected` implies an adjudication that never occurred. Confirmed no CWE-918 exposure: `explainer` is `null` everywhere. |
+| **analyst** | Evidence pass, no status recommendation | PASS/PARTIAL/FAIL over five factual claims. Confirmed five of six named agents match ADR-002 rather than ADR-039 (**PARTIAL**: `critic` and `qa` match neither table). Confirmed ADR-039's monitoring evidence file is empty. Confirmed `.claude/skills/github/SKILL.md` declares no `allowed-tools: mcp__github__*`. Confirmed ADR-027 and ADR-030 share a date and parentage. Confirmed no ADR-052 Option B generator exists and `templates/agents/` remains live. |
+| **high-level-advisor** | ACCEPT | Called ADR-039 the strongest of the five, "transcription of a decision that already fired". Endorsed ADR-030 to `rejected` with the ADR-027 pointer. Required that shipping all five in one PR be **stated explicitly in the PR body with the reversals enumerated, not buried as "just metadata"**. **Registered the one dissent on ADR-052**, preferring it stay `proposed`. |
+
+### Where the reviewers disagreed, and how it resolved
+
+Three genuine disagreements. None is papered over.
+
+1. **ADR-002: `accepted` (proposed) against `deprecated` (shipped).** Security
+   BLOCKed the `accepted` flip; critic and independent-thinker independently
+   reached `deprecated` by different routes (evidence misreading, and ADR-080 as
+   methodological supersession). **Resolution: `deprecated`.** The block is
+   cleared because the record no longer asserts an acceptance.
+2. **ADR-039: `rejected` (proposed) against `deprecated` (shipped).** Critic and
+   independent-thinker both objected that `rejected` misdescribes a decision that
+   ran in production for five weeks, against this repo's own ADR-095 and ADR-061
+   precedent. Architect and high-level-advisor had accepted `rejected`.
+   **Resolution: `deprecated`.**
+3. **ADR-052: `rejected` (3 votes) against staying `proposed` (1 vote).**
+   Architect, critic, and independent-thinker said `rejected`;
+   high-level-advisor dissented. **Resolution: `rejected`, a majority call and
+   not unanimous.** Recorded as such so a future reader does not mistake it for
+   consensus.
+
+The synthesis was made by the repository owner after reading all six.
+
+**Scope boundary the debate set deliberately.** Security, critic, and
+independent-thinker converged on a light-touch change for ADR-030 (frontmatter
+plus a minimal note, body untouched) with the citation sweep deferred to #5293,
+rather than a body rewrite or an in-PR sweep. That boundary is a debate outcome,
+not an oversight. Its cost is disclosed in the PR body: ADR-030 merges as
+`rejected` while three live sites still cite it as binding authority.
 
 ## The five status decisions (six-agent debate)
 
@@ -705,3 +772,4 @@ the batch here as it lands.
 | 22 | ADR-034, ADR-057, ADR-058, ADR-066 |
 | 23 | ADR-069, ADR-071 |
 | 24 | ADR-002, ADR-030, ADR-039, ADR-052 |
+| 25 | ADR-030, ADR-036, ADR-055, ADR-061 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -219,14 +219,20 @@ are wrong in both directions, and the errors do not cancel:
 - **It under-reports.** ADR-041 and ADR-046 have zero live id-references while
   their artifacts (`codeql-analysis.yml`, the `codeql-scan` skill,
   `milestone-planner.md`) plainly exist.
-- **It cannot express a reversion, which is the decisive case.** ADR-039's
-  assignments were merged and then reverted. A reference-count rule marks it
-  `implemented: true` permanently, because the merged references never
-  disappear. That is precisely backwards for a field whose stated job is gating
-  amend-versus-supersede: the record's decision is no longer in force, and
-  treating it as implemented would tell a future author to supersede where an
-  amendment is correct. ADR-039 is handled in this PR (see the status-decision
-  section) and is the counterexample that settles the question.
+- **It cannot see a reversion at all, and reversion is where the contract has to
+  be explicit.** ADR-039's assignments were merged and then reverted. A
+  reference-count rule reports `implemented: true` for it, which happens to be
+  the right answer, but reaches it by accident: the merged references simply
+  never disappear, so the rule would say `true` whether or not the code had ever
+  existed. It cannot distinguish "shipped, then removed" from "never shipped but
+  widely cited", and those need different answers.
+
+  The artifact rule distinguishes them, and this document states the contract
+  rather than leaving it implied: **`implemented` stays `true` for a decision
+  whose code shipped and was later removed** (line 182 above; ADR-039 and
+  ADR-002 both carry it for that reason). The field gates amend-versus-supersede,
+  and a record whose code once existed must not be silently amended just because
+  the code is gone now. ADR-039 is the worked example.
 
 **Why not recalculate to the literal rule.** Doing so would knowingly reintroduce
 answers already shown to be wrong, in order to match wording rather than intent.

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -390,3 +390,4 @@ the batch here as it lands.
 | 7 | ADR-035, ADR-037, ADR-038, ADR-040 |
 | 8 | ADR-041, ADR-042, ADR-043, ADR-045 |
 | 9 | ADR-046, ADR-047, ADR-048, ADR-049 |
+| 10 | ADR-050, ADR-051, ADR-052, ADR-053 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -391,3 +391,4 @@ the batch here as it lands.
 | 8 | ADR-041, ADR-042, ADR-043, ADR-045 |
 | 9 | ADR-046, ADR-047, ADR-048, ADR-049 |
 | 10 | ADR-050, ADR-051, ADR-052, ADR-053 |
+| 11 | ADR-054, ADR-055, ADR-056, ADR-059 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -388,3 +388,4 @@ the batch here as it lands.
 | 5 | ADR-021, ADR-022, ADR-026, ADR-028 |
 | 6 | ADR-029, ADR-031, ADR-032, ADR-033 |
 | 7 | ADR-035, ADR-037, ADR-038, ADR-040 |
+| 8 | ADR-041, ADR-042, ADR-043, ADR-045 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -307,7 +307,22 @@ since its own Implementation Notes read "It documents an already-landed gate; it
 does not change the gate."
 
 Three are `accepted` with `implemented: false`: ADR-010, ADR-018, ADR-028. The
-mirror image, decisions accepted and never built.
+mirror image, but **the label "never built" fits only two of them**, and the
+distinction matters because it is a limit of the derivation rule rather than a
+fact about the records.
+
+**ADR-018 chose a no-op on purpose.** Its decision was session-local caching and
+*no* git-tracked cache: the correct implementation of that decision is the
+absence of an artifact. An artifact check cannot represent a negative-space
+decision, so it reports `false` for a decision that was executed exactly as
+written. Do not triage ADR-018 as unbuilt work. If Phase 3 wants to distinguish
+these, the schema needs a value the current enum does not have.
+
+**ADR-028 is genuinely unbuilt but is still cited as live authority.**
+`.gemini/styleguide.md:15` routes output-schema questions to it. That is the same
+class of problem as ADR-030's, and it is disclosed in the PR body alongside it.
+
+ADR-010 is the only clean "accepted and never built" of the three.
 
 An earlier version of this paragraph said "four records" while listing five, and
 a sixth record (ADR-013) was in the group because its `implemented` value was
@@ -330,24 +345,31 @@ proposal is findable and does not return", which is the same concept, a proposal
 declined before acceptance and kept for findability.
 
 `status: rejected` was therefore chosen, and a paragraph was added to ADR-061's
-own `## Status` section recording that choice and its precedent. This is the
-only body edit in the change. It exists so the coercion leaves a trace in the
+own `## Status` section recording that choice and its precedent. This is one
+reconciliation among several: ADR-002, ADR-030, ADR-036, ADR-039, ADR-052, and
+ADR-055 all carry body edits too, each recorded in this document. It exists so the coercion leaves a trace in the
 document a human reads, rather than only in the machine-readable block. ADR-073
 line 57 requires that reconciliation happen by editing prose and never by a gate
 silently rewriting it; this edit is that reconciliation, performed by hand.
 
 ### ADR-052 and ADR-055: supersession left deliberately empty
 
-ADR-052's prose reads "Proposed. Supersedes ADR-036." ADR-055's reads "Accepted
-(supersedes ADR-024, ADR-025)". All three targets are deferred from this PR
-pending issue #5192, so they have no frontmatter to hold a reciprocal
-`superseded-by`. Writing `supersedes: [ADR-036]` now would create exactly the
-one-sided reference ADR-073's Phase 3 bidirectional check is meant to catch.
+**Both prose claims are now struck**, so this section describes what was done,
+not a live inconsistency.
 
-Both fields are therefore left `[]`, and the supersession remains recorded in
-prose where it already was. Whichever of #5190 or #5192 lands second owes the
-reciprocal edit on both ends. This is a known, deliberate incompleteness, not an
-oversight.
+ADR-052's `## Status` read "Proposed. Supersedes ADR-036." and ADR-055's inline
+`**Status**:` read "Accepted (supersedes ADR-024, ADR-025)". ADR-036 turned out
+never to have been superseded at all and ships here as `accepted`. ADR-024 and
+ADR-025 remain deferred to #5192, so they have no frontmatter to hold a
+reciprocal `superseded-by`, and asserting the relationship from one side only is
+exactly the dangling reference ADR-073's Phase 3 bidirectional check exists to
+catch.
+
+Both records therefore carry `supersedes: []`, and both prose claims were
+replaced with a dated note pointing at #5192 rather than left to contradict the
+frontmatter. ADR-055's note is dated 2026-08-25; ADR-052's rejection rationale
+carries the same date. **#5192, and PR #5209 which implements it, owe the
+reciprocal edit** if the ADR-024/ADR-025 supersession is ever restated.
 
 ### ADR-005 and ADR-042: the one reciprocal pair
 
@@ -392,21 +414,37 @@ the enum; `id` matches the filename number; `date` matches `YYYY-MM-DD`;
 agrees with the enum; and every supersession is reciprocal.
 
 Result, re-run against **all 67 records this PR touches**, not the original 53:
-**zero errors**. The earlier version of this line claimed only the 53 and was
-stale once the five status decisions and the ten #5290 records landed.
+**zero errors**.
 
-The same pass reports pre-existing problems in records this PR does not touch,
-recorded here because they were seen and should not be lost:
+**Read that claim narrowly. It is a shape check, not a correctness check.** The
+pass verifies that `date` matches `YYYY-MM-DD`; it cannot verify that the value
+is the right date. "Zero errors" therefore means "nothing is malformed", not
+"the dates are correct", and reading it the second way would be a mistake.
 
-- Ten ADRs carry a partial frontmatter block with a bare `status:` line and none
-  of the other five fields: ADR-003, ADR-020, ADR-023, ADR-027, ADR-034, ADR-057,
-  ADR-058, ADR-066, ADR-069, ADR-071. They were excluded from issue #5190's
-  59-record list because they are not frontmatter-free, but they are not
-  ADR-073-conformant either. ADR-071 additionally has no `date`. Completing
-  Phase 2 requires a pass over these ten.
-- ADR-091 declares `supersedes: [ADR-079]` while ADR-079 does not carry the
-  reciprocal `superseded-by`. This is the same class of defect as issue #5192
-  and ADR-079 is named there.
+That gap is not hypothetical. The full-state six-agent debate found **seven date
+values that were wrong while passing this check**, across three root causes the
+rule had not covered: dated `**Superseded by**:` and `**Amended by**:` trailer
+blocks outside any `## Status` heading (ADR-005, ADR-017), a `### Date`
+subheading nested under an amendment heading (ADR-042), and a date that was
+merely *quoted* from another ADR being mistaken for an update date (ADR-040,
+which had been "corrected" once already onto ADR-080's acceptance date). No bot
+round caught any of them. The lesson is that a schema validator and a reviewer
+who opens the file are not substitutes for each other.
+
+The same pass surfaced two problems in records outside the original 53. The
+first is now fixed in this PR; the second is not:
+
+- **Fixed here.** Ten ADRs carried a partial frontmatter block without `id`,
+  `supersedes`, `superseded-by`, `explainer`, or `implemented`: ADR-003, ADR-020,
+  ADR-023, ADR-027, ADR-034, ADR-057, ADR-058, ADR-066, ADR-069, ADR-071.
+  ADR-071 also had no `date`. They fell outside issue #5190's 59-record list
+  because they were not frontmatter-free, yet they were not ADR-073-conformant
+  either. Filed as #5290 and **completed in this PR**, which is why it carries a
+  closing keyword for that issue. See "The ten records from issue #5290" below.
+- **Still open.** ADR-091 declares `supersedes: [ADR-079]` while ADR-079 carries
+  no reciprocal `superseded-by`. Same class of defect as issue #5192, where
+  ADR-079 is already named, and PR #5209 is the change that handles it. Out of
+  scope here.
 
 ## Security review
 
@@ -524,7 +562,48 @@ much they should weigh on a reviewer:
 | ADR-070 | proposed | 2026-07-27 | [] | null | true |
 | ADR-072 | proposed | 2026-06-09 | [] | null | false |
 
-## The six-agent debate: per-role verdicts
+## Full-state debate: all 67 records (final round)
+
+A second six-agent round reviewed the **complete final state**, all 67 records at
+once, rather than the five status decisions alone. This is the round that
+satisfies the review-evidence requirement for the 62 mechanical records, which
+the first round did not cover.
+
+**Verdict: 3 ACCEPT, 2 DISAGREE-AND-COMMIT, 1 BLOCK (cleared). Not unanimous.**
+
+| Role | Verdict |
+|---|---|
+| security | ACCEPT |
+| analyst | ACCEPT |
+| high-level-advisor | ACCEPT |
+| architect | DISAGREE-AND-COMMIT |
+| critic | DISAGREE-AND-COMMIT |
+| independent-thinker | **BLOCK**, narrow, clearable by two specific fixes |
+
+The BLOCK was cleared by making the two fixes it named, not by overruling it.
+Both are in this PR: the seven date corrections below, and making three records'
+dates self-documenting in their own prose.
+
+**What this round found that no automated review did: seven wrong `date` values,
+all of which passed the schema validator.** Three root causes, one underlying
+gap. The rule matched a curated set of patterns rather than scanning each file
+for every date-shaped signal:
+
+| ADR | Was | Now | Why the rule missed it |
+|---|---|---|---|
+| ADR-005 | 2025-12-18 | 2026-01-17 | Dated `**Superseded by**:` trailer block, outside any `## Status` heading. Now agrees with ADR-042's own record of the same event. |
+| ADR-017 | 2025-12-23 | 2025-12-28 | Same trailer-block gap, via `**Amended by**:` Session 93 entries. |
+| ADR-042 | 2026-01-17 | 2026-04-13 | A `### Date` subheading nested under `## Amendment 1`. The amendment-heading scan did not look inside the heading's own subsection. Confirmed by commit `4d1aaa5e1` (PR #1647). |
+| ADR-040 | 2026-07-11 | 2026-08-14 | **Two bugs stacked.** `2026-07-11` is ADR-080's acceptance date, merely *quoted* inside ADR-040's supersession callout: a mentioned date mistaken for an update date, and it had already been "corrected" onto that wrong value once. Real last edit confirmed by commit `333a80b74` (74 insertions), and the file's own line 274 reads "As of 2026-08-14", a sentence that cannot have been written earlier. |
+| ADR-036, ADR-055, ADR-061 | 2026-08-25 | 2026-08-25 | Values were right; nothing in the records' prose let a reader derive them. Each now carries a short dated clause. |
+
+The ADR-040 case is the instructive one: a date-shaped string in a record is not
+evidence about that record. It may be a quotation about a different one. Any
+future automation over this field has to distinguish "the date this record was
+changed" from "a date this record mentions", and the current rule does that by
+context, not by pattern.
+
+## The five status decisions: per-role verdicts (first round)
 
 The roster below reviewed the five status decisions. **Consensus was
 DISAGREE-AND-COMMIT, not unanimous ACCEPT**, and the disagreement was
@@ -733,12 +812,15 @@ the six hook-bypass mechanisms `.claude/rules/universal.md` MUST-NOT-2 forbids.
 No other hook was skipped: every batch cleared `adr-review-policy`,
 `staged-dash-policy`, and markdown lint.
 
-The justification the gate asks for: the file count is set by issue #5190, which
-names all 53 records; the diff is one identical nine-line block per file, plus a
-single prose paragraph in ADR-061 and four pre-existing em dashes removed from
-records already on the path; and a validation pass over all 96
-frontmatter-bearing ADRs proves conformance mechanically. Reviewing 53 copies of
-one block is not the burden the 50-file limit exists to prevent.
+The justification the gate asks for: the file count is set by issue #5190 (53
+records) and issue #5290 (10 more), plus 4 records added for status decisions,
+giving **67 ADRs across 73 files**. Sixty-two of those carry one identical
+nine-line block and nothing else. The remainder is five status decisions with
+prose changes, seven dated clauses, a handful of em-dash repairs, and the
+taste-lints fix with its tests. A validation pass over all 100
+frontmatter-bearing ADRs proves conformance mechanically. Reviewing 62 copies of
+one block is not the burden the 50-file limit exists to prevent, and the 5 that
+are real decisions are argued individually above.
 
 ## Commit batches
 
@@ -773,3 +855,4 @@ the batch here as it lands.
 | 23 | ADR-069, ADR-071 |
 | 24 | ADR-002, ADR-030, ADR-039, ADR-052 |
 | 25 | ADR-030, ADR-036, ADR-055, ADR-061 |
+| 26 | ADR-005, ADR-017, ADR-026, ADR-036 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -470,3 +470,4 @@ the batch here as it lands.
 | 12 | ADR-060, ADR-061, ADR-062, ADR-063 |
 | 13 | ADR-064, ADR-065, ADR-067, ADR-070 |
 | 14 | ADR-072 |
+| 15 | ADR-014, ADR-033, ADR-040, ADR-041 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -1,0 +1,384 @@
+# ADR-073 Phase 2 backfill: review and debate log
+
+Subject: adding ADR-073 lifecycle frontmatter to 53 existing ADRs that carry no
+frontmatter block. Issue #5190. Branch `claude/autoplan-goal-vd6pmg`.
+
+ADR-073 (`.agents/architecture/ADR-073-adr-lifecycle-frontmatter.md`) is Accepted
+(2026-06-19) and is not reopened here. Its schema is taken as given. This review
+covers one question only: is the prose-to-enum mapping proposed for each of the
+53 records correct, and are the derivation rules behind it sound?
+
+## How this review was conducted
+
+**Read this section before treating this document as consensus evidence.**
+
+The `adr-review` skill specifies a six-agent debate (architect, critic,
+independent-thinker, security, analyst, high-level-advisor). That roster could
+not be convened: sub-agent delegation was unavailable in the session that
+produced this change, so no agent other than the authoring one participated.
+
+What this document is instead: a single-reviewer structured review worked
+through the six adr-review axes in sequence, in which every factual claim was
+verified against a file or a git command rather than asserted. It is review
+evidence and it is not a six-agent consensus artifact. A reviewer weighing it
+should discount it accordingly, and the acceptance of this change rests on human
+review of the PR, not on a consensus that did not happen.
+
+The review was not a formality. It changed six of the fifty-three records before
+they were written. Those corrections are recorded under "Findings" below.
+
+The repository was un-shallowed (`git fetch --unshallow`, 2630 commits) before
+any date or implementation claim was made. The session began with a 50-commit
+shallow clone in which `git log --follow -1` returns 2026-08-18 for every ADR,
+because a single commit (`2c85d254`) touches all of them. Deriving `date` or
+`implemented` on that clone would have produced a uniform, wrong answer for
+every record with no visible symptom. Any future re-run of this backfill must
+check `git rev-parse --is-shallow-repository` first.
+
+## Derivation rules
+
+**`status`.** The first line of the record's `## Status` section, or its inline
+`**Status**:` line, mapped to the ADR-073 enum
+(`proposed | accepted | rejected | deprecated | superseded`). Amendment nuance
+("Accepted (amended 2026-07-19...)", "Accepted as amended...") maps to
+`accepted`; the nuance stays in prose. No prose was rewritten to fit the enum,
+with one deliberate exception recorded under ADR-061 below.
+
+**`date`.** The most recent date the record states in a date-bearing field: the
+`## Date` section (its last value when it lists several) or an inline `**Date**:`
+or `**Revised**:` line. Where no such field exists, and only there, the value is
+`git log --follow -1 --format=%ad --date=short`. Two records needed the git
+fallback: ADR-001 (2025-12-13) and ADR-026 (2026-07-27).
+
+Amendment dates appearing only inside `## Status` prose are deliberately not
+used. This is a real trade and it is recorded rather than hidden: ADR-040's
+prose records a partial supersession dated 2026-07-11 while its frontmatter
+`date` reads 2026-01-03, and ADR-062 and ADR-063 have the same shape. The rule
+was kept because the issue's acceptance criterion names the `## Date` section as
+the source, and because a rule that scrapes narrative prose for dates is exactly
+the brittleness ADR-073 exists to remove. The cost is that `date` means "last
+dated field", not "last touched".
+
+**`decision-makers`.** `[rjmurillo]` on all 53. This follows ADR-073's own
+frontmatter, which lists only `rjmurillo` even though its acceptance rested on a
+six-agent debate. Several records carry a `**Deciders**` line naming agents
+(ADR-006: "User, High-Level-Advisor Agent"; ADR-054: "Security Agent, DevOps
+Agent"). Those lines are preserved untouched in the body. The judgment is that
+agents named there are reviewers, not deciders, and that the repository owner is
+the party who accepts. This is the weakest of the four rules and is flagged as
+such: it discards recorded information in favor of uniformity, and a reviewer who
+prefers the recorded names has a fair objection.
+
+**`implemented`.** ADR-073 line 54 defines the field as flipping true "at first
+merged change" and gating amend-versus-supersede. It is therefore derived from
+whether a merged change implemented the decision, independent of the status
+label, and it stays `true` for a decision that shipped and was later retired,
+because such a record still must not be silently amended.
+
+Two proxies were tried and both were rejected as unreliable:
+
+- Counting references to the ADR id in live files. It reports 0 for ADR-041 and
+  ADR-046, whose artifacts demonstrably exist, and inflates ADR-011 and ADR-072,
+  whose references are prose describing an unbuilt proposal.
+- Counting merged commits whose message cites the id and which touch code. It
+  credits ADR-032 to a commit implementing ADR-033, and ADR-018 to a commit
+  implementing ADR-017.
+
+The value finally used is the artifact test: does the thing the ADR decided
+exist in the working tree now, or did it provably exist and merge before being
+removed? Every `implemented` value below was settled that way, by path.
+
+**`supersedes` / `superseded-by`.** Populated only where both ends are in scope,
+so no one-sided reference is created. Exactly one pair qualifies.
+
+## Findings
+
+Six records were corrected during review. All six were initially wrong in the
+same direction: a reference-count proxy said "never built" about a decision that
+had in fact shipped.
+
+1. **ADR-050, corrected false to true.** The initial value rested on the claim
+   that `scripts/sync_adr_protocol.py` does not exist, which is true today.
+   History shows the script was added 2026-02-28 in `4c0d01a0`
+   ("feat(governance): add ADR-to-Protocol sync process (#1247)") together with
+   `tests/test_sync_adr_protocol.py`, and removed 2026-08-20 in `ba541c21`
+   with the session-protocol retirement. A merged change implemented it.
+
+   Adjacent finding, not fixed here: ADR-073 line 150 lists
+   `scripts/sync_adr_protocol.py` in its Impact table as a component to check.
+   That citation is now dangling. Out of scope for this PR; worth an issue.
+
+2. **ADR-060, corrected false to true.** `_run_rework_warning_step` is absent
+   today but was added 2026-05-25 in `157737a0`
+   ("fix(#2063): persist rework warning in session log"). Shipped, then retired
+   with session logs.
+
+3. **ADR-067, corrected false to true.** The function its Implementation Notes
+   specify by name, `_change_claim_regions`, exists at
+   `scripts/validation/pr_description.py:510` and is called at line 542. The
+   record is still `proposed`; its implementation landed anyway.
+
+4. **ADR-049, corrected false to true.** The ADR names
+   `scripts/validate_pr_readiness.py`, which does not exist. The gate it decided
+   shipped under a different name as `scripts/validation/pre_pr.py`, which is
+   live and is the pre-PR gate this repository runs. Matching on the ADR's
+   proposed filename rather than on the decided capability would have scored
+   this wrong.
+
+5. **ADR-021, corrected false to true.** `.agents/governance/AI-REVIEW-MODEL-POLICY.md`
+   is the artifact; the routing policy shipped even though ADR-080 later
+   overtook parts of it.
+
+6. **ADR-059, corrected false to true.** `.claude/commands/pr-review.md` exists.
+
+Records where `implemented: false` survived verification: ADR-010 (no
+evaluator/optimizer artifact in the tree, and the only commits citing it are
+documentation cross-reference fixes), ADR-011, ADR-012, ADR-048 (three MCP
+servers, none built; there is no `mcp/` tree), ADR-018 (the decision was
+session-local caching and no git-tracked cache, which left no artifact),
+ADR-022, ADR-028 (zero artifacts and zero commits of any kind citing it),
+ADR-031, ADR-052, ADR-061, ADR-064, ADR-065 (`success_criterion` appears
+nowhere in the tree), ADR-072.
+
+### Records carrying a status/implementation mismatch, deliberately
+
+Four records are `proposed` with `implemented: true`: ADR-038, ADR-049, ADR-059,
+ADR-067, plus ADR-070. This is not an error. It is the field behaving as ADR-073
+specifies, and it surfaces a real governance gap the schema was built to make
+visible: decisions that shipped without ever being formally accepted. ADR-070 is
+the clearest case, since its own Implementation Notes read "It documents an
+already-landed gate; it does not change the gate."
+
+Three records are `accepted` with `implemented: false`: ADR-010, ADR-018,
+ADR-028. These are the mirror image, decisions accepted and never built.
+
+Both groups are worth a follow-up triage issue. Neither is fixed here, because
+changing a status is a governance act and this PR is a metadata backfill.
+
+### ADR-061: the one prose edit
+
+Prose status is "Withdrawn (2026-05-27, before acceptance, based on 6-agent
+debate verdict)". The enum has no `withdrawn` member. ADR-095
+(`.agents/architecture/ADR-095-scoped-re-review-axes.md`) is the precedent: it
+carries `status: rejected` with prose reading "Rejected. Recorded so the
+proposal is findable and does not return", which is the same concept, a proposal
+declined before acceptance and kept for findability.
+
+`status: rejected` was therefore chosen, and a paragraph was added to ADR-061's
+own `## Status` section recording that choice and its precedent. This is the
+only body edit in the change. It exists so the coercion leaves a trace in the
+document a human reads, rather than only in the machine-readable block. ADR-073
+line 57 requires that reconciliation happen by editing prose and never by a gate
+silently rewriting it; this edit is that reconciliation, performed by hand.
+
+### ADR-052 and ADR-055: supersession left deliberately empty
+
+ADR-052's prose reads "Proposed. Supersedes ADR-036." ADR-055's reads "Accepted
+(supersedes ADR-024, ADR-025)". All three targets are deferred from this PR
+pending issue #5192, so they have no frontmatter to hold a reciprocal
+`superseded-by`. Writing `supersedes: [ADR-036]` now would create exactly the
+one-sided reference ADR-073's Phase 3 bidirectional check is meant to catch.
+
+Both fields are therefore left `[]`, and the supersession remains recorded in
+prose where it already was. Whichever of #5190 or #5192 lands second owes the
+reciprocal edit on both ends. This is a known, deliberate incompleteness, not an
+oversight.
+
+### ADR-005 and ADR-042: the one reciprocal pair
+
+ADR-005's prose says "Superseded by [ADR-042]". ADR-042's prose claims the
+supersession from its own side in three places (lines 46, 134, 221: "Supersedes
+ADR-005"). Both records are in scope, so the pair is written reciprocally:
+ADR-005 gets `superseded-by: ADR-042` and ADR-042 gets `supersedes: [ADR-005]`.
+A validation pass confirms this is the only bidirectional pair among all 53.
+
+### The consumer-gate objection
+
+ADR-073 line 64 states that Phase 2 and beyond "are explicitly deferred and are
+conditional on a concrete consumer existing (a stale-ADR detector, a generated
+current-state index, or a dependency viewer)". Line 161 repeats it: "Do not
+start until a concrete consumer (below) exists."
+
+No such consumer exists in the tree today. Searching `scripts/` and
+`scripts/validation/` finds `check_adr_uniqueness.py` and
+`detect_adr_changes.py`, neither of which is a current-state index, a stale-ADR
+detector, or a dependency viewer.
+
+So this PR proceeds against its own governing ADR's stated precondition. The
+justification is that issue #5190 is an explicit owner instruction to do the
+backfill, and an owner instruction overrides a self-imposed sequencing
+constraint. That is a legitimate override and it should be visible rather than
+quiet, which is why it is recorded here and in the PR description. A reviewer who
+wants the consumer built first has a well-grounded objection rooted in the ADR's
+own text.
+
+The risk this precondition was protecting against is low for this change
+specifically: Phase 2 is additive and reversible, and no gate is being flipped to
+enforcing (that is Phase 3/4 and explicitly out of scope). The cost of doing it
+early is a backfill that might need revision if a future consumer wants different
+fields.
+
+## Verification performed
+
+A validation pass over all 96 frontmatter-bearing ADRs checks, for each record:
+YAML parses under `yaml.safe_load`; all six required keys present; `status` in
+the enum; `id` matches the filename number; `date` matches `YYYY-MM-DD`;
+`implemented` is a bool; `supersedes` is a list; the prose `## Status` first word
+agrees with the enum; and every supersession is reciprocal.
+
+Result on the 53 records this PR touches: zero errors.
+
+The same pass reports pre-existing problems in records this PR does not touch,
+recorded here because they were seen and should not be lost:
+
+- Ten ADRs carry a partial frontmatter block with a bare `status:` line and none
+  of the other five fields: ADR-003, ADR-020, ADR-023, ADR-027, ADR-034, ADR-057,
+  ADR-058, ADR-066, ADR-069, ADR-071. They were excluded from issue #5190's
+  59-record list because they are not frontmatter-free, but they are not
+  ADR-073-conformant either. ADR-071 additionally has no `date`. Completing
+  Phase 2 requires a pass over these ten.
+- ADR-091 declares `supersedes: [ADR-079]` while ADR-079 does not carry the
+  reciprocal `superseded-by`. This is the same class of defect as issue #5192
+  and ADR-079 is named there.
+
+## Security review
+
+Three concerns, per ADR-073's own integrity rules.
+
+**Mass `status: accepted` as a forgeable approval signal.** ADR-073 line 61
+warns that a hand-edit to `accepted` must not be treated as governance approval.
+This change writes `status: accepted` into 33 records at once, which is exactly
+the shape that rule distrusts. It is legitimate here only because of a narrow
+distinction: none of the 33 is a *transition*. Each record's prose already reads
+"Accepted", in most cases for months; the frontmatter is a transcription of an
+approval that already happened and is visible in the body above it. No record's
+governance state changes.
+
+That distinction is load-bearing and it must be stated in the PR description,
+because a reader who cannot see it has no way to tell this change apart from a
+mass self-approval. The reviewable invariant is: for all 53, frontmatter
+`status` agrees with prose `## Status`, and the validation pass above checks
+exactly that. The one record where they would have disagreed is ADR-061, whose
+prose was edited by hand and recorded above.
+
+**`explainer`.** Set to `null` on all 53. ADR-073 line 62 makes the field
+display-only and forbids auto-fetch (CWE-918, server-side request forgery, where
+a tool that fetches a URL from a document can be pointed at internal hosts). No
+in-scope record pairs with a living design doc, so `null` is both correct and the
+safe value. No external URL enters the frontmatter of any record.
+
+**YAML parse safety.** ADR-073 line 132 warns that malformed frontmatter "can
+fail parsing for every downstream consumer at once". The risk here is contained
+by construction: every emitted value is a machine-generated literal from a fixed
+table (an enum member, an ISO date, a bracketed id list, a bool, `null`), so no
+record's prose reaches a YAML value position. The long, colon-bearing, and
+bracket-bearing status prose in ADR-040 and ADR-041 stays in the body, below the
+closing delimiter, where YAML never sees it.
+
+Two mechanical checks guarded insertion: every target file was confirmed to begin
+with its own `# ADR-NNN` heading before writing, so no record with a pre-existing
+`---` near the top could be corrupted, and the writer refuses any file that
+already starts with `---`. Both checks passed on all 53. The verification pass
+then re-parses every block with `yaml.safe_load`, the loader ADR-073 mandates.
+
+Assessment: cleared. No P0 or P1 finding. The one residual is governance, not
+technical, and is the consumer-gate objection recorded above.
+
+## Verdict
+
+Accept with the caveats recorded in this document, which are, in order of how
+much they should weigh on a reviewer:
+
+1. This is a single-reviewer review, not the six-agent consensus the adr-review
+   skill specifies. Sub-agent delegation was unavailable.
+2. The backfill runs ahead of ADR-073's own consumer-gate precondition, on the
+   authority of issue #5190.
+3. `decision-makers` is uniformly `[rjmurillo]`, discarding `**Deciders**` lines
+   that name other parties.
+4. ADR-052 and ADR-055 carry deliberately empty `supersedes` pending #5192.
+5. `date` tracks the last dated field, not the last amendment recorded in prose.
+
+## Status mapping for all 53 records reviewed
+
+| ADR | status | date | supersedes | superseded-by | implemented |
+|-----|--------|------|------------|---------------|-------------|
+| ADR-001 | accepted | 2025-12-13 | [] | null | true |
+| ADR-005 | superseded | 2025-12-18 | [] | ADR-042 | true |
+| ADR-006 | accepted | 2025-12-18 | [] | null | true |
+| ADR-007 | accepted | 2026-01-01 | [] | null | true |
+| ADR-008 | accepted | 2025-12-20 | [] | null | true |
+| ADR-009 | accepted | 2025-12-20 | [] | null | true |
+| ADR-010 | accepted | 2025-12-20 | [] | null | false |
+| ADR-011 | proposed | 2025-12-21 | [] | null | false |
+| ADR-012 | proposed | 2025-12-21 | [] | null | false |
+| ADR-013 | proposed | 2025-12-21 | [] | null | true |
+| ADR-014 | accepted | 2025-12-22 | [] | null | true |
+| ADR-015 | accepted | 2025-12-22 | [] | null | true |
+| ADR-016 | accepted | 2025-12-22 | [] | null | true |
+| ADR-017 | accepted | 2025-12-23 | [] | null | true |
+| ADR-018 | accepted | 2025-12-23 | [] | null | false |
+| ADR-019 | accepted | 2025-12-23 | [] | null | true |
+| ADR-021 | accepted | 2025-12-23 | [] | null | true |
+| ADR-022 | proposed | 2025-12-23 | [] | null | false |
+| ADR-026 | accepted | 2026-07-27 | [] | null | true |
+| ADR-028 | accepted | 2025-12-23 | [] | null | false |
+| ADR-029 | accepted | 2025-12-27 | [] | null | true |
+| ADR-031 | proposed | 2025-12-29 | [] | null | false |
+| ADR-032 | accepted | 2025-12-30 | [] | null | true |
+| ADR-033 | accepted | 2025-12-30 | [] | null | true |
+| ADR-035 | accepted | 2025-12-30 | [] | null | true |
+| ADR-037 | accepted | 2026-07-20 | [] | null | true |
+| ADR-038 | proposed | 2026-01-01 | [] | null | true |
+| ADR-040 | accepted | 2026-01-03 | [] | null | true |
+| ADR-041 | accepted | 2026-01-16 | [] | null | true |
+| ADR-042 | accepted | 2026-01-17 | [ADR-005] | null | true |
+| ADR-043 | accepted | 2026-01-21 | [] | null | true |
+| ADR-045 | accepted | 2026-02-07 | [] | null | true |
+| ADR-046 | accepted | 2026-02-08 | [] | null | true |
+| ADR-047 | accepted | 2026-02-16 | [] | null | true |
+| ADR-048 | proposed | 2026-02-23 | [] | null | false |
+| ADR-049 | proposed | 2026-02-24 | [] | null | true |
+| ADR-050 | accepted | 2026-02-21 | [] | null | true |
+| ADR-051 | accepted | 2026-03-07 | [] | null | true |
+| ADR-052 | proposed | 2026-03-01 | [] | null | false |
+| ADR-053 | accepted | 2026-03-07 | [] | null | true |
+| ADR-054 | accepted | 2026-07-20 | [] | null | true |
+| ADR-055 | accepted | 2025-12-29 | [] | null | true |
+| ADR-056 | accepted | 2026-03-08 | [] | null | true |
+| ADR-059 | proposed | 2026-05-08 | [] | null | true |
+| ADR-060 | accepted | 2026-05-25 | [] | null | true |
+| ADR-061 | rejected | 2026-05-27 | [] | null | false |
+| ADR-062 | accepted | 2026-05-31 | [] | null | true |
+| ADR-063 | accepted | 2026-06-01 | [] | null | true |
+| ADR-064 | proposed | 2026-06-01 | [] | null | false |
+| ADR-065 | proposed | 2026-05-29 | [] | null | false |
+| ADR-067 | proposed | 2026-06-02 | [] | null | true |
+| ADR-070 | proposed | 2026-05-31 | [] | null | true |
+| ADR-072 | proposed | 2026-06-09 | [] | null | false |
+
+## Records excluded from this change
+
+Six of the 59 frontmatter-free ADRs are deliberately not touched, because each
+needs a decision that belongs to another open issue:
+
+| ADR | Reason | Owning issue |
+|-----|--------|--------------|
+| ADR-002, ADR-039 | Status is a "provisional" window that expired 2026-01-17. No enum member represents it. | #5193 |
+| ADR-030 | Not a decision record. Skill documentation carrying a "Critical Update" status. Its fate is being decided elsewhere. | #5195 |
+| ADR-024, ADR-025, ADR-036 | Prose-marked Accepted but actually superseded. The reciprocal `superseded-by` fix belongs with the other dangling supersessions. | #5192 |
+
+Because these six are excluded, issue #5190's acceptance criterion that every
+`ADR-[0-9]*.md` carry frontmatter is not fully met by this change. It is
+therefore referenced with `Refs`, not `Fixes`. A follow-up after #5192, #5193,
+and #5195 land can pick up the remaining six, plus the ten partial-frontmatter
+records listed under "Verification performed", and close it.
+
+## Commit batches
+
+The `adr-policy` pre-commit gate requires a debate log staged alongside every
+commit that touches an ADR, so this log is staged with each batch and records
+the batch here as it lands.
+
+| Batch | ADRs |
+|-------|------|
+| 1 | ADR-001, ADR-005, ADR-006, ADR-007 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -141,12 +141,13 @@ had in fact shipped.
 
 Records where `implemented: false` survived verification: ADR-010 (no
 evaluator/optimizer artifact in the tree, and the only commits citing it are
-documentation cross-reference fixes), ADR-011, ADR-012, ADR-048 (three MCP
-servers, none built; there is no `mcp/` tree), ADR-018 (the decision was
-session-local caching and no git-tracked cache, which left no artifact),
-ADR-022, ADR-028 (zero artifacts and zero commits of any kind citing it),
-ADR-031, ADR-052, ADR-061, ADR-064, ADR-065 (`success_criterion` appears
-nowhere in the tree), ADR-072.
+documentation cross-reference fixes), ADR-011, ADR-012, ADR-013, ADR-048 (four
+MCP servers, none built; there is no `mcp/` tree; ADR-013's schema stub at
+`src/agent-registry-schema.ts` is unused TypeScript interfaces, not the decided
+MCP server), ADR-018 (the decision was session-local caching and no git-tracked
+cache, which left no artifact), ADR-022, ADR-028 (zero artifacts and zero
+commits of any kind citing it), ADR-031, ADR-052, ADR-061, ADR-064, ADR-065
+(`success_criterion` appears nowhere in the tree), ADR-072.
 
 ### Records carrying a status/implementation mismatch, deliberately
 
@@ -319,7 +320,7 @@ much they should weigh on a reviewer:
 | ADR-010 | accepted | 2025-12-20 | [] | null | false |
 | ADR-011 | proposed | 2025-12-21 | [] | null | false |
 | ADR-012 | proposed | 2025-12-21 | [] | null | false |
-| ADR-013 | proposed | 2025-12-21 | [] | null | true |
+| ADR-013 | proposed | 2025-12-21 | [] | null | false |
 | ADR-014 | accepted | 2025-12-22 | [] | null | true |
 | ADR-015 | accepted | 2025-12-22 | [] | null | true |
 | ADR-016 | accepted | 2025-12-22 | [] | null | true |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -519,3 +519,4 @@ the batch here as it lands.
 | 16 | ADR-047, ADR-060, ADR-061, ADR-062 |
 | 17 | ADR-063, ADR-070 |
 | 18 | ADR-055 |
+| 19 | ADR-002, ADR-030, ADR-036, ADR-039 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -383,3 +383,4 @@ the batch here as it lands.
 |-------|------|
 | 1 | ADR-001, ADR-005, ADR-006, ADR-007 |
 | 2 | ADR-008, ADR-009, ADR-010, ADR-011 |
+| 3 | ADR-012, ADR-013, ADR-014, ADR-015 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -27,6 +27,14 @@ review of the PR, not on a consensus that did not happen.
 The review was not a formality. It changed six of the fifty-three records before
 they were written. Those corrections are recorded under "Findings" below.
 
+**The reviewer of this PR must choose one of two paths before merge, and the
+choice belongs to the repository owner, not to a default.** Either (a) convene
+the real six-agent adr-review debate in a session where sub-agent delegation
+works, and merge on that consensus, or (b) decide that single-reviewer
+structured review is sufficient evidence for a mechanical metadata backfill
+against an already-accepted schema, and record that decision. Do not merge on
+the assumption that a six-agent debate happened, because it did not.
+
 The repository was un-shallowed (`git fetch --unshallow`, 2630 commits) before
 any date or implementation claim was made. The session began with a 50-commit
 shallow clone in which `git log --follow -1` returns 2026-08-18 for every ADR,
@@ -373,6 +381,23 @@ therefore referenced with `Refs`, not `Fixes`. A follow-up after #5192, #5193,
 and #5195 land can pick up the remaining six, plus the ten partial-frontmatter
 records listed under "Verification performed", and close it.
 
+## Scope-gate note
+
+The final batches were committed with the `scope-policy` check's own opt-out.
+That check (`scripts/detect_scope_explosion.py`) blocks a branch changing more
+than 50 files, and this change touches 54. Its module docstring documents the
+opt-out as a first-class parameter for justified large PRs, and it is not one of
+the six hook-bypass mechanisms `.claude/rules/universal.md` MUST-NOT-2 forbids.
+No other hook was skipped: every batch cleared `adr-review-policy`,
+`staged-dash-policy`, and markdown lint.
+
+The justification the gate asks for: the file count is set by issue #5190, which
+names all 53 records; the diff is one identical nine-line block per file, plus a
+single prose paragraph in ADR-061 and four pre-existing em dashes removed from
+records already on the path; and a validation pass over all 96
+frontmatter-bearing ADRs proves conformance mechanically. Reviewing 53 copies of
+one block is not the burden the 50-file limit exists to prevent.
+
 ## Commit batches
 
 The `adr-policy` pre-commit gate requires a debate log staged alongside every
@@ -393,3 +418,4 @@ the batch here as it lands.
 | 10 | ADR-050, ADR-051, ADR-052, ADR-053 |
 | 11 | ADR-054, ADR-055, ADR-056, ADR-059 |
 | 12 | ADR-060, ADR-061, ADR-062, ADR-063 |
+| 13 | ADR-064, ADR-065, ADR-067, ADR-070 |

--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -2,10 +2,10 @@
 
 # ADR-073 Phase 2 backfill: review and debate log
 
-Subject: ADR-073 lifecycle frontmatter across 68 records. Issues #5190 and
+Subject: ADR-073 lifecycle frontmatter across 67 records. Issues #5190 and
 #5290. Branch `claude/autoplan-goal-vd6pmg`.
 
-Scope: **67 distinct ADR files**, 70 files in the PR. That is 53 records which
+Scope: **67 distinct ADR files**, 73 files in the PR. That is 53 records which
 carried no frontmatter, 10 which carried a partial block (#5290), and 4 further
 records added for status decisions (ADR-002, ADR-030, ADR-036, ADR-039). A fifth
 status decision, ADR-052, was already among the 53, so counting the status
@@ -88,8 +88,26 @@ update context:
   just the first;
 - an amendment or revision heading (`## Amendment 2026-07-21`,
   `### Current-State Amendment (2026-08-16)`);
-- a dated amendment, acceptance, supersession, or withdrawal statement inside
-  `## Status`.
+- a dated amendment, acceptance, supersession, withdrawal, **deprecation, or
+  rejection** statement inside `## Status`, or a dated record note added when the
+  status changed.
+
+The deprecation and rejection wordings were missing from an earlier version of
+this list, and their absence was not cosmetic: the five status decisions in this
+PR are exactly the records whose new prose reads "Deprecated (2026-08-25)" or
+"Rejected (2026-08-25)", so the rule as first written did not recognise the
+statements it had just caused to be written. Cursor Bugbot caught the
+consequence. Four records now carry `date: 2026-08-25`, the day their status
+actually changed: **ADR-002, ADR-030, ADR-039, ADR-052**.
+
+**ADR-036 deliberately keeps `date: 2026-01-01`.** It is the fifth status
+decision, but its status did not change: it was `accepted` in prose and is
+`accepted` in frontmatter. The only edit was repointing two stale
+`Generate-Agents.ps1` references, which is a citation repair, not a decision
+change. This is the line the rule draws: `date` tracks when the decision content
+last changed as the record itself states it, not when the file was last touched.
+Were it the latter, all 67 records would read 2026-08-25 and the field would
+carry no information at all.
 
 Dates in evidence tables, cited incidents, PR references, and measurement rows
 are excluded: those are dates the record mentions, not dates the record was
@@ -470,7 +488,7 @@ much they should weigh on a reviewer:
 | ADR-049 | proposed | 2026-02-24 | [] | null | true |
 | ADR-050 | accepted | 2026-02-21 | [] | null | true |
 | ADR-051 | accepted | 2026-03-07 | [] | null | true |
-| ADR-052 | proposed | 2026-03-01 | [] | null | false |
+| ADR-052 | proposed | 2026-08-25 | [] | null | false |
 | ADR-053 | accepted | 2026-03-07 | [] | null | true |
 | ADR-054 | accepted | 2026-07-20 | [] | null | true |
 | ADR-055 | accepted | 2025-12-29 | [] | null | true |
@@ -686,3 +704,4 @@ the batch here as it lands.
 | 21 | ADR-003, ADR-020, ADR-023, ADR-027 |
 | 22 | ADR-034, ADR-057, ADR-058, ADR-066 |
 | 23 | ADR-069, ADR-071 |
+| 24 | ADR-002, ADR-030, ADR-039, ADR-052 |

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -127,6 +127,46 @@ not surface a second one, but a future ADR-tooling change should expect it.
    dangling citation to a deleted script, and the ten ADRs carrying only a bare
    `status:` line that the #5190 record list did not cover.
 
+## Failure-Mode Classification
+
+**FM-10: Silent defaults and guard-clause suppression** (partial fit).
+
+The shallow-clone failure matches FM-10's core shape: a command succeeds,
+returns a plausible value, and is silently wrong. `git log --follow -1` on a
+shallow boundary returns a date; the date is the boundary commit, not the file's
+true origin. Nothing raises, nothing warns. The only symptom is that the value
+looks implausible if you already know what it should be.
+
+The fit is partial because FM-10 is primarily about code-level suppressions
+(`except: pass`, `or default`, verdict fall-through), and this failure is an
+environment precondition violation. But the unifying property holds: **the call
+site has no way to know the operation didn't actually do what its name claims.**
+`git log --follow -1 --format=%ad` claims to return the file's earliest date; on
+a shallow clone it returns the boundary date, and there is no return code or
+warning that distinguishes them.
+
+## Evidence
+
+| Artifact | Link |
+|----------|------|
+| Issue tracking the backfill | [#5190](https://github.com/rjmurillo/moq.analyzers/issues/5190) |
+| Debate log with `implemented` corrections | [ADR-073-phase2-backfill-debate-log.md](./../critique/ADR-073-phase2-backfill-debate-log.md) |
+| Commit exposing shallow-clone boundary | `2c85d254` (117 files, 35845 insertions, all-additions signature) |
+| ADR-073 lifecycle frontmatter schema | [ADR-073](../architecture/ADR-073-adr-lifecycle-frontmatter.md) |
+| Deferred supersession issues | [#5192](https://github.com/rjmurillo/moq.analyzers/issues/5192), [#5193](https://github.com/rjmurillo/moq.analyzers/issues/5193), [#5195](https://github.com/rjmurillo/moq.analyzers/issues/5195) |
+| ADR-policy gate weakness | [#5205](https://github.com/rjmurillo/moq.analyzers/issues/5205) |
+
+## Remediation
+
+| Action | Owner/Issue | Status |
+|--------|-------------|--------|
+| Add shallow-clone check rule (`.claude/rules/shallow-clone-guard.md`) | TBD | Pending |
+| Triage proposed-but-implemented mismatches (ADR-038, 049, 059, 067, 070) | TBD | Pending |
+| Triage accepted-but-unbuilt records (ADR-010, 018, 028) | TBD | Pending |
+| Fix ADR-073 dangling citation to `scripts/sync_adr_protocol.py` | TBD | Pending |
+| Complete Phase 2 for ten partial-frontmatter ADRs | [#5190](https://github.com/rjmurillo/moq.analyzers/issues/5190) | Pending |
+| Complete Phase 2 for six deferred ADRs | [#5192](https://github.com/rjmurillo/moq.analyzers/issues/5192), [#5193](https://github.com/rjmurillo/moq.analyzers/issues/5193), [#5195](https://github.com/rjmurillo/moq.analyzers/issues/5195) | Pending |
+
 ## Open at hand-off
 
 The PR is a draft and references #5190 with `Refs`, not `Fixes`. Six records

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -98,7 +98,7 @@ legible; the honest version was no more expensive to produce.
 `check_adr_review_policy` requires the debate log in `git diff --cached` for
 every commit touching an ADR, not merely once on the branch. Combined with the
 five-authored-file limit from `AGENTS.md`, that fixes the batch size at four ADRs
-plus the log. The log therefore had to change in each of the 14 commits, which
+plus the log. The log therefore had to change in every ADR-touching commit, which
 was resolved by having it record each batch as it landed, so the edit is real
 content rather than a touch to satisfy the gate.
 
@@ -106,7 +106,7 @@ content rather than a touch to satisfy the gate.
 
 | Gate | Cause | Resolution |
 |------|-------|------------|
-| `adr-policy` | ADR commits need a staged debate log | Review log staged with all 14 batches |
+| `adr-policy` | ADR commits need a staged debate log | Review log staged with every batch, each recording itself in the log |
 | `staged-dash-policy` | Four in-scope ADRs carried pre-existing em dashes | Replaced with colons and commas in ADR-021, 032, 053, 056 |
 | `scope-policy` / `branch-scope` | 73 files at final count, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
 | `python-tests` | `test_adr_063` read the title from `splitlines()[0]` | Test now finds the first H1; frontmatter legitimately precedes the title now |

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -206,7 +206,7 @@ Per `.claude/rules/retros.md` MUST-4, each item carries an owner or an issue.
 | 3 | Repair ADR-073's dangling citation to `scripts/sync_adr_protocol.py` | ADR amendment | rjmurillo/ai-agents#5289 | Filed |
 | 4 | Complete Phase 2 across the ten partial-frontmatter ADRs | Backfill | rjmurillo/ai-agents#5290 | Filed, folded into PR #5291 |
 | 5 | Triage the eight status/implementation mismatches surfaced by the schema (five `proposed` but shipped, three `accepted` but never built) | Governance triage | rjmurillo, needs an issue; not fixable in a metadata backfill because a status change is a governance act | Open |
-| 6 | Decide the review-evidence question for PR #5291: convene the full six-agent debate, or record acceptance of narrower evidence | Process decision | rjmurillo, on PR #5291 | Open |
+| 6 | Decide the review-evidence question for PR #5291: convene the full six-agent debate, or record acceptance of narrower evidence | Process decision | rjmurillo, on PR #5291 | **Done.** The full-state round ran over all 67 records: 3 ACCEPT, 2 DISAGREE-AND-COMMIT, 1 BLOCK cleared. It found seven wrong `date` values that no automated round caught, which is the empirical answer to whether the extra pass was worth its cost. |
 | 7 | Sweep the six ADR-030 citation sites, and decide where skill-first lives now that ADR-030 is rejected | Cleanup plus a governance decision | rjmurillo/ai-agents#5293 | Filed |
 
 ## What to carry forward

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -1,7 +1,7 @@
 # Retrospective: ADR-073 Phase 2 frontmatter backfill (issue #5190)
 
-Branch `claude/autoplan-goal-vd6pmg`. 53 ADRs backfilled with ADR-073 lifecycle
-frontmatter, one review log, one test fix. 15 commits.
+Branch `claude/autoplan-goal-vd6pmg`. 67 ADRs carrying ADR-073 lifecycle
+frontmatter, one review log, one test fix. 70 files.
 
 ## What was supposed to happen
 
@@ -108,7 +108,7 @@ content rather than a touch to satisfy the gate.
 |------|-------|------------|
 | `adr-policy` | ADR commits need a staged debate log | Review log staged with all 14 batches |
 | `staged-dash-policy` | Four in-scope ADRs carried pre-existing em dashes | Replaced with colons and commas in ADR-021, 032, 053, 056 |
-| `scope-policy` / `branch-scope` | 55 files, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
+| `scope-policy` / `branch-scope` | 70 files at final count, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
 | `python-tests` | `test_adr_063` read the title from `splitlines()[0]` | Test now finds the first H1; frontmatter legitimately precedes the title now |
 | `retrospective-policy` | Test fix made the push non-documentation-only | This file |
 
@@ -183,7 +183,7 @@ Per `.claude/rules/retros.md` MUST-4, each item carries an owner or an issue.
 | 4 | Complete Phase 2 across the ten partial-frontmatter ADRs | Backfill | rjmurillo/ai-agents#5290 | Filed, folded into PR #5291 |
 | 5 | Triage the eight status/implementation mismatches surfaced by the schema (five `proposed` but shipped, three `accepted` but never built) | Governance triage | rjmurillo, needs an issue; not fixable in a metadata backfill because a status change is a governance act | Open |
 | 6 | Decide the review-evidence question for PR #5291: convene the full six-agent debate, or record acceptance of narrower evidence | Process decision | rjmurillo, on PR #5291 | Open |
-| 7 | Sweep the six ADR-030 citation sites once its status change lands | Cleanup | Filed as a follow-up issue from this PR | Filed |
+| 7 | Sweep the six ADR-030 citation sites, and decide where skill-first lives now that ADR-030 is rejected | Cleanup plus a governance decision | rjmurillo/ai-agents#5293 | Filed |
 
 ## What to carry forward
 

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -19,10 +19,16 @@ would have shipped wrong answers.
 
 The acceptance criterion says `date` falls back to
 `git log --follow -1 --format=%ad --date=short` where a record has no `## Date`
-section. On arrival, `git rev-parse --is-shallow-repository` returned `true`
-with 50 commits, all dated 2026-08-18, because one commit (`2c85d254`) touches
-every ADR in the tree. That fallback would have returned 2026-08-18 for every
-record it was applied to, and for the `implemented` derivation every
+section. That command returns the date of the **most recent** commit touching
+the path, following renames; `-1` caps the log at one entry and the log is
+newest-first. On a complete clone that is the record's last-modified date, which
+is what the field wants.
+
+On arrival, `git rev-parse --is-shallow-repository` returned `true` with 50
+commits, all dated 2026-08-18, because one commit (`2c85d254`) touches every ADR
+in the tree. At a shallow boundary the most recent commit and the only visible
+commit are the same commit, so the fallback would have returned 2026-08-18 for
+every record it was applied to. For the `implemented` derivation, every
 `git log --grep` would have searched 50 commits instead of 2630.
 
 Nothing about this failure announces itself. The commands succeed, return
@@ -108,8 +114,76 @@ content rather than a touch to satisfy the gate.
 
 The `python-tests` failure is the one worth noting: the ADR-073 schema puts YAML
 ahead of the H1, so any test asserting a title on line 1 breaks. Exactly one test
-in the suite made that assumption. The remaining 39 frontmatter-free ADRs will
-not surface a second one, but a future ADR-tooling change should expect it.
+in the suite made that assumption. The six frontmatter-free ADRs still deferred
+will not surface a second one, but a future ADR-tooling change should expect it.
+
+## Failure mode classification
+
+Classified against `.agents/governance/FAILURE-MODES.md`. Both classes below
+were **near misses**: each was caught before merge, so this retro records what
+almost shipped rather than what did. That is worth writing down precisely
+because nothing external would have caught either one.
+
+| Failure | Class | Severity | Why it fits |
+|---|---|---|---|
+| Shallow clone read as complete history | **10. Silent defaults and guard-clause suppression** | High | The class covers absence-of-signal treated as signal. `git log --follow -1` on a shallow clone does not error; it returns the boundary commit's date, so missing history is indistinguishable from a real answer. Had it shipped, all 53 records carry one wrong date and no gate objects. |
+| Both `implemented` proxies trusted | **9. Confident-incorrectness recurrence** | High | The class shape is "partial signal, premature conclusion, confident delivery, multi-round correction". A reference count is partial signal; it was nearly delivered as fact for 53 records. Six were wrong and were only caught by opening the artifacts. |
+
+**Proposed addition to class 10, no new class needed.** Class 10's shape list
+enumerates six suppression forms, all of them in-process (`try/except: pass`,
+`value or default`, `dict.get` with a default, guard-clause early exit, schema
+fall-through, verdict parser emitting PASS on no output). It has no entry for
+*a truncated external data source read as complete*, which is what a shallow
+clone, a paginated API returning page 1, or a `grep` over a partial checkout all
+produce. Suggested seventh bullet:
+
+> - A query against a truncated data source (shallow git clone, unpaginated API
+>   result, partial checkout) whose truncation is not an error condition, so the
+>   partial answer is returned with the same shape and confidence as a complete
+>   one
+
+This is an addition to an existing class rather than a new class, so per
+`.claude/rules/retros.md` MUST-2 it does not require a linked ADR. Tracked as a
+remediation item below.
+
+## Evidence
+
+Commits and artifacts, all on branch `claude/autoplan-goal-vd6pmg` in
+`rjmurillo/ai-agents`:
+
+| Item | Reference |
+|---|---|
+| The PR | rjmurillo/ai-agents#5291 |
+| Driving issue | rjmurillo/ai-agents#5190 |
+| Deferred-record issues | rjmurillo/ai-agents#5192, #5193, #5195 |
+| Follow-ups filed from this work | rjmurillo/ai-agents#5289 (ADR-073 dangling script citation), #5290 (ten partial-frontmatter ADRs) |
+| Weak debate-log gate, not exploited | rjmurillo/ai-agents#5205 |
+| The shallow-boundary commit that made every ADR read as 2026-08-18 | `2c85d254` |
+| ADR-050's artifact: added, then removed | `4c0d01a0` (2026-02-28, #1247), `ba541c21` (2026-08-20, #5179) |
+| ADR-060's artifact: added | `157737a0` (2026-05-25, #2063) |
+| ADR-067's artifact, still live | `scripts/validation/pr_description.py:510` |
+| Review log with the full mapping and findings | `.agents/critique/ADR-073-phase2-backfill-debate-log.md` |
+| Test broken and fixed by the schema change | `tests/test_adr_063_memory_skill_decomposition.py` |
+
+Every issue reference above is in `rjmurillo/ai-agents`. Copilot's second review
+round reported these as pointing at `rjmurillo/moq.analyzers`; that finding was
+checked against this file and the review log and is a false positive. No
+`moq.analyzers` string appears in either. The only occurrences in the repository
+are in unrelated files this PR does not touch.
+
+## Remediation
+
+Per `.claude/rules/retros.md` MUST-4, each item carries an owner or an issue.
+
+| # | Action | Kind | Owner / issue | Status |
+|---|---|---|---|---|
+| 1 | Add the shallow-clone precondition to the rule tree, so any git-derived value checks `git rev-parse --is-shallow-repository` before it is trusted | Rule change | rjmurillo, needs an issue filed before a rule lands | Open |
+| 2 | Add the truncated-source bullet to FAILURE-MODES class 10 (text drafted above) | Governance change | rjmurillo | Open |
+| 3 | Repair ADR-073's dangling citation to `scripts/sync_adr_protocol.py` | ADR amendment | rjmurillo/ai-agents#5289 | Filed |
+| 4 | Complete Phase 2 across the ten partial-frontmatter ADRs | Backfill | rjmurillo/ai-agents#5290 | Filed, folded into PR #5291 |
+| 5 | Triage the eight status/implementation mismatches surfaced by the schema (five `proposed` but shipped, three `accepted` but never built) | Governance triage | rjmurillo, needs an issue; not fixable in a metadata backfill because a status change is a governance act | Open |
+| 6 | Decide the review-evidence question for PR #5291: convene the full six-agent debate, or record acceptance of narrower evidence | Process decision | rjmurillo, on PR #5291 | Open |
+| 7 | Sweep the six ADR-030 citation sites once its status change lands | Cleanup | Filed as a follow-up issue from this PR | Filed |
 
 ## What to carry forward
 
@@ -117,7 +191,7 @@ not surface a second one, but a future ADR-tooling change should expect it.
    highest-value lesson here and the only one that fails silently.
 2. **`implemented` cannot be proxied.** Verify by artifact, and check whether the
    artifact was removed after merging.
-3. **Four `proposed` records carry `implemented: true` and three `accepted`
+3. **Five `proposed` records carry `implemented: true` and three `accepted`
    records carry `implemented: false`.** This is the schema working as designed:
    it makes visible the decisions that shipped without formal acceptance
    (ADR-038, 049, 059, 067, 070) and those accepted but never built (ADR-010,

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -1,7 +1,7 @@
 # Retrospective: ADR-073 Phase 2 frontmatter backfill (issue #5190)
 
 Branch `claude/autoplan-goal-vd6pmg`. 67 ADRs carrying ADR-073 lifecycle
-frontmatter, one review log, one test fix. 70 files.
+frontmatter, one review log, a taste-lints fix, and two test files. 73 files.
 
 ## What was supposed to happen
 
@@ -108,14 +108,14 @@ content rather than a touch to satisfy the gate.
 |------|-------|------------|
 | `adr-policy` | ADR commits need a staged debate log | Review log staged with all 14 batches |
 | `staged-dash-policy` | Four in-scope ADRs carried pre-existing em dashes | Replaced with colons and commas in ADR-021, 032, 053, 056 |
-| `scope-policy` / `branch-scope` | 70 files at final count, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
+| `scope-policy` / `branch-scope` | 73 files at final count, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
 | `python-tests` | `test_adr_063` read the title from `splitlines()[0]` | Test now finds the first H1; frontmatter legitimately precedes the title now |
 | `retrospective-policy` | Test fix made the push non-documentation-only | This file |
 
 The `python-tests` failure is the one worth noting: the ADR-073 schema puts YAML
 ahead of the H1, so any test asserting a title on line 1 breaks. Exactly one test
-in the suite made that assumption. The six frontmatter-free ADRs still deferred
-will not surface a second one, but a future ADR-tooling change should expect it.
+in the suite made that assumption. The two ADRs still deferred will not surface
+a second one, but a future ADR-tooling change should expect it.
 
 ## Failure mode classification
 
@@ -227,8 +227,14 @@ Per `.claude/rules/retros.md` MUST-4, each item carries an owner or an issue.
 
 ## Open at hand-off
 
-The PR is a draft and references #5190 with `Refs`, not `Fixes`. Six records
-(ADR-002, 024, 025, 030, 036, 039) are deferred pending #5193, #5195, and #5192,
-so the issue's own acceptance criterion is not fully met. A follow-up after those
-three land can pick up the remaining six plus the ten partial-frontmatter
-records and close it.
+The PR references #5190 with Refs, not a closing keyword, and closes #5290.
+
+**Two records remain deferred: ADR-024 and ADR-025**, both owned by #5192, which
+is also where PR #5209 is doing the reciprocal-supersession work. Four records
+that were deferred when this retro was first written are no longer: ADR-002 and
+ADR-039 ship as `deprecated`, ADR-030 as `rejected`, and ADR-036 turned out never
+to have belonged to the #5192 problem at all. The ten partial-frontmatter records
+from #5290 are complete.
+
+So #5190's criterion that every `ADR-[0-9]*.md` carry frontmatter is met except
+for those two. A follow-up after #5192 lands closes the gap.

--- a/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
+++ b/.agents/retrospective/2026-08-25-adr-073-phase2-frontmatter-backfill.md
@@ -1,0 +1,136 @@
+# Retrospective: ADR-073 Phase 2 frontmatter backfill (issue #5190)
+
+Branch `claude/autoplan-goal-vd6pmg`. 53 ADRs backfilled with ADR-073 lifecycle
+frontmatter, one review log, one test fix. 15 commits.
+
+## What was supposed to happen
+
+Read each in-scope ADR's `## Status` and `## Date` sections, map the prose to
+the ADR-073 enum, write a nine-line frontmatter block, run a six-agent
+adr-review debate, commit in batches, push, open a draft PR. The task brief
+described this as a mechanical metadata backfill.
+
+## What actually happened
+
+It was not mechanical. Four things bit, in descending order of how quietly they
+would have shipped wrong answers.
+
+### 1. The clone was shallow and the date rule silently depended on it
+
+The acceptance criterion says `date` falls back to
+`git log --follow -1 --format=%ad --date=short` where a record has no `## Date`
+section. On arrival, `git rev-parse --is-shallow-repository` returned `true`
+with 50 commits, all dated 2026-08-18, because one commit (`2c85d254`) touches
+every ADR in the tree. That fallback would have returned 2026-08-18 for every
+record it was applied to, and for the `implemented` derivation every
+`git log --grep` would have searched 50 commits instead of 2630.
+
+Nothing about this failure announces itself. The commands succeed, return
+plausible ISO dates, and are wrong. It was caught only because a date of
+2026-08-18 on a December 2025 ADR looked odd enough to check the commit, and the
+commit turned out to be a 117-file, 35845-insertion, all-additions diff, which is
+the signature of a shallow boundary rather than a real edit.
+
+**Lesson.** Any derivation that reads git history must check
+`git rev-parse --is-shallow-repository` first and `git fetch --unshallow` before
+trusting a single date or `--grep` result. This is worth a rule, not just a
+retrospective line: the failure is silent, plausible, and would have poisoned 53
+records at once.
+
+### 2. Both cheap proxies for `implemented` were wrong, in opposite directions
+
+The field is defined as flipping true "at first merged change". Two proxies were
+tried before the artifact test:
+
+- **Counting ADR-id references in live files.** Reported 0 for ADR-041 and
+  ADR-046, whose artifacts (`codeql-analysis.yml`, `milestone-planner.md`)
+  plainly exist, and inflated ADR-011 and ADR-072, whose references are prose
+  describing proposals that were never built.
+- **Counting merged commits citing the id that touch code.** Credited ADR-032 to
+  a commit implementing ADR-033, and ADR-018 to a commit implementing ADR-017,
+  because commit messages cite neighbouring ADRs freely.
+
+Only the artifact test held: does the thing the ADR decided exist now, or did it
+provably exist and merge before removal? That test corrected six records
+(ADR-021, 049, 050, 059, 060, 067), all in the same direction, all cases where a
+proxy said "never built" about a decision that had shipped.
+
+Two of the six shipped and were later *removed*
+(`scripts/sync_adr_protocol.py`, `_run_rework_warning_step`), so present-tense
+existence alone would also have been wrong. One (ADR-049) shipped under a
+different filename than the ADR proposed, so matching the ADR's own named path
+would have scored it wrong too.
+
+**Lesson.** For a field that gates amend-versus-supersede, cheap proxies are not
+merely imprecise, they are wrong in both directions and the errors do not cancel.
+Verify by artifact, and check history for removal.
+
+### 3. Sub-agent delegation was unavailable and the honest response cost nothing
+
+The `adr-review` skill specifies a six-agent debate, and the `adr-policy`
+pre-commit gate requires a debate log staged with every ADR commit. `Task` was
+disabled in this session, so the roster could not be convened.
+
+The gate would have accepted a fabricated log. Issue #5205 already documents that
+its ADR-id matching is weak enough that any staged log mentioning one id
+satisfies a whole batch. Writing "architect: Accept. critic: Accept." would have
+passed every check and been undetectable from the diff.
+
+What was written instead is a single-reviewer structured review that opens by
+saying so, states that acceptance rests on human review of the PR, and asks the
+reviewer to choose explicitly between convening the real debate and accepting
+single-reviewer evidence for a mechanical backfill. The disclosure cost one
+paragraph. The review still did real work: it changed six records before they
+were written.
+
+**Lesson.** When a gate can be satisfied by an artifact that misrepresents what
+happened, the gate is not the audience. Write what is true and make the gap
+legible; the honest version was no more expensive to produce.
+
+### 4. The commit gate shape forced the batch structure
+
+`check_adr_review_policy` requires the debate log in `git diff --cached` for
+every commit touching an ADR, not merely once on the branch. Combined with the
+five-authored-file limit from `AGENTS.md`, that fixes the batch size at four ADRs
+plus the log. The log therefore had to change in each of the 14 commits, which
+was resolved by having it record each batch as it landed, so the edit is real
+content rather than a touch to satisfy the gate.
+
+## Gates hit, and how each was resolved
+
+| Gate | Cause | Resolution |
+|------|-------|------------|
+| `adr-policy` | ADR commits need a staged debate log | Review log staged with all 14 batches |
+| `staged-dash-policy` | Four in-scope ADRs carried pre-existing em dashes | Replaced with colons and commas in ADR-021, 032, 053, 056 |
+| `scope-policy` / `branch-scope` | 55 files, hard limit 50 | Owner-authorized, scoped `SKIP_SCOPE_CHECK=1`; documented in the log and the PR |
+| `python-tests` | `test_adr_063` read the title from `splitlines()[0]` | Test now finds the first H1; frontmatter legitimately precedes the title now |
+| `retrospective-policy` | Test fix made the push non-documentation-only | This file |
+
+The `python-tests` failure is the one worth noting: the ADR-073 schema puts YAML
+ahead of the H1, so any test asserting a title on line 1 breaks. Exactly one test
+in the suite made that assumption. The remaining 39 frontmatter-free ADRs will
+not surface a second one, but a future ADR-tooling change should expect it.
+
+## What to carry forward
+
+1. **Check for a shallow clone before deriving anything from git history.** The
+   highest-value lesson here and the only one that fails silently.
+2. **`implemented` cannot be proxied.** Verify by artifact, and check whether the
+   artifact was removed after merging.
+3. **Four `proposed` records carry `implemented: true` and three `accepted`
+   records carry `implemented: false`.** This is the schema working as designed:
+   it makes visible the decisions that shipped without formal acceptance
+   (ADR-038, 049, 059, 067, 070) and those accepted but never built (ADR-010,
+   018, 028). Worth a triage issue; not fixable in a metadata backfill, because
+   changing a status is a governance act.
+4. **Two follow-ups were filed** rather than left in the transcript: ADR-073's
+   dangling citation to a deleted script, and the ten ADRs carrying only a bare
+   `status:` line that the #5190 record list did not cover.
+
+## Open at hand-off
+
+The PR is a draft and references #5190 with `Refs`, not `Fixes`. Six records
+(ADR-002, 024, 025, 030, 036, 039) are deferred pending #5193, #5195, and #5192,
+so the issue's own acceptance criterion is not fully met. A follow-up after those
+three land can pick up the remaining six plus the ten partial-frontmatter
+records and close it.

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -395,9 +395,43 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+def _suppression_window(lines: list[str]) -> list[str]:
+    """Lines a suppression may appear in: any frontmatter block, plus 10 more.
+
+    The window means "near the top of the file", not "the first 10 bytes of
+    metadata". Both placements are in use in this repository and both must keep
+    working:
+
+    - Inside the frontmatter, as a YAML comment on line 2. ADR-068 and ADR-085
+      do this ("accepted append-only record; splitting breaks audit
+      continuity").
+    - After the frontmatter, as an HTML comment under the title. ADR-035 does
+      this.
+
+    A plain first-10-lines window only sees the first. ADR-073 lifecycle
+    frontmatter is exactly 10 lines (``---``, eight keys, ``---``), so on a
+    record carrying it the window closes before any content is read: ADR-035's
+    suppression sat at line 3, moved to line 14 when the issue #5190 backfill
+    added frontmatter, and silently stopped counting.
+
+    Widening rather than shifting is deliberate. This window is a strict
+    superset of the old one, so it cannot retire a suppression that works today.
+    An earlier attempt skipped the frontmatter instead and broke ADR-068 and
+    ADR-085, which is the failure this docstring exists to prevent recurring.
+
+    A closing delimiter is required. Without one, a leading ``---`` that is
+    really a horizontal rule would extend the window to the end of the file.
+    """
+    if lines and lines[0].strip() == "---":
+        for index in range(1, len(lines)):
+            if lines[index].strip() in {"---", "..."}:
+                return lines[: index + 11]
+    return lines[:10]
+
+
 def has_suppression(lines: list[str], rule: str) -> bool:
     """Check if file has a suppression comment for the given rule."""
-    for line in lines[:10]:
+    for line in _suppression_window(lines):
         match = SUPPRESSION_PATTERN.search(line)
         if match and match.group(1) == rule:
             return True

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -17,9 +17,16 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
 EXIT_VIOLATIONS = 10
+
+# Frontmatter is metadata. A block that has not closed by here is not
+# frontmatter, and bounding the scan keeps _suppression_window cheap on every
+# file in the repository.
+_MAX_FRONTMATTER_LINES = 50
 
 SUPPRESSION_PATTERN = re.compile(
     r"#\s*taste-lint:\s*ignore\s+([\w-]+)",
@@ -419,13 +426,30 @@ def _suppression_window(lines: list[str]) -> list[str]:
     An earlier attempt skipped the frontmatter instead and broke ADR-068 and
     ADR-085, which is the failure this docstring exists to prevent recurring.
 
-    A closing delimiter is required. Without one, a leading ``---`` that is
-    really a horizontal rule would extend the window to the end of the file.
+    A closing delimiter is not sufficient on its own. A document that opens with
+    a horizontal rule and carries an unrelated ``---`` separator far below would
+    otherwise have its window widened to that separator, silently disabling a
+    lint hundreds of lines from any real suppression. So the block must also
+    parse as a YAML mapping, which is what frontmatter is. A horizontal rule
+    followed by prose does not.
+
+    The scan for the closing delimiter is bounded. Frontmatter is metadata, so a
+    block that has not closed within ``_MAX_FRONTMATTER_LINES`` is not
+    frontmatter, and stopping there keeps this cheap on every file in the repo.
     """
-    if lines and lines[0].strip() == "---":
-        for index in range(1, len(lines)):
-            if lines[index].strip() in {"---", "..."}:
-                return lines[: index + 11]
+    if not lines or lines[0].strip() != "---":
+        return lines[:10]
+
+    for index in range(1, min(len(lines), _MAX_FRONTMATTER_LINES)):
+        if lines[index].strip() not in {"---", "..."}:
+            continue
+        try:
+            block = yaml.safe_load("".join(lines[1:index]))
+        except yaml.YAMLError:
+            return lines[:10]
+        if isinstance(block, dict):
+            return lines[: index + 11]
+        return lines[:10]
     return lines[:10]
 
 

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -400,6 +400,15 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+# A YAML mapping key: a token with no whitespace or colon in it, then a colon
+# that is followed by whitespace or ends the line. The trailing requirement is
+# what separates `explainer: https://example.com` (a key whose value is a URL)
+# from `See https://example.com for details` (prose whose only colon belongs to
+# a URL scheme). Matching a bare colon anywhere in the line classified the
+# second as a mapping and widened the suppression window past an unrelated
+# `---` later in the file, which is the regression this whole check prevents.
+_YAML_KEY_LINE = re.compile(r"[^\s:]+\s*:(\s|$)")
+
 def _looks_like_yaml_mapping(block: list[str]) -> bool:
     """True when ``block`` has the shape of a YAML mapping.
 
@@ -423,8 +432,7 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
             continue
         if line[:1] in {" ", "\t"} or stripped.startswith("- "):
             continue  # continuation: nested mapping, list item, folded scalar
-        key, sep, _ = stripped.partition(":")
-        if not sep or not key or key != key.strip():
+        if not _YAML_KEY_LINE.match(stripped):
             return False
         saw_key = True
     return saw_key

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -17,8 +17,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import yaml
-
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
 EXIT_VIOLATIONS = 10
@@ -402,6 +400,36 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+def _looks_like_yaml_mapping(block: list[str]) -> bool:
+    """True when ``block`` has the shape of a YAML mapping.
+
+    Deliberately a stdlib shape check rather than ``yaml.safe_load``. This
+    linter is invoked with a bare ``python3`` in seven places in its own
+    SKILL.md, and a job whose only preceding step is a checkout has installed
+    nothing, so a third-party import here fails at module load and takes the
+    gate red on every PR (`.claude/rules/ci-scripts.md` MUST-18). The question
+    is only "is this frontmatter or a horizontal rule", which does not need a
+    parser.
+
+    A mapping needs at least one top-level ``key:`` line, and every non-blank,
+    non-comment line must be either such a key or an indented continuation of
+    one. Prose under a horizontal rule fails on its first unindented line.
+    """
+    saw_key = False
+    for raw in block:
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line[:1] in {" ", "\t"} or stripped.startswith("- "):
+            continue  # continuation: nested mapping, list item, folded scalar
+        key, sep, _ = stripped.partition(":")
+        if not sep or not key or key != key.strip():
+            return False
+        saw_key = True
+    return saw_key
+
+
 def _suppression_window(lines: list[str]) -> list[str]:
     """Lines a suppression may appear in: any frontmatter block, plus 10 more.
 
@@ -443,11 +471,7 @@ def _suppression_window(lines: list[str]) -> list[str]:
     for index in range(1, min(len(lines), _MAX_FRONTMATTER_LINES)):
         if lines[index].strip() not in {"---", "..."}:
             continue
-        try:
-            block = yaml.safe_load("".join(lines[1:index]))
-        except yaml.YAMLError:
-            return lines[:10]
-        if isinstance(block, dict):
+        if _looks_like_yaml_mapping(lines[1:index]):
             return lines[: index + 11]
         return lines[:10]
     return lines[:10]

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -395,9 +395,43 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+def _suppression_window(lines: list[str]) -> list[str]:
+    """Lines a suppression may appear in: any frontmatter block, plus 10 more.
+
+    The window means "near the top of the file", not "the first 10 bytes of
+    metadata". Both placements are in use in this repository and both must keep
+    working:
+
+    - Inside the frontmatter, as a YAML comment on line 2. ADR-068 and ADR-085
+      do this ("accepted append-only record; splitting breaks audit
+      continuity").
+    - After the frontmatter, as an HTML comment under the title. ADR-035 does
+      this.
+
+    A plain first-10-lines window only sees the first. ADR-073 lifecycle
+    frontmatter is exactly 10 lines (``---``, eight keys, ``---``), so on a
+    record carrying it the window closes before any content is read: ADR-035's
+    suppression sat at line 3, moved to line 14 when the issue #5190 backfill
+    added frontmatter, and silently stopped counting.
+
+    Widening rather than shifting is deliberate. This window is a strict
+    superset of the old one, so it cannot retire a suppression that works today.
+    An earlier attempt skipped the frontmatter instead and broke ADR-068 and
+    ADR-085, which is the failure this docstring exists to prevent recurring.
+
+    A closing delimiter is required. Without one, a leading ``---`` that is
+    really a horizontal rule would extend the window to the end of the file.
+    """
+    if lines and lines[0].strip() == "---":
+        for index in range(1, len(lines)):
+            if lines[index].strip() in {"---", "..."}:
+                return lines[: index + 11]
+    return lines[:10]
+
+
 def has_suppression(lines: list[str], rule: str) -> bool:
     """Check if file has a suppression comment for the given rule."""
-    for line in lines[:10]:
+    for line in _suppression_window(lines):
         match = SUPPRESSION_PATTERN.search(line)
         if match and match.group(1) == rule:
             return True

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -17,9 +17,16 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
 EXIT_VIOLATIONS = 10
+
+# Frontmatter is metadata. A block that has not closed by here is not
+# frontmatter, and bounding the scan keeps _suppression_window cheap on every
+# file in the repository.
+_MAX_FRONTMATTER_LINES = 50
 
 SUPPRESSION_PATTERN = re.compile(
     r"#\s*taste-lint:\s*ignore\s+([\w-]+)",
@@ -419,13 +426,30 @@ def _suppression_window(lines: list[str]) -> list[str]:
     An earlier attempt skipped the frontmatter instead and broke ADR-068 and
     ADR-085, which is the failure this docstring exists to prevent recurring.
 
-    A closing delimiter is required. Without one, a leading ``---`` that is
-    really a horizontal rule would extend the window to the end of the file.
+    A closing delimiter is not sufficient on its own. A document that opens with
+    a horizontal rule and carries an unrelated ``---`` separator far below would
+    otherwise have its window widened to that separator, silently disabling a
+    lint hundreds of lines from any real suppression. So the block must also
+    parse as a YAML mapping, which is what frontmatter is. A horizontal rule
+    followed by prose does not.
+
+    The scan for the closing delimiter is bounded. Frontmatter is metadata, so a
+    block that has not closed within ``_MAX_FRONTMATTER_LINES`` is not
+    frontmatter, and stopping there keeps this cheap on every file in the repo.
     """
-    if lines and lines[0].strip() == "---":
-        for index in range(1, len(lines)):
-            if lines[index].strip() in {"---", "..."}:
-                return lines[: index + 11]
+    if not lines or lines[0].strip() != "---":
+        return lines[:10]
+
+    for index in range(1, min(len(lines), _MAX_FRONTMATTER_LINES)):
+        if lines[index].strip() not in {"---", "..."}:
+            continue
+        try:
+            block = yaml.safe_load("".join(lines[1:index]))
+        except yaml.YAMLError:
+            return lines[:10]
+        if isinstance(block, dict):
+            return lines[: index + 11]
+        return lines[:10]
     return lines[:10]
 
 

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -400,6 +400,15 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+# A YAML mapping key: a token with no whitespace or colon in it, then a colon
+# that is followed by whitespace or ends the line. The trailing requirement is
+# what separates `explainer: https://example.com` (a key whose value is a URL)
+# from `See https://example.com for details` (prose whose only colon belongs to
+# a URL scheme). Matching a bare colon anywhere in the line classified the
+# second as a mapping and widened the suppression window past an unrelated
+# `---` later in the file, which is the regression this whole check prevents.
+_YAML_KEY_LINE = re.compile(r"[^\s:]+\s*:(\s|$)")
+
 def _looks_like_yaml_mapping(block: list[str]) -> bool:
     """True when ``block`` has the shape of a YAML mapping.
 
@@ -423,8 +432,7 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
             continue
         if line[:1] in {" ", "\t"} or stripped.startswith("- "):
             continue  # continuation: nested mapping, list item, folded scalar
-        key, sep, _ = stripped.partition(":")
-        if not sep or not key or key != key.strip():
+        if not _YAML_KEY_LINE.match(stripped):
             return False
         saw_key = True
     return saw_key

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -17,8 +17,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import yaml
-
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
 EXIT_VIOLATIONS = 10
@@ -402,6 +400,36 @@ def read_file_lines(filepath: str) -> list[str]:
         return []
 
 
+def _looks_like_yaml_mapping(block: list[str]) -> bool:
+    """True when ``block`` has the shape of a YAML mapping.
+
+    Deliberately a stdlib shape check rather than ``yaml.safe_load``. This
+    linter is invoked with a bare ``python3`` in seven places in its own
+    SKILL.md, and a job whose only preceding step is a checkout has installed
+    nothing, so a third-party import here fails at module load and takes the
+    gate red on every PR (`.claude/rules/ci-scripts.md` MUST-18). The question
+    is only "is this frontmatter or a horizontal rule", which does not need a
+    parser.
+
+    A mapping needs at least one top-level ``key:`` line, and every non-blank,
+    non-comment line must be either such a key or an indented continuation of
+    one. Prose under a horizontal rule fails on its first unindented line.
+    """
+    saw_key = False
+    for raw in block:
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line[:1] in {" ", "\t"} or stripped.startswith("- "):
+            continue  # continuation: nested mapping, list item, folded scalar
+        key, sep, _ = stripped.partition(":")
+        if not sep or not key or key != key.strip():
+            return False
+        saw_key = True
+    return saw_key
+
+
 def _suppression_window(lines: list[str]) -> list[str]:
     """Lines a suppression may appear in: any frontmatter block, plus 10 more.
 
@@ -443,11 +471,7 @@ def _suppression_window(lines: list[str]) -> list[str]:
     for index in range(1, min(len(lines), _MAX_FRONTMATTER_LINES)):
         if lines[index].strip() not in {"---", "..."}:
             continue
-        try:
-            block = yaml.safe_load("".join(lines[1:index]))
-        except yaml.YAMLError:
-            return lines[:10]
-        if isinstance(block, dict):
+        if _looks_like_yaml_mapping(lines[1:index]):
             return lines[: index + 11]
         return lines[:10]
     return lines[:10]

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -1042,6 +1042,30 @@ class TestSuppressionSurvivesFrontmatter:
 
         assert has_suppression(lines, "file-size") is True
 
+    def test_block_style_yaml_list_is_valid_frontmatter(self) -> None:
+        # Every other fixture uses inline arrays (`supersedes: []`), so the
+        # block-style branch that accepts `- item` continuation lines had no
+        # coverage. Multiline lists are valid frontmatter and several records in
+        # this repository use them for `decision-makers` and `consulted`.
+        lines = [
+            "---\n",
+            "id: ADR-034\n",
+            "status: accepted\n",
+            "decision-makers:\n",
+            "  - orchestrator\n",
+            "consulted:\n",
+            "  - analyst\n",
+            "  - security\n",
+            "informed: []\n",
+            "---\n",
+            "\n",
+            "# ADR-034: Title\n",
+            "\n",
+            self.SUPPRESSION,
+        ]
+
+        assert has_suppression(lines, "file-size") is True
+
     def test_prose_with_a_colon_is_not_a_mapping(self) -> None:
         # The discriminator is shape, so a sentence that happens to contain a
         # colon must still be rejected: its key half is not a bare key.

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -1066,6 +1066,42 @@ class TestSuppressionSurvivesFrontmatter:
 
         assert has_suppression(lines, "file-size") is True
 
+    def test_a_bare_url_in_prose_is_not_a_mapping_key(self) -> None:
+        # A URL scheme's colon is not a `key:` separator. Matching any colon
+        # classified this line as frontmatter and widened the window past the
+        # `---` below it, finding a suppression that is out of range.
+        lines = [
+            "---\n",
+            "See https://example.com for details\n",
+            "---\n",
+            *["filler\n"] * 8,
+            self.SUPPRESSION,
+        ]
+
+        assert _suppression_window(lines) == lines[:10]
+        assert has_suppression(lines, "file-size") is False
+
+    def test_a_key_whose_value_is_a_url_is_still_a_mapping(self) -> None:
+        # The other half of the same rule: the colon here is followed by a
+        # space, so `explainer` is a real key and this really is frontmatter.
+        lines = [
+            "---\n",
+            "id: ADR-035\n",
+            "explainer: https://example.com/design-doc\n",
+            "---\n",
+            *["filler\n"] * 9,
+            self.SUPPRESSION,
+        ]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_a_key_with_an_empty_value_is_a_mapping(self) -> None:
+        # `key:` at end of line is valid YAML and must not be rejected by the
+        # requirement that a colon be followed by whitespace.
+        lines = ["---\n", "superseded-by:\n", "---\n", *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is True
+
     def test_prose_with_a_colon_is_not_a_mapping(self) -> None:
         # The discriminator is shape, so a sentence that happens to contain a
         # colon must still be rejected: its key half is not a bare key.

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -1008,12 +1008,35 @@ class TestSuppressionSurvivesFrontmatter:
 
         assert has_suppression(lines, "file-size") is False
 
-    def test_unterminated_frontmatter_does_not_swallow_the_body(self) -> None:
+    def test_unterminated_frontmatter_does_not_widen_the_window(self) -> None:
         # A leading `---` with no closing delimiter is a horizontal rule, not
-        # frontmatter. Skipping to EOF would hide every suppression in the file.
-        lines = ["---\n", self.SUPPRESSION, "body\n"]
+        # frontmatter, so the window stays at 10 lines. The suppression sits
+        # past line 10 on purpose: on line 2 it would fall inside both the
+        # correct window and a buggy to-EOF one, and the test could not fail.
+        lines = ["---\n", *["filler\n"] * 12, self.SUPPRESSION]
 
-        assert has_suppression(lines, "file-size") is True
+        assert has_suppression(lines, "file-size") is False
+
+    def test_a_horizontal_rule_pair_is_not_frontmatter(self) -> None:
+        # The regression Copilot found: a doc opening with a horizontal rule and
+        # carrying an unrelated `---` separator far below. Accepting any second
+        # `---` as the terminator widened the window to that separator and
+        # disabled a lint hundreds of lines from any real suppression. The body
+        # between the delimiters is prose, not a YAML mapping.
+        lines = ["---\n", "# Title\n", *["filler\n"] * 300, "---\n", self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is False
+
+    def test_frontmatter_scalar_body_is_not_a_mapping(self) -> None:
+        # Parses as YAML, but as a string rather than a mapping. Not frontmatter.
+        lines = ["---\n", "just a sentence\n", "---\n", *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is False
+
+    def test_malformed_yaml_between_delimiters_falls_back_to_ten_lines(self) -> None:
+        lines = ["---\n", "key: [unclosed\n", "---\n", *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is False
 
     def test_empty_file_is_safe(self) -> None:
         assert has_suppression([], "file-size") is False

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -42,6 +42,8 @@ get_base_file_line_count = mod.get_base_file_line_count
 _parse_hunk_header = mod._parse_hunk_header
 _filter_violations_for_diff = mod._filter_violations_for_diff
 _lint_file_rules = mod._lint_file_rules
+has_suppression = mod.has_suppression
+_suppression_window = mod._suppression_window
 
 
 class TestCheckFileSize:
@@ -963,3 +965,78 @@ class TestDiffScopeLineFilteringTasteLints:
         assert not any(v.file == cplx for v in result.violations), (
             "pre-existing complexity violation on unchanged line 1 must be suppressed"
         )
+
+
+class TestSuppressionSurvivesFrontmatter:
+    """A suppression must be findable on a file carrying YAML frontmatter.
+
+    ADR-073 lifecycle frontmatter is exactly 10 lines, which is the whole
+    suppression window. ADR-035 lost a working `file-size` suppression this way
+    during the issue #5190 backfill.
+    """
+
+    FM = [
+        "---\n", "id: ADR-035\n", "status: accepted\n", "date: 2025-12-30\n",
+        "decision-makers: [rjmurillo]\n", "supersedes: []\n",
+        "superseded-by: null\n", "explainer: null\n", "implemented: true\n",
+        "---\n",
+    ]
+    SUPPRESSION = "<!-- # taste-lint: ignore file-size (prose ADR) -->\n"
+
+    def test_suppression_found_after_frontmatter(self) -> None:
+        lines = [*self.FM, "\n", "# ADR-035: Title\n", "\n", self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_suppression_still_found_without_frontmatter(self) -> None:
+        lines = ["# ADR-035: Title\n", "\n", self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_absent_suppression_still_reports_false(self) -> None:
+        lines = [*self.FM, "\n", "# ADR-035: Title\n", "\n", "Body text.\n"]
+
+        assert has_suppression(lines, "file-size") is False
+
+    def test_suppression_for_a_different_rule_does_not_match(self) -> None:
+        lines = [*self.FM, "<!-- # taste-lint: ignore long-function -->\n"]
+
+        assert has_suppression(lines, "file-size") is False
+
+    def test_suppression_far_below_frontmatter_is_still_out_of_window(self) -> None:
+        lines = [*self.FM, *["filler\n"] * 11, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is False
+
+    def test_unterminated_frontmatter_does_not_swallow_the_body(self) -> None:
+        # A leading `---` with no closing delimiter is a horizontal rule, not
+        # frontmatter. Skipping to EOF would hide every suppression in the file.
+        lines = ["---\n", self.SUPPRESSION, "body\n"]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_empty_file_is_safe(self) -> None:
+        assert has_suppression([], "file-size") is False
+
+    def test_suppression_inside_the_frontmatter_still_counts(self) -> None:
+        # ADR-068 and ADR-085 put it on line 2, as a YAML comment. Widening the
+        # window must not retire that placement.
+        lines = [
+            "---\n",
+            "# taste-lint: ignore file-size, accepted append-only record.\n",
+            *self.FM[1:],
+            "# ADR-068: Title\n",
+        ]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_window_covers_frontmatter_plus_ten_content_lines(self) -> None:
+        lines = [*self.FM, *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert _suppression_window(lines)[-1] == self.SUPPRESSION
+        assert has_suppression(lines, "file-size") is True
+
+    def test_window_is_ten_lines_without_a_block(self) -> None:
+        lines = ["# Title\n", "body\n"]
+
+        assert _suppression_window(lines) == lines

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -1033,8 +1033,26 @@ class TestSuppressionSurvivesFrontmatter:
 
         assert has_suppression(lines, "file-size") is False
 
-    def test_malformed_yaml_between_delimiters_falls_back_to_ten_lines(self) -> None:
+    def test_mapping_shaped_but_malformed_yaml_still_counts_as_frontmatter(self) -> None:
+        # `key: [unclosed` would fail a real YAML parse, but between two `---`
+        # at the top of a file it is frontmatter the author got wrong, not a
+        # horizontal rule. The window is deciding which of those two things it
+        # is looking at, and a broken value does not make it prose.
         lines = ["---\n", "key: [unclosed\n", "---\n", *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is True
+
+    def test_prose_with_a_colon_is_not_a_mapping(self) -> None:
+        # The discriminator is shape, so a sentence that happens to contain a
+        # colon must still be rejected: its key half is not a bare key.
+        lines = [
+            "---\n",
+            "Note: this document was written on a Tuesday, see below\n",
+            "and it continues without indentation\n",
+            "---\n",
+            *["filler\n"] * 9,
+            self.SUPPRESSION,
+        ]
 
         assert has_suppression(lines, "file-size") is False
 

--- a/tests/test_adr_063_memory_skill_decomposition.py
+++ b/tests/test_adr_063_memory_skill_decomposition.py
@@ -57,10 +57,16 @@ class TestExistenceAndTitle:
         assert ADR_PATH.is_file()
 
     def test_title_names_the_decomposition_decision(self, adr_text: str) -> None:
-        first_line = adr_text.splitlines()[0]
-        assert first_line.startswith("# ADR-063:")
-        assert "memory" in first_line.lower()
-        assert "decompos" in first_line.lower()
+        # The title is the first H1, not the first line: ADR-073 lifecycle
+        # frontmatter now precedes it (issue #5190 backfill).
+        title = next(
+            (line for line in adr_text.splitlines() if line.startswith("# ")),
+            None,
+        )
+        assert title is not None, "ADR has no H1 title"
+        assert title.startswith("# ADR-063:")
+        assert "memory" in title.lower()
+        assert "decompos" in title.lower()
 
 
 class TestRequiredSections:


### PR DESCRIPTION
# Pull Request

> **Review-evidence status: complete.** Two six-agent adr-review rounds ran, the second covering all 67 records. Final verdict **3 ACCEPT, 2 DISAGREE-AND-COMMIT, 1 BLOCK cleared**. Not unanimous; the dissents are recorded per role in the review log.

## Summary

### What

Brings **67 ADRs** onto the ADR-073 lifecycle frontmatter schema, across 73 files. Three kinds of change, and they are not equivalent:

| Kind | Count | Nature |
|---|---|---|
| **Status decisions** | 5 | Real governance transitions with prose changes. ADR-002, ADR-030, ADR-036, ADR-039, ADR-052. |
| **Frontmatter-free backfill** (#5190) | 53 | Transcription of a status the prose already asserted. |
| **Partial-frontmatter completion** (#5290) | 10 | Adding the missing five fields to records that had `status`/`date`/`decision-makers`. |

ADR-052 is in both the 53 and the 5, so the distinct total is 67, not 68. Of these, **62 are mechanical and 5 are decisions**.

### Why

ADR-073 (Accepted 2026-06-19) defines the schema and defers the backfill to Phase 2. Phases 3 and 4 flip `validate-adr` to require a valid enum, and ADR-073 line 159 requires that to ship only after Phase 2 completes so the gate is never a tripwire on an un-migrated record.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5190 | Backfill lifecycle frontmatter into the 59 ADRs that lack it |
| **ADR** | `.agents/architecture/ADR-073-adr-lifecycle-frontmatter.md` | The schema and phased rollout |
| **Review** | `.agents/critique/ADR-073-phase2-backfill-debate-log.md` | Mapping, derivation rules, both rounds' per-role verdicts, security review |

Closes #5290

Refs #5190, deliberately not a closing keyword. Two records remain untouched (ADR-024, ADR-025), owned by #5192, so #5190's criterion that *every* `ADR-[0-9]*.md` carry frontmatter is not fully met here. All ten of #5290's records are complete.

## The five status decisions

These carry governance weight. Each was verified against the live tree, not inferred. **Two of the five were overturned by the debate**: the originally proposed pattern was `accepted` for ADR-002 and `rejected` for ADR-039, and both are now `deprecated`.

### ADR-002 and ADR-039 to `deprecated`

One question, not two. ADR-039 claimed to supersede ADR-002 "pending validation" over a window of 2026-01-03 to 2026-01-17.

The window closed with **zero of its four acceptance criteria measured** (`.agents/governance/model-pin-evidence.json` holds `"pins": []`). The downgrades were reverted, but not by ADR-039's own rollback procedure: incidentally on 2026-02-07, three weeks late, inside commit `568af6775` (PR #1046), which rewrote 41 agent files for an unrelated reason and **does not mention ADR-039 at all**. Verified: orchestrator, architect, independent-thinker, roadmap, high-level-advisor, and security all read `model: opus` today, which is ADR-002's assignment. So ADR-039's `supersedes` stays `[]`.

**ADR-002 is not revived to `accepted`.** Its own table assigns `critic` and `qa` to Sonnet where both are `opus`; it scopes itself to "All 18 agents" where 33 exist. And ADR-080 (accepted, 2026-07-11) re-answered the question on evidence, its Context rejecting ADR-002's method directly: "The pins encode a guess, not a measurement."

**`deprecated`, not `rejected`,** because both shipped and ran (ADR-039 for roughly five weeks). This repo uses `rejected` for a proposal declined *before* it was in force (ADR-095, ADR-061). This follows the **ADR-098 / ADR-093 precedent**, whose Status section states that "the acceptance of a governance ADR is a maintainer act": which is why both ship `proposed` against `implemented: true` rather than self-asserting acceptance. Security registered a **BLOCK** on flipping ADR-002 to `accepted` for exactly that reason; the block is cleared because the record no longer asserts an acceptance.

### ADR-030 to `rejected`, body untouched

Not a decision record: a same-day amendment memo to ADR-027 (still `proposed`). Its "Option E" was not built (`.claude/skills/github/SKILL.md` wraps Python scripts, zero `mcp__github` references). It gets frontmatter, a record note, and a reconciled `**Status**:` line; **the body is deliberately left alone**, because it is the only record of what was argued on 2025-12-23.

> ### Read this before approving: ADR-030 merges rejected while still cited as binding
>
> **This PR knowingly leaves the repository internally inconsistent, and the inconsistency is in executable code.**
>
> Three live sites still treat ADR-030 as authority after this merge:
>
> | Site | What it does |
> |---|---|
> | `scripts/validation/check_agent_skill_discriminator.py:40,53` | **A validator.** Names ADR-030 as its authority and hardcodes `ADR_PATH = ".agents/architecture/ADR-030-skills-pattern-superiority.md"`. After this merge it enforces a rule whose stated source is a rejected memo. |
> | `.claude/skills/ai-agents-architecture-contract/SKILL.md:56` | Table row calling skill-first "binding", citing `ADR-030 line 31`. That line number is **now wrong**: the frontmatter and note shift the body by roughly 16 lines, and line 31 is prose, not the comparison table. |
> | `src/copilot-cli/skills/ai-agents-architecture-contract/SKILL.md:56` | Generated mirror of the row above, same stale line number. **This one ships to plugin consumers.** |
>
> The underlying principle, skill-first over subagent dispatch, is still live practice. Rejecting ADR-030 removes its only written home without removing the practice.
>
> **Why it is deferred rather than fixed here.** The six-agent debate weighed this exact tension. Security, critic, and independent-thinker converged on a light-touch change plus a deferred sweep, over a body rewrite or an in-PR citation sweep. #5293 owns the sweep and the prior question of where skill-first should live (ADR-064 is a candidate, but is itself still `proposed`).
>
> **A reviewer who disagrees with that boundary should say so before merge**, because the alternative is to hold the whole status transition. Copilot's automated review argued exactly that. This is a considered debate outcome, not an oversight, but it is the reviewer's call to overturn.

### ADR-036 to `accepted` (and a correction)

**This PR's earlier review log wrongly grouped ADR-036 with ADR-024/ADR-025 as "actually superseded".** That was wrong, and the architect caught it. ADR-036 is the live operative architecture: 31 `templates/agents/*.shared.md` files that `build/generate_agents.py` reads on every build. It ships as an ordinary `accepted` transcription. Two stale `Generate-Agents.ps1` references are repointed, matching what the file already says at line 231.

### ADR-052 to `rejected`

Its generator and `platform-overrides/` never existed. Its central drift evidence was already rebutted by ADR-036 ("Similarity metrics ... measure divergence that is **BY DESIGN**, not sync failure"), which it never engages. The prose "Supersedes ADR-036." is struck to match `supersedes: []`.

**This was a 3-to-1 majority, not consensus.** High-level-advisor dissented, preferring it stay `proposed`. Recorded in the review log so it is not mistaken for unanimity.

**Issue #124 (whether the two-source template pattern should continue) remains open and unresolved. This rejection closes ADR-052's specific proposal, not the underlying question.**

## Review evidence

**Two six-agent rounds ran. Both are recorded per role in the review log. Neither was unanimous.**

| Round | Scope | Verdict |
|---|---|---|
| First | The 5 status decisions | DISAGREE-AND-COMMIT. **Two of the five statuses were overturned by the debate.** |
| Second (final) | **All 67 records** | **3 ACCEPT** (security, analyst, high-level-advisor), **2 DISAGREE-AND-COMMIT** (architect, critic), **1 BLOCK** (independent-thinker), cleared by making the two fixes it named. |

The second round is the authoritative review for the whole batch and closes the gap the earlier body flagged for the 62 mechanical records.

**It earned its cost.** It found **seven wrong `date` values that no bot round caught and that the schema validator passed**, because the validator checks `YYYY-MM-DD` shape and cannot check whether a value is right. Details under finding 20.

## Bot findings addressed

Both Copilot rounds, Cursor Bugbot, the spec validator, and the two debates. Each verified before fixing.

| # | Finding | Verdict | Fix |
|---|---|---|---|
| 1 | ADR-013 `implemented: true` wrong | Real | Now `false`. No `mcp/` tree; siblings ADR-011/012/048 all `false`. |
| 2 | Retro missing MUST-2/3/4 sections | Real | Failure classification, evidence, remediation with owners |
| 3 | ADR-061 prose "Withdrawn" vs enum `rejected` | Real | Prose now opens "Rejected (withdrawn ...)" |
| 4 | Mismatch paragraph said "four", named five | Real | Generated from files: 5 + 3 = 8 |
| 5 | `date` rule contradicts ADR-073's `# last updated` | **Real, and worse** | See below |
| 6 | "39 remain" | Real | Corrected |
| 7 | File count 54 vs 55 | Real | True count is 73 files / 67 ADRs |
| 8 | ADR-055 prose vs `supersedes: []` | Real | Prose reconciled, pending #5192 |
| 9 | `git log --follow` described as returning the earliest date | Real | Corrected: it returns the **most recent** commit |
| 10 | `implemented` deviates from ADR-073's literal text | Real | Documented, not silently changed. See below |
| 11 | Retro issue links point at `moq.analyzers`; 4 `TBD` owners | **Real, in a commit I did not have** | See "Concurrent edits" |
| 12 | Debate log claimed a six-agent debate without showing its evidence | Real | Per-role verdict tables for both rounds |
| 13 | `date` not advanced on ADR-036, ADR-055, ADR-061 | Real | Seven records carry 2026-08-25, the full set whose body content changed |
| 14 | ADR-030's `**Status**:` line still read "Critical Update" | Real | Reconciled to lead with `Rejected` |
| 15 | Debate log mapping table showed ADR-052 as `proposed` | Real | Corrected, with five other rows |
| 16 | "Zero validation errors" covered only the original 53 | Real | Re-run over all 67, and the claim is now qualified: it is a shape check, not a correctness check |
| 17 | Retro's deferred count stale | Real | Two records (ADR-024, ADR-025), not six |
| 18 | **Logic bug in the `taste_lints.py` fix** | **Real** | See below |
| 19 | ADR-003/ADR-020 have "no visible `## Status` section" | **False positive** | Pre-existing MADR-style records that open into `## Context and Problem Statement`. No prose status exists to disagree with the frontmatter. Predates this PR. |
| 20 | **Seven wrong `date` values**, found by the full-state debate | **Real** | See below |
| 21 | ADR-039's Related Decisions asserted a supersession the same file disclaims | Real | Reworded to point at the 2026-08-25 resolution |
| 22 | ADR-026 `**Update (2024-12-24)**` wrong year | Real | Now 2025-12-24, matching commit `4ce736819` |
| 23 | ADR-018 mislabelled "accepted, never built" | Real | It deliberately chose a no-op; the artifact check cannot represent a negative-space decision. Corrected in the log. |
| 24 | Stray body-level `status:` lines in ADR-063/ADR-064 | Real | Removed; the detector reads the frontmatter first |
| 25 | Block-style YAML list branch had no test | Real | Regression test added |
| 26 | ADR-022 Appendix C "leftover template scaffolding" | **Declined** | It sits inside a fenced markdown block under "Appendix C: Templates". Deliberate documentation of the ADR template, not dead scaffolding. Deleting it would remove real content. |

### Finding 20: seven wrong dates, none caught by automation

The full-state debate read the files. The validator had passed all seven, because it checks that `date` matches `YYYY-MM-DD`, not that the value is correct. Three root causes, one gap: the rule matched a curated set of patterns rather than scanning each file for every date-shaped signal.

| ADR | Was | Now | Why it was missed |
|---|---|---|---|
| ADR-005 | 2025-12-18 | 2026-01-17 | Dated `**Superseded by**:` trailer block, outside any `## Status` heading. Now agrees with ADR-042's own record of the same event. |
| ADR-017 | 2025-12-23 | 2025-12-28 | Same trailer gap, via `**Amended by**:` Session 93 entries. |
| ADR-042 | 2026-01-17 | 2026-04-13 | A `### Date` subheading nested under `## Amendment 1`. Confirmed by commit `4d1aaa5e1` (PR #1647). |
| ADR-040 | 2026-07-11 | 2026-08-14 | **Two bugs stacked.** `2026-07-11` is ADR-080's acceptance date, merely *quoted* in ADR-040's supersession callout: a mentioned date mistaken for an update date, and it had already been "corrected" onto that wrong value once. Confirmed by commit `333a80b74` and the file's own line 274, "As of 2026-08-14". |
| ADR-036, ADR-055, ADR-061 | 2026-08-25 | unchanged | Values were right, but nothing in the prose let a reader derive them. Each now carries a short dated clause. |

The ADR-040 case is the instructive one: **a date-shaped string in a record is not evidence about that record.** It may be a quotation about a different one.

### Finding 18: a real logic bug, fixed twice

The first frontmatter fix accepted **any** second `---` as the terminator. A document opening with a horizontal rule and carrying an unrelated `---` far below had its window widened to that separator. Reproduced: a 304-line window on a fixture whose suppression should have been out of range.

The block between delimiters must now have the shape of a YAML mapping. Copilot also caught that the test could not fail against the bug (its suppression sat on line 2, inside both the correct window and a buggy to-EOF one); it now sits past line 10 and asserts `False`, with four further cases and a negative control.

**A second bug came out of the first fix.** Using `yaml.safe_load` made a stdlib-only linter depend on a third-party package, and its own `SKILL.md` invokes it with a bare `python3` in seven places. `pre_pr.py` caught it (`DRIFT ... 7 invocations, baseline 0`), the trap `.claude/rules/ci-scripts.md` MUST-18 describes. Replaced with a stdlib shape check; the linter imports nothing outside the standard library.

### Finding 5 was the substantive one

The `date` rule read only the *first* formal date field. ADR-073 line 54 comments the field `# last updated`. The rule now scans amendment headings and dated `## Status` statements too. **This corrected 13 of the 53.** ADR-006 was wrong even under the old rule's own terms: a single `re.search` missed its second `**Date**:` field. The git fallback now reads `origin/main`, not `HEAD`, which would have dated every record to the day the backfill ran.

### Finding 10: a documented deviation, not a bug

ADR-073 and #5190 literally say `implemented` comes from "whether a merged change references the ADR". This PR verifies by **artifact** instead. A reference-count rule is wrong in both directions, and decisively so on reversion: it would mark **ADR-039 `implemented: true` forever** even though its changes were reverted, which inverts the field's stated job of gating amend-versus-supersede. If the maintainer prefers the literal reading, the fix is to amend ADR-073's Phase 2 wording. Full entry in the review log.

## Concurrent edits on this branch

A second agent (Cursor) was editing this branch in parallel and pushed overlapping work twice. Both are **merged, not overwritten**; duplicate sections were removed and one better idea (the "call site has no way to know" framing) was folded in with attribution.

This also resolves finding 11. Checked locally, the `moq.analyzers` links looked like a false positive because they were not in my tree. They were in the pushed branch. The retro records the lesson: **on a shared branch, "I checked and it is not there" is a statement about your working tree, not about the branch.**

## Known incompleteness a reviewer should not read as a bug

- **ADR-052 and ADR-055 carry empty `supersedes` pending #5192.** Both prose claims are struck rather than left contradicting the frontmatter. **Whichever of this PR or #5192 lands second owes the reciprocal edit.**
- **ADR-005 and ADR-042 form the only reciprocal pair,** confirmed by validation.
- **Eight status/implementation mismatches, deliberately.** Five `proposed` but shipped (ADR-038, 049, 059, 067, 070) plus ADR-058 from the #5290 set, and three `accepted` but never built. The schema surfacing real governance gaps. Not fixed here: changing a status is a governance act.
- **ADR-091 declares `supersedes: [ADR-079]` with no reciprocal.** Pre-existing, same class as #5192.
- **ADR-028 is cited as live authority while marked `implemented: false`.** `.gemini/styleguide.md:15` routes output-schema questions to it as canonical. Same class as the ADR-030 disclosure above, surfaced by the full-state debate. Not fixed here: this PR adds its frontmatter and does not change its status.
- **ADR-018 is `implemented: false` but was not "never built".** It deliberately chose a no-op (session-local caching, no git-tracked cache), so the absence of an artifact *is* the decision executed as written. The artifact-check rule cannot represent a negative-space decision. Do not triage it as unbuilt work.

## Relationship to PR #5209

**PR #5209 (open, unmerged) independently handles ADR-024/025/055/079/092 reciprocity and the #5191/#5197/#5198 infrastructure. This PR does not touch that scope.** File-level conflict is expected on ADR-005, ADR-042, ADR-055, and `tests/test_adr_063_memory_skill_decomposition.py`; whichever merges second rebases.

## Follow-ups filed from this work

- **#5289**: ADR-073 line 150 cites a script deleted in #5179.
- **#5290**: the ten partial-frontmatter records. **Closed by this PR.**
- **#5293**: ADR-030's citation sites, plus where skill-first lives now.

## Changes

- 67 ADRs carry ADR-073 frontmatter; 5 of them are status decisions with prose changes.
- **`fix(taste-lints)`**: `has_suppression` now scans the frontmatter block plus 10 further lines, and requires the block to have the shape of a YAML mapping. ADR-073 frontmatter is exactly 10 lines, so the old window closed before any content and silently retired ADR-035's working suppression. Widened rather than shifted, because a first attempt that *skipped* frontmatter broke ADR-068 and ADR-085, which put the comment inside the block. Both regressions are now tests. Verified by diffing the whole-repo violation set against `origin/main`: **zero added, zero removed**. Touches `.claude/skills/taste-lints/scripts/taste_lints.py`, its generated mirror under `src/copilot-cli/` (regenerated via the standard build pipeline, not hand-edited), and `tests/skills/taste-lints/test_taste_lints.py`.
- `tests/test_adr_063_memory_skill_decomposition.py` finds the title by first H1, not `splitlines()[0]`.

## Acceptance criteria

- [x] Every ADR touched has parseable frontmatter with all six required fields
- [x] Every `status` is one of the five enum members
- [x] `id` matches the filename number for every record
- [x] Frontmatter `status` and prose `## Status` agree, including first token (ADR-061, ADR-030)
- [x] Non-enum prose states resolved by explicit documented decision (ADR-061, ADR-030, ADR-002, ADR-039)
- [x] `date` derived as "last updated" per ADR-073's own field comment, and seven wrong values corrected
- [x] `implemented` verified by artifact; the deviation from ADR-073's literal wording is documented
- [x] Issue #5290's ten records complete
- [x] No validation gate flipped to enforcing (Phase 3/4 out of scope)
- [x] Six-agent debate evidence recorded per role for both rounds, including the dissents
- [x] Full-state six-agent debate covering all 67 records: complete, 3 ACCEPT / 2 DISAGREE-AND-COMMIT / 1 BLOCK cleared

## Type of Change

- [x] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: design review, high scrutiny (5 real governance transitions, two of them reversals, plus a shared-validator change), no rush.

**Focus areas**:

1. **The ADR-030 disclosure box above.** A validator will cite a rejected memo as its authority after this merge. A deliberate, debated scope boundary, and yours to overturn.
2. **The five status decisions**, especially the two reversals to `deprecated`.
3. **The `implemented` deviation** (finding 10). Accept the reasoning, or amend ADR-073's wording.
4. **The `taste-lints` change**, the only behavioral code change, affecting a repo-wide gate.
5. **`decision-makers`.** `[rjmurillo]` on the 53 that recorded none; the ten from #5290 keep their own recorded names. That asymmetry is deliberate.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Full suite green on push. `uv run python scripts/validation/pre_pr.py` reports "All validations passed". Frontmatter validation over all 100 blocks: only the pre-existing ADR-091/079 pair, which this PR does not touch.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

- **Mass `status: accepted` is not a mass self-approval.** ADR-073 line 61 distrusts hand-edits to `accepted`. None of the 62 mechanical records is a *transition*: each prose `## Status` already read "Accepted", and the invariant is checked mechanically. Security reviewed the five that *do* transition and BLOCKed one; that block shaped the outcome.
- **`explainer: null`** everywhere. No external URL enters any frontmatter (CWE-918), confirmed by the security reviewer.
- **YAML parse safety.** Every value is a machine-generated literal from a fixed table; no record's prose reaches a YAML value position.

### Other Agent Reviews

- [x] Architect / critic / independent-thinker / security / analyst / high-level-advisor reviewed the **5 status decisions**
- [x] Same roster for the 62 mechanical records, in the full-state round

## Author Pre-flight

- [x] Builds locally
- [x] Pre-PR validation passed
- [x] Lint and formatting clean
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated
- [x] No new warnings introduced

## Process disclosures

**Scope gate.** 73 files exceeds the 50-file limit in `scripts/detect_scope_explosion.py`. The owner authorized `SKIP_SCOPE_CHECK=1` for this branch. That variable is a documented parameter of that one check and is **not** among the six hook bypasses `.claude/rules/universal.md` MUST-NOT-2 forbids. No other hook was skipped.

**Shallow clone.** The authoring session started with a 50-commit shallow clone where `git log --follow -1` returns 2026-08-18 for every ADR. `git fetch --unshallow` was run first. Any re-run must check `git rev-parse --is-shallow-repository` before trusting a git-derived value.

## Related Issues

Refs #5190. Refs #5192 (ADR-024/025, still deferred), #5193, #5195. Refs #5289, #5293. Refs #5205. Refs #124 (left open by ADR-052's rejection). Related: PR #5209.