### PR TITLE
fix(adr): reject backslash-escaped html comment openers in status masking

### DIFF
--- a/.agents/qa/2026-08-21-adr-corpus-campaign-qa.md
+++ b/.agents/qa/2026-08-21-adr-corpus-campaign-qa.md
@@ -1,14 +1,14 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5189-54e494d-adr-corpus-evaluation-and-tooling.json
-qaCommit: 0011acb00cc5138c32920a4788d41383683cff3c
+qaCommit: 4aaa8be9873ed4122b213bfb075c65c48b08b10f
 ---
 <!-- # taste-lint: ignore file-size, this is an append-only QA audit trail; addenda are numbered sequentially and splitting the file would break that numbering and scatter one campaign's evidence across files (issue #3779). -->
 
 # QA: ADR Corpus Evaluation and Repair Campaign (issues #5189 to #5201, #5205)
 
 **Branch**: `claude/adr-evaluation-tooling-6od8rd`
-**Validated at commit**: `0011acb00cc5138c32920a4788d41383683cff3c` (see Addendum 64)
+**Validated at commit**: `4aaa8be9873ed4122b213bfb075c65c48b08b10f` (see Addendum 64)
 **Session log**: `.agents/sessions/2026-08-21-session-5189-54e494d-adr-corpus-evaluation-and-tooling.json`
 
 ## Verdict
@@ -2642,11 +2642,11 @@ Round 21's fix closed the escape-parity gap in `_html_comment_inline_ranges`'s `
 
 **The mechanism.** A backslash-escaped `<!--` earlier in the source (`` \<!-- ``) is a literal `<!--` character sequence to CommonMark, not a comment opener: markdown-it resolves it to plain `text` tokens, with no `html_inline` counterpart. The bare `find` has no way to know this, since it only matches raw bytes. Verified empirically: parsing `"prose \\<!--\n**Status**: Accepted\n--> more <!--\n**Status**: Accepted\n-->\n"` produces `text("prose <!--")` (the escaped opener, its backslash consumed and its `<!--` now literal text with no token of its own), `strong_open`/text/`strong_close` for the un-hidden `**Status**: Accepted` that follows (parsing continues as ordinary prose, since no comment ever opened), `text("--> more ")`, then the REAL `html_inline("<!--\n**Status**: Accepted\n-->")`. A bare `find` for that content, starting from the paragraph's beginning, matched the FIRST, escaped occurrence: the backslash is simply one extra byte the search skips over, so it found the decoy's `<!--...-->` bytes before the real comment's own, later position. The masker then blanked the VISIBLE decoy prose (mistaking it for a comment) while leaving the REAL, later comment's hidden `**Status**: Accepted` completely unmasked and readable by `check_adr_lifecycle.py`'s status regex, exactly the status-forgery bypass this function exists to prevent. Verified empirically: `blank_non_prose_block_lines` on this exact input, before this fix, blanked the decoy's visible text and left the real comment's hidden status fully readable (`"Accepted"` appeared once in the output, from the wrong occurrence).
 
-**The fix** (commit `0011acb00`): a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, retries forward past any candidate match whose start position is backslash-escaped. This is sound because a genuine `html_inline` token's raw start position can never itself be backslash-escaped: if it were, markdown-it would never have tokenized that position as `html_inline` in the first place, so the filter never skips a real match, only positions the parser itself never treated as one. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`, asserting the decoy's visible `Accepted` survives (it is real prose, not a comment) and the real comment's own hidden `Accepted` is masked. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
+**The fix** (commit `4aaa8be98`): a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, retries forward past any candidate match whose start position is backslash-escaped. This is sound because a genuine `html_inline` token's raw start position can never itself be backslash-escaped: if it were, markdown-it would never have tokenized that position as `html_inline` in the first place, so the filter never skips a real match, only positions the parser itself never treated as one. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`, asserting the decoy's visible `Accepted` survives (it is real prose, not a comment) and the real comment's own hidden `Accepted` is masked. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
 
 The companion suppressed comment on the same review (citing `tests/test_markdown_parser.py:695`, that the PR description still read as of round 19) is stale as of this addendum: the live PR body has been updated through round 21 in the interim, and this addendum's own commit brings it current through round 22.
 
 Full suite re-run clean after the round-22 fix: `tests/test_markdown_parser.py` (82 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 387 passed. `ruff check` on both touched files: clean. `python3 -W error::SyntaxWarning -c "import scripts.utils.markdown_parser"`: no warnings. `taste count ratchet`: OK, unchanged at baseline 575 (the file-size/complexity taste-lint findings on both touched files are advisory-only and pre-existing, unchanged in kind since round 15). `pre_pr.py` (full suite): passed on the round-22 commit.
 
-**Rebound to** `0011acb00cc5138c32920a4788d41383683cff3c`.
+**Rebound to** `4aaa8be9873ed4122b213bfb075c65c48b08b10f`.
 

--- a/.agents/qa/2026-08-21-adr-corpus-campaign-qa.md
+++ b/.agents/qa/2026-08-21-adr-corpus-campaign-qa.md
@@ -1,14 +1,14 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5189-54e494d-adr-corpus-evaluation-and-tooling.json
-qaCommit: f87a1585f756ae4536256c4f9b9be3699137a776
+qaCommit: 0011acb00cc5138c32920a4788d41383683cff3c
 ---
 <!-- # taste-lint: ignore file-size, this is an append-only QA audit trail; addenda are numbered sequentially and splitting the file would break that numbering and scatter one campaign's evidence across files (issue #3779). -->
 
 # QA: ADR Corpus Evaluation and Repair Campaign (issues #5189 to #5201, #5205)
 
 **Branch**: `claude/adr-evaluation-tooling-6od8rd`
-**Validated at commit**: `f87a1585f756ae4536256c4f9b9be3699137a776` (see Addendum 63)
+**Validated at commit**: `0011acb00cc5138c32920a4788d41383683cff3c` (see Addendum 64)
 **Session log**: `.agents/sessions/2026-08-21-session-5189-54e494d-adr-corpus-evaluation-and-tooling.json`
 
 ## Verdict
@@ -2635,4 +2635,18 @@ The round-20 fix located each `code_inline` span by its opening and closing back
 Full suite re-run clean after the round-21 fix: `tests/test_markdown_parser.py` (81 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 386 passed. `ruff check` on both touched files: clean. `python3 -W error::SyntaxWarning -c "import scripts.utils.markdown_parser"`: no warnings. `taste count ratchet`: OK, unchanged at baseline 575 (the file-size and complexity findings `pre_pr.py`'s taste-lints reported on `markdown_parser.py` and `test_markdown_parser.py` are advisory-only per its own output, and are pre-existing findings on functions and files this round did not touch: `_extract_table`'s and `parse_sections`'s complexity, and both files' line counts, unchanged in kind since round 15). `pre_pr.py` (full suite): passed on the round-21 commit.
 
 **Rebound to** `f87a1585f756ae4536256c4f9b9be3699137a776`.
+
+## Addendum 64: round 22, the html_inline branch had the same escape-parity gap one branch over
+
+Round 21's fix closed the escape-parity gap in `_html_comment_inline_ranges`'s `code_inline` branch (`_find_exact_backtick_run`'s opening lookup). A round-21 Copilot review, delivered as a suppressed comment alongside that finding, found the SAME gap in the sibling `html_inline` branch: it located a child's content with a bare `markdown.find`, which has no notion of CommonMark's backslash-escape rule.
+
+**The mechanism.** A backslash-escaped `<!--` earlier in the source (`` \<!-- ``) is a literal `<!--` character sequence to CommonMark, not a comment opener: markdown-it resolves it to plain `text` tokens, with no `html_inline` counterpart. The bare `find` has no way to know this, since it only matches raw bytes. Verified empirically: parsing `"prose \\<!--\n**Status**: Accepted\n--> more <!--\n**Status**: Accepted\n-->\n"` produces `text("prose <!--")` (the escaped opener, its backslash consumed and its `<!--` now literal text with no token of its own), `strong_open`/text/`strong_close` for the un-hidden `**Status**: Accepted` that follows (parsing continues as ordinary prose, since no comment ever opened), `text("--> more ")`, then the REAL `html_inline("<!--\n**Status**: Accepted\n-->")`. A bare `find` for that content, starting from the paragraph's beginning, matched the FIRST, escaped occurrence: the backslash is simply one extra byte the search skips over, so it found the decoy's `<!--...-->` bytes before the real comment's own, later position. The masker then blanked the VISIBLE decoy prose (mistaking it for a comment) while leaving the REAL, later comment's hidden `**Status**: Accepted` completely unmasked and readable by `check_adr_lifecycle.py`'s status regex, exactly the status-forgery bypass this function exists to prevent. Verified empirically: `blank_non_prose_block_lines` on this exact input, before this fix, blanked the decoy's visible text and left the real comment's hidden status fully readable (`"Accepted"` appeared once in the output, from the wrong occurrence).
+
+**The fix** (commit `0011acb00`): a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, retries forward past any candidate match whose start position is backslash-escaped. This is sound because a genuine `html_inline` token's raw start position can never itself be backslash-escaped: if it were, markdown-it would never have tokenized that position as `html_inline` in the first place, so the filter never skips a real match, only positions the parser itself never treated as one. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`, asserting the decoy's visible `Accepted` survives (it is real prose, not a comment) and the real comment's own hidden `Accepted` is masked. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
+
+The companion suppressed comment on the same review (citing `tests/test_markdown_parser.py:695`, that the PR description still read as of round 19) is stale as of this addendum: the live PR body has been updated through round 21 in the interim, and this addendum's own commit brings it current through round 22.
+
+Full suite re-run clean after the round-22 fix: `tests/test_markdown_parser.py` (82 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 387 passed. `ruff check` on both touched files: clean. `python3 -W error::SyntaxWarning -c "import scripts.utils.markdown_parser"`: no warnings. `taste count ratchet`: OK, unchanged at baseline 575 (the file-size/complexity taste-lint findings on both touched files are advisory-only and pre-existing, unchanged in kind since round 15). `pre_pr.py` (full suite): passed on the round-22 commit.
+
+**Rebound to** `0011acb00cc5138c32920a4788d41383683cff3c`.
 

--- a/.agents/qa/session-5209-adr-review-fixes-stacked.md
+++ b/.agents/qa/session-5209-adr-review-fixes-stacked.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5209-14a6f1844-adr-review-fixes-stacked.json
-qaCommit: 0011acb00cc5138c32920a4788d41383683cff3c
+qaCommit: 4aaa8be9873ed4122b213bfb075c65c48b08b10f
 ---
 <!-- # taste-lint: ignore file-size, this is an append-only QA audit trail; addenda are numbered sequentially and splitting the file would break that numbering and scatter this stack's evidence across files (issue #3779). -->
 
@@ -9,7 +9,7 @@ qaCommit: 0011acb00cc5138c32920a4788d41383683cff3c
 
 **Branch**: `claude/adr-5209-review-fixes`
 **Base**: `main` (retargeted by GitHub after PR #5209 squash-merged and its branch was deleted; was `claude/adr-evaluation-tooling-6od8rd`)
-**Validated at commit**: `0011acb00cc5138c32920a4788d41383683cff3c` (see Addendum 65)
+**Validated at commit**: `4aaa8be9873ed4122b213bfb075c65c48b08b10f` (see Addendum 65)
 
 ## Verdict
 
@@ -1437,7 +1437,7 @@ Full suite re-run clean after the round-21 fix: `tests/test_markdown_parser.py` 
 
 Same finding, same fix as Addendum 64 of the campaign report: the round-21 fix closed the escape-parity gap in the `code_inline` branch of `_html_comment_inline_ranges`, and a round-21 Copilot review (delivered as a suppressed comment alongside that finding) found the SAME gap in the sibling `html_inline` branch. A bare `markdown.find` for a child's content has no notion of CommonMark's backslash-escape rule, so a backslash-escaped `<!--` earlier in the source (a literal character sequence, not a comment opener) could steal the match from the real, later `html_inline` token sharing the same raw bytes. `"prose \<!--\n**Status**: Accepted\n--> more <!--\n**Status**: Accepted\n-->\n"` reproduced this exactly: `find` matched the escaped decoy's position first, masking the visible decoy prose while leaving the real, later comment's hidden `**Status**: Accepted` completely unmasked and readable, the exact status-forgery bypass this function exists to prevent.
 
-Fixed (commit `0011acb00`) with a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, that retries forward past any candidate whose start position is backslash-escaped. Sound because a genuine `html_inline` token's start position can never itself be backslash-escaped: if it were, the parser would never have tokenized that position as `html_inline` in the first place. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
+Fixed (commit `4aaa8be98`) with a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, that retries forward past any candidate whose start position is backslash-escaped. Sound because a genuine `html_inline` token's start position can never itself be backslash-escaped: if it were, the parser would never have tokenized that position as `html_inline` in the first place. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
 
 The companion suppressed comment on the same review (PR description staleness through round 19) is stale as of this addendum: the live PR body was already updated through round 21 by the time this fix landed, and this addendum's own commit brings it current through round 22.
 
@@ -1445,5 +1445,5 @@ Full evidence, including the exact token structures verified and the full mutati
 
 Full suite re-run clean after the round-22 fix: `tests/test_markdown_parser.py` (82 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 387 passed. `ruff check`: clean on both touched files. Taste-count ratchet unchanged at baseline 575. `pre_pr.py` (full suite): passed on the round-22 commit (confirmed via exit code before this addendum was written).
 
-**Rebound to** `0011acb00cc5138c32920a4788d41383683cff3c`.
+**Rebound to** `4aaa8be9873ed4122b213bfb075c65c48b08b10f`.
 

--- a/.agents/qa/session-5209-adr-review-fixes-stacked.md
+++ b/.agents/qa/session-5209-adr-review-fixes-stacked.md
@@ -1,7 +1,7 @@
 ---
 qaVerdict: PASS
 qaSessionLog: .agents/sessions/2026-08-21-session-5209-14a6f1844-adr-review-fixes-stacked.json
-qaCommit: f87a1585f756ae4536256c4f9b9be3699137a776
+qaCommit: 0011acb00cc5138c32920a4788d41383683cff3c
 ---
 <!-- # taste-lint: ignore file-size, this is an append-only QA audit trail; addenda are numbered sequentially and splitting the file would break that numbering and scatter this stack's evidence across files (issue #3779). -->
 
@@ -9,7 +9,7 @@ qaCommit: f87a1585f756ae4536256c4f9b9be3699137a776
 
 **Branch**: `claude/adr-5209-review-fixes`
 **Base**: `main` (retargeted by GitHub after PR #5209 squash-merged and its branch was deleted; was `claude/adr-evaluation-tooling-6od8rd`)
-**Validated at commit**: `f87a1585f756ae4536256c4f9b9be3699137a776` (see Addendum 64)
+**Validated at commit**: `0011acb00cc5138c32920a4788d41383683cff3c` (see Addendum 65)
 
 ## Verdict
 
@@ -1432,4 +1432,18 @@ Full evidence, including the exact token structures verified and the full mutati
 Full suite re-run clean after the round-21 fix: `tests/test_markdown_parser.py` (81 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 386 passed. `ruff check`: clean on both touched files. Taste-count ratchet unchanged at baseline 575 (the file-size and complexity findings on both files are advisory-only, pre-existing, and untouched by this round). `pre_pr.py` (full suite): passed on the round-21 commit.
 
 **Rebound to** `f87a1585f756ae4536256c4f9b9be3699137a776`.
+
+## Addendum 65: same round-22 finding and fix as Addendum 64 of the campaign report
+
+Same finding, same fix as Addendum 64 of the campaign report: the round-21 fix closed the escape-parity gap in the `code_inline` branch of `_html_comment_inline_ranges`, and a round-21 Copilot review (delivered as a suppressed comment alongside that finding) found the SAME gap in the sibling `html_inline` branch. A bare `markdown.find` for a child's content has no notion of CommonMark's backslash-escape rule, so a backslash-escaped `<!--` earlier in the source (a literal character sequence, not a comment opener) could steal the match from the real, later `html_inline` token sharing the same raw bytes. `"prose \<!--\n**Status**: Accepted\n--> more <!--\n**Status**: Accepted\n-->\n"` reproduced this exactly: `find` matched the escaped decoy's position first, masking the visible decoy prose while leaving the real, later comment's hidden `**Status**: Accepted` completely unmasked and readable, the exact status-forgery bypass this function exists to prevent.
+
+Fixed (commit `0011acb00`) with a new `_find_unescaped_occurrence` helper, reusing round 21's `_is_backslash_escaped`, that retries forward past any candidate whose start position is backslash-escaped. Sound because a genuine `html_inline` token's start position can never itself be backslash-escaped: if it were, the parser would never have tokenized that position as `html_inline` in the first place. Added `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`. Mutation-proven: reverting the fix reproduces the exact pre-fix broken output and fails exactly this new test, while all 81 other tests in the file stay green.
+
+The companion suppressed comment on the same review (PR description staleness through round 19) is stale as of this addendum: the live PR body was already updated through round 21 by the time this fix landed, and this addendum's own commit brings it current through round 22.
+
+Full evidence, including the exact token structures verified and the full mutation-proof output, is in Addendum 64 of the campaign report.
+
+Full suite re-run clean after the round-22 fix: `tests/test_markdown_parser.py` (82 passed) combined with `tests/validation/test_check_adr_lifecycle.py`, `tests/validation/test_check_adr_links.py`, and `tests/test_adr_063_memory_skill_decomposition.py`: 387 passed. `ruff check`: clean on both touched files. Taste-count ratchet unchanged at baseline 575. `pre_pr.py` (full suite): passed on the round-22 commit (confirmed via exit code before this addendum was written).
+
+**Rebound to** `0011acb00cc5138c32920a4788d41383683cff3c`.
 

--- a/scripts/utils/markdown_parser.py
+++ b/scripts/utils/markdown_parser.py
@@ -577,6 +577,52 @@ def _code_span_end(markdown: str, markup: str, start: int, end: int) -> int:
     return close_start + len(markup)
 
 
+def _find_unescaped_occurrence(
+    markdown: str, content: str, start: int, end: int
+) -> int:
+    """First position in ``markdown[start:end]`` where ``content`` occurs and
+    is not backslash-escaped, or -1 if none exists.
+
+    Used only for an ``html_inline`` child's ``.content``, which CommonMark
+    guarantees is always a verbatim copy of the source starting at ``<``, with
+    no separate delimiter to strip. A backslash immediately before that ``<``
+    escapes it (spec section 2.4): markdown-it then tokenizes the position as
+    plain `text`, never as `html_inline`, so a REAL `html_inline` token's own
+    start position can never itself be backslash-escaped. Rejecting an
+    escaped candidate and retrying forward therefore never skips the real
+    match; it only skips positions the parser itself never treated as one.
+
+    Without this check, an unqualified `str.find` can bind an `html_inline`
+    child's content to an EARLIER escaped decoy sharing the same raw text
+    instead of the child's own later, real position. `` "prose \\<!--\\n"
+    "**Status**: Accepted\\n--> more <!--\\n**Status**: Accepted\\n-->\\n" ``
+    tokenizes as `text("prose <!--")` (the escaped comment opener, now a
+    literal `<!--` with no separate token), `strong_open`/text/`strong_close`
+    for the un-hidden `**Status**: Accepted` that follows it (parsing
+    continues normally since no comment ever opened), `text("--> more ")`,
+    then the REAL `html_inline("<!--\\n**Status**: Accepted\\n-->")`. A bare
+    `find` for that content matches the FIRST, escaped occurrence (the
+    backslash is simply skipped over, since `find` has no notion of
+    escaping), masking the VISIBLE decoy prose while leaving the REAL,
+    later comment's hidden `**Status**: Accepted` completely unmasked,
+    exactly the status-forgery bypass this function exists to prevent.
+    Verified empirically: `blank_non_prose_block_lines` on this input
+    blanked the decoy's visible text and left the real comment's hidden
+    status fully readable, before this fix. Copilot found this on PR #5230
+    round 21 (delivered as a suppressed comment alongside the round-21
+    Mandatory finding on the opening backtick lookup), citing the same
+    escape-parity gap one branch over.
+    """
+    pos = start
+    while True:
+        idx = markdown.find(content, pos, end)
+        if idx < 0:
+            return -1
+        if not _is_backslash_escaped(markdown, idx):
+            return idx
+        pos = idx + 1
+
+
 def _html_comment_inline_ranges(
     tokens: list[Token],
     markdown: str,
@@ -691,7 +737,7 @@ def _html_comment_inline_ranges(
                 content = child.content or ""
                 if not content:
                     continue
-                found = markdown.find(content, cursor, span_end)
+                found = _find_unescaped_occurrence(markdown, content, cursor, span_end)
                 if found < 0:
                     continue
                 cursor = found + len(content)

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -762,6 +762,46 @@ class TestBlankNonProseBlockLines:
         assert out.startswith("\\` `<!-- x -->`")
         assert "<!--" not in out[out.index("-->") + len("-->") :]
 
+    def test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match(
+        self,
+    ):
+        # Real gap in the round-20 delimiter-based fix above, found by
+        # Copilot (PR #5230, round 21, delivered as a suppressed comment
+        # alongside the escaped-backtick finding fixed above): the
+        # html_inline branch located a child's content with a bare
+        # `str.find`, which has no notion of CommonMark's backslash-escape
+        # rule. `` "prose \\<!--\n**Status**: Accepted\n--> more <!--\n"
+        # "**Status**: Accepted\n-->\n" `` tokenizes as `text("prose <!--")`
+        # (the escaped opener resolves to a literal "<!--" character with
+        # no comment token of its own), `strong_open`/text/`strong_close`
+        # for the un-hidden "**Status**: Accepted" that follows (parsing
+        # continues normally, since no comment ever opened), `text("-->
+        # more ")`, then the REAL `html_inline("<!--\n**Status**:
+        # Accepted\n-->")`. A bare `find` for that content matched the
+        # FIRST, escaped occurrence (skipping over the backslash, since
+        # `find` cannot see it), masking the VISIBLE decoy prose while
+        # leaving the REAL, later comment's hidden `**Status**: Accepted`
+        # completely unmasked, exactly the status-forgery bypass this
+        # function exists to prevent. Verified empirically: this exact
+        # input, before this fix, blanked the decoy's visible text and
+        # left the real comment's hidden status fully readable ("Accepted"
+        # appeared once in the output, from the wrong occurrence).
+        # Fixed by requiring the html_inline content match itself be
+        # unescaped (`_find_unescaped_occurrence`, reusing
+        # `_is_backslash_escaped`): a genuine `html_inline` token's start
+        # position can never be backslash-escaped, since an escaped `<`
+        # never becomes an `html_inline` token in the first place, so this
+        # filter never skips a real match. Asserts the decoy's visible
+        # "Accepted" survives (it is real prose, not a comment) and the
+        # real comment's own hidden "Accepted" is masked.
+        text = (
+            "prose \\<!--\n**Status**: Accepted\n--> more <!--\n"
+            "**Status**: Accepted\n-->\n"
+        )
+        out = blank_non_prose_block_lines(text)
+        assert out.startswith("prose \\<!--\n**Status**: Accepted\n--> more ")
+        assert out.count("Accepted") == 1
+
     def test_preserves_line_count(self):
         text = "a\n<!--\nb\nc\n-->\nd\n"
         original = len(text.split("\n"))


### PR DESCRIPTION
# Pull Request

## Summary

### What

Fixes a real status-forgery bypass in `blank_non_prose_block_lines`'s inline HTML-comment masking, found by Copilot on PR #5230 immediately after that PR merged. Stacked on `main` at the tip that includes PR #5230's own escaped-backtick fix (round 21).

### Why

PR #5230 (already merged) added inline HTML-comment masking to `scripts/utils/markdown_parser.py` so check_adr_lifecycle.py cannot be tricked by a `**Status**: Accepted` declaration hidden inside an HTML comment. Round 21 of that PR closed an escape-parity gap in the `code_inline` branch of the masking helper. A Copilot review on that same PR round, delivered as a suppressed comment, found the SAME gap one branch over, in the `html_inline` branch: a bare `str.find` has no notion of CommonMark's backslash-escape rule, so a backslash-escaped `<!--` earlier in the source (a literal character sequence, not a real comment) can steal the match from a REAL, later `html_inline` comment sharing the same raw bytes. The owner merged PR #5230 before this finding was addressed, so this PR lands the fix as a follow-up.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5209 | ADR lifecycle status-forgery hardening this PR continues |
| **Issue** | Refs #5189 | ADR-063 relied on the parser this touches |

## Changes

- `scripts/utils/markdown_parser.py`: new `_find_unescaped_occurrence` helper (reuses PR #5230's `_is_backslash_escaped`) that retries forward past any `html_inline` content match whose start position is backslash-escaped. The `html_inline` branch of `_html_comment_inline_ranges` now calls this instead of a bare `markdown.find`.
- `tests/test_markdown_parser.py`: `test_an_escaped_html_comment_opener_cannot_steal_a_real_comments_match`, reproducing the exact decoy shape Copilot reported.
- `.agents/qa/2026-08-21-adr-corpus-campaign-qa.md` and `.agents/qa/session-5209-adr-review-fixes-stacked.md`: Addendum 64 (campaign) / Addendum 65 (stacked), documenting the finding, the fix, and the mutation-proof evidence, rebound to this PR's commit.

### The mechanism

A backslash-escaped `<!--` (`` \<!-- ``) is a literal `<!--` character sequence to CommonMark, not a comment opener: markdown-it resolves it to plain `text` tokens, with no `html_inline` counterpart. Verified empirically: parsing `"prose \\<!--\n**Status**: Accepted\n--> more <!--\n**Status**: Accepted\n-->\n"` produces `text("prose <!--")` (the escaped opener, its backslash consumed, now literal text with no token of its own), `strong_open`/text/`strong_close` for the un-hidden `**Status**: Accepted` that follows (parsing continues as ordinary prose, since no comment ever opened), `text("--> more ")`, then the REAL `html_inline("<!--\n**Status**: Accepted\n-->")`.

A bare `find` for that real comment's content, starting from the paragraph's beginning, matched the FIRST, escaped occurrence: the backslash is simply one extra byte the search skips over, so it found the decoy's `<!--...-->` bytes before the real comment's own, later position. The masker then blanked the VISIBLE decoy prose (mistaking it for a comment) while leaving the REAL, later comment's hidden `**Status**: Accepted` completely unmasked and readable by check_adr_lifecycle.py's status regex, exactly the status-forgery bypass this function exists to prevent. Verified empirically: `blank_non_prose_block_lines` on this exact input, before this fix, blanked the decoy's visible text and left the real comment's hidden status fully readable (`"Accepted"` appeared once in the output, from the wrong occurrence).

### The fix

A new `_find_unescaped_occurrence` helper, reusing `_is_backslash_escaped` (added in PR #5230 round 21 for the sibling `code_inline` gap), retries forward past any candidate match whose start position is backslash-escaped. This is sound because a genuine `html_inline` token's raw start position can never itself be backslash-escaped: if it were, markdown-it would never have tokenized that position as `html_inline` in the first place, so the filter never skips a real match, only positions the parser itself never treated as one.

Mutation-proven: reverting the fix (restoring the bare `markdown.find` call) reproduces the exact pre-fix broken output and fails exactly the new discriminating test, while all 81 other tests in the file stay green.

```
tests/test_markdown_parser.py: 82 passed (81 before this PR's test, +1)
combined with tests/validation/test_check_adr_lifecycle.py, tests/validation/test_check_adr_links.py,
and tests/test_adr_063_memory_skill_decomposition.py: 387 passed
ruff check on both touched files: clean
python3 -W error::SyntaxWarning -c "import scripts.utils.markdown_parser": no warnings
taste count ratchet: OK (count == baseline 575, unchanged)
merge-tree-ratchet against origin/main: OK
pre_pr.py (full suite): passed
```

## Acceptance criteria

- [x] `_html_comment_inline_ranges`'s `html_inline` branch rejects a backslash-escaped decoy match and finds the real, later comment instead
- [x] Discriminating regression test added and mutation-proven
- [x] No regression in the other 81 tests in `tests/test_markdown_parser.py` or the combined 387-test suite

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: focused review, high scrutiny (status-forgery/security-adjacent parsing logic), no rush.

**Focus areas**: whether `_find_unescaped_occurrence`'s soundness argument holds (a genuine `html_inline` token's start position can never be backslash-escaped), and whether the discriminating test's fixture actually reproduces the reported decoy shape.

## Testing

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes

**Files requiring security review:**

- `scripts/utils/markdown_parser.py` (status-forgery bypass; the code this fixes gates the ADR lifecycle validator's status detection, unchanged in this PR)

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`; pass `--quick` to skip slow validations or `--skip-tests` for very fast iterations)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines ([.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md)) and code quality standards ([.agents/governance/code-quality.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-quality.md))
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

This PR's commits were originally developed as round 22 of PR #5230, which the owner merged (at the round-21 state, commit `0e21c73190`) before this finding was addressed. Rather than force-push a rewrite of the already-merged branch's history (which `universal.md` MUST NOT #1 forbids, and which this repo's own `push-ref-policy` pre-push hook enforces), the two commits (`4aaa8be98` fix, `dcc32faa2` QA docs) were rebased cleanly onto `main` immediately after the merge and pushed here as a fresh branch. Rebasing changes commit SHAs the same way amending does (see `.claude/rules/session-logs.md` MUST 2-3 for the general pattern), which left the QA files' internal `qaCommit`/`Validated at commit` references pointing at the pre-rebase SHA; a follow-up commit corrects them to the post-rebase fix-commit SHA (`4aaa8be98`).

`.agents/qa/session-5209-adr-review-fixes-stacked.md` (Addendum 65) and `.agents/qa/2026-08-21-adr-corpus-campaign-qa.md` (Addendum 64) carry the full evidence, including the exact token structures verified and the complete mutation-proof output.

## Related Issues

Refs #5209, Refs #5189 (neither closes; both are the broader ADR-lifecycle hardening context this PR continues).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TuN2tAjhRdSB1oxdSBwo6G)_