### PR TITLE
fix(taste-lints): single-line label false positive + stale debate-log dates

### DIFF
--- a/.agents/critique/ADR-073-phase2-backfill-debate-log.md
+++ b/.agents/critique/ADR-073-phase2-backfill-debate-log.md
@@ -159,7 +159,7 @@ Corrected records, with the context that supplied the new value:
 | ADR-008 | 2025-12-20 | 2026-08-19 | `### Amendment 2026-08-19 (Issue #5168, PR #5170)` |
 | ADR-014 | 2025-12-22 | 2026-08-16 | `### Current-State Amendment (2026-08-16)` |
 | ADR-033 | 2025-12-30 | 2026-08-16 | `### Current-State Amendment (2026-08-16)` |
-| ADR-040 | 2026-01-03 | 2026-07-11 | dated supersession statement in `## Status` |
+| ADR-040 | 2026-01-03 | 2026-07-11 | dated supersession statement in `## Status` (further corrected to 2026-08-14 by finding 20 below; 2026-07-11 was itself a quoted date, not an update date) |
 | ADR-041 | 2026-01-16 | 2026-07-21 | `## Amendment 2026-07-21: Retire Tier 3` |
 | ADR-047 | 2026-02-16 | 2026-04-29 | dated amendment statement in `## Status` |
 | ADR-060, ADR-061, ADR-062, ADR-063, ADR-070 | various | 2026-07-27 | `## Amendment 2026-07-27`, the ADR-088 citation repoint that touched all five |
@@ -540,9 +540,9 @@ much they should weigh on a reviewer:
 | ADR-035 | accepted | 2025-12-30 | [] | null | true |
 | ADR-037 | accepted | 2026-07-20 | [] | null | true |
 | ADR-038 | proposed | 2026-01-01 | [] | null | true |
-| ADR-040 | accepted | 2026-07-11 | [] | null | true |
+| ADR-040 | accepted | 2026-08-14 | [] | null | true |
 | ADR-041 | accepted | 2026-07-21 | [] | null | true |
-| ADR-042 | accepted | 2026-01-17 | [ADR-005] | null | true |
+| ADR-042 | accepted | 2026-04-13 | [ADR-005] | null | true |
 | ADR-043 | accepted | 2026-01-21 | [] | null | true |
 | ADR-045 | accepted | 2026-02-07 | [] | null | true |
 | ADR-046 | accepted | 2026-02-08 | [] | null | true |

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -409,6 +409,26 @@ def read_file_lines(filepath: str) -> list[str]:
 # `---` later in the file, which is the regression this whole check prevents.
 _YAML_KEY_LINE = re.compile(r"[^\s:]+\s*:(\s|$)")
 
+
+def _looks_like_yaml_value(value: str) -> bool:
+    """True when ``value`` has the shape of a YAML scalar, not free prose.
+
+    A real mapping value is empty (`superseded-by:`), a flow collection
+    (`[...]`, `{...}`), a quoted string, or a single unquoted token. Prose is
+    none of these: it is several bare words. Without this check, a key-shaped
+    regex alone accepts a sentence like `Note: release details` as a mapping,
+    because "Note" plus a colon plus a space matches `_YAML_KEY_LINE` exactly
+    the way `explainer:` does. Rejecting a multi-word, unquoted, unbracketed
+    remainder is what tells the two apart.
+    """
+    value = value.strip()
+    if not value:
+        return True
+    if value[0] in "[{'\"":
+        return True
+    return " " not in value
+
+
 def _looks_like_yaml_mapping(block: list[str]) -> bool:
     """True when ``block`` has the shape of a YAML mapping.
 
@@ -422,7 +442,9 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
 
     A mapping needs at least one top-level ``key:`` line, and every non-blank,
     non-comment line must be either such a key or an indented continuation of
-    one. Prose under a horizontal rule fails on its first unindented line.
+    one. Prose under a horizontal rule fails on its first unindented line, or
+    on the value half of that same line when the sentence itself is shaped
+    like `Word: rest of the sentence` (see ``_looks_like_yaml_value``).
     """
     saw_key = False
     for raw in block:
@@ -432,7 +454,10 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
             continue
         if line[:1] in {" ", "\t"} or stripped.startswith("- "):
             continue  # continuation: nested mapping, list item, folded scalar
-        if not _YAML_KEY_LINE.match(stripped):
+        match = _YAML_KEY_LINE.match(stripped)
+        if not match:
+            return False
+        if not _looks_like_yaml_value(stripped[match.end():]):
             return False
         saw_key = True
     return saw_key

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -409,6 +409,26 @@ def read_file_lines(filepath: str) -> list[str]:
 # `---` later in the file, which is the regression this whole check prevents.
 _YAML_KEY_LINE = re.compile(r"[^\s:]+\s*:(\s|$)")
 
+
+def _looks_like_yaml_value(value: str) -> bool:
+    """True when ``value`` has the shape of a YAML scalar, not free prose.
+
+    A real mapping value is empty (`superseded-by:`), a flow collection
+    (`[...]`, `{...}`), a quoted string, or a single unquoted token. Prose is
+    none of these: it is several bare words. Without this check, a key-shaped
+    regex alone accepts a sentence like `Note: release details` as a mapping,
+    because "Note" plus a colon plus a space matches `_YAML_KEY_LINE` exactly
+    the way `explainer:` does. Rejecting a multi-word, unquoted, unbracketed
+    remainder is what tells the two apart.
+    """
+    value = value.strip()
+    if not value:
+        return True
+    if value[0] in "[{'\"":
+        return True
+    return " " not in value
+
+
 def _looks_like_yaml_mapping(block: list[str]) -> bool:
     """True when ``block`` has the shape of a YAML mapping.
 
@@ -422,7 +442,9 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
 
     A mapping needs at least one top-level ``key:`` line, and every non-blank,
     non-comment line must be either such a key or an indented continuation of
-    one. Prose under a horizontal rule fails on its first unindented line.
+    one. Prose under a horizontal rule fails on its first unindented line, or
+    on the value half of that same line when the sentence itself is shaped
+    like `Word: rest of the sentence` (see ``_looks_like_yaml_value``).
     """
     saw_key = False
     for raw in block:
@@ -432,7 +454,10 @@ def _looks_like_yaml_mapping(block: list[str]) -> bool:
             continue
         if line[:1] in {" ", "\t"} or stripped.startswith("- "):
             continue  # continuation: nested mapping, list item, folded scalar
-        if not _YAML_KEY_LINE.match(stripped):
+        match = _YAML_KEY_LINE.match(stripped)
+        if not match:
+            return False
+        if not _looks_like_yaml_value(stripped[match.end():]):
             return False
         saw_key = True
     return saw_key

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -1116,6 +1116,17 @@ class TestSuppressionSurvivesFrontmatter:
 
         assert has_suppression(lines, "file-size") is False
 
+    def test_a_single_line_label_is_not_a_mapping(self) -> None:
+        # Copilot's finding on PR #5291: a single unindented line shaped like
+        # `Label: rest of sentence` matches `_YAML_KEY_LINE` on its own, with
+        # no second line to trip the continuation check the way
+        # `test_prose_with_a_colon_is_not_a_mapping` does. The discriminator
+        # has to reject it on the value half: "release details" is prose, not
+        # a YAML scalar, unlike the URL in `explainer: https://example.com`.
+        lines = ["---\n", "Note: release details\n", "---\n", *["filler\n"] * 9, self.SUPPRESSION]
+
+        assert has_suppression(lines, "file-size") is False
+
     def test_empty_file_is_safe(self) -> None:
         assert has_suppression([], "file-size") is False
 


### PR DESCRIPTION
## Summary

### What

Two small, independently verified fixes that GitHub Copilot's automated review found on PR #5291, committed after that PR's auto-merge had already fired and squashed. They never reached `main`. This PR carries only those two commits, rebuilt on top of the merged `main`.

### Why

PR #5291 (ADR-073 lifecycle frontmatter backfill) had auto-merge enabled. Two real bugs were found and fixed in the final minutes of review, but the fix commits raced the squash-merge: by the time the second push completed its ~10-minute pre-push hook suite, the PR had already merged and its branch was deleted. Both fixes are real, tested, and worth shipping rather than losing.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5190 | Follow-up fixes to the ADR-073 Phase 2 backfill (PR #5291, merged as `1d15e0d06`) |

## Changes

- **`.agents/critique/ADR-073-phase2-backfill-debate-log.md`**: the mapping table at lines 543/545 still showed the pre-correction dates for ADR-040 (`2026-07-11`) and ADR-042 (`2026-01-17`), which finding 20 elsewhere in the same file had already superseded with `2026-08-14` and `2026-04-13`. Corrected to match the actual frontmatter (verified against the live files) and the file's own later table. Also annotated the earlier "13 corrected records" table so a reader stopping there doesn't take the superseded value as final. Flagged by the AI Spec Validator's `PARTIAL` verdict on PR #5291.
- **`.claude/skills/taste-lints/scripts/taste_lints.py`** (+ its generated mirror `src/copilot-cli/skills/taste-lints/scripts/taste_lints.py`): `_looks_like_yaml_mapping` accepted a single unindented line shaped like `Label: rest of sentence` as YAML frontmatter, because the key-shaped regex alone can't tell `Note: release details` apart from `explainer: https://example.com`. Added `_looks_like_yaml_value`, requiring a real mapping value to be empty, a flow collection (`[...]`/`{...}`), a quoted string, or a single unquoted token, not a multi-word sentence. `Note: release details` now fails on the value half; `explainer: https://example.com` (no space) still passes. The mirror was regenerated through the standard build pipeline, not hand-edited; a byte diff confirms it matches the canonical file.
- **`tests/skills/taste-lints/test_taste_lints.py`**: added `test_a_single_line_label_is_not_a_mapping`, the exact case Copilot's review named. Verified as a genuine discrimination probe: the pre-fix logic returns `True` on this input (bug present), the fixed logic returns `False`.

## Acceptance criteria

- [x] Debate-log mapping table dates for ADR-040/ADR-042 match the actual frontmatter and the file's own later "finding 20" table
- [x] `_looks_like_yaml_value` rejects a single-line `Label: prose sentence` block while still accepting `key: <url>`, `key:` (empty), `key: [flow]`, and `key: "quoted value"`
- [x] Regression test added with a discrimination probe (pre-fix logic returns `True` on the reported input)
- [x] Whole-repo taste-lints violation diff against `origin/main`: zero added, zero removed
- [x] Generated mirror regenerated through the standard build pipeline and confirmed byte-identical to canonical

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny (two small, independently verified fixes; no design decisions), no rush.

**Focus areas**: the `_looks_like_yaml_value` value-shape heuristic, specifically whether empty/bracket/quote/no-space is the right boundary for "looks like a YAML scalar", or whether it should be narrower or wider.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Repo-wide taste-lints scan diffed by `(file, rule)` identity against the pre-fix version: 3018 violations before, 3018 after, 0 added, 0 removed. `uv run --frozen python -m pytest tests/skills/taste-lints/test_taste_lints.py -q`: 115 passed.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] Fixes verified against GitHub Copilot's automated-review findings on PR #5291, each with a concrete discrimination probe rather than trusting the report

## Author Pre-flight

- [x] Builds locally
- [x] Pre-PR validation passed
- [x] Lint and formatting clean
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Related Issues

Refs #5190. Follow-up to PR #5291 (merged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7FmaBC2npPH32n4dxWxNS)_