### PR TITLE
fix(build): stop injecting unjustified versioned model pins into generated agents

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -13,8 +13,8 @@ priority: high
 1. **Regenerate after edits**. Changes MUST be followed by running `uv run python build/generate_agents.py` before commit. Uncommitted generator output is a protocol failure.
 2. **Commit generated output**. Regenerated files under `src/copilot-cli/agents/` and `src/vs-code-agents/` MUST be committed in the same PR as the template change. Those two are the only trees `build/generate_agents.py` writes; `src/claude/`, `.claude/agents/`, and `.github/agents/` are hand-maintained and the generator does not touch them (see `.agents/governance/GENERATOR-FILES.md`).
 3. **Toolset integrity**. Changes that add or remove tools MUST update `templates/toolsets.yaml` consistently.
-4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`, `model`) present and valid per ADR-002.
-5. **Model selection**. Model choices MUST match ADR-002 (`opus` / `sonnet` / `haiku` assignments).
+4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`) present and valid. `model_tier` is optional: ADR-080 governs whether a generated agent may carry a `model:` pin at all (see MUST-5). ADR-002, formerly cited here, is deprecated in favor of ADR-080 (2026-08-25).
+5. **Model selection**. A template's `model_tier` MUST comply with ADR-080: the generator resolves only the `haiku` tier, the sole cost exception ADR-080 rule 3 recognizes, into a versioned `model:` pin for the generated Copilot/VS Code/Visual Studio mirrors. `model_tier: opus` or `model_tier: sonnet`, and no `model_tier` at all, MUST resolve to no `model:` field, so the mirror inherits the harness default rather than shipping an unjustified pin that breaks on the next model retirement (issue #5313).
 
 ## SHOULD
 
@@ -30,6 +30,6 @@ priority: high
 ## References
 
 - `build/generate_agents.py`. Canonical generator
-- `.agents/architecture/ADR-002-agent-model-selection-optimization.md`. Model assignments
+- `.agents/architecture/ADR-080-model-pin-justification-policy.md`. Model pin policy (supersedes ADR-002's method, per ADR-002's own 2026-08-25 deprecation note)
 - `.agents/steering/agent-prompts.md`. Prompt authoring standards
 - `templates/README.md`. Template structure

--- a/.github/instructions/templates.instructions.md
+++ b/.github/instructions/templates.instructions.md
@@ -11,8 +11,8 @@ applyTo: templates/**
 1. **Regenerate after edits**. Changes MUST be followed by running `uv run python build/generate_agents.py` before commit. Uncommitted generator output is a protocol failure.
 2. **Commit generated output**. Regenerated files under `src/copilot-cli/agents/` and `src/vs-code-agents/` MUST be committed in the same PR as the template change. Those two are the only trees `build/generate_agents.py` writes; `src/claude/`, `.claude/agents/`, and `.github/agents/` are hand-maintained and the generator does not touch them (see `.agents/governance/GENERATOR-FILES.md`).
 3. **Toolset integrity**. Changes that add or remove tools MUST update `templates/toolsets.yaml` consistently.
-4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`, `model`) present and valid per ADR-002.
-5. **Model selection**. Model choices MUST match ADR-002 (`opus` / `sonnet` / `haiku` assignments).
+4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`) present and valid. `model_tier` is optional: ADR-080 governs whether a generated agent may carry a `model:` pin at all (see MUST-5). ADR-002, formerly cited here, is deprecated in favor of ADR-080 (2026-08-25).
+5. **Model selection**. A template's `model_tier` MUST comply with ADR-080: the generator resolves only the `haiku` tier, the sole cost exception ADR-080 rule 3 recognizes, into a versioned `model:` pin for the generated Copilot/VS Code/Visual Studio mirrors. `model_tier: opus` or `model_tier: sonnet`, and no `model_tier` at all, MUST resolve to no `model:` field, so the mirror inherits the harness default rather than shipping an unjustified pin that breaks on the next model retirement (issue #5313).
 
 ## SHOULD
 
@@ -28,6 +28,6 @@ applyTo: templates/**
 ## References
 
 - `build/generate_agents.py`. Canonical generator
-- `.agents/architecture/ADR-002-agent-model-selection-optimization.md`. Model assignments
+- `.agents/architecture/ADR-080-model-pin-justification-policy.md`. Model pin policy (supersedes ADR-002's method, per ADR-002's own 2026-08-25 deprecation note)
 - `.agents/steering/agent-prompts.md`. Prompt authoring standards
 - `templates/README.md`. Template structure

--- a/build/generate_agents_common.py
+++ b/build/generate_agents_common.py
@@ -219,18 +219,21 @@ def convert_frontmatter_for_platform(
         else:
             result.pop("name", None)
 
-        # Resolve model: use model_tier mapping if template specifies a tier
+        # Resolve model: only the 'haiku' tier is ever emitted, matching the
+        # sole cost exception ADR-080 rule 3 recognizes (a rolling alias
+        # resolving, via this same model_tiers map, to an id priced below the
+        # harness default). Any other tier, and the platform's own default
+        # model, injected a versioned pin no manifest evidence justified
+        # (ADR-080 rule 2), which breaks on the next retirement (issue #5313,
+        # the retired claude-opus-4.5). Omitting the field lets the harness
+        # inherit its own default at runtime instead.
         model_tier = frontmatter.get("model_tier")
         # Look for model_tiers in legacy block first, then top-level for backward compat
         model_tiers = legacy.get("model_tiers") or platform_config.get("model_tiers")
-        if model_tier and isinstance(model_tiers, dict) and model_tier in model_tiers:
-            result["model"] = str(model_tiers[model_tier])
+        if model_tier == "haiku" and isinstance(model_tiers, dict) and "haiku" in model_tiers:
+            result["model"] = str(model_tiers["haiku"])
         else:
-            model = fm.get("model")
-            if model:
-                result["model"] = str(model)
-            else:
-                result.pop("model", None)
+            result.pop("model", None)
     else:
         result.pop("name", None)
         result.pop("model", None)

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -23,7 +23,6 @@ tools:
   - serena/list_memories
   - serena/read_memory
   - serena/initial_instructions
-model: claude-opus-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/architect.agent.md
+++ b/src/copilot-cli/agents/architect.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: strategic
 ---
 # Architect Agent

--- a/src/copilot-cli/agents/backlog-generator.agent.md
+++ b/src/copilot-cli/agents/backlog-generator.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 # Backlog Generator Agent

--- a/src/copilot-cli/agents/code-simplifier.agent.md
+++ b/src/copilot-cli/agents/code-simplifier.agent.md
@@ -7,7 +7,6 @@ tools:
   - edit
   - search
   - shell
-model: claude-sonnet-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/comment-analyzer.agent.md
+++ b/src/copilot-cli/agents/comment-analyzer.agent.md
@@ -18,7 +18,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-sonnet-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/critic.agent.md
+++ b/src/copilot-cli/agents/critic.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: coordinator
 ---
 

--- a/src/copilot-cli/agents/debug.agent.md
+++ b/src/copilot-cli/agents/debug.agent.md
@@ -19,7 +19,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 

--- a/src/copilot-cli/agents/dependency-auditor.agent.md
+++ b/src/copilot-cli/agents/dependency-auditor.agent.md
@@ -9,7 +9,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-sonnet-4.6
 role: executor
 ---
 # Dependency Auditor

--- a/src/copilot-cli/agents/devops.agent.md
+++ b/src/copilot-cli/agents/devops.agent.md
@@ -17,7 +17,6 @@ tools:
   - github/get_file_contents
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 # DevOps Agent

--- a/src/copilot-cli/agents/explainer.agent.md
+++ b/src/copilot-cli/agents/explainer.agent.md
@@ -7,7 +7,6 @@ tools:
   - edit
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/high-level-advisor.agent.md
+++ b/src/copilot-cli/agents/high-level-advisor.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: strategic
 ---
 # High-Level Advisor Agent

--- a/src/copilot-cli/agents/implementer.agent.md
+++ b/src/copilot-cli/agents/implementer.agent.md
@@ -17,7 +17,6 @@ tools:
   - github/add_issue_comment
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 isolation_required: true
 ---

--- a/src/copilot-cli/agents/independent-thinker.agent.md
+++ b/src/copilot-cli/agents/independent-thinker.agent.md
@@ -11,7 +11,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: strategic
 ---
 # Independent Thinker Agent

--- a/src/copilot-cli/agents/issue-feature-review.agent.md
+++ b/src/copilot-cli/agents/issue-feature-review.agent.md
@@ -12,7 +12,6 @@ tools:
   - github/list_commits
   - cloudmcp-manager/*
   - serena/*
-model: claude-sonnet-4.6
 role: coordinator
 ---
 

--- a/src/copilot-cli/agents/janitor.agent.md
+++ b/src/copilot-cli/agents/janitor.agent.md
@@ -19,7 +19,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/merge-resolver.agent.md
+++ b/src/copilot-cli/agents/merge-resolver.agent.md
@@ -20,7 +20,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 

--- a/src/copilot-cli/agents/milestone-planner.agent.md
+++ b/src/copilot-cli/agents/milestone-planner.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: coordinator
 ---
 

--- a/src/copilot-cli/agents/negotiation.agent.md
+++ b/src/copilot-cli/agents/negotiation.agent.md
@@ -12,7 +12,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/orchestrator.agent.md
+++ b/src/copilot-cli/agents/orchestrator.agent.md
@@ -18,7 +18,6 @@ tools:
   - github/get_workflow_run
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: coordinator
 ---
 

--- a/src/copilot-cli/agents/pr-comment-responder.agent.md
+++ b/src/copilot-cli/agents/pr-comment-responder.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - github.vscode-pull-request-github/*
   - serena/*
-model: claude-opus-4.6
 role: coordinator
 ---
 # PR Comment Responder Agent

--- a/src/copilot-cli/agents/pr-test-analyzer.agent.md
+++ b/src/copilot-cli/agents/pr-test-analyzer.agent.md
@@ -18,7 +18,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 

--- a/src/copilot-cli/agents/qa.agent.md
+++ b/src/copilot-cli/agents/qa.agent.md
@@ -9,7 +9,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 # QA Agent

--- a/src/copilot-cli/agents/quality-auditor.agent.md
+++ b/src/copilot-cli/agents/quality-auditor.agent.md
@@ -9,7 +9,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-sonnet-4.6
 role: support
 ---
 # Quality Auditor Agent

--- a/src/copilot-cli/agents/retrospective.agent.md
+++ b/src/copilot-cli/agents/retrospective.agent.md
@@ -9,7 +9,6 @@ tools:
   - agent
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 # Retrospective Agent (Reflector)

--- a/src/copilot-cli/agents/roadmap.agent.md
+++ b/src/copilot-cli/agents/roadmap.agent.md
@@ -7,7 +7,6 @@ tools:
   - edit
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: strategic
 ---
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -14,7 +14,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 # Security Agent

--- a/src/copilot-cli/agents/silent-failure-hunter.agent.md
+++ b/src/copilot-cli/agents/silent-failure-hunter.agent.md
@@ -18,7 +18,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 

--- a/src/copilot-cli/agents/skillbook.agent.md
+++ b/src/copilot-cli/agents/skillbook.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 

--- a/src/copilot-cli/agents/task-decomposer.agent.md
+++ b/src/copilot-cli/agents/task-decomposer.agent.md
@@ -8,7 +8,6 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: support
 ---
 # Task Decomposer Agent

--- a/src/copilot-cli/agents/type-design-analyzer.agent.md
+++ b/src/copilot-cli/agents/type-design-analyzer.agent.md
@@ -18,7 +18,6 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
 role: executor
 ---
 

--- a/src/copilot-cli/instructions/templates.instructions.md
+++ b/src/copilot-cli/instructions/templates.instructions.md
@@ -11,8 +11,8 @@ applyTo: templates/**
 1. **Regenerate after edits**. Changes MUST be followed by running `uv run python build/generate_agents.py` before commit. Uncommitted generator output is a protocol failure.
 2. **Commit generated output**. Regenerated files under `src/copilot-cli/agents/` and `src/vs-code-agents/` MUST be committed in the same PR as the template change. Those two are the only trees `build/generate_agents.py` writes; `src/claude/`, `.claude/agents/`, and `.github/agents/` are hand-maintained and the generator does not touch them (see `.agents/governance/GENERATOR-FILES.md`).
 3. **Toolset integrity**. Changes that add or remove tools MUST update `templates/toolsets.yaml` consistently.
-4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`, `model`) present and valid per ADR-002.
-5. **Model selection**. Model choices MUST match ADR-002 (`opus` / `sonnet` / `haiku` assignments).
+4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`) present and valid. `model_tier` is optional: ADR-080 governs whether a generated agent may carry a `model:` pin at all (see MUST-5). ADR-002, formerly cited here, is deprecated in favor of ADR-080 (2026-08-25).
+5. **Model selection**. A template's `model_tier` MUST comply with ADR-080: the generator resolves only the `haiku` tier, the sole cost exception ADR-080 rule 3 recognizes, into a versioned `model:` pin for the generated Copilot/VS Code/Visual Studio mirrors. `model_tier: opus` or `model_tier: sonnet`, and no `model_tier` at all, MUST resolve to no `model:` field, so the mirror inherits the harness default rather than shipping an unjustified pin that breaks on the next model retirement (issue #5313).
 
 ## SHOULD
 
@@ -28,6 +28,6 @@ applyTo: templates/**
 ## References
 
 - `build/generate_agents.py`. Canonical generator
-- `.agents/architecture/ADR-002-agent-model-selection-optimization.md`. Model assignments
+- `.agents/architecture/ADR-080-model-pin-justification-policy.md`. Model pin policy (supersedes ADR-002's method, per ADR-002's own 2026-08-25 deprecation note)
 - `.agents/steering/agent-prompts.md`. Prompt authoring standards
 - `templates/README.md`. Template structure

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -22,7 +22,6 @@ tools:
   - serena/list_memories
   - serena/read_memory
   - serena/initial_instructions
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/architect.agent.md
+++ b/src/vs-code-agents/architect.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: strategic
 ---
 # Architect Agent

--- a/src/vs-code-agents/backlog-generator.agent.md
+++ b/src/vs-code-agents/backlog-generator.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 # Backlog Generator Agent

--- a/src/vs-code-agents/code-simplifier.agent.md
+++ b/src/vs-code-agents/code-simplifier.agent.md
@@ -7,7 +7,6 @@ tools:
   - edit
   - search
   - execute
-model: Claude Sonnet 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/comment-analyzer.agent.md
+++ b/src/vs-code-agents/comment-analyzer.agent.md
@@ -19,7 +19,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Sonnet 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/critic.agent.md
+++ b/src/vs-code-agents/critic.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: coordinator
 ---
 

--- a/src/vs-code-agents/debug.agent.md
+++ b/src/vs-code-agents/debug.agent.md
@@ -20,7 +20,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 

--- a/src/vs-code-agents/dependency-auditor.agent.md
+++ b/src/vs-code-agents/dependency-auditor.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Sonnet 4.6 (copilot)
 role: executor
 ---
 # Dependency Auditor

--- a/src/vs-code-agents/devops.agent.md
+++ b/src/vs-code-agents/devops.agent.md
@@ -18,7 +18,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 # DevOps Agent

--- a/src/vs-code-agents/explainer.agent.md
+++ b/src/vs-code-agents/explainer.agent.md
@@ -8,7 +8,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/high-level-advisor.agent.md
+++ b/src/vs-code-agents/high-level-advisor.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: strategic
 ---
 # High-Level Advisor Agent

--- a/src/vs-code-agents/implementer.agent.md
+++ b/src/vs-code-agents/implementer.agent.md
@@ -18,7 +18,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 isolation_required: true
 ---

--- a/src/vs-code-agents/independent-thinker.agent.md
+++ b/src/vs-code-agents/independent-thinker.agent.md
@@ -12,7 +12,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: strategic
 ---
 # Independent Thinker Agent

--- a/src/vs-code-agents/issue-feature-review.agent.md
+++ b/src/vs-code-agents/issue-feature-review.agent.md
@@ -13,7 +13,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Sonnet 4.6 (copilot)
 role: coordinator
 ---
 

--- a/src/vs-code-agents/janitor.agent.md
+++ b/src/vs-code-agents/janitor.agent.md
@@ -20,7 +20,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/merge-resolver.agent.md
+++ b/src/vs-code-agents/merge-resolver.agent.md
@@ -21,7 +21,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 

--- a/src/vs-code-agents/milestone-planner.agent.md
+++ b/src/vs-code-agents/milestone-planner.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: coordinator
 ---
 

--- a/src/vs-code-agents/negotiation.agent.md
+++ b/src/vs-code-agents/negotiation.agent.md
@@ -13,7 +13,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/orchestrator.agent.md
+++ b/src/vs-code-agents/orchestrator.agent.md
@@ -18,7 +18,6 @@ tools:
   - github/get_workflow_run
   - cloudmcp-manager/*
   - serena/*
-model: Claude Opus 4.6 (copilot)
 role: coordinator
 ---
 

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - github.vscode-pull-request-github/*
   - serena/*
-model: Claude Opus 4.6 (copilot)
 role: coordinator
 ---
 # PR Comment Responder Agent

--- a/src/vs-code-agents/pr-test-analyzer.agent.md
+++ b/src/vs-code-agents/pr-test-analyzer.agent.md
@@ -19,7 +19,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 

--- a/src/vs-code-agents/qa.agent.md
+++ b/src/vs-code-agents/qa.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 # QA Agent

--- a/src/vs-code-agents/quality-auditor.agent.md
+++ b/src/vs-code-agents/quality-auditor.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Sonnet 4.6 (copilot)
 role: support
 ---
 # Quality Auditor Agent

--- a/src/vs-code-agents/retrospective.agent.md
+++ b/src/vs-code-agents/retrospective.agent.md
@@ -10,7 +10,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 # Retrospective Agent (Reflector)

--- a/src/vs-code-agents/roadmap.agent.md
+++ b/src/vs-code-agents/roadmap.agent.md
@@ -8,7 +8,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: strategic
 ---
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -15,7 +15,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 # Security Agent

--- a/src/vs-code-agents/silent-failure-hunter.agent.md
+++ b/src/vs-code-agents/silent-failure-hunter.agent.md
@@ -19,7 +19,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 

--- a/src/vs-code-agents/skillbook.agent.md
+++ b/src/vs-code-agents/skillbook.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 

--- a/src/vs-code-agents/task-decomposer.agent.md
+++ b/src/vs-code-agents/task-decomposer.agent.md
@@ -9,7 +9,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: support
 ---
 # Task Decomposer Agent

--- a/src/vs-code-agents/type-design-analyzer.agent.md
+++ b/src/vs-code-agents/type-design-analyzer.agent.md
@@ -19,7 +19,6 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
 role: executor
 ---
 

--- a/templates/platforms/copilot-cli.yaml
+++ b/templates/platforms/copilot-cli.yaml
@@ -95,8 +95,15 @@ legacy:
   outputDir: "src/copilot-cli/agents"
   fileExtension: ".agent.md"
   frontmatter:
-    model: "claude-opus-4.6"
     includeNameField: true
+  # ADR-080 rule 5 / issue #5313: no default `model:` is injected here.
+  # generate_agents_common.py resolves only the `haiku` entry below (the sole
+  # cost exception ADR-080 rule 3 recognizes); every other agent inherits the
+  # harness default rather than carrying an unjustified versioned pin that
+  # breaks on the next model retirement (the retired claude-opus-4.5 that
+  # motivated this issue). The opus/sonnet entries stay so
+  # check_model_pins.py's load_tier_map() can still validate a source unit's
+  # bare-alias cost rationale (ADR-080 rule 3).
   model_tiers:
     opus: "claude-opus-4.6"
     sonnet: "claude-sonnet-4.6"

--- a/templates/platforms/visual-studio.yaml
+++ b/templates/platforms/visual-studio.yaml
@@ -9,8 +9,12 @@ legacy:
   outputDir: "src/vs-code-agents"
   fileExtension: ".agent.md"
   frontmatter:
-    model: "Claude Opus 4.6 (copilot)"
     includeNameField: false
+  # ADR-080 rule 5 / issue #5313: no default `model:` is injected here.
+  # generate_agents_common.py resolves only the `haiku` entry below (the sole
+  # cost exception ADR-080 rule 3 recognizes); every other agent inherits the
+  # harness default rather than carrying an unjustified versioned pin that
+  # breaks on the next model retirement.
   model_tiers:
     opus: "Claude Opus 4.6 (copilot)"
     sonnet: "Claude Sonnet 4.6 (copilot)"

--- a/templates/platforms/vscode.yaml
+++ b/templates/platforms/vscode.yaml
@@ -9,8 +9,12 @@ legacy:
   outputDir: "src/vs-code-agents"
   fileExtension: ".agent.md"
   frontmatter:
-    model: "Claude Opus 4.6 (copilot)"
     includeNameField: false
+  # ADR-080 rule 5 / issue #5313: no default `model:` is injected here.
+  # generate_agents_common.py resolves only the `haiku` entry below (the sole
+  # cost exception ADR-080 rule 3 recognizes); every other agent inherits the
+  # harness default rather than carrying an unjustified versioned pin that
+  # breaks on the next model retirement.
   model_tiers:
     opus: "Claude Opus 4.6 (copilot)"
     sonnet: "Claude Sonnet 4.6 (copilot)"

--- a/tests/test_generate_agents.py
+++ b/tests/test_generate_agents.py
@@ -41,7 +41,6 @@ def _create_test_structure(tmp_path: Path) -> tuple[Path, Path, Path]:
         "outputDir: src/vs-code-agents\n"
         "fileExtension: .agent.md\n"
         "frontmatter:\n"
-        '  model: "Claude Opus 4.5 (copilot)"\n'
         "  includeNameField: false\n"
         'handoffSyntax: "#runSubagent"\n'
         'memoryPrefix: "serena/"\n',
@@ -156,8 +155,11 @@ class TestGenerateAgents:
         output_file = output_root / "vs-code-agents" / "test-agent.agent.md"
         content = output_file.read_text(encoding="utf-8")
         assert content.startswith("---")
-        assert "model:" in content
         assert "description:" in content
+        # ADR-080 rule 5 / issue #5313: no model_tier on the source unit means
+        # no injected model, so a retired pin (e.g. claude-opus-4.5) can never
+        # ship unjustified.
+        assert "model:" not in content
 
     def test_generated_content_has_lf_not_crlf(self, tmp_path: Path) -> None:
         repo_root, templates_path, output_root = _create_test_structure(tmp_path)

--- a/tests/test_generate_agents.py
+++ b/tests/test_generate_agents.py
@@ -330,6 +330,11 @@ class TestGenerateAgents:
 
         copilot_content = copilot_file.read_text(encoding="utf-8")
         assert "name: test-agent" in copilot_content
+        # ADR-080 rule 5 / issue #5313: the fixture's legacy platform default
+        # is the retired claude-opus-4.5 pin that broke every un-overridden
+        # agent. The unfixed generator would copy it straight into the
+        # output; the fix must drop it instead of ever emitting it.
+        assert "model:" not in copilot_content
 
     def test_rejects_non_allowlisted_agent_output_directory(
         self, tmp_path: Path

--- a/tests/test_generate_agents_common.py
+++ b/tests/test_generate_agents_common.py
@@ -207,30 +207,32 @@ class TestConvertFrontmatterForPlatform:
         fm: dict[str, str | None] = {"name": "test", "description": "A test"}
         config: dict[str, object] = {
             "platform": "vscode",
-            "frontmatter": {"includeNameField": False, "model": "Claude Opus 4.6 (copilot)"},
+            "frontmatter": {"includeNameField": False},
         }
         result = convert_frontmatter_for_platform(fm, config, "test")
         assert "name" not in result
-        assert result["model"] == "Claude Opus 4.6 (copilot)"
+        # ADR-080 rule 5 / issue #5313: no model_tier means no injected model.
+        assert "model" not in result
 
     def test_copilot_platform_includes_name(self) -> None:
         fm: dict[str, str | None] = {"description": "A test"}
         config: dict[str, object] = {
             "platform": "copilot-cli",
-            "frontmatter": {"includeNameField": True, "model": "claude-opus-4.6"},
+            "frontmatter": {"includeNameField": True},
         }
         result = convert_frontmatter_for_platform(fm, config, "test-agent")
         assert result["name"] == "test-agent"
-        assert result["model"] == "claude-opus-4.6"
+        # ADR-080 rule 5 / issue #5313: no model_tier means no injected model.
+        assert "model" not in result
 
     def test_skips_placeholder_values(self) -> None:
-        fm: dict[str, str | None] = {"name": "test", "model": "{{PLATFORM_MODEL}}"}
+        fm: dict[str, str | None] = {"name": "test", "argument-hint": "{{PLATFORM_ARGUMENT_HINT}}"}
         config: dict[str, object] = {
             "platform": "vscode",
-            "frontmatter": {"includeNameField": False, "model": "Claude Opus 4.6 (copilot)"},
+            "frontmatter": {"includeNameField": False},
         }
         result = convert_frontmatter_for_platform(fm, config, "test")
-        assert result["model"] == "Claude Opus 4.6 (copilot)"
+        assert "argument-hint" not in result
 
     def test_uses_platform_specific_tools(self) -> None:
         fm: dict[str, str | None] = {
@@ -308,14 +310,15 @@ class TestConvertFrontmatterForPlatform:
         result = convert_frontmatter_for_platform(fm, config, "test")
         assert result.get("tools") == "['read', 'edit']"
 
-    def test_model_tier_overrides_platform_default(self) -> None:
+    def test_haiku_tier_resolves_to_versioned_id(self) -> None:
+        """The sole ADR-080 rule 3 cost exception still resolves (issue #5313)."""
         fm: dict[str, str | None] = {
             "description": "test",
-            "model_tier": "sonnet",
+            "model_tier": "haiku",
         }
         config: dict[str, object] = {
             "platform": "copilot-cli",
-            "frontmatter": {"includeNameField": True, "model": "claude-opus-4.6"},
+            "frontmatter": {"includeNameField": True},
             "model_tiers": {
                 "opus": "claude-opus-4.6",
                 "sonnet": "claude-sonnet-4.6",
@@ -323,20 +326,43 @@ class TestConvertFrontmatterForPlatform:
             },
         }
         result = convert_frontmatter_for_platform(fm, config, "test")
-        assert result["model"] == "claude-sonnet-4.6"
+        assert result["model"] == "claude-haiku-4.5"
 
-    def test_model_tier_absent_uses_platform_default(self) -> None:
+    def test_non_haiku_tier_omits_model(self) -> None:
+        """ADR-080 rule 5 / issue #5313: opus/sonnet tiers carry no manifest
+        evidence, so the generator must not inject an unjustified versioned
+        pin. The unit inherits the harness default instead."""
+        fm: dict[str, str | None] = {
+            "description": "test",
+            "model_tier": "sonnet",
+        }
+        config: dict[str, object] = {
+            "platform": "copilot-cli",
+            "frontmatter": {"includeNameField": True},
+            "model_tiers": {
+                "opus": "claude-opus-4.6",
+                "sonnet": "claude-sonnet-4.6",
+                "haiku": "claude-haiku-4.5",
+            },
+        }
+        result = convert_frontmatter_for_platform(fm, config, "test")
+        assert "model" not in result
+
+    def test_model_tier_absent_omits_model(self) -> None:
+        """ADR-080 rule 5 / issue #5313: the generator must not inject a
+        platform-wide default model (the retired claude-opus-4.5 that broke
+        every un-overridden agent). No tier means no model field."""
         fm: dict[str, str | None] = {"description": "test"}
         config: dict[str, object] = {
             "platform": "vscode",
-            "frontmatter": {"includeNameField": False, "model": "Claude Opus 4.6 (copilot)"},
+            "frontmatter": {"includeNameField": False},
             "model_tiers": {
                 "opus": "Claude Opus 4.6 (copilot)",
                 "sonnet": "Claude Sonnet 4.6 (copilot)",
             },
         }
         result = convert_frontmatter_for_platform(fm, config, "test")
-        assert result["model"] == "Claude Opus 4.6 (copilot)"
+        assert "model" not in result
 
     def test_model_tier_removed_from_output(self) -> None:
         fm: dict[str, str | None] = {
@@ -345,7 +371,7 @@ class TestConvertFrontmatterForPlatform:
         }
         config: dict[str, object] = {
             "platform": "copilot-cli",
-            "frontmatter": {"includeNameField": True, "model": "claude-opus-4.6"},
+            "frontmatter": {"includeNameField": True},
             "model_tiers": {
                 "opus": "claude-opus-4.6",
                 "sonnet": "claude-sonnet-4.6",


### PR DESCRIPTION
## Summary

### What

The Copilot CLI, VS Code, and Visual Studio agent generators injected a platform-wide default `model:` value (`claude-opus-4.6` / `Claude Opus 4.6 (copilot)`) for every agent with no cost-tier override, and resolved `opus`/`sonnet` `model_tier` values to a versioned model id the same way. Neither pin had manifest evidence backing it under ADR-080. This PR restricts the generator's `model_tier` resolution to the `haiku` tier (the sole cost exception ADR-080 rule 3 recognizes) and removes the default-model injection entirely, so every other generated agent now carries no `model:` field and inherits the harness default at runtime.

### Why

Issue #5313: many agents hard-pinned `model: claude-opus-4.5` in their frontmatter. That model was retired, so every affected agent failed to launch on the Copilot CLI harness with "Model 'claude-opus-4.5' is not available." The retired id had already been bumped to `claude-opus-4.6` on `main`, but the generator kept minting a fresh versioned pin the same fragile way, so the exact same failure class was guaranteed to recur on the next retirement.

ADR-080 (accepted 2026-07-11, amended 2026-08-12) already decided this: skills, agents, and commands should default to the harness-inherited model, and a versioned agent pin is allowed only with cited sweep evidence in the model-pin evidence manifest (currently empty, no agent has such evidence). Rule 5 of that ADR explicitly named this generator's default-injection as the thing that needed to stop; this PR implements that rule.

ADR-002, the older model-selection ADR that `.claude/rules/templates.md` cited for requiring a `model:` field on every template, was deprecated 2026-08-25 in favor of ADR-080. The second commit updates that rule text so it stops contradicting the fix in the first commit.

This PR does not touch the `.claude/agents` source tree (already ADR-080-compliant bare aliases) or the model-pin governance check's scanned units. That check does not scan the generated mirrors at all, which is exactly the gap this PR closes at the source.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5313 | Agents hard-pinned to retired model 'claude-opus-4.5' fail to launch |
| **Spec** | `.agents/architecture/ADR-080-model-pin-justification-policy.md` | Model pin justification policy (rule 5 implemented here) |

## Changes

- `build/generate_agents_common.py`: `convert_frontmatter_for_platform` now resolves only `model_tier: haiku` into a versioned id; every other tier (or no tier) omits the `model:` field instead of falling back to a platform-wide default.
- `templates/platforms/copilot-cli.yaml`, `templates/platforms/vscode.yaml`, `templates/platforms/visual-studio.yaml`: removed the hardcoded default `model:` line from `legacy.frontmatter`; kept `model_tiers` (still needed for `haiku` resolution and for the source-side cost-rationale validation the ADR-080 governance check performs).
- Regenerated `src/copilot-cli/agents/*.agent.md` and `src/vs-code-agents/*.agent.md`: only `code-reviewer` still carries a `model:` line (`haiku`, its existing ADR-080 rule 3 cost exception); every other agent now inherits the harness default.
- `.claude/rules/templates.md` (+ its two generated instruction mirrors): repointed the frontmatter/model-selection rules from the deprecated ADR-002 to ADR-080, so the rule text matches the new generator behavior.
- Tests: updated `tests/test_generate_agents_common.py` and `tests/test_generate_agents.py` for the new contract (haiku tier still resolves, every other case omits `model:`), including a regression case built from this issue's exact scenario.

## Acceptance criteria

- [x] Generated Copilot CLI/VS Code/Visual Studio agents no longer carry an unjustified versioned `model:` pin
- [x] The one ADR-080-recognized cost exception (`code-reviewer` maps to `haiku`) still resolves correctly
- [x] `build/generate_agents.py --validate` passes (no generator/output drift)
- [x] `scripts/validation/check_model_pins.py --mode enforce` passes (no new source-side pin violations)
- [x] Full `scripts/validation/pre_pr.py` suite passes

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: bug fix, standard scrutiny, no rush

**Focus areas**: whether restricting the tier resolution to `haiku` only (vs. keeping `opus`/`sonnet` resolution too) is the right call. See the ADR-080 rule 3 analysis in the commit message. Also whether removing the default model line from all three platform configs, not just the Copilot CLI one, is in scope, given ADR-080's amendment explicitly flagged the other two as carrying the same fragile pattern.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

Evidence from this branch's current head (35e89141e), re-run after the fixes above:

```
$ uv run python build/generate_agents.py --validate
=== Summary ===
Duration: 0.04s
VALIDATION PASSED: All generated files match committed files

$ uv run python scripts/validation/check_model_pins.py --mode enforce
[model-pins] OK: no new or changed pin violations

$ uv run python scripts/validation/pre_pr.py
=== Validation Summary ===
Duration: 114.44s
Total Validations: 59
Passed: 59
Failed: 0
Skipped: 0

RESULT: All validations passed
```

Note on the Visual Studio target named in the acceptance criteria: `templates/platforms/vscode.yaml` and `templates/platforms/visual-studio.yaml` both write to the same `src/vs-code-agents/` output tree (see `legacy.outputDir` in each file), so there is no separate Visual Studio generated-agent directory to inspect; the shared output already reflects both configs' `model_tiers` change.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5313
