### PR TITLE
fix(rules): ruff format is not this repo's enforced formatter

### DIFF
--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -54,9 +54,9 @@ config, and `mypy` settings over personal preference.
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
 - **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
-  runs the formatter, and main does not conform (1287 of 2061 files would
-  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
+  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
+  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
   finding, and running the formatter over a file or directory charges unrelated
   drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
   `tests/validation/test_ruff_format_not_enforced.py` pin both facts.

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -15,9 +15,8 @@ blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
 requires every tracked file to parse at the hook-portability syntax floor,
 currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
 695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
-(3.14). `ruff` targets that floor, not the install target
-(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
-config, and `mypy` settings over personal preference.
+(3.14). Defer to `pyproject.toml`, `ruff` config, and `mypy` settings over
+personal preference.
 
 ## Typing
 
@@ -47,19 +46,15 @@ config, and `mypy` settings over personal preference.
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff check` for lint (it
-  replaces isort and flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint; `mypy`
+  for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
-- **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
-  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
-  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
-  finding, and running the formatter over a file or directory charges unrelated
-  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
-  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
+- **Never run `ruff format` or cite `ruff format --check` as a gate.**
+  No gate runs it; main does not conform. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` hold the evidence.
 
 ## Errors
 

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -9,23 +9,22 @@ description: Python idioms, typing, tooling, and pitfalls. Applies when editing 
 # Python Rules
 
 These rules apply when you write or review Python. The dev and install target is
-3.14 (`.python-version`, CI, `requires-python = ">=3.14"`, `ruff` target-version
-`py314`). But plugin hooks and skill scripts run under the host's ambient
-interpreter, which may be older, so a blocking gate
-(`scripts/validation/validate_python_syntax.py`, issue #2655) requires every
-tracked file to parse at the hook-portability syntax floor, currently 3.10.
-Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
-(`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:` (3.14). Defer to
-`pyproject.toml`, `ruff` config, and `mypy` settings over personal preference.
+3.14 (`.python-version`, CI, `requires-python = ">=3.14"`). But plugin hooks and
+skill scripts run under the host's ambient interpreter, which may be older, so a
+blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
+requires every tracked file to parse at the hook-portability syntax floor,
+currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
+695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
+(3.14). `ruff` targets that floor, not the install target
+(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
+config, and `mypy` settings over personal preference.
 
 ## Typing
 
 - Type every public function signature: parameters and return. Internal helpers
   with obvious types may omit annotations, but a boundary without types is a bug.
 - Use built-in generics (`list[str]`, `dict[str, int]`, `tuple[int, ...]`) and
-  `X | None` instead of `Optional[X]`. Do not use PEP 695 generic syntax
-  (`def f[T](x: T) -> T`): it needs 3.12+ and the syntax-floor gate (3.10)
-  rejects it repo-wide.
+  `X | None` instead of `Optional[X]`.
 - Prefer precise types: `Sequence`/`Mapping` for read-only parameters,
   `Protocol` for structural interfaces, `Literal` for fixed string sets,
   `TypedDict` for structured dict payloads at a boundary.
@@ -48,12 +47,19 @@ Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff` for lint and format
-  (it replaces black, isort, flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint (it
+  replaces isort and flake8); `mypy` for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
+- **`ruff format` is not this repo's formatter. Do not run it, and never cite
+  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
+  runs the formatter, and main does not conform (1287 of 2061 files would
+  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  finding, and running the formatter over a file or directory charges unrelated
+  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
 
 ## Errors
 

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -176,7 +176,7 @@ as an implementer.
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
 **always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,874 bytes
+of what you touch. The **effective context on a `.py` edit is 98,398 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -176,7 +176,7 @@ as an implementer.
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
 **always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+of what you touch. The **effective context on a `.py` edit is 98,861 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -176,7 +176,7 @@ as an implementer.
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
 **always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,861 bytes
+of what you touch. The **effective context on a `.py` edit is 98,874 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -12,9 +12,8 @@ blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
 requires every tracked file to parse at the hook-portability syntax floor,
 currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
 695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
-(3.14). `ruff` targets that floor, not the install target
-(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
-config, and `mypy` settings over personal preference.
+(3.14). Defer to `pyproject.toml`, `ruff` config, and `mypy` settings over
+personal preference.
 
 ## Typing
 
@@ -44,19 +43,15 @@ config, and `mypy` settings over personal preference.
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff check` for lint (it
-  replaces isort and flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint; `mypy`
+  for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
-- **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
-  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
-  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
-  finding, and running the formatter over a file or directory charges unrelated
-  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
-  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
+- **Never run `ruff format` or cite `ruff format --check` as a gate.**
+  No gate runs it; main does not conform. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` hold the evidence.
 
 ## Errors
 

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -51,9 +51,9 @@ config, and `mypy` settings over personal preference.
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
 - **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
-  runs the formatter, and main does not conform (1287 of 2061 files would
-  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
+  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
+  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
   finding, and running the formatter over a file or directory charges unrelated
   drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
   `tests/validation/test_ruff_format_not_enforced.py` pin both facts.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -6,23 +6,22 @@ applyTo: '**/*.py,**/pyproject.toml,**/requirements*.txt'
 # Python Rules
 
 These rules apply when you write or review Python. The dev and install target is
-3.14 (`.python-version`, CI, `requires-python = ">=3.14"`, `ruff` target-version
-`py314`). But plugin hooks and skill scripts run under the host's ambient
-interpreter, which may be older, so a blocking gate
-(`scripts/validation/validate_python_syntax.py`, issue #2655) requires every
-tracked file to parse at the hook-portability syntax floor, currently 3.10.
-Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
-(`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:` (3.14). Defer to
-`pyproject.toml`, `ruff` config, and `mypy` settings over personal preference.
+3.14 (`.python-version`, CI, `requires-python = ">=3.14"`). But plugin hooks and
+skill scripts run under the host's ambient interpreter, which may be older, so a
+blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
+requires every tracked file to parse at the hook-portability syntax floor,
+currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
+695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
+(3.14). `ruff` targets that floor, not the install target
+(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
+config, and `mypy` settings over personal preference.
 
 ## Typing
 
 - Type every public function signature: parameters and return. Internal helpers
   with obvious types may omit annotations, but a boundary without types is a bug.
 - Use built-in generics (`list[str]`, `dict[str, int]`, `tuple[int, ...]`) and
-  `X | None` instead of `Optional[X]`. Do not use PEP 695 generic syntax
-  (`def f[T](x: T) -> T`): it needs 3.12+ and the syntax-floor gate (3.10)
-  rejects it repo-wide.
+  `X | None` instead of `Optional[X]`.
 - Prefer precise types: `Sequence`/`Mapping` for read-only parameters,
   `Protocol` for structural interfaces, `Literal` for fixed string sets,
   `TypedDict` for structured dict payloads at a boundary.
@@ -45,12 +44,19 @@ Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff` for lint and format
-  (it replaces black, isort, flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint (it
+  replaces isort and flake8); `mypy` for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
+- **`ruff format` is not this repo's formatter. Do not run it, and never cite
+  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
+  runs the formatter, and main does not conform (1287 of 2061 files would
+  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  finding, and running the formatter over a file or directory charges unrelated
+  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
 
 ## Errors
 

--- a/src/copilot-cli/instructions/python.instructions.md
+++ b/src/copilot-cli/instructions/python.instructions.md
@@ -12,9 +12,8 @@ blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
 requires every tracked file to parse at the hook-portability syntax floor,
 currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
 695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
-(3.14). `ruff` targets that floor, not the install target
-(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
-config, and `mypy` settings over personal preference.
+(3.14). Defer to `pyproject.toml`, `ruff` config, and `mypy` settings over
+personal preference.
 
 ## Typing
 
@@ -44,19 +43,15 @@ config, and `mypy` settings over personal preference.
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff check` for lint (it
-  replaces isort and flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint; `mypy`
+  for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
-- **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
-  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
-  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
-  finding, and running the formatter over a file or directory charges unrelated
-  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
-  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
+- **Never run `ruff format` or cite `ruff format --check` as a gate.**
+  No gate runs it; main does not conform. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` hold the evidence.
 
 ## Errors
 

--- a/src/copilot-cli/instructions/python.instructions.md
+++ b/src/copilot-cli/instructions/python.instructions.md
@@ -51,9 +51,9 @@ config, and `mypy` settings over personal preference.
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
 - **`ruff format` is not this repo's formatter. Do not run it, and never cite
-  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
-  runs the formatter, and main does not conform (1287 of 2061 files would
-  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  `ruff format --check` as a gate result.** Every ruff gate runs `ruff check`;
+  nothing runs the formatter, and main does not conform (1287 of 2061 tracked
+  files would reformat on `cdf688a`). A green check proves nothing, a red one is not a
   finding, and running the formatter over a file or directory charges unrelated
   drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
   `tests/validation/test_ruff_format_not_enforced.py` pin both facts.

--- a/src/copilot-cli/instructions/python.instructions.md
+++ b/src/copilot-cli/instructions/python.instructions.md
@@ -6,23 +6,22 @@ applyTo: '**/*.py,**/pyproject.toml,**/requirements*.txt'
 # Python Rules
 
 These rules apply when you write or review Python. The dev and install target is
-3.14 (`.python-version`, CI, `requires-python = ">=3.14"`, `ruff` target-version
-`py314`). But plugin hooks and skill scripts run under the host's ambient
-interpreter, which may be older, so a blocking gate
-(`scripts/validation/validate_python_syntax.py`, issue #2655) requires every
-tracked file to parse at the hook-portability syntax floor, currently 3.10.
-Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
-(`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:` (3.14). Defer to
-`pyproject.toml`, `ruff` config, and `mypy` settings over personal preference.
+3.14 (`.python-version`, CI, `requires-python = ">=3.14"`). But plugin hooks and
+skill scripts run under the host's ambient interpreter, which may be older, so a
+blocking gate (`scripts/validation/validate_python_syntax.py`, issue #2655)
+requires every tracked file to parse at the hook-portability syntax floor,
+currently 3.10. Write to that floor: avoid syntax newer than 3.10, such as PEP
+695 generics (`def f[T]()`, 3.12+) and PEP 758 unparenthesized `except A, B:`
+(3.14). `ruff` targets that floor, not the install target
+(`target-version = "py310"`, issue #3126). Defer to `pyproject.toml`, `ruff`
+config, and `mypy` settings over personal preference.
 
 ## Typing
 
 - Type every public function signature: parameters and return. Internal helpers
   with obvious types may omit annotations, but a boundary without types is a bug.
 - Use built-in generics (`list[str]`, `dict[str, int]`, `tuple[int, ...]`) and
-  `X | None` instead of `Optional[X]`. Do not use PEP 695 generic syntax
-  (`def f[T](x: T) -> T`): it needs 3.12+ and the syntax-floor gate (3.10)
-  rejects it repo-wide.
+  `X | None` instead of `Optional[X]`.
 - Prefer precise types: `Sequence`/`Mapping` for read-only parameters,
   `Protocol` for structural interfaces, `Literal` for fixed string sets,
   `TypedDict` for structured dict payloads at a boundary.
@@ -45,12 +44,19 @@ Write to that floor: avoid syntax newer than 3.10, such as PEP 695 generics
 
 ## Tooling
 
-- `uv` for environments and dependency resolution; `ruff` for lint and format
-  (it replaces black, isort, flake8); `mypy` for types; `pytest` for tests.
+- `uv` for environments and dependency resolution; `ruff check` for lint (it
+  replaces isort and flake8); `mypy` for types; `pytest` for tests.
 - Tests follow Arrange/Act/Assert, one behavior per test, names that describe the
   behavior (`returns_empty_when_no_rows`). Mock only at I/O and process
   boundaries; never mock the function under test.
 - Pin the interpreter and dependencies. Do not rely on the system Python.
+- **`ruff format` is not this repo's formatter. Do not run it, and never cite
+  `ruff format --check` as a gate result.** Every gate runs `ruff check`; nothing
+  runs the formatter, and main does not conform (1287 of 2061 files would
+  reformat on `cdf688a`). A green check proves nothing, a red one is not a
+  finding, and running the formatter over a file or directory charges unrelated
+  drift to your diff. Cite `ruff check` on changed files instead. Issue #5304 and
+  `tests/validation/test_ruff_format_not_enforced.py` pin both facts.
 
 ## Errors
 

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -176,7 +176,7 @@ as an implementer.
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
 **always-on corpus is 7 rules, 70,471 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,400 bytes
+of what you touch. The **effective context on a `.py` edit is 98,398 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.

--- a/tests/validation/test_ruff_format_not_enforced.py
+++ b/tests/validation/test_ruff_format_not_enforced.py
@@ -88,8 +88,8 @@ def test_no_enforcement_surface_invokes_ruff_format() -> None:
 
     assert not offenders, (
         "`ruff format` now runs in an enforcement surface, so the Tooling "
-        "section of .claude/rules/python.md ('ruff format is not this repo's "
-        "formatter. Do not run it.') is false. Either revert the gate or "
+        "section of .claude/rules/python.md ('Never run `ruff format` or cite "
+        "`ruff format --check` as a gate.') is false. Either revert the gate or "
         "reformat the tree and rewrite that rule, then update this test. "
         f"Found: {offenders}"
     )

--- a/tests/validation/test_ruff_format_not_enforced.py
+++ b/tests/validation/test_ruff_format_not_enforced.py
@@ -1,0 +1,166 @@
+"""``ruff format`` is not this repository's enforced formatter (issue #5304).
+
+``.claude/rules/python.md`` tells every agent not to run ``ruff format`` and not
+to cite ``ruff format --check`` as a gate result. That instruction is only
+honest while two facts hold: no gate invokes the formatter, and the tree does
+not conform to it. Both are measurable, and both can change without anybody
+remembering the rule, so this module pins them.
+
+Adopting the formatter is a legitimate future decision. This module is not a
+veto on it; it is the tripwire that makes the rule text part of that decision
+instead of a stale paragraph left behind by it.
+
+- pos: no enforcement surface invokes ``ruff format``
+- neg: the scanner does flag a surface that invokes it, and does flag the
+       subprocess list form, proving the positive assertion has teeth
+- edge: a commented-out or prose mention of ``ruff format`` is not an invocation
+- guard: the tree is still materially non-conforming, and the rule text still
+         carries the instruction these assertions back
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYTHON_RULE = REPO_ROOT / ".claude" / "rules" / "python.md"
+
+# Every surface that can make a check blocking for a contributor: the local hook
+# scheduler, CI, and the two validation runners CI and pre-push both call. A
+# `ruff format` invocation anywhere in here is an enforcement, whatever its
+# exit-code handling, because it puts the formatter on the path to a red gate.
+_ENFORCEMENT_GLOBS = (
+    "lefthook.yml",
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    "scripts/ci/*.py",
+    "scripts/validation/pre_pr.py",
+    "scripts/validation/pre_pr_sequence.py",
+    "scripts/validation/git_hook_policy.py",
+)
+
+# Shell form (`ruff format`, including `uv run ... ruff format`) and the
+# subprocess list form (`["ruff", "format", ...]`) that a Python runner uses.
+_SHELL_INVOCATION = re.compile(r"\bruff\s+format\b")
+_LIST_INVOCATION = re.compile(r"""(['"])ruff\1\s*,\s*(['"])format\2""")
+
+
+def _strip_comment_lines(text: str) -> str:
+    """Drop whole-line comments, the only place these files discuss tooling.
+
+    Deliberately conservative: it removes lines whose first non-space character
+    is ``#`` and nothing else. A trailing-comment stripper would need to know
+    about quoting in both YAML and Python, and guessing wrong there would hide a
+    real invocation, which is the one failure this module must not have.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _invocations(text: str) -> list[str]:
+    """Return the ``ruff format`` invocations in ``text``, comments excluded."""
+    body = _strip_comment_lines(text)
+    return [
+        line
+        for line in body.splitlines()
+        if _SHELL_INVOCATION.search(line) or _LIST_INVOCATION.search(line)
+    ]
+
+
+def _enforcement_files() -> list[Path]:
+    found = [path for glob in _ENFORCEMENT_GLOBS for path in sorted(REPO_ROOT.glob(glob))]
+    assert found, f"no enforcement surface matched {_ENFORCEMENT_GLOBS}; globs are stale"
+    return found
+
+
+def test_no_enforcement_surface_invokes_ruff_format() -> None:
+    offenders = {
+        path.relative_to(REPO_ROOT).as_posix(): lines
+        for path in _enforcement_files()
+        if (lines := _invocations(path.read_text(encoding="utf-8")))
+    }
+
+    assert not offenders, (
+        "`ruff format` now runs in an enforcement surface, so the Tooling "
+        "section of .claude/rules/python.md ('ruff format is not this repo's "
+        "formatter. Do not run it.') is false. Either revert the gate or "
+        "reformat the tree and rewrite that rule, then update this test. "
+        f"Found: {offenders}"
+    )
+
+
+def test_scanner_flags_a_shell_invocation_negative_control() -> None:
+    surface = "      - name: format\n        run: uv run --frozen ruff format --check .\n"
+
+    assert _invocations(surface) == ["        run: uv run --frozen ruff format --check ."]
+
+
+def test_scanner_flags_a_subprocess_list_invocation_negative_control() -> None:
+    surface = '    subprocess.run(["ruff", "format", "--check", *files], check=False)\n'
+
+    assert len(_invocations(surface)) == 1
+
+
+def test_scanner_ignores_a_commented_mention() -> None:
+    surface = "# Do not add a `ruff format` job here; see issue #5304.\n  # ruff format .\n"
+
+    assert _invocations(surface) == []
+
+
+def test_scanner_ignores_ruff_check() -> None:
+    surface = "        run: uv run --frozen --extra dev ruff check --fix --exit-zero\n"
+
+    assert _invocations(surface) == []
+
+
+def test_tree_is_still_materially_non_conforming_to_ruff_format() -> None:
+    """The rule's second premise: the formatter disagrees with most of main.
+
+    A green ``ruff format --check`` would mean the tree converged and the
+    do-not-run instruction had lost its cost argument. The threshold is loose on
+    purpose; the claim under test is "materially non-conforming", not a count.
+    Issue #5304 measured 1287 of 2061 files on ``cdf688a``.
+    """
+    if shutil.which("ruff") is None:
+        pytest.skip("ruff is not on PATH; run under the uv dev environment")
+
+    result = subprocess.run(
+        ["ruff", "format", "--check", "."],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    would_reformat = sum(
+        1 for line in result.stdout.splitlines() if line.startswith("Would reformat:")
+    )
+
+    assert would_reformat > 100, (
+        "the tree now nearly conforms to `ruff format` "
+        f"({would_reformat} files would reformat). Adopting the formatter is "
+        "now cheap, so revisit .claude/rules/python.md rather than leaving a "
+        "do-not-run instruction whose premise has expired."
+    )
+
+
+def test_python_rule_still_carries_the_instruction_this_module_backs() -> None:
+    """Keep the guard and the instruction it backs from drifting apart.
+
+    Collapses whitespace first so re-wrapping the rule (which the instruction
+    budget regularly forces) does not read as the instruction being removed.
+    """
+    text = " ".join(PYTHON_RULE.read_text(encoding="utf-8").split())
+
+    assert "`ruff format` is not this repo's formatter. Do not run it" in text
+    assert "never cite `ruff format --check` as a gate result" in text
+    assert Path(__file__).name in text, (
+        "python.md should point at this module so a reader who changes the rule "
+        "finds the guard that pins it"
+    )

--- a/tests/validation/test_ruff_format_not_enforced.py
+++ b/tests/validation/test_ruff_format_not_enforced.py
@@ -158,8 +158,8 @@ def test_python_rule_still_carries_the_instruction_this_module_backs() -> None:
     """
     text = " ".join(PYTHON_RULE.read_text(encoding="utf-8").split())
 
-    assert "`ruff format` is not this repo's formatter. Do not run it" in text
-    assert "never cite `ruff format --check` as a gate result" in text
+    assert "Never run `ruff format`" in text
+    assert "cite `ruff format --check` as a gate" in text
     assert Path(__file__).name in text, (
         "python.md should point at this module so a reader who changes the rule "
         "finds the guard that pins it"


### PR DESCRIPTION
# Pull Request

## Summary

### What

`.claude/rules/python.md` told every agent that `ruff` is this repo's formatter. Nothing enforces `ruff format`, and main is 62% non-conforming to it. This corrects the claim, corrects a second stale citation on the same path, and adds a guard so the rule and the gates cannot drift apart again.

### Why

The false claim caused repeated, measurable waste. Agents ran `ruff format` and pulled unrelated files into their diffs, and QA reports cited `ruff format --check` as a pass/fail gate where green proves nothing and red is not a finding. Full evidence in #5304.

Measured on `cdf688a` (`origin/main` at branch point):

```
$ uv run --frozen --extra dev ruff format --check .
1287 files would be reformatted, 774 files already formatted
```

Every ruff gate runs `ruff check`: lefthook's `python-autofix` and `python-check`, and both CI ratchets. No surface invokes the formatter.

A Serena memory under `.serena/memories/linting/` already recorded "`ruff format` is NOT the repo standard", but Serena is MCP-gated and does not bind Codex or Copilot. Per the knowledge-persistence rule's MUST-1 the binding surface is `.claude/rules/`, which said the opposite.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5304 | python.md claims ruff formats this repo, but `ruff format` gates nothing |

This reference does not close its linked item: #5304 also raises whether to adopt `ruff format` repo-wide, which this PR deliberately does not decide. That is a 1287-file diff that would conflict with every open PR.

## Changes

- `.claude/rules/python.md`: Tooling now reads `ruff check` for lint and adds "Never run `ruff format` or cite `ruff format --check` as a gate." The intro drops its stale "`ruff` target-version `py314`" citation. The Typing bullet's duplicate PEP 695 sentence is removed to pay for the addition.
- `tests/validation/test_ruff_format_not_enforced.py`: new, 7 tests. Fails if `ruff format` enters an enforcement surface, if the tree converges on the formatter, or if the rule loses the instruction.
- `.claude/skills/context-optimizer/references/model-context-doctrine.md`: the `.py` effective-context figure moves to the new measurement.
- `.github/instructions/python.instructions.md`, `src/copilot-cli/instructions/python.instructions.md`, `src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md`: regenerated mirrors, not hand-edited.

Six files: three authored, three generated.

## Implementation notes

### Why the rule text is short

The always-on `.py` instruction corpus is gated on a 600-byte reserve below the 99,000 ceiling by `scripts/validation/instruction_budget.py`, and main sat at exactly 98,400. Net growth on that path fails the pre-push gate, and the ceiling is a may-only-fall ratchet pinned by `tests/validation/test_instruction_ceiling_ratchet.py`, so raising it was not an option.

So the rule carries the instruction and a pointer, while #5304 and the guard's own docstring carry the measurement, the PR #5176 incident, and the #4153 and #3126 reasons the formatter is actively harmful here. Paid for by deleting the Typing bullet's PEP 695 sentence, which was the third statement of one fact (the intro paragraph and the Version Compatibility section both still carry it), and by dropping a tool-list parenthetical. **Final: 98,398 bytes, two under main.** A net reduction, not a reclaim that merely pays for itself.

The doctrine figure had to move with it: `tests/validation/test_always_on_corpus_claims.py` pins that number against a live measurement.

### On the `py314` citation

`pyproject.toml` pins `target-version = "py310"` deliberately, per #3126, and `tests/validation/test_ruff_format_floor_compat.py` holds it there. The rule cited `py314` as evidence for a 3.14 target, which contradicted both that config and the rule's own next sentence about the 3.10 floor gate.

### Flagging, not fixing

- The `.py` corpus sits at the reserve boundary either way, so the next rule addition on that path has nowhere to go. #3419 AC #2 already tracks the fix (rescoping book-derived rules to task-invoked skills); it is bigger than this PR.
- The Version Compatibility Reviews section of the same rule calls `>=3.14` "the current floor" while the syntax floor for tracked files is 3.10. The advice under it is correct; only the label is loose. Left alone.

## Acceptance criteria

- [x] The Python rule no longer claims `ruff` formats this repo
- [x] The stale `py314` target-version citation is gone
- [x] A guard fails if `ruff format` becomes an enforcement surface, verified by mutation
- [x] Both instruction mirrors and the skill mirror regenerated, not hand-edited
- [x] The `.py` instruction budget passes without raising the ceiling

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether deleting the Typing bullet's PEP 695 sentence is the right way to pay for the new bullet, versus some other reclaim. And whether the rule should answer "what if I do want formatting on a file I authored", which it currently does not.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence, all on this branch's head:

| Check | Command | Result |
|---|---|---|
| New guard | `uv run --frozen pytest tests/validation/test_ruff_format_not_enforced.py` | 7 passed |
| Guard has teeth | Appended a `ruff format --check` job to `lefthook.yml`, re-ran the guard | Failed, naming the offending line; `lefthook.yml` restored |
| Validation suite | `uv run --frozen pytest tests/validation -q` | 3320 passed, 10 skipped |
| Budget, ratchet, doctrine | the three pinning modules named above | 150 passed |
| Instruction budget | `uv run --frozen python scripts/validation/instruction_budget.py` | `.py` 98,398 of 99,000, PASS on all four languages |
| Generated staleness | `uv run --frozen python build/scripts/build_all.py --check` | no drift |
| Lint | `ruff check` on the new test | All checks passed |
| Markdown | `pre_pr.py --markdown-lint-only` on the changed docs | clean |
| Taste lints | `git_hook_policy.py taste` on changed files | 0 errors, 1 pre-existing size warning on the doctrine file |

Not run: `ruff format --check` as a pass/fail signal, for the reason this PR documents.

Two gates failed on the first push attempt (generated-artifact staleness, and the budget reserve) and were fixed in `383eb0c44`. The commit history shows that rather than hiding it.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5304, #3126, #4153, #3419