### PR TITLE
feat(pr-review): admit a bundled plugin config as an install-trusted origin

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -16,20 +16,35 @@ sits beside the PR review command.
 
 The bundled copy IS runnable from an installed plugin (issue #5112, Option 1).
 When `resolve_pr_review_config` lands on a config inside a host-declared plugin
-root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) that is itself outside the
-consumer's git work tree, the completion gate treats that origin as
+root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) whose tree is **disjoint
+from** the consumer's git work tree, the completion gate treats that origin as
 install-trusted: the operator installed it and PR content cannot write there, so
 the gate skips the byte-identity check it would otherwise run against the trusted
 ref. This reverses an earlier stance that called the bundled copy a reference
 artifact; under that stance an installed `/pr-review` could not dispatch at all,
 because path containment refused the config before any check ran.
 
-Two limits, because the widening is narrow. The `$repo_root/.claude` fallback in
-the list below gets NO such treatment even if a plugin-root variable points at
-it: that path is written by the checked-out PR and keeps the full trust check.
-And only the config origin widens. The commands the config names are still
+**Disjoint, not merely "outside."** Neither tree may be at or under the other,
+and the difference is not pedantic. A root of `$HOME` with the repository at
+`$HOME/repo` is "outside" the work tree in the loose sense (it is not a
+subdirectory of it) while containing every file the checked-out PR wrote. That
+reading was in an earlier draft of this paragraph, and the matching one-way test
+in the gate admitted exactly that root, so a PR-authored config became
+install-trusted and skipped verification. Both directions are checked now.
+The boundary is the real work tree from `git rev-parse --show-toplevel`,
+because a directory marker inside the repository can be created by the PR and
+therefore cannot anchor trust. If the work tree cannot be established, no root
+install-trusts anything and the gate exits 3.
+
+Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
+in the list below gets NO such treatment even if a plugin-root variable points
+at it: that path is written by the checked-out PR and keeps the full trust
+check. Only the config ORIGIN widens; the commands the config names are still
 verified against the trusted ref, so an install-trusted config cannot execute a
-PR-rewritten verifier script.
+PR-rewritten verifier script. And `--trusted-ref` is validated on this path like
+any other, including the requirement that it resolve to a remote-tracking ref:
+`HEAD` and local branches can be moved by the checked-out PR, so they cannot
+anchor trust and are refused.
 
 ## Context
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -12,8 +12,24 @@ Respond to PR review comments for: $ARGUMENTS
 
 Load configuration from `pr-review-config.yaml` for scripts, completion criteria,
 error recovery, and failure handling tables. In this repository the live config
-sits beside the PR review command. The bundled Copilot CLI copy is a reference
-artifact, not a runnable completion-gate config.
+sits beside the PR review command.
+
+The bundled copy IS runnable from an installed plugin (issue #5112, Option 1).
+When `resolve_pr_review_config` lands on a config inside a host-declared plugin
+root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) that is itself outside the
+consumer's git work tree, the completion gate treats that origin as
+install-trusted: the operator installed it and PR content cannot write there, so
+the gate skips the byte-identity check it would otherwise run against the trusted
+ref. This reverses an earlier stance that called the bundled copy a reference
+artifact; under that stance an installed `/pr-review` could not dispatch at all,
+because path containment refused the config before any check ran.
+
+Two limits, because the widening is narrow. The `$repo_root/.claude` fallback in
+the list below gets NO such treatment even if a plugin-root variable points at
+it: that path is written by the checked-out PR and keeps the full trust check.
+And only the config origin widens. The commands the config names are still
+verified against the trusted ref, so an install-trusted config cannot execute a
+PR-rewritten verifier script.
 
 ## Context
 

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -41,12 +41,29 @@ possible.
 Trust model
 -----------
 
-This dispatcher executes ``command`` strings read from the YAML config.
-The config path MUST be controlled by the repository, never
-user-supplied beyond the validated default. Path traversal protection:
-``--config`` is canonicalised and rejected unless it lives under the
-repository root via
-``scripts.utils.path_validation.validate_safe_path``. The
+This dispatcher executes ``command`` strings read from the YAML config,
+so the config must come from an origin the checked-out PR cannot write.
+There are exactly TWO such origins, and conflating them is what earlier
+revisions of this paragraph did:
+
+  * A **repository** config, the default. ``--config`` is canonicalised
+    and rejected unless it lives under the repository root via
+    ``scripts.utils.path_validation.validate_safe_path``, and its bytes
+    are then verified against the trusted ref, because the repository
+    root is exactly the tree the PR CAN write.
+  * An **install-trusted** config (issue #5112, Option 1). It lives in a
+    host-declared plugin root whose tree is DISJOINT from both the
+    consumer's git work tree and ``_PROJECT_ROOT``, checked in both
+    containment directions. Byte verification is skipped because there
+    is nothing in the consumer repository to compare against; the origin
+    carries the trust. See :func:`_install_trusted_root` for the four
+    conditions and for what this does not close. The trust ANCHOR is
+    still validated on this path, including the ``refs/remotes/*``
+    requirement.
+
+"Disjoint" is not "outside": a root of ``$HOME`` with the repository at
+``$HOME/repo`` is outside the repository while containing every file the
+PR wrote, and a one-way test admitted exactly that (CWE-829). The
 ``pass_when_python`` evaluator no longer calls ``eval``: it parses the
 lambda with ``ast`` and walks a whitelisted node set, so a config
 expression cannot reach Python's class hierarchy or any builtin. This
@@ -531,7 +548,22 @@ def _require_remote_tracking_ref(
     them (Copilot review, PR #5329). One implementation, two callers, is
     what keeps the two paths honest about the same requirement.
     """
-    proc = _run_git(["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd)
+    # Guarded HERE, not at the call sites. _verify_config_trust happens to
+    # call this inside its own try, but the install-trusted caller invokes it
+    # directly, so a git timeout or a missing binary escaped as a traceback
+    # and exit 1 instead of the documented non-overridable exit 3. Putting
+    # the catch in the shared helper is what stops the two callers from
+    # disagreeing about it, which is the same failure that produced this
+    # helper in the first place (Copilot review, PR #5329).
+    try:
+        proc = _run_git(
+            ["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return TrustCheck(
+            TRUST_GIT_ERROR,
+            f"could not resolve trusted ref {trust_anchor_ref!r}: {exc}",
+        )
     full_name = proc.stdout.decode(errors="replace").strip()
     if proc.returncode == 0 and full_name.startswith("refs/remotes/"):
         return None

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -252,6 +252,7 @@ import shlex
 import subprocess
 import sys
 import unicodedata
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -1179,6 +1180,20 @@ def _is_within(path: Path, root: Path) -> bool:
     return True
 
 
+def _are_disjoint(first: Path, second: Path) -> bool:
+    """True when neither path is at or under the other.
+
+    Containment in EITHER direction is the thing callers care about, and
+    testing only one of them is a live defect shape rather than a style
+    point: :func:`_install_trusted_root` shipped a one-way test and a
+    declared plugin root that was an ANCESTOR of the project passed it
+    while every PR-controlled file sat inside that root (CWE-829, found
+    by Copilot review on PR #5329). Naming the symmetric question once
+    keeps the two directions from drifting apart again.
+    """
+    return not (_is_within(first, second) or _is_within(second, first))
+
+
 def _first_symlinked_component(candidate: Path, root: Path) -> Path | None:
     """First symlinked component of ``candidate`` at or below ``root``.
 
@@ -2059,6 +2074,27 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
+def _declared_plugin_roots() -> Iterator[Path]:
+    """Existing directories named by the host's plugin-root variables.
+
+    Yields in ``_PLUGIN_ROOT_ENV_VARS`` order, so a host that exports both
+    resolves through the Copilot variable first, and skips a variable that
+    is unset, empty, whitespace, unresolvable, or not a directory. Declaring
+    a root is necessary for install trust and nowhere near sufficient:
+    :func:`_install_trusted_root` applies the boundary conditions.
+    """
+    for env_var in _PLUGIN_ROOT_ENV_VARS:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            continue
+        try:
+            root = Path(raw).resolve()
+        except OSError:
+            continue
+        if root.is_dir():
+            yield root
+
+
 def _install_trusted_root(config_arg: str) -> Path | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
@@ -2085,7 +2121,9 @@ def _install_trusted_root(config_arg: str) -> Path | None:
 
     1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
        non-empty. An unset environment changes nothing.
+       (Applied by :func:`_declared_plugin_roots`.)
     2. The root resolves to an existing directory.
+       (Applied by :func:`_declared_plugin_roots`.)
     3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
        is what withholds install trust from the in-repo ``.claude/``
        fallback that the same command offers: that path is PR-controlled
@@ -2118,16 +2156,7 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     work_tree: Path | None = None
     work_tree_resolved = False
 
-    for env_var in _PLUGIN_ROOT_ENV_VARS:
-        raw = os.environ.get(env_var, "").strip()
-        if not raw:
-            continue
-        try:
-            root = Path(raw).resolve()
-        except OSError:
-            continue
-        if not root.is_dir():
-            continue
+    for root in _declared_plugin_roots():
         # Condition 3: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
@@ -2155,9 +2184,9 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # cannot relocate. _PROJECT_ROOT is then checked as well, because
         # in the installed case it may resolve somewhere the work-tree
         # check does not cover, and a root overlapping either is refused.
-        if _is_within(root, work_tree) or _is_within(work_tree, root):
+        if not _are_disjoint(root, work_tree):
             continue
-        if _is_within(root, project_root) or _is_within(project_root, root):
+        if not _are_disjoint(root, project_root):
             continue
         try:
             resolved_config = candidate.resolve()

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -2095,6 +2095,35 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _resolve_or_none(path: Path) -> Path | None:
+    """``path.resolve()``, or ``None`` when it cannot be resolved.
+
+    Exists to normalize ONE portability trap into a single place.
+    ``Path.resolve()`` does not raise a single exception family across the
+    versions this ships to: on a symlink loop, CPython 3.10, 3.11 and 3.12
+    raise ``RuntimeError("Symlink loop from ...")`` from ``pathlib``, while
+    3.14 returns the unresolved path without raising. ``RuntimeError`` is
+    not an ``OSError``, so an ``except OSError`` guard lets the loop escape
+    as an unhandled traceback on exactly the interpreters the repo's
+    hook-portability floor targets (``.claude/rules/python.md``: skill
+    scripts run under the host's ambient interpreter, floor 3.10).
+
+    Measured rather than assumed: grep of ``pathlib.py`` in the 3.10, 3.11
+    and 3.12 stdlibs shows the raise; 3.14 returned the path for the same
+    two-link loop. Found by Copilot review on PR #5329, which is a
+    reminder that "it did not raise locally" says nothing about the
+    versions a plugin is installed onto.
+
+    Callers decide what ``None`` means. None of them may treat it as
+    success: an unresolvable path cannot be shown to lie inside or outside
+    any boundary.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
 def _consumer_work_tree() -> Path:
     """The consumer's git work-tree root, or :exc:`WorkTreeUnavailableError`.
 
@@ -2151,12 +2180,12 @@ def _consumer_work_tree() -> Path:
         raise WorkTreeUnavailableError(
             f"git reported an empty work-tree root for {Path.cwd()}",
         )
-    try:
-        return Path(toplevel).resolve()
-    except OSError as exc:
+    resolved = _resolve_or_none(Path(toplevel))
+    if resolved is None:
         raise WorkTreeUnavailableError(
-            f"work-tree root {toplevel!r} does not resolve: {exc}",
-        ) from exc
+            f"work-tree root {toplevel!r} does not resolve",
+        )
+    return resolved
 
 
 def _absolute_config_candidate(config_arg: str) -> Path:
@@ -2228,11 +2257,8 @@ def _host_declared_roots() -> Iterator[Path]:
         raw = os.environ.get(env_var, "").strip()
         if not raw:
             continue
-        try:
-            root = Path(raw).resolve()
-        except OSError:
-            continue
-        if root.is_dir():
+        root = _resolve_or_none(Path(raw))
+        if root is not None and root.is_dir():
             yield root
 
 
@@ -2309,7 +2335,11 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     smaller capability than they already hold, and it is not a boundary
     this gate can close.
     """
-    project_root = _PROJECT_ROOT.resolve()
+    project_root = _resolve_or_none(_PROJECT_ROOT)
+    if project_root is None:
+        # Fail closed. Condition 3 compares against this tree, and a
+        # boundary that cannot be resolved cannot be compared against.
+        return None
     candidate = _absolute_config_candidate(config_arg)
     # Resolved lazily, on first use, and at most once. Only a DECLARED root
     # can install-trust anything, so a run with neither variable set (the
@@ -2349,9 +2379,8 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
             continue
         if not _are_disjoint(root, project_root):
             continue
-        try:
-            resolved_config = candidate.resolve()
-        except OSError:
+        resolved_config = _resolve_or_none(candidate)
+        if resolved_config is None:
             return None
         # Condition 4: resolution already followed any symlink, so a
         # link out of the install directory fails this containment.
@@ -2453,7 +2482,15 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
             return ResolvedConfig(None, None, None, 2)
         try:
             config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
-        except (FileNotFoundError, ValueError) as exc:
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            # RuntimeError joins the pair because validate_safe_path calls
+            # (resolved_base / path).resolve() unguarded, and resolve()
+            # raises RuntimeError on a symlink loop under CPython 3.10 to
+            # 3.12 (see _resolve_or_none). Caught HERE rather than in that
+            # shared helper, which many other scripts call and which is out
+            # of scope for this change; that broader fix is flagged on the
+            # PR instead. Exit 2: a loop in --config is a bad config path,
+            # the same class as the containment failures beside it.
             print(
                 f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
                 file=sys.stderr,

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -1995,6 +1995,48 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _consumer_work_tree() -> Path | None:
+    """The consumer's git work-tree root, or ``None`` if not establishable.
+
+    This, and NOT ``_PROJECT_ROOT``, is the boundary install trust must be
+    disjoint from. ``_resolve_project_root`` exists to locate the repo's
+    ``scripts/`` package and falls back to the nearest ancestor of the cwd
+    holding ``.claude`` OR ``.git``. That heuristic is fine for finding
+    imports and is unsafe as a trust boundary, because **PR content can
+    create a `.claude` directory** and thereby move it.
+
+    The attack it enables (Copilot review, PR #5329): the host starts in
+    ``repo/subdir``; the PR adds ``repo/subdir/.claude``; ``_PROJECT_ROOT``
+    becomes ``repo/subdir``; a declared root of ``repo/.claude`` is then
+    neither above nor below it, so a disjointness test anchored on
+    ``_PROJECT_ROOT`` passes and a wholly PR-controlled config becomes
+    install-trusted, skipping byte-identity verification (CWE-829).
+    Reproduced end to end before this fix.
+
+    ``git rev-parse --show-toplevel`` cannot be moved this way: it reports
+    the real work tree, which is exactly the set of files the checked-out
+    PR controls.
+
+    Returns ``None`` when git is absent, errors, or the cwd is not in a work
+    tree. Callers MUST treat ``None`` as "no install trust" (fail closed):
+    if the extent of PR-controlled content cannot be established, nothing
+    can be shown to lie outside it.
+    """
+    try:
+        proc = _run_git(["rev-parse", "--show-toplevel"], Path.cwd())
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    toplevel = proc.stdout.decode(errors="replace").strip()
+    if not toplevel:
+        return None
+    try:
+        return Path(toplevel).resolve()
+    except OSError:
+        return None
+
+
 def _absolute_config_candidate(config_arg: str) -> Path:
     """``--config`` as an absolute path, resolved against the cwd once.
 
@@ -2069,6 +2111,12 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     """
     project_root = _PROJECT_ROOT.resolve()
     candidate = _absolute_config_candidate(config_arg)
+    # Resolved lazily, on first use, and at most once. Only a DECLARED root
+    # can install-trust anything, so a run with neither variable set (the
+    # overwhelmingly common case, and every caller that predates issue
+    # #5112) must not pay a subprocess call or perturb a test's git mocks.
+    work_tree: Path | None = None
+    work_tree_resolved = False
 
     for env_var in _PLUGIN_ROOT_ENV_VARS:
         raw = os.environ.get(env_var, "").strip()
@@ -2095,6 +2143,20 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # /home/user install-trusted
         # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
         # Found by Copilot review on PR #5329.
+        if not work_tree_resolved:
+            work_tree = _consumer_work_tree()
+            work_tree_resolved = True
+        # Fail closed: with no establishable work tree, nothing can be shown
+        # to lie OUTSIDE PR-controlled content, so nothing install-trusts.
+        if work_tree is None:
+            return None
+        # Disjoint from the real work tree FIRST: that is the authoritative
+        # extent of PR-controlled content and the only one PR content
+        # cannot relocate. _PROJECT_ROOT is then checked as well, because
+        # in the installed case it may resolve somewhere the work-tree
+        # check does not cover, and a root overlapping either is refused.
+        if _is_within(root, work_tree) or _is_within(work_tree, root):
+            continue
         if _is_within(root, project_root) or _is_within(project_root, root):
             continue
         try:

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -87,6 +87,25 @@ window). The outcomes:
   * **git-error** -- verification itself is impossible (not a git work
     tree, trusted ref absent or not remote-tracking, git missing or
     timing out). Halt, exit 3.
+  * **install-trusted** -- the config lives inside a host-declared
+    plugin root (``COPILOT_PLUGIN_ROOT`` / ``CLAUDE_PLUGIN_ROOT``) that
+    is outside the consumer's work tree, so no comparison is attempted
+    and dispatch proceeds (issue #5112, Option 1). This is an ORIGIN
+    claim, not a verification outcome: the operator installed the
+    directory and PR content cannot write it, which is the same
+    reasoning ``_ARGV_EXTERNAL`` already applies to an installed-plugin
+    script named in a criterion's argv. The in-repo ``.claude/``
+    fallback is excluded by construction, because it is inside the work
+    tree and therefore PR-controlled. See
+    :func:`_install_trusted_root` for the four conditions and for the
+    residual this does not close.
+
+Before issue #5112 there was no such status and the bundled config was
+unreachable rather than untrusted: containment refused any ``--config``
+outside the project root, so an installed ``/pr-review`` halted before
+the trust check ran at all. Widening only the origin, and leaving the
+command boundary below untouched, is what keeps that fix from becoming
+a general relaxation.
 
 A human who has inspected the surfaced diff can approve execution
 explicitly by re-running with ``--approve-untrusted-config``, which
@@ -384,6 +403,20 @@ TRUST_GIT_ERROR = "git-error"
 # (exit 2), not a verification outcome, so it does not reuse
 # TRUST_GIT_ERROR (whose contract is exit 3).
 TRUST_MALFORMED_REF = "malformed-ref"
+# Trust status for a config that lives inside a host-declared plugin root
+# outside the consumer's work tree (issue #5112, Option 1). It is NOT a
+# verification outcome: nothing is compared against the trusted ref,
+# because there is nothing in the consumer repository to compare against.
+# The origin itself carries the trust, exactly as _ARGV_EXTERNAL already
+# treats an installed-plugin script the argv names.
+TRUST_INSTALL_TRUSTED = "install-trusted"
+
+# Host-declared plugin roots, in the order resolve_pr_review_config() in
+# .claude/commands/pr-review.md consults them
+# (${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}). Quoted from
+# that command per .claude/rules/canonical-source-mirror.md so the gate
+# and the command cannot drift about which variable wins.
+_PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
 # A trusted ref must look like a git revision and must not start with
 # ``-`` so it can never be parsed as a git option (argument injection).
@@ -609,6 +642,7 @@ def _enforce_config_trust(
     trust_anchor_ref: str,
     approved: bool,
     tree_bytes: bytes,
+    install_root: Path | None = None,
 ) -> tuple[TrustCheck, int | None]:
     """Gate dispatch on config trust; returns ``(trust, exit_code_or_None)``.
 
@@ -621,7 +655,29 @@ def _enforce_config_trust(
     inspectable diff or file for the human to have reviewed. git-error is
     never overridable, because approving with nothing to inspect would
     turn an unverifiable state into an execution path.
+
+    ``install_root``, when not ``None``, is the host-declared plugin root
+    that install-trusts this config (issue #5112, Option 1). Verification
+    is skipped rather than attempted: the config is outside the
+    consumer's work tree, so the trusted ref has no copy of it to compare
+    against and :func:`_verify_config_trust` would return git-error, which
+    is not overridable and would halt at exit 3. That is precisely the
+    dead end the issue reports. Skipping is sound only because the origin
+    carries the trust, which is what :func:`_install_trusted_root`
+    establishes; do not extend this branch to any config the consumer
+    repository can write.
     """
+    if install_root is not None:
+        return (
+            TrustCheck(
+                TRUST_INSTALL_TRUSTED,
+                f"config {config_path} is install-trusted: it resides in "
+                f"host-declared plugin root {install_root}, outside the "
+                f"consumer work tree, which PR content cannot write",
+            ),
+            None,
+        )
+
     if not _TRUSTED_REF_RE.match(trust_anchor_ref):
         print(
             f"Refusing malformed --trusted-ref {trust_anchor_ref!r}",
@@ -1939,39 +1995,137 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _install_trusted_root(config_arg: str) -> Path | None:
+    """The host-declared plugin root that install-trusts ``config_arg``.
+
+    Returns the resolved root when every condition below holds, else
+    ``None`` (the caller then applies the normal work-tree containment
+    and trusted-ref verification unchanged).
+
+    Issue #5112: ``resolve_pr_review_config()`` in
+    ``.claude/commands/pr-review.md`` offers plugin roots as config
+    sources, but containment refused any ``--config`` outside
+    ``_PROJECT_ROOT``, so an installed ``/pr-review`` whose config
+    resolved to the bundled copy could not dispatch at all. Option 1 of
+    that issue admits the bundled copy as a second trusted ORIGIN.
+
+    Why an origin can carry trust here: the operator installed the
+    plugin, and PR content cannot write into the install directory
+    through the consumer repository. That is the same reasoning
+    :func:`_classify_argv_token` already applies under ``_ARGV_EXTERNAL``
+    to an installed-plugin script an argv names, so this widens the
+    config boundary to match a boundary the gate already draws, rather
+    than inventing a new trust class.
+
+    Conditions, each load-bearing:
+
+    1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
+       non-empty. An unset environment changes nothing.
+    2. The root resolves to an existing directory.
+    3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
+       is what withholds install trust from the in-repo ``.claude/``
+       fallback that the same command offers: that path is PR-controlled
+       and must keep the full byte-identity check. A repository whose
+       own ``.claude`` is the plugin root gets no widening.
+    4. The **resolved** config is inside the resolved root. Resolution
+       happens before containment, so a symlink planted in the install
+       directory that points back into the checked-out PR tree lands
+       outside the root and is refused (CWE-59). Only a link whose
+       target is also install-controlled survives.
+
+    Not widened by this function: the command boundary.
+    :func:`_enforce_command_trust` still verifies every work-tree file
+    the criteria name, so an install-trusted config cannot execute a
+    PR-rewritten verifier script.
+
+    Residual, recorded rather than claimed closed: an actor who can
+    already edit the workflow that invokes this gate can both set these
+    variables and write the directory they name. That actor can run
+    arbitrary commands in the same workflow, so this is a strictly
+    smaller capability than they already hold, and it is not a boundary
+    this gate can close.
+    """
+    project_root = _PROJECT_ROOT.resolve()
+    candidate = Path(config_arg)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+
+    for env_var in _PLUGIN_ROOT_ENV_VARS:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            continue
+        try:
+            root = Path(raw).resolve()
+        except OSError:
+            continue
+        if not root.is_dir():
+            continue
+        # Condition 3: the in-repo fallback root never install-trusts.
+        if _is_within(root, project_root):
+            continue
+        try:
+            resolved_config = candidate.resolve()
+        except OSError:
+            return None
+        # Condition 4: resolution already followed any symlink, so a
+        # link out of the install directory fails this containment.
+        if _is_within(resolved_config, root):
+            return root
+    return None
+
+
 def _resolve_and_read_config(
     config_arg: str,
-) -> tuple[Path, bytes] | tuple[None, None]:
+) -> tuple[Path, bytes, Path | None] | tuple[None, None, None]:
     """Validate the config path and read it exactly once.
 
-    Returns ``(None, None)`` after printing to stderr when the path is
-    unsafe (CWE-22 containment), reaches through a repo-local symlink
-    (CWE-59), or is unreadable; the caller exits 2. The returned buffer
-    is the single read that gets trust-verified and then parsed
+    Returns ``(None, None, None)`` after printing to stderr when the
+    path is unsafe (CWE-22 containment), reaches through a repo-local
+    symlink (CWE-59), or is unreadable; the caller exits 2. The returned
+    buffer is the single read that gets trust-verified and then parsed
     (CWE-367).
+
+    The third element is the install-trusted plugin root
+    (:func:`_install_trusted_root`) or ``None``. It is resolved HERE,
+    once, and threaded to :func:`_enforce_config_trust` rather than
+    recomputed there, so the root that decided containment is provably
+    the root that decides trust. Recomputing invites the two to
+    disagree if the environment changes between the calls.
     """
-    symlink = _symlinked_config_component(config_arg)
-    if symlink is not None:
-        print(
-            f"Refusing config path with symlinked component {symlink}: "
-            f"a repo-local symlink would redirect trust verification to "
-            f"its target and surface that file in the approval diff.",
-            file=sys.stderr,
-        )
-        return None, None
+    install_root = _install_trusted_root(config_arg)
+    containment_base = install_root if install_root is not None else _PROJECT_ROOT
+
+    # The symlink probe is bounded to the project root by
+    # _first_symlinked_component, which skips every component outside it
+    # (run_completion_gate.py, "if not _is_within(probe, root): continue").
+    # For an install-trusted config it therefore inspects nothing and
+    # returns None, so it is skipped rather than run misleadingly. The
+    # CWE-59 hazard it guards is a PR-CREATED link; PR content cannot
+    # write the install directory, and condition 4 of
+    # _install_trusted_root already refuses a link that escapes it.
+    if install_root is None:
+        symlink = _symlinked_config_component(config_arg)
+        if symlink is not None:
+            print(
+                f"Refusing config path with symlinked component {symlink}: "
+                f"a repo-local symlink would redirect trust verification to "
+                f"its target and surface that file in the approval diff.",
+                file=sys.stderr,
+            )
+            return None, None, None
     try:
-        config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
+        config_path = validate_safe_path(config_arg, containment_base)
     except (FileNotFoundError, ValueError) as exc:
         print(
             f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
             file=sys.stderr,
         )
-        return None, None
+        return None, None, None
     try:
-        return config_path, _read_config_bytes(config_path)
+        return config_path, _read_config_bytes(config_path), install_root
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
-        return None, None
+        return None, None, None
 
 
 def _extract_criteria(config: dict[str, Any]) -> list[Any] | None:
@@ -2002,18 +2156,23 @@ def main(argv: list[str] | None = None) -> int:
         print("Pull request number must be positive.", file=sys.stderr)
         return 2
 
-    config_path, raw_config = _resolve_and_read_config(args.config)
+    config_path, raw_config, install_root = _resolve_and_read_config(args.config)
     if config_path is None or raw_config is None:
         return 2
 
     # CWE-829 trust boundary: no criterion command runs unless the
-    # working-tree config is byte-identical to the trusted-ref copy or a
-    # human has explicitly approved the divergence.
+    # working-tree config is byte-identical to the trusted-ref copy, a
+    # human has explicitly approved the divergence, or the config came
+    # from an install-trusted origin the consumer repository cannot
+    # write (issue #5112). The command boundary below is NOT widened by
+    # the third case: an install-trusted config still cannot execute a
+    # PR-rewritten verifier script.
     trust, halt_code = _enforce_config_trust(
         config_path,
         args.trust_anchor_ref,
         args.approve_untrusted_config,
         raw_config,
+        install_root,
     )
     if halt_code is not None:
         return halt_code

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -1995,6 +1995,28 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _absolute_config_candidate(config_arg: str) -> Path:
+    """``--config`` as an absolute path, resolved against the cwd once.
+
+    One helper so every consumer of ``--config`` agrees on which file the
+    argument names. ``validate_safe_path`` builds its result as
+    ``(resolved_base / path).resolve()``, so a RELATIVE ``--config``
+    resolves against whatever base it is handed. Passing a different base
+    would therefore silently name a different file than the one an
+    earlier check approved, which is the authorized-path-is-not-the-read-
+    path shape this gate exists to prevent (see ``_verify_config_trust``
+    on verifying the bytes that are executed).
+
+    The cwd is the right anchor because it is what ``_symlinked_config_
+    component`` already uses and what ``subprocess.run`` in
+    :func:`_evaluate_criterion` inherits.
+    """
+    candidate = Path(config_arg)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate
+
+
 def _install_trusted_root(config_arg: str) -> Path | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
@@ -2046,9 +2068,7 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     this gate can close.
     """
     project_root = _PROJECT_ROOT.resolve()
-    candidate = Path(config_arg)
-    if not candidate.is_absolute():
-        candidate = Path.cwd() / candidate
+    candidate = _absolute_config_candidate(config_arg)
 
     for env_var in _PLUGIN_ROOT_ENV_VARS:
         raw = os.environ.get(env_var, "").strip()
@@ -2093,17 +2113,38 @@ def _resolve_and_read_config(
     disagree if the environment changes between the calls.
     """
     install_root = _install_trusted_root(config_arg)
-    containment_base = install_root if install_root is not None else _PROJECT_ROOT
 
-    # The symlink probe is bounded to the project root by
-    # _first_symlinked_component, which skips every component outside it
-    # (run_completion_gate.py, "if not _is_within(probe, root): continue").
-    # For an install-trusted config it therefore inspects nothing and
-    # returns None, so it is skipped rather than run misleadingly. The
-    # CWE-59 hazard it guards is a PR-CREATED link; PR content cannot
-    # write the install directory, and condition 4 of
-    # _install_trusted_root already refuses a link that escapes it.
-    if install_root is None:
+    if install_root is not None:
+        # Do NOT route this through validate_safe_path with install_root
+        # as the base. That helper builds its result as
+        # (resolved_base / path).resolve(), which would make the
+        # environment-declared root a component of the path READ rather
+        # than only the boundary it is CHECKED against, and for a
+        # relative --config would name a different file than the one
+        # _install_trusted_root just approved. Containment against the
+        # root is already established, on this exact resolved path, by
+        # that function's condition 4, so reuse it.
+        #
+        # Keeping the root deny-only is also what stops an environment
+        # variable from participating in constructing a path whose
+        # contents become a criterion's argv.
+        #
+        # The symlink probe is skipped here rather than run: it is
+        # bounded to the project root by _first_symlinked_component
+        # ("if not _is_within(probe, root): continue"), so for an
+        # out-of-tree config it inspects nothing and returns None. The
+        # CWE-59 hazard it guards is a PR-CREATED link, and condition 4
+        # already refuses any link that escapes the install root.
+        try:
+            config_path = _absolute_config_candidate(config_arg).resolve()
+        except OSError as exc:
+            print(
+                f"Refusing to load config from unresolvable path "
+                f"{config_arg!r}: {exc}",
+                file=sys.stderr,
+            )
+            return None, None, None
+    else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
             print(
@@ -2113,14 +2154,14 @@ def _resolve_and_read_config(
                 file=sys.stderr,
             )
             return None, None, None
-    try:
-        config_path = validate_safe_path(config_arg, containment_base)
-    except (FileNotFoundError, ValueError) as exc:
-        print(
-            f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
-            file=sys.stderr,
-        )
-        return None, None, None
+        try:
+            config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
+        except (FileNotFoundError, ValueError) as exc:
+            print(
+                f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
+                file=sys.stderr,
+            )
+            return None, None, None
     try:
         return config_path, _read_config_bytes(config_path), install_root
     except ConfigError as exc:

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -2080,8 +2080,22 @@ def _install_trusted_root(config_arg: str) -> Path | None:
             continue
         if not root.is_dir():
             continue
-        # Condition 3: the in-repo fallback root never install-trusts.
-        if _is_within(root, project_root):
+        # Condition 3: the declared root and the project tree must be
+        # DISJOINT, checked in BOTH directions.
+        #
+        # Testing only "root is not below the project" leaves the
+        # ancestor direction open, and that direction is the whole
+        # bypass: with the project at $HOME/repo and
+        # CLAUDE_PLUGIN_ROOT=$HOME, the root is not below the project
+        # (so a one-way test passes it) while every PR-controlled file
+        # in the repo IS inside the root, so condition 4 passes too. A
+        # config the checked-out PR wrote would then be install-trusted
+        # and skip byte-identity verification entirely (CWE-829).
+        # Reproduced on this branch before the fix: declared root
+        # /home/user install-trusted
+        # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
+        # Found by Copilot review on PR #5329.
+        if _is_within(root, project_root) or _is_within(project_root, root):
             continue
         try:
             resolved_config = candidate.resolve()

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -474,6 +474,26 @@ TRUST_INSTALL_TRUSTED = "install-trusted"
 # on PR #5329.
 _PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
+# This dispatcher's own location, used to bind install trust to the plugin
+# that SHIPS this file. Module-level so tests can rebind it; the value is
+# never read from the environment.
+#
+# Being a directory the host named is not evidence the root belongs to us.
+# This repository already documents that it may not: _resolve_lib_dir in
+# pr-comment-responder/scripts/cluster_threads.py says COPILOT_PLUGIN_ROOT is
+# "set by the Copilot CLI host, may point to whichever plugin triggered the
+# context-mode hook, not this one", and resolve_pr_conflicts.py records the
+# same for CLAUDE_PLUGIN_ROOT under issue #4961. Both defend by validating
+# each candidate before use; this function did not.
+#
+# Reproduced before the fix (Copilot review, PR #5329): a co-installed plugin
+# root exported as COPILOT_PLUGIN_ROOT, holding its own
+# commands/pr-review-config.yaml, was install-trusted, and its criterion
+# `sh -c '...'` EXECUTED, printing its marker to stderr. Command trust caught
+# nothing because a bare `sh`, an option `-c`, and an option VALUE are all
+# skipped, so no argv token resolved to a work-tree file (CWE-829).
+_DISPATCHER_PATH = Path(__file__).resolve()
+
 # A trusted ref must look like a git revision and must not start with
 # ``-`` so it can never be parsed as a git option (argument injection).
 _TRUSTED_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@^~{}-]*$")
@@ -2385,7 +2405,14 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     work_tree: Path | None = None
 
     for root in _host_declared_roots():
-        # Condition 3: the declared root and the project tree must be
+        # Condition 3a: the root must be the plugin that ships THIS file.
+        # A host variable names a plugin root; it does not promise the root
+        # is ours. See _DISPATCHER_PATH for the reproduction and for this
+        # repository's own record that the variable can name a foreign
+        # context-mode plugin.
+        if not _is_within(_DISPATCHER_PATH, root):
+            continue
+        # Condition 3b: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
         # Testing only "root is not below the project" leaves the

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -344,6 +344,25 @@ class ConfigError(Exception):
     """
 
 
+class WorkTreeUnavailableError(Exception):
+    """The consumer's git work tree could not be established.
+
+    Raised by :func:`_consumer_work_tree` and handled in
+    :func:`_resolve_and_read_config`, which exits **3**, not 2. Per
+    ADR-035 and this repo's exit-code table (0 ok, 1 logic, 2 config,
+    3 external, 4 auth), a git probe that cannot run, times out, or
+    reports no work tree is an EXTERNAL failure. The config path is not
+    what is wrong, so reporting it as one sends the reader to the wrong
+    place. This is the same reasoning that already makes
+    :data:`TRUST_GIT_ERROR` exit 3 and non-overridable: with the extent
+    of PR-controlled content unknown, no approval could be informed.
+
+    It is raised only after a plugin-root variable has been declared and
+    named an existing directory. A run with neither variable set never
+    probes git and is unaffected.
+    """
+
+
 def _read_config_bytes(path: Path) -> bytes:
     """Read the config exactly once. Raises ConfigError on any failure mode.
 
@@ -413,10 +432,29 @@ TRUST_MALFORMED_REF = "malformed-ref"
 TRUST_INSTALL_TRUSTED = "install-trusted"
 
 # Host-declared plugin roots, in the order resolve_pr_review_config() in
-# .claude/commands/pr-review.md consults them
-# (${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}). Quoted from
-# that command per .claude/rules/canonical-source-mirror.md so the gate
-# and the command cannot drift about which variable wins.
+# .claude/commands/pr-review.md consults them. Quoted verbatim from that
+# function per .claude/rules/canonical-source-mirror.md, first two list
+# entries only (the rest are the in-repo and installed-plugin fallbacks,
+# which this constant deliberately does not cover):
+#
+#     for root in \
+#       "${COPILOT_PLUGIN_ROOT:-}" \
+#       "${CLAUDE_PLUGIN_ROOT:-}" \
+#       ...
+#       if [ -n "$root" ] && [ -f "$root/commands/pr-review-config.yaml" ]; then
+#
+# The loop CONTINUES when a root is set but does not hold the config, so
+# COPILOT_PLUGIN_ROOT being set does not by itself exclude
+# CLAUDE_PLUGIN_ROOT. _host_declared_roots below matches that: it yields
+# both in order and the caller falls through to the second when the
+# first does not contain the config.
+#
+# An earlier revision cited ${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}
+# as the canonical form. That expression lives elsewhere and means
+# something DIFFERENT: it selects COPILOT_PLUGIN_ROOT whenever that is
+# set, with no fall-through on a missing config. Copying its semantics
+# here would have broken the second-root case. Found by Copilot review
+# on PR #5329.
 _PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
 # A trusted ref must look like a git revision and must not start with
@@ -2010,8 +2048,8 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
-def _consumer_work_tree() -> Path | None:
-    """The consumer's git work-tree root, or ``None`` if not establishable.
+def _consumer_work_tree() -> Path:
+    """The consumer's git work-tree root, or :exc:`WorkTreeUnavailableError`.
 
     This, and NOT ``_PROJECT_ROOT``, is the boundary install trust must be
     disjoint from. ``_resolve_project_root`` exists to locate the repo's
@@ -2032,24 +2070,46 @@ def _consumer_work_tree() -> Path | None:
     the real work tree, which is exactly the set of files the checked-out
     PR controls.
 
-    Returns ``None`` when git is absent, errors, or the cwd is not in a work
-    tree. Callers MUST treat ``None`` as "no install trust" (fail closed):
-    if the extent of PR-controlled content cannot be established, nothing
-    can be shown to lie outside it.
+    Raises :exc:`WorkTreeUnavailableError` rather than returning a sentinel when
+    git is absent, times out, errors, or reports no work tree for the cwd.
+    That is an exit-3 ``git-error`` condition under this module's contract,
+    not an exit-2 config problem: the failure is external, the config path
+    may be perfectly well-formed, and it is the same "verification is
+    impossible" state that :data:`TRUST_GIT_ERROR` already covers and
+    deliberately makes non-overridable.
+
+    An earlier revision returned ``None`` here and let the caller fall
+    through to work-tree containment. It still failed closed, but it exited
+    2 printing "Refusing to load config from unsafe path", which names the
+    wrong cause: the path was not the problem, the unestablishable work tree
+    was. Found by Copilot review on PR #5329.
+
+    ``subprocess.TimeoutExpired`` is caught explicitly because it is NOT an
+    ``OSError`` (its MRO is TimeoutExpired -> SubprocessError -> Exception),
+    so an ``except OSError`` alone lets a 30-second git hang escape as an
+    unhandled traceback. The two other guarded ``_run_git`` callers in this
+    module already catch the pair; this one did not, which was the defect.
     """
     try:
         proc = _run_git(["rev-parse", "--show-toplevel"], Path.cwd())
-    except OSError:
-        return None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise WorkTreeUnavailableError(f"could not run git: {exc}") from exc
     if proc.returncode != 0:
-        return None
+        raise WorkTreeUnavailableError(
+            f"git reported no work tree for {Path.cwd()}: "
+            f"{proc.stderr.decode(errors='replace').strip()}",
+        )
     toplevel = proc.stdout.decode(errors="replace").strip()
     if not toplevel:
-        return None
+        raise WorkTreeUnavailableError(
+            f"git reported an empty work-tree root for {Path.cwd()}",
+        )
     try:
         return Path(toplevel).resolve()
-    except OSError:
-        return None
+    except OSError as exc:
+        raise WorkTreeUnavailableError(
+            f"work-tree root {toplevel!r} does not resolve: {exc}",
+        ) from exc
 
 
 def _absolute_config_candidate(config_arg: str) -> Path:
@@ -2074,8 +2134,19 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
-def _declared_plugin_roots() -> Iterator[Path]:
+def _host_declared_roots() -> Iterator[Path]:
     """Existing directories named by the host's plugin-root variables.
+
+    Named to avoid the substring ``_plugin_root``. That is not cosmetic:
+    ``TestBootstrapSourceCode`` in ``tests/skills/github/test_bootstrap_fallback.py``
+    selects "bootstrap scripts" with ``"_plugin_root" in f.read_text()`` and then
+    requires each one to carry the literal
+    ``os.path.isdir(os.path.join(_plugin_root, "lib", "github_core"))``.
+    This module reads those variables to decide config TRUST and never puts a
+    plugin root on ``sys.path`` (the only ``sys.path`` insert here is
+    ``_PROJECT_ROOT``), so it has no ``_plugin_root`` variable and that literal
+    would be dead code. An earlier name matched the fragment by accident and
+    failed the guard. Do not reintroduce the fragment.
 
     Yields in ``_PLUGIN_ROOT_ENV_VARS`` order, so a host that exports both
     resolves through the Copilot variable first, and skips a variable that
@@ -2121,14 +2192,35 @@ def _install_trusted_root(config_arg: str) -> Path | None:
 
     1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
        non-empty. An unset environment changes nothing.
-       (Applied by :func:`_declared_plugin_roots`.)
+       (Applied by :func:`_host_declared_roots`.)
     2. The root resolves to an existing directory.
-       (Applied by :func:`_declared_plugin_roots`.)
-    3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
-       is what withholds install trust from the in-repo ``.claude/``
-       fallback that the same command offers: that path is PR-controlled
-       and must keep the full byte-identity check. A repository whose
-       own ``.claude`` is the plugin root gets no widening.
+       (Applied by :func:`_host_declared_roots`.)
+    3. The resolved root is **disjoint** from BOTH the consumer's git
+       work tree (:func:`_consumer_work_tree`) and ``_PROJECT_ROOT``,
+       where disjoint means neither path is at or under the other
+       (:func:`_are_disjoint`). All four containments are load-bearing
+       and each direction failed once:
+
+       * root under either boundary: withholds install trust from the
+         in-repo fallback the same command offers, which the checked-out
+         PR writes and which must keep the full byte-identity check.
+       * either boundary under root: a declared root of ``$HOME`` with
+         the project at ``$HOME/repo`` is not *below* the project, so a
+         one-way test admitted it while it contained every PR-controlled
+         file in the repo (CWE-829).
+
+       The work tree is checked FIRST and is the authoritative boundary,
+       because ``_PROJECT_ROOT`` is attacker-influenceable:
+       :func:`_resolve_project_root` stops at the nearest ancestor
+       holding a plugin directory, so a PR that adds one in a
+       subdirectory relocates it and makes a wholly PR-controlled root
+       look disjoint. ``git rev-parse --show-toplevel`` cannot be moved
+       that way. ``_PROJECT_ROOT`` is still checked as well, because in
+       the installed case it can resolve somewhere the work tree does
+       not cover.
+
+       Both bypasses were found by Copilot review on PR #5329, in
+       consecutive rounds, the second defeating the fix for the first.
     4. The **resolved** config is inside the resolved root. Resolution
        happens before containment, so a symlink planted in the install
        directory that points back into the checked-out PR tree lands
@@ -2153,10 +2245,14 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     # can install-trust anything, so a run with neither variable set (the
     # overwhelmingly common case, and every caller that predates issue
     # #5112) must not pay a subprocess call or perturb a test's git mocks.
+    # A failed probe raises WorkTreeUnavailableError out of this function rather
+    # than degrading to "no install trust"; see that class for why exit 3.
+    # Since the probe now returns a Path or raises, "still None" means
+    # "not yet resolved", so no separate resolved-flag is needed and the
+    # type narrows without an assert.
     work_tree: Path | None = None
-    work_tree_resolved = False
 
-    for root in _declared_plugin_roots():
+    for root in _host_declared_roots():
         # Condition 3: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
@@ -2172,13 +2268,8 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # /home/user install-trusted
         # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
         # Found by Copilot review on PR #5329.
-        if not work_tree_resolved:
-            work_tree = _consumer_work_tree()
-            work_tree_resolved = True
-        # Fail closed: with no establishable work tree, nothing can be shown
-        # to lie OUTSIDE PR-controlled content, so nothing install-trusts.
         if work_tree is None:
-            return None
+            work_tree = _consumer_work_tree()
         # Disjoint from the real work tree FIRST: that is the authoritative
         # extent of PR-controlled content and the only one PR content
         # cannot relocate. _PROJECT_ROOT is then checked as well, because
@@ -2199,25 +2290,56 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     return None
 
 
-def _resolve_and_read_config(
-    config_arg: str,
-) -> tuple[Path, bytes, Path | None] | tuple[None, None, None]:
+class ResolvedConfig(NamedTuple):
+    """Outcome of resolving ``--config``.
+
+    ``exit_code`` is set if and only if resolution FAILED, and it carries
+    the code the process must exit with. Callers branch on it rather than
+    on ``path is None``, because the two failure kinds exit differently:
+    2 for a config problem (containment, symlink, unreadable) and 3 for an
+    external one (:exc:`WorkTreeUnavailableError`). The earlier 3-tuple form
+    could express only one of those, which is how a git-probe failure came
+    to be reported as an unsafe path (Copilot review, PR #5329).
+    """
+
+    path: Path | None
+    raw: bytes | None
+    install_root: Path | None
+    exit_code: int | None
+
+
+def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
     """Validate the config path and read it exactly once.
 
-    Returns ``(None, None, None)`` after printing to stderr when the
-    path is unsafe (CWE-22 containment), reaches through a repo-local
-    symlink (CWE-59), or is unreadable; the caller exits 2. The returned
-    buffer is the single read that gets trust-verified and then parsed
-    (CWE-367).
+    On success returns the path, the single read of its bytes, and the
+    install-trusted root or ``None``, with ``exit_code`` unset. That one
+    read is what gets trust-verified AND parsed, so there is no window for
+    the file to change between the two (CWE-367).
 
-    The third element is the install-trusted plugin root
-    (:func:`_install_trusted_root`) or ``None``. It is resolved HERE,
-    once, and threaded to :func:`_enforce_config_trust` rather than
-    recomputed there, so the root that decided containment is provably
-    the root that decides trust. Recomputing invites the two to
-    disagree if the environment changes between the calls.
+    On failure prints to stderr and sets ``exit_code``: **2** when the path
+    is unsafe (CWE-22 containment), reaches through a repo-local symlink
+    (CWE-59), or is unreadable; **3** when the consumer's git work tree
+    could not be established, which is external rather than a config fault.
+
+    ``install_root`` is resolved HERE, once, and threaded to
+    :func:`_enforce_config_trust` rather than recomputed there, so the root
+    that decided containment is provably the root that decides trust.
+    Recomputing invites the two to disagree if the environment changes
+    between the calls.
     """
-    install_root = _install_trusted_root(config_arg)
+    try:
+        install_root = _install_trusted_root(config_arg)
+    except WorkTreeUnavailableError as exc:
+        # Exit 3, never 2: see WorkTreeUnavailableError. Not overridable by
+        # --approve-untrusted-config, matching TRUST_GIT_ERROR, because
+        # there is no inspectable artifact for an approval to be based on.
+        print(
+            f"Refusing to evaluate install trust: {exc}. A plugin root is "
+            f"declared, so the consumer work tree must be known to decide "
+            f"whether that root lies outside it.",
+            file=sys.stderr,
+        )
+        return ResolvedConfig(None, None, None, 3)
 
     if install_root is not None:
         # Do NOT route this through validate_safe_path with install_root
@@ -2248,7 +2370,7 @@ def _resolve_and_read_config(
                 f"{config_arg!r}: {exc}",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
     else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
@@ -2258,7 +2380,7 @@ def _resolve_and_read_config(
                 f"its target and surface that file in the approval diff.",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
         try:
             config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
         except (FileNotFoundError, ValueError) as exc:
@@ -2266,12 +2388,14 @@ def _resolve_and_read_config(
                 f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
     try:
-        return config_path, _read_config_bytes(config_path), install_root
+        return ResolvedConfig(
+            config_path, _read_config_bytes(config_path), install_root, None,
+        )
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
-        return None, None, None
+        return ResolvedConfig(None, None, None, 2)
 
 
 def _extract_criteria(config: dict[str, Any]) -> list[Any] | None:
@@ -2302,9 +2426,16 @@ def main(argv: list[str] | None = None) -> int:
         print("Pull request number must be positive.", file=sys.stderr)
         return 2
 
-    config_path, raw_config, install_root = _resolve_and_read_config(args.config)
-    if config_path is None or raw_config is None:
-        return 2
+    resolved = _resolve_and_read_config(args.config)
+    if resolved.path is None or resolved.raw is None:
+        # One branch, not two: testing path/raw narrows the types AND
+        # detects failure, since exit_code is set on exactly the paths
+        # that leave them None. The conditional expression is the
+        # unreachable-default; `or 2` would be the falsy-override bug
+        # python.md rejects, even though 0 never occurs here.
+        return 2 if resolved.exit_code is None else resolved.exit_code
+    config_path, raw_config = resolved.path, resolved.raw
+    install_root = resolved.install_root
 
     # CWE-829 trust boundary: no criterion command runs unless the
     # working-tree config is byte-identical to the trusted-ref copy, a

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -513,6 +513,38 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[bytes]:
     )
 
 
+def _require_remote_tracking_ref(
+    trust_anchor_ref: str,
+    cwd: Path,
+) -> TrustCheck | None:
+    """``None`` when the ref anchors trust; a git-error TrustCheck otherwise.
+
+    The ref must resolve to ``refs/remotes/*``. ``HEAD``, a local branch, a
+    tag, and a bare SHA are all refused, because the checked-out PR can move
+    or create them, which would make trust self-referential: the PR's own
+    content would become the thing its content is compared against.
+
+    Extracted so the install-trusted path and :func:`_verify_config_trust`
+    cannot diverge. They did: this check lived only in the latter, which
+    install trust skips, and `--trusted-ref HEAD` then let command trust
+    compare PR-modified verifiers against the PR's own commit and execute
+    them (Copilot review, PR #5329). One implementation, two callers, is
+    what keeps the two paths honest about the same requirement.
+    """
+    proc = _run_git(["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd)
+    full_name = proc.stdout.decode(errors="replace").strip()
+    if proc.returncode == 0 and full_name.startswith("refs/remotes/"):
+        return None
+    return TrustCheck(
+        TRUST_GIT_ERROR,
+        f"trusted ref {trust_anchor_ref!r} must resolve to a "
+        f"remote-tracking ref (refs/remotes/*), got "
+        f"{full_name or 'a local, detached, or unknown revision'}; "
+        f"HEAD and local branches can be moved by the checked-out "
+        f"PR and cannot anchor trust",
+    )
+
+
 def _verify_config_trust(
     config_path: Path,
     trust_anchor_ref: str,
@@ -588,19 +620,9 @@ def _verify_config_trust(
                 f"config {config_path} resolves outside git work tree {toplevel}",
             )
 
-        proc = _run_git(
-            ["rev-parse", "--symbolic-full-name", trust_anchor_ref], toplevel,
-        )
-        full_name = proc.stdout.decode(errors="replace").strip()
-        if proc.returncode != 0 or not full_name.startswith("refs/remotes/"):
-            return TrustCheck(
-                TRUST_GIT_ERROR,
-                f"trusted ref {trust_anchor_ref!r} must resolve to a "
-                f"remote-tracking ref (refs/remotes/*), got "
-                f"{full_name or 'a local, detached, or unknown revision'}; "
-                f"HEAD and local branches can be moved by the checked-out "
-                f"PR and cannot anchor trust",
-            )
+        anchor_error = _require_remote_tracking_ref(trust_anchor_ref, toplevel)
+        if anchor_error is not None:
+            return anchor_error
 
         proc = _run_git(
             ["rev-parse", "--verify", "--quiet", f"{trust_anchor_ref}^{{commit}}"],
@@ -681,7 +703,7 @@ def _enforce_config_trust(
     trust_anchor_ref: str,
     approved: bool,
     tree_bytes: bytes,
-    install_root: Path | None = None,
+    install: InstallTrust | None = None,
 ) -> tuple[TrustCheck, int | None]:
     """Gate dispatch on config trust; returns ``(trust, exit_code_or_None)``.
 
@@ -695,7 +717,7 @@ def _enforce_config_trust(
     never overridable, because approving with nothing to inspect would
     turn an unverifiable state into an execution path.
 
-    ``install_root``, when not ``None``, is the host-declared plugin root
+    ``install``, when not ``None``, carries the host-declared plugin root
     that install-trusts this config (issue #5112, Option 1). Verification
     is skipped rather than attempted: the config is outside the
     consumer's work tree, so the trusted ref has no copy of it to compare
@@ -706,23 +728,48 @@ def _enforce_config_trust(
     establishes; do not extend this branch to any config the consumer
     repository can write.
     """
-    if install_root is not None:
-        return (
-            TrustCheck(
-                TRUST_INSTALL_TRUSTED,
-                f"config {config_path} is install-trusted: it resides in "
-                f"host-declared plugin root {install_root}, outside the "
-                f"consumer work tree, which PR content cannot write",
-            ),
-            None,
-        )
-
+    # Ref validation runs BEFORE the install-trusted short-circuit, not
+    # after. Both guards on --trusted-ref used to sit on the path install
+    # trust skips: this regex, and the refs/remotes/* requirement inside
+    # _verify_config_trust. _enforce_command_trust repeats neither, so an
+    # install-trusted config left the ref wholly unvalidated while command
+    # trust still consumed it.
+    #
+    # Reproduced before this fix (Copilot review, PR #5329, High):
+    # --trusted-ref HEAD under install trust made command trust compare
+    # every work-tree verifier against the PR's OWN commit, so a
+    # PR-modified verify.sh was declared trusted and EXECUTED (its stderr
+    # marker reached the output). An option-shaped ref likewise reached a
+    # git invocation. Widening the config origin must not widen the
+    # command boundary, and skipping these checks did exactly that.
     if not _TRUSTED_REF_RE.match(trust_anchor_ref):
         print(
             f"Refusing malformed --trusted-ref {trust_anchor_ref!r}",
             file=sys.stderr,
         )
         return TrustCheck(TRUST_MALFORMED_REF, "malformed trusted ref"), 2
+
+    if install is not None:
+        # The regex admits HEAD, so it alone does not close the reproduction
+        # above. The refs/remotes/* requirement is the one that does, and
+        # _verify_config_trust (its usual home) is skipped here, so enforce
+        # it directly, in the work tree the install decision was made
+        # against rather than in some other repository.
+        anchor_error = _require_remote_tracking_ref(
+            trust_anchor_ref, install.work_tree,
+        )
+        if anchor_error is not None:
+            print(anchor_error.detail, file=sys.stderr)
+            return anchor_error, 3
+        return (
+            TrustCheck(
+                TRUST_INSTALL_TRUSTED,
+                f"config {config_path} is install-trusted: it resides in "
+                f"host-declared plugin root {install.root}, outside the "
+                f"consumer work tree, which PR content cannot write",
+            ),
+            None,
+        )
 
     trust = _verify_config_trust(config_path, trust_anchor_ref, tree_bytes)
     if trust.status == TRUST_TRUSTED:
@@ -2134,6 +2181,29 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
+class InstallTrust(NamedTuple):
+    """A config admitted by its ORIGIN, with everything that decision used.
+
+    Three fields, each carried rather than recomputed, because recomputing
+    any of them reopens a hole:
+
+    ``config_path`` is the resolved path :func:`_install_trusted_root`
+    actually approved. Resolving ``--config`` a second time to read it is a
+    TOCTOU window (CWE-367): a repo-controlled symlink swapped between the
+    two calls resolves inside the root for the decision and outside it for
+    the read, while ``root`` stays non-null and byte verification stays
+    skipped. Found by Copilot review on PR #5329.
+
+    ``work_tree`` is the boundary the decision was made against. It is also
+    the repository the trust anchor must be validated in, and validating it
+    somewhere else would answer a different question.
+    """
+
+    root: Path
+    config_path: Path
+    work_tree: Path
+
+
 def _host_declared_roots() -> Iterator[Path]:
     """Existing directories named by the host's plugin-root variables.
 
@@ -2166,7 +2236,7 @@ def _host_declared_roots() -> Iterator[Path]:
             yield root
 
 
-def _install_trusted_root(config_arg: str) -> Path | None:
+def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
     Returns the resolved root when every condition below holds, else
@@ -2285,8 +2355,10 @@ def _install_trusted_root(config_arg: str) -> Path | None:
             return None
         # Condition 4: resolution already followed any symlink, so a
         # link out of the install directory fails this containment.
+        # resolved_config is RETURNED, not recomputed by the caller: it is
+        # the exact path this containment approved (CWE-367).
         if _is_within(resolved_config, root):
-            return root
+            return InstallTrust(root, resolved_config, work_tree)
     return None
 
 
@@ -2304,7 +2376,7 @@ class ResolvedConfig(NamedTuple):
 
     path: Path | None
     raw: bytes | None
-    install_root: Path | None
+    install: InstallTrust | None
     exit_code: int | None
 
 
@@ -2328,7 +2400,7 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
     between the calls.
     """
     try:
-        install_root = _install_trusted_root(config_arg)
+        install = _install_trusted_root(config_arg)
     except WorkTreeUnavailableError as exc:
         # Exit 3, never 2: see WorkTreeUnavailableError. Not overridable by
         # --approve-untrusted-config, matching TRUST_GIT_ERROR, because
@@ -2341,8 +2413,8 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
         )
         return ResolvedConfig(None, None, None, 3)
 
-    if install_root is not None:
-        # Do NOT route this through validate_safe_path with install_root
+    if install is not None:
+        # Do NOT route this through validate_safe_path with the install root
         # as the base. That helper builds its result as
         # (resolved_base / path).resolve(), which would make the
         # environment-declared root a component of the path READ rather
@@ -2362,15 +2434,13 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
         # out-of-tree config it inspects nothing and returns None. The
         # CWE-59 hazard it guards is a PR-CREATED link, and condition 4
         # already refuses any link that escapes the install root.
-        try:
-            config_path = _absolute_config_candidate(config_arg).resolve()
-        except OSError as exc:
-            print(
-                f"Refusing to load config from unresolvable path "
-                f"{config_arg!r}: {exc}",
-                file=sys.stderr,
-            )
-            return ResolvedConfig(None, None, None, 2)
+        #
+        # Reused, never re-resolved. Calling .resolve() again here would
+        # be a second resolution of the same argument, and a repo-controlled
+        # symlink swapped between the two lands inside the root for the
+        # DECISION and outside it for the READ, with verification still
+        # skipped (CWE-367, Copilot review on PR #5329).
+        config_path = install.config_path
     else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
@@ -2391,7 +2461,10 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
             return ResolvedConfig(None, None, None, 2)
     try:
         return ResolvedConfig(
-            config_path, _read_config_bytes(config_path), install_root, None,
+            config_path,
+            _read_config_bytes(config_path),
+            install,
+            None,
         )
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
@@ -2435,7 +2508,7 @@ def main(argv: list[str] | None = None) -> int:
         # python.md rejects, even though 0 never occurs here.
         return 2 if resolved.exit_code is None else resolved.exit_code
     config_path, raw_config = resolved.path, resolved.raw
-    install_root = resolved.install_root
+    install = resolved.install
 
     # CWE-829 trust boundary: no criterion command runs unless the
     # working-tree config is byte-identical to the trusted-ref copy, a
@@ -2449,7 +2522,7 @@ def main(argv: list[str] | None = None) -> int:
         args.trust_anchor_ref,
         args.approve_untrusted_config,
         raw_config,
-        install_root,
+        install,
     )
     if halt_code is not None:
         return halt_code

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -41,12 +41,29 @@ possible.
 Trust model
 -----------
 
-This dispatcher executes ``command`` strings read from the YAML config.
-The config path MUST be controlled by the repository, never
-user-supplied beyond the validated default. Path traversal protection:
-``--config`` is canonicalised and rejected unless it lives under the
-repository root via
-``scripts.utils.path_validation.validate_safe_path``. The
+This dispatcher executes ``command`` strings read from the YAML config,
+so the config must come from an origin the checked-out PR cannot write.
+There are exactly TWO such origins, and conflating them is what earlier
+revisions of this paragraph did:
+
+  * A **repository** config, the default. ``--config`` is canonicalised
+    and rejected unless it lives under the repository root via
+    ``scripts.utils.path_validation.validate_safe_path``, and its bytes
+    are then verified against the trusted ref, because the repository
+    root is exactly the tree the PR CAN write.
+  * An **install-trusted** config (issue #5112, Option 1). It lives in a
+    host-declared plugin root whose tree is DISJOINT from both the
+    consumer's git work tree and ``_PROJECT_ROOT``, checked in both
+    containment directions. Byte verification is skipped because there
+    is nothing in the consumer repository to compare against; the origin
+    carries the trust. See :func:`_install_trusted_root` for the four
+    conditions and for what this does not close. The trust ANCHOR is
+    still validated on this path, including the ``refs/remotes/*``
+    requirement.
+
+"Disjoint" is not "outside": a root of ``$HOME`` with the repository at
+``$HOME/repo`` is outside the repository while containing every file the
+PR wrote, and a one-way test admitted exactly that (CWE-829). The
 ``pass_when_python`` evaluator no longer calls ``eval``: it parses the
 lambda with ``ast`` and walks a whitelisted node set, so a config
 expression cannot reach Python's class hierarchy or any builtin. This
@@ -531,7 +548,22 @@ def _require_remote_tracking_ref(
     them (Copilot review, PR #5329). One implementation, two callers, is
     what keeps the two paths honest about the same requirement.
     """
-    proc = _run_git(["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd)
+    # Guarded HERE, not at the call sites. _verify_config_trust happens to
+    # call this inside its own try, but the install-trusted caller invokes it
+    # directly, so a git timeout or a missing binary escaped as a traceback
+    # and exit 1 instead of the documented non-overridable exit 3. Putting
+    # the catch in the shared helper is what stops the two callers from
+    # disagreeing about it, which is the same failure that produced this
+    # helper in the first place (Copilot review, PR #5329).
+    try:
+        proc = _run_git(
+            ["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return TrustCheck(
+            TRUST_GIT_ERROR,
+            f"could not resolve trusted ref {trust_anchor_ref!r}: {exc}",
+        )
     full_name = proc.stdout.decode(errors="replace").strip()
     if proc.returncode == 0 and full_name.startswith("refs/remotes/"):
         return None

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -252,6 +252,7 @@ import shlex
 import subprocess
 import sys
 import unicodedata
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -1179,6 +1180,20 @@ def _is_within(path: Path, root: Path) -> bool:
     return True
 
 
+def _are_disjoint(first: Path, second: Path) -> bool:
+    """True when neither path is at or under the other.
+
+    Containment in EITHER direction is the thing callers care about, and
+    testing only one of them is a live defect shape rather than a style
+    point: :func:`_install_trusted_root` shipped a one-way test and a
+    declared plugin root that was an ANCESTOR of the project passed it
+    while every PR-controlled file sat inside that root (CWE-829, found
+    by Copilot review on PR #5329). Naming the symmetric question once
+    keeps the two directions from drifting apart again.
+    """
+    return not (_is_within(first, second) or _is_within(second, first))
+
+
 def _first_symlinked_component(candidate: Path, root: Path) -> Path | None:
     """First symlinked component of ``candidate`` at or below ``root``.
 
@@ -2059,6 +2074,27 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
+def _declared_plugin_roots() -> Iterator[Path]:
+    """Existing directories named by the host's plugin-root variables.
+
+    Yields in ``_PLUGIN_ROOT_ENV_VARS`` order, so a host that exports both
+    resolves through the Copilot variable first, and skips a variable that
+    is unset, empty, whitespace, unresolvable, or not a directory. Declaring
+    a root is necessary for install trust and nowhere near sufficient:
+    :func:`_install_trusted_root` applies the boundary conditions.
+    """
+    for env_var in _PLUGIN_ROOT_ENV_VARS:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            continue
+        try:
+            root = Path(raw).resolve()
+        except OSError:
+            continue
+        if root.is_dir():
+            yield root
+
+
 def _install_trusted_root(config_arg: str) -> Path | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
@@ -2085,7 +2121,9 @@ def _install_trusted_root(config_arg: str) -> Path | None:
 
     1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
        non-empty. An unset environment changes nothing.
+       (Applied by :func:`_declared_plugin_roots`.)
     2. The root resolves to an existing directory.
+       (Applied by :func:`_declared_plugin_roots`.)
     3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
        is what withholds install trust from the in-repo ``.claude/``
        fallback that the same command offers: that path is PR-controlled
@@ -2118,16 +2156,7 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     work_tree: Path | None = None
     work_tree_resolved = False
 
-    for env_var in _PLUGIN_ROOT_ENV_VARS:
-        raw = os.environ.get(env_var, "").strip()
-        if not raw:
-            continue
-        try:
-            root = Path(raw).resolve()
-        except OSError:
-            continue
-        if not root.is_dir():
-            continue
+    for root in _declared_plugin_roots():
         # Condition 3: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
@@ -2155,9 +2184,9 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # cannot relocate. _PROJECT_ROOT is then checked as well, because
         # in the installed case it may resolve somewhere the work-tree
         # check does not cover, and a root overlapping either is refused.
-        if _is_within(root, work_tree) or _is_within(work_tree, root):
+        if not _are_disjoint(root, work_tree):
             continue
-        if _is_within(root, project_root) or _is_within(project_root, root):
+        if not _are_disjoint(root, project_root):
             continue
         try:
             resolved_config = candidate.resolve()

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -2095,6 +2095,35 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _resolve_or_none(path: Path) -> Path | None:
+    """``path.resolve()``, or ``None`` when it cannot be resolved.
+
+    Exists to normalize ONE portability trap into a single place.
+    ``Path.resolve()`` does not raise a single exception family across the
+    versions this ships to: on a symlink loop, CPython 3.10, 3.11 and 3.12
+    raise ``RuntimeError("Symlink loop from ...")`` from ``pathlib``, while
+    3.14 returns the unresolved path without raising. ``RuntimeError`` is
+    not an ``OSError``, so an ``except OSError`` guard lets the loop escape
+    as an unhandled traceback on exactly the interpreters the repo's
+    hook-portability floor targets (``.claude/rules/python.md``: skill
+    scripts run under the host's ambient interpreter, floor 3.10).
+
+    Measured rather than assumed: grep of ``pathlib.py`` in the 3.10, 3.11
+    and 3.12 stdlibs shows the raise; 3.14 returned the path for the same
+    two-link loop. Found by Copilot review on PR #5329, which is a
+    reminder that "it did not raise locally" says nothing about the
+    versions a plugin is installed onto.
+
+    Callers decide what ``None`` means. None of them may treat it as
+    success: an unresolvable path cannot be shown to lie inside or outside
+    any boundary.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
 def _consumer_work_tree() -> Path:
     """The consumer's git work-tree root, or :exc:`WorkTreeUnavailableError`.
 
@@ -2151,12 +2180,12 @@ def _consumer_work_tree() -> Path:
         raise WorkTreeUnavailableError(
             f"git reported an empty work-tree root for {Path.cwd()}",
         )
-    try:
-        return Path(toplevel).resolve()
-    except OSError as exc:
+    resolved = _resolve_or_none(Path(toplevel))
+    if resolved is None:
         raise WorkTreeUnavailableError(
-            f"work-tree root {toplevel!r} does not resolve: {exc}",
-        ) from exc
+            f"work-tree root {toplevel!r} does not resolve",
+        )
+    return resolved
 
 
 def _absolute_config_candidate(config_arg: str) -> Path:
@@ -2228,11 +2257,8 @@ def _host_declared_roots() -> Iterator[Path]:
         raw = os.environ.get(env_var, "").strip()
         if not raw:
             continue
-        try:
-            root = Path(raw).resolve()
-        except OSError:
-            continue
-        if root.is_dir():
+        root = _resolve_or_none(Path(raw))
+        if root is not None and root.is_dir():
             yield root
 
 
@@ -2309,7 +2335,11 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     smaller capability than they already hold, and it is not a boundary
     this gate can close.
     """
-    project_root = _PROJECT_ROOT.resolve()
+    project_root = _resolve_or_none(_PROJECT_ROOT)
+    if project_root is None:
+        # Fail closed. Condition 3 compares against this tree, and a
+        # boundary that cannot be resolved cannot be compared against.
+        return None
     candidate = _absolute_config_candidate(config_arg)
     # Resolved lazily, on first use, and at most once. Only a DECLARED root
     # can install-trust anything, so a run with neither variable set (the
@@ -2349,9 +2379,8 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
             continue
         if not _are_disjoint(root, project_root):
             continue
-        try:
-            resolved_config = candidate.resolve()
-        except OSError:
+        resolved_config = _resolve_or_none(candidate)
+        if resolved_config is None:
             return None
         # Condition 4: resolution already followed any symlink, so a
         # link out of the install directory fails this containment.
@@ -2453,7 +2482,15 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
             return ResolvedConfig(None, None, None, 2)
         try:
             config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
-        except (FileNotFoundError, ValueError) as exc:
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            # RuntimeError joins the pair because validate_safe_path calls
+            # (resolved_base / path).resolve() unguarded, and resolve()
+            # raises RuntimeError on a symlink loop under CPython 3.10 to
+            # 3.12 (see _resolve_or_none). Caught HERE rather than in that
+            # shared helper, which many other scripts call and which is out
+            # of scope for this change; that broader fix is flagged on the
+            # PR instead. Exit 2: a loop in --config is a bad config path,
+            # the same class as the containment failures beside it.
             print(
                 f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
                 file=sys.stderr,

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -1995,6 +1995,48 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _consumer_work_tree() -> Path | None:
+    """The consumer's git work-tree root, or ``None`` if not establishable.
+
+    This, and NOT ``_PROJECT_ROOT``, is the boundary install trust must be
+    disjoint from. ``_resolve_project_root`` exists to locate the repo's
+    ``scripts/`` package and falls back to the nearest ancestor of the cwd
+    holding ``.claude`` OR ``.git``. That heuristic is fine for finding
+    imports and is unsafe as a trust boundary, because **PR content can
+    create a `.claude` directory** and thereby move it.
+
+    The attack it enables (Copilot review, PR #5329): the host starts in
+    ``repo/subdir``; the PR adds ``repo/subdir/.claude``; ``_PROJECT_ROOT``
+    becomes ``repo/subdir``; a declared root of ``repo/.claude`` is then
+    neither above nor below it, so a disjointness test anchored on
+    ``_PROJECT_ROOT`` passes and a wholly PR-controlled config becomes
+    install-trusted, skipping byte-identity verification (CWE-829).
+    Reproduced end to end before this fix.
+
+    ``git rev-parse --show-toplevel`` cannot be moved this way: it reports
+    the real work tree, which is exactly the set of files the checked-out
+    PR controls.
+
+    Returns ``None`` when git is absent, errors, or the cwd is not in a work
+    tree. Callers MUST treat ``None`` as "no install trust" (fail closed):
+    if the extent of PR-controlled content cannot be established, nothing
+    can be shown to lie outside it.
+    """
+    try:
+        proc = _run_git(["rev-parse", "--show-toplevel"], Path.cwd())
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    toplevel = proc.stdout.decode(errors="replace").strip()
+    if not toplevel:
+        return None
+    try:
+        return Path(toplevel).resolve()
+    except OSError:
+        return None
+
+
 def _absolute_config_candidate(config_arg: str) -> Path:
     """``--config`` as an absolute path, resolved against the cwd once.
 
@@ -2069,6 +2111,12 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     """
     project_root = _PROJECT_ROOT.resolve()
     candidate = _absolute_config_candidate(config_arg)
+    # Resolved lazily, on first use, and at most once. Only a DECLARED root
+    # can install-trust anything, so a run with neither variable set (the
+    # overwhelmingly common case, and every caller that predates issue
+    # #5112) must not pay a subprocess call or perturb a test's git mocks.
+    work_tree: Path | None = None
+    work_tree_resolved = False
 
     for env_var in _PLUGIN_ROOT_ENV_VARS:
         raw = os.environ.get(env_var, "").strip()
@@ -2095,6 +2143,20 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # /home/user install-trusted
         # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
         # Found by Copilot review on PR #5329.
+        if not work_tree_resolved:
+            work_tree = _consumer_work_tree()
+            work_tree_resolved = True
+        # Fail closed: with no establishable work tree, nothing can be shown
+        # to lie OUTSIDE PR-controlled content, so nothing install-trusts.
+        if work_tree is None:
+            return None
+        # Disjoint from the real work tree FIRST: that is the authoritative
+        # extent of PR-controlled content and the only one PR content
+        # cannot relocate. _PROJECT_ROOT is then checked as well, because
+        # in the installed case it may resolve somewhere the work-tree
+        # check does not cover, and a root overlapping either is refused.
+        if _is_within(root, work_tree) or _is_within(work_tree, root):
+            continue
         if _is_within(root, project_root) or _is_within(project_root, root):
             continue
         try:

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -87,6 +87,25 @@ window). The outcomes:
   * **git-error** -- verification itself is impossible (not a git work
     tree, trusted ref absent or not remote-tracking, git missing or
     timing out). Halt, exit 3.
+  * **install-trusted** -- the config lives inside a host-declared
+    plugin root (``COPILOT_PLUGIN_ROOT`` / ``CLAUDE_PLUGIN_ROOT``) that
+    is outside the consumer's work tree, so no comparison is attempted
+    and dispatch proceeds (issue #5112, Option 1). This is an ORIGIN
+    claim, not a verification outcome: the operator installed the
+    directory and PR content cannot write it, which is the same
+    reasoning ``_ARGV_EXTERNAL`` already applies to an installed-plugin
+    script named in a criterion's argv. The in-repo ``.claude/``
+    fallback is excluded by construction, because it is inside the work
+    tree and therefore PR-controlled. See
+    :func:`_install_trusted_root` for the four conditions and for the
+    residual this does not close.
+
+Before issue #5112 there was no such status and the bundled config was
+unreachable rather than untrusted: containment refused any ``--config``
+outside the project root, so an installed ``/pr-review`` halted before
+the trust check ran at all. Widening only the origin, and leaving the
+command boundary below untouched, is what keeps that fix from becoming
+a general relaxation.
 
 A human who has inspected the surfaced diff can approve execution
 explicitly by re-running with ``--approve-untrusted-config``, which
@@ -384,6 +403,20 @@ TRUST_GIT_ERROR = "git-error"
 # (exit 2), not a verification outcome, so it does not reuse
 # TRUST_GIT_ERROR (whose contract is exit 3).
 TRUST_MALFORMED_REF = "malformed-ref"
+# Trust status for a config that lives inside a host-declared plugin root
+# outside the consumer's work tree (issue #5112, Option 1). It is NOT a
+# verification outcome: nothing is compared against the trusted ref,
+# because there is nothing in the consumer repository to compare against.
+# The origin itself carries the trust, exactly as _ARGV_EXTERNAL already
+# treats an installed-plugin script the argv names.
+TRUST_INSTALL_TRUSTED = "install-trusted"
+
+# Host-declared plugin roots, in the order resolve_pr_review_config() in
+# .claude/commands/pr-review.md consults them
+# (${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}). Quoted from
+# that command per .claude/rules/canonical-source-mirror.md so the gate
+# and the command cannot drift about which variable wins.
+_PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
 # A trusted ref must look like a git revision and must not start with
 # ``-`` so it can never be parsed as a git option (argument injection).
@@ -609,6 +642,7 @@ def _enforce_config_trust(
     trust_anchor_ref: str,
     approved: bool,
     tree_bytes: bytes,
+    install_root: Path | None = None,
 ) -> tuple[TrustCheck, int | None]:
     """Gate dispatch on config trust; returns ``(trust, exit_code_or_None)``.
 
@@ -621,7 +655,29 @@ def _enforce_config_trust(
     inspectable diff or file for the human to have reviewed. git-error is
     never overridable, because approving with nothing to inspect would
     turn an unverifiable state into an execution path.
+
+    ``install_root``, when not ``None``, is the host-declared plugin root
+    that install-trusts this config (issue #5112, Option 1). Verification
+    is skipped rather than attempted: the config is outside the
+    consumer's work tree, so the trusted ref has no copy of it to compare
+    against and :func:`_verify_config_trust` would return git-error, which
+    is not overridable and would halt at exit 3. That is precisely the
+    dead end the issue reports. Skipping is sound only because the origin
+    carries the trust, which is what :func:`_install_trusted_root`
+    establishes; do not extend this branch to any config the consumer
+    repository can write.
     """
+    if install_root is not None:
+        return (
+            TrustCheck(
+                TRUST_INSTALL_TRUSTED,
+                f"config {config_path} is install-trusted: it resides in "
+                f"host-declared plugin root {install_root}, outside the "
+                f"consumer work tree, which PR content cannot write",
+            ),
+            None,
+        )
+
     if not _TRUSTED_REF_RE.match(trust_anchor_ref):
         print(
             f"Refusing malformed --trusted-ref {trust_anchor_ref!r}",
@@ -1939,39 +1995,137 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _install_trusted_root(config_arg: str) -> Path | None:
+    """The host-declared plugin root that install-trusts ``config_arg``.
+
+    Returns the resolved root when every condition below holds, else
+    ``None`` (the caller then applies the normal work-tree containment
+    and trusted-ref verification unchanged).
+
+    Issue #5112: ``resolve_pr_review_config()`` in
+    ``.claude/commands/pr-review.md`` offers plugin roots as config
+    sources, but containment refused any ``--config`` outside
+    ``_PROJECT_ROOT``, so an installed ``/pr-review`` whose config
+    resolved to the bundled copy could not dispatch at all. Option 1 of
+    that issue admits the bundled copy as a second trusted ORIGIN.
+
+    Why an origin can carry trust here: the operator installed the
+    plugin, and PR content cannot write into the install directory
+    through the consumer repository. That is the same reasoning
+    :func:`_classify_argv_token` already applies under ``_ARGV_EXTERNAL``
+    to an installed-plugin script an argv names, so this widens the
+    config boundary to match a boundary the gate already draws, rather
+    than inventing a new trust class.
+
+    Conditions, each load-bearing:
+
+    1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
+       non-empty. An unset environment changes nothing.
+    2. The root resolves to an existing directory.
+    3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
+       is what withholds install trust from the in-repo ``.claude/``
+       fallback that the same command offers: that path is PR-controlled
+       and must keep the full byte-identity check. A repository whose
+       own ``.claude`` is the plugin root gets no widening.
+    4. The **resolved** config is inside the resolved root. Resolution
+       happens before containment, so a symlink planted in the install
+       directory that points back into the checked-out PR tree lands
+       outside the root and is refused (CWE-59). Only a link whose
+       target is also install-controlled survives.
+
+    Not widened by this function: the command boundary.
+    :func:`_enforce_command_trust` still verifies every work-tree file
+    the criteria name, so an install-trusted config cannot execute a
+    PR-rewritten verifier script.
+
+    Residual, recorded rather than claimed closed: an actor who can
+    already edit the workflow that invokes this gate can both set these
+    variables and write the directory they name. That actor can run
+    arbitrary commands in the same workflow, so this is a strictly
+    smaller capability than they already hold, and it is not a boundary
+    this gate can close.
+    """
+    project_root = _PROJECT_ROOT.resolve()
+    candidate = Path(config_arg)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+
+    for env_var in _PLUGIN_ROOT_ENV_VARS:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            continue
+        try:
+            root = Path(raw).resolve()
+        except OSError:
+            continue
+        if not root.is_dir():
+            continue
+        # Condition 3: the in-repo fallback root never install-trusts.
+        if _is_within(root, project_root):
+            continue
+        try:
+            resolved_config = candidate.resolve()
+        except OSError:
+            return None
+        # Condition 4: resolution already followed any symlink, so a
+        # link out of the install directory fails this containment.
+        if _is_within(resolved_config, root):
+            return root
+    return None
+
+
 def _resolve_and_read_config(
     config_arg: str,
-) -> tuple[Path, bytes] | tuple[None, None]:
+) -> tuple[Path, bytes, Path | None] | tuple[None, None, None]:
     """Validate the config path and read it exactly once.
 
-    Returns ``(None, None)`` after printing to stderr when the path is
-    unsafe (CWE-22 containment), reaches through a repo-local symlink
-    (CWE-59), or is unreadable; the caller exits 2. The returned buffer
-    is the single read that gets trust-verified and then parsed
+    Returns ``(None, None, None)`` after printing to stderr when the
+    path is unsafe (CWE-22 containment), reaches through a repo-local
+    symlink (CWE-59), or is unreadable; the caller exits 2. The returned
+    buffer is the single read that gets trust-verified and then parsed
     (CWE-367).
+
+    The third element is the install-trusted plugin root
+    (:func:`_install_trusted_root`) or ``None``. It is resolved HERE,
+    once, and threaded to :func:`_enforce_config_trust` rather than
+    recomputed there, so the root that decided containment is provably
+    the root that decides trust. Recomputing invites the two to
+    disagree if the environment changes between the calls.
     """
-    symlink = _symlinked_config_component(config_arg)
-    if symlink is not None:
-        print(
-            f"Refusing config path with symlinked component {symlink}: "
-            f"a repo-local symlink would redirect trust verification to "
-            f"its target and surface that file in the approval diff.",
-            file=sys.stderr,
-        )
-        return None, None
+    install_root = _install_trusted_root(config_arg)
+    containment_base = install_root if install_root is not None else _PROJECT_ROOT
+
+    # The symlink probe is bounded to the project root by
+    # _first_symlinked_component, which skips every component outside it
+    # (run_completion_gate.py, "if not _is_within(probe, root): continue").
+    # For an install-trusted config it therefore inspects nothing and
+    # returns None, so it is skipped rather than run misleadingly. The
+    # CWE-59 hazard it guards is a PR-CREATED link; PR content cannot
+    # write the install directory, and condition 4 of
+    # _install_trusted_root already refuses a link that escapes it.
+    if install_root is None:
+        symlink = _symlinked_config_component(config_arg)
+        if symlink is not None:
+            print(
+                f"Refusing config path with symlinked component {symlink}: "
+                f"a repo-local symlink would redirect trust verification to "
+                f"its target and surface that file in the approval diff.",
+                file=sys.stderr,
+            )
+            return None, None, None
     try:
-        config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
+        config_path = validate_safe_path(config_arg, containment_base)
     except (FileNotFoundError, ValueError) as exc:
         print(
             f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
             file=sys.stderr,
         )
-        return None, None
+        return None, None, None
     try:
-        return config_path, _read_config_bytes(config_path)
+        return config_path, _read_config_bytes(config_path), install_root
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
-        return None, None
+        return None, None, None
 
 
 def _extract_criteria(config: dict[str, Any]) -> list[Any] | None:
@@ -2002,18 +2156,23 @@ def main(argv: list[str] | None = None) -> int:
         print("Pull request number must be positive.", file=sys.stderr)
         return 2
 
-    config_path, raw_config = _resolve_and_read_config(args.config)
+    config_path, raw_config, install_root = _resolve_and_read_config(args.config)
     if config_path is None or raw_config is None:
         return 2
 
     # CWE-829 trust boundary: no criterion command runs unless the
-    # working-tree config is byte-identical to the trusted-ref copy or a
-    # human has explicitly approved the divergence.
+    # working-tree config is byte-identical to the trusted-ref copy, a
+    # human has explicitly approved the divergence, or the config came
+    # from an install-trusted origin the consumer repository cannot
+    # write (issue #5112). The command boundary below is NOT widened by
+    # the third case: an install-trusted config still cannot execute a
+    # PR-rewritten verifier script.
     trust, halt_code = _enforce_config_trust(
         config_path,
         args.trust_anchor_ref,
         args.approve_untrusted_config,
         raw_config,
+        install_root,
     )
     if halt_code is not None:
         return halt_code

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -1995,6 +1995,28 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
+def _absolute_config_candidate(config_arg: str) -> Path:
+    """``--config`` as an absolute path, resolved against the cwd once.
+
+    One helper so every consumer of ``--config`` agrees on which file the
+    argument names. ``validate_safe_path`` builds its result as
+    ``(resolved_base / path).resolve()``, so a RELATIVE ``--config``
+    resolves against whatever base it is handed. Passing a different base
+    would therefore silently name a different file than the one an
+    earlier check approved, which is the authorized-path-is-not-the-read-
+    path shape this gate exists to prevent (see ``_verify_config_trust``
+    on verifying the bytes that are executed).
+
+    The cwd is the right anchor because it is what ``_symlinked_config_
+    component`` already uses and what ``subprocess.run`` in
+    :func:`_evaluate_criterion` inherits.
+    """
+    candidate = Path(config_arg)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate
+
+
 def _install_trusted_root(config_arg: str) -> Path | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
@@ -2046,9 +2068,7 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     this gate can close.
     """
     project_root = _PROJECT_ROOT.resolve()
-    candidate = Path(config_arg)
-    if not candidate.is_absolute():
-        candidate = Path.cwd() / candidate
+    candidate = _absolute_config_candidate(config_arg)
 
     for env_var in _PLUGIN_ROOT_ENV_VARS:
         raw = os.environ.get(env_var, "").strip()
@@ -2093,17 +2113,38 @@ def _resolve_and_read_config(
     disagree if the environment changes between the calls.
     """
     install_root = _install_trusted_root(config_arg)
-    containment_base = install_root if install_root is not None else _PROJECT_ROOT
 
-    # The symlink probe is bounded to the project root by
-    # _first_symlinked_component, which skips every component outside it
-    # (run_completion_gate.py, "if not _is_within(probe, root): continue").
-    # For an install-trusted config it therefore inspects nothing and
-    # returns None, so it is skipped rather than run misleadingly. The
-    # CWE-59 hazard it guards is a PR-CREATED link; PR content cannot
-    # write the install directory, and condition 4 of
-    # _install_trusted_root already refuses a link that escapes it.
-    if install_root is None:
+    if install_root is not None:
+        # Do NOT route this through validate_safe_path with install_root
+        # as the base. That helper builds its result as
+        # (resolved_base / path).resolve(), which would make the
+        # environment-declared root a component of the path READ rather
+        # than only the boundary it is CHECKED against, and for a
+        # relative --config would name a different file than the one
+        # _install_trusted_root just approved. Containment against the
+        # root is already established, on this exact resolved path, by
+        # that function's condition 4, so reuse it.
+        #
+        # Keeping the root deny-only is also what stops an environment
+        # variable from participating in constructing a path whose
+        # contents become a criterion's argv.
+        #
+        # The symlink probe is skipped here rather than run: it is
+        # bounded to the project root by _first_symlinked_component
+        # ("if not _is_within(probe, root): continue"), so for an
+        # out-of-tree config it inspects nothing and returns None. The
+        # CWE-59 hazard it guards is a PR-CREATED link, and condition 4
+        # already refuses any link that escapes the install root.
+        try:
+            config_path = _absolute_config_candidate(config_arg).resolve()
+        except OSError as exc:
+            print(
+                f"Refusing to load config from unresolvable path "
+                f"{config_arg!r}: {exc}",
+                file=sys.stderr,
+            )
+            return None, None, None
+    else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
             print(
@@ -2113,14 +2154,14 @@ def _resolve_and_read_config(
                 file=sys.stderr,
             )
             return None, None, None
-    try:
-        config_path = validate_safe_path(config_arg, containment_base)
-    except (FileNotFoundError, ValueError) as exc:
-        print(
-            f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
-            file=sys.stderr,
-        )
-        return None, None, None
+        try:
+            config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
+        except (FileNotFoundError, ValueError) as exc:
+            print(
+                f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
+                file=sys.stderr,
+            )
+            return None, None, None
     try:
         return config_path, _read_config_bytes(config_path), install_root
     except ConfigError as exc:

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -2080,8 +2080,22 @@ def _install_trusted_root(config_arg: str) -> Path | None:
             continue
         if not root.is_dir():
             continue
-        # Condition 3: the in-repo fallback root never install-trusts.
-        if _is_within(root, project_root):
+        # Condition 3: the declared root and the project tree must be
+        # DISJOINT, checked in BOTH directions.
+        #
+        # Testing only "root is not below the project" leaves the
+        # ancestor direction open, and that direction is the whole
+        # bypass: with the project at $HOME/repo and
+        # CLAUDE_PLUGIN_ROOT=$HOME, the root is not below the project
+        # (so a one-way test passes it) while every PR-controlled file
+        # in the repo IS inside the root, so condition 4 passes too. A
+        # config the checked-out PR wrote would then be install-trusted
+        # and skip byte-identity verification entirely (CWE-829).
+        # Reproduced on this branch before the fix: declared root
+        # /home/user install-trusted
+        # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
+        # Found by Copilot review on PR #5329.
+        if _is_within(root, project_root) or _is_within(project_root, root):
             continue
         try:
             resolved_config = candidate.resolve()

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -474,6 +474,26 @@ TRUST_INSTALL_TRUSTED = "install-trusted"
 # on PR #5329.
 _PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
+# This dispatcher's own location, used to bind install trust to the plugin
+# that SHIPS this file. Module-level so tests can rebind it; the value is
+# never read from the environment.
+#
+# Being a directory the host named is not evidence the root belongs to us.
+# This repository already documents that it may not: _resolve_lib_dir in
+# pr-comment-responder/scripts/cluster_threads.py says COPILOT_PLUGIN_ROOT is
+# "set by the Copilot CLI host, may point to whichever plugin triggered the
+# context-mode hook, not this one", and resolve_pr_conflicts.py records the
+# same for CLAUDE_PLUGIN_ROOT under issue #4961. Both defend by validating
+# each candidate before use; this function did not.
+#
+# Reproduced before the fix (Copilot review, PR #5329): a co-installed plugin
+# root exported as COPILOT_PLUGIN_ROOT, holding its own
+# commands/pr-review-config.yaml, was install-trusted, and its criterion
+# `sh -c '...'` EXECUTED, printing its marker to stderr. Command trust caught
+# nothing because a bare `sh`, an option `-c`, and an option VALUE are all
+# skipped, so no argv token resolved to a work-tree file (CWE-829).
+_DISPATCHER_PATH = Path(__file__).resolve()
+
 # A trusted ref must look like a git revision and must not start with
 # ``-`` so it can never be parsed as a git option (argument injection).
 _TRUSTED_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@^~{}-]*$")
@@ -2385,7 +2405,14 @@ def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     work_tree: Path | None = None
 
     for root in _host_declared_roots():
-        # Condition 3: the declared root and the project tree must be
+        # Condition 3a: the root must be the plugin that ships THIS file.
+        # A host variable names a plugin root; it does not promise the root
+        # is ours. See _DISPATCHER_PATH for the reproduction and for this
+        # repository's own record that the variable can name a foreign
+        # context-mode plugin.
+        if not _is_within(_DISPATCHER_PATH, root):
+            continue
+        # Condition 3b: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
         # Testing only "root is not below the project" leaves the

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -344,6 +344,25 @@ class ConfigError(Exception):
     """
 
 
+class WorkTreeUnavailableError(Exception):
+    """The consumer's git work tree could not be established.
+
+    Raised by :func:`_consumer_work_tree` and handled in
+    :func:`_resolve_and_read_config`, which exits **3**, not 2. Per
+    ADR-035 and this repo's exit-code table (0 ok, 1 logic, 2 config,
+    3 external, 4 auth), a git probe that cannot run, times out, or
+    reports no work tree is an EXTERNAL failure. The config path is not
+    what is wrong, so reporting it as one sends the reader to the wrong
+    place. This is the same reasoning that already makes
+    :data:`TRUST_GIT_ERROR` exit 3 and non-overridable: with the extent
+    of PR-controlled content unknown, no approval could be informed.
+
+    It is raised only after a plugin-root variable has been declared and
+    named an existing directory. A run with neither variable set never
+    probes git and is unaffected.
+    """
+
+
 def _read_config_bytes(path: Path) -> bytes:
     """Read the config exactly once. Raises ConfigError on any failure mode.
 
@@ -413,10 +432,29 @@ TRUST_MALFORMED_REF = "malformed-ref"
 TRUST_INSTALL_TRUSTED = "install-trusted"
 
 # Host-declared plugin roots, in the order resolve_pr_review_config() in
-# .claude/commands/pr-review.md consults them
-# (${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}). Quoted from
-# that command per .claude/rules/canonical-source-mirror.md so the gate
-# and the command cannot drift about which variable wins.
+# .claude/commands/pr-review.md consults them. Quoted verbatim from that
+# function per .claude/rules/canonical-source-mirror.md, first two list
+# entries only (the rest are the in-repo and installed-plugin fallbacks,
+# which this constant deliberately does not cover):
+#
+#     for root in \
+#       "${COPILOT_PLUGIN_ROOT:-}" \
+#       "${CLAUDE_PLUGIN_ROOT:-}" \
+#       ...
+#       if [ -n "$root" ] && [ -f "$root/commands/pr-review-config.yaml" ]; then
+#
+# The loop CONTINUES when a root is set but does not hold the config, so
+# COPILOT_PLUGIN_ROOT being set does not by itself exclude
+# CLAUDE_PLUGIN_ROOT. _host_declared_roots below matches that: it yields
+# both in order and the caller falls through to the second when the
+# first does not contain the config.
+#
+# An earlier revision cited ${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}
+# as the canonical form. That expression lives elsewhere and means
+# something DIFFERENT: it selects COPILOT_PLUGIN_ROOT whenever that is
+# set, with no fall-through on a missing config. Copying its semantics
+# here would have broken the second-root case. Found by Copilot review
+# on PR #5329.
 _PLUGIN_ROOT_ENV_VARS = ("COPILOT_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
 
 # A trusted ref must look like a git revision and must not start with
@@ -2010,8 +2048,8 @@ def _symlinked_config_component(config_arg: str) -> Path | None:
     return _first_symlinked_component(candidate, _PROJECT_ROOT)
 
 
-def _consumer_work_tree() -> Path | None:
-    """The consumer's git work-tree root, or ``None`` if not establishable.
+def _consumer_work_tree() -> Path:
+    """The consumer's git work-tree root, or :exc:`WorkTreeUnavailableError`.
 
     This, and NOT ``_PROJECT_ROOT``, is the boundary install trust must be
     disjoint from. ``_resolve_project_root`` exists to locate the repo's
@@ -2032,24 +2070,46 @@ def _consumer_work_tree() -> Path | None:
     the real work tree, which is exactly the set of files the checked-out
     PR controls.
 
-    Returns ``None`` when git is absent, errors, or the cwd is not in a work
-    tree. Callers MUST treat ``None`` as "no install trust" (fail closed):
-    if the extent of PR-controlled content cannot be established, nothing
-    can be shown to lie outside it.
+    Raises :exc:`WorkTreeUnavailableError` rather than returning a sentinel when
+    git is absent, times out, errors, or reports no work tree for the cwd.
+    That is an exit-3 ``git-error`` condition under this module's contract,
+    not an exit-2 config problem: the failure is external, the config path
+    may be perfectly well-formed, and it is the same "verification is
+    impossible" state that :data:`TRUST_GIT_ERROR` already covers and
+    deliberately makes non-overridable.
+
+    An earlier revision returned ``None`` here and let the caller fall
+    through to work-tree containment. It still failed closed, but it exited
+    2 printing "Refusing to load config from unsafe path", which names the
+    wrong cause: the path was not the problem, the unestablishable work tree
+    was. Found by Copilot review on PR #5329.
+
+    ``subprocess.TimeoutExpired`` is caught explicitly because it is NOT an
+    ``OSError`` (its MRO is TimeoutExpired -> SubprocessError -> Exception),
+    so an ``except OSError`` alone lets a 30-second git hang escape as an
+    unhandled traceback. The two other guarded ``_run_git`` callers in this
+    module already catch the pair; this one did not, which was the defect.
     """
     try:
         proc = _run_git(["rev-parse", "--show-toplevel"], Path.cwd())
-    except OSError:
-        return None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise WorkTreeUnavailableError(f"could not run git: {exc}") from exc
     if proc.returncode != 0:
-        return None
+        raise WorkTreeUnavailableError(
+            f"git reported no work tree for {Path.cwd()}: "
+            f"{proc.stderr.decode(errors='replace').strip()}",
+        )
     toplevel = proc.stdout.decode(errors="replace").strip()
     if not toplevel:
-        return None
+        raise WorkTreeUnavailableError(
+            f"git reported an empty work-tree root for {Path.cwd()}",
+        )
     try:
         return Path(toplevel).resolve()
-    except OSError:
-        return None
+    except OSError as exc:
+        raise WorkTreeUnavailableError(
+            f"work-tree root {toplevel!r} does not resolve: {exc}",
+        ) from exc
 
 
 def _absolute_config_candidate(config_arg: str) -> Path:
@@ -2074,8 +2134,19 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
-def _declared_plugin_roots() -> Iterator[Path]:
+def _host_declared_roots() -> Iterator[Path]:
     """Existing directories named by the host's plugin-root variables.
+
+    Named to avoid the substring ``_plugin_root``. That is not cosmetic:
+    ``TestBootstrapSourceCode`` in ``tests/skills/github/test_bootstrap_fallback.py``
+    selects "bootstrap scripts" with ``"_plugin_root" in f.read_text()`` and then
+    requires each one to carry the literal
+    ``os.path.isdir(os.path.join(_plugin_root, "lib", "github_core"))``.
+    This module reads those variables to decide config TRUST and never puts a
+    plugin root on ``sys.path`` (the only ``sys.path`` insert here is
+    ``_PROJECT_ROOT``), so it has no ``_plugin_root`` variable and that literal
+    would be dead code. An earlier name matched the fragment by accident and
+    failed the guard. Do not reintroduce the fragment.
 
     Yields in ``_PLUGIN_ROOT_ENV_VARS`` order, so a host that exports both
     resolves through the Copilot variable first, and skips a variable that
@@ -2121,14 +2192,35 @@ def _install_trusted_root(config_arg: str) -> Path | None:
 
     1. ``COPILOT_PLUGIN_ROOT`` or ``CLAUDE_PLUGIN_ROOT`` is set and
        non-empty. An unset environment changes nothing.
-       (Applied by :func:`_declared_plugin_roots`.)
+       (Applied by :func:`_host_declared_roots`.)
     2. The root resolves to an existing directory.
-       (Applied by :func:`_declared_plugin_roots`.)
-    3. The resolved root is **not** at or under ``_PROJECT_ROOT``. This
-       is what withholds install trust from the in-repo ``.claude/``
-       fallback that the same command offers: that path is PR-controlled
-       and must keep the full byte-identity check. A repository whose
-       own ``.claude`` is the plugin root gets no widening.
+       (Applied by :func:`_host_declared_roots`.)
+    3. The resolved root is **disjoint** from BOTH the consumer's git
+       work tree (:func:`_consumer_work_tree`) and ``_PROJECT_ROOT``,
+       where disjoint means neither path is at or under the other
+       (:func:`_are_disjoint`). All four containments are load-bearing
+       and each direction failed once:
+
+       * root under either boundary: withholds install trust from the
+         in-repo fallback the same command offers, which the checked-out
+         PR writes and which must keep the full byte-identity check.
+       * either boundary under root: a declared root of ``$HOME`` with
+         the project at ``$HOME/repo`` is not *below* the project, so a
+         one-way test admitted it while it contained every PR-controlled
+         file in the repo (CWE-829).
+
+       The work tree is checked FIRST and is the authoritative boundary,
+       because ``_PROJECT_ROOT`` is attacker-influenceable:
+       :func:`_resolve_project_root` stops at the nearest ancestor
+       holding a plugin directory, so a PR that adds one in a
+       subdirectory relocates it and makes a wholly PR-controlled root
+       look disjoint. ``git rev-parse --show-toplevel`` cannot be moved
+       that way. ``_PROJECT_ROOT`` is still checked as well, because in
+       the installed case it can resolve somewhere the work tree does
+       not cover.
+
+       Both bypasses were found by Copilot review on PR #5329, in
+       consecutive rounds, the second defeating the fix for the first.
     4. The **resolved** config is inside the resolved root. Resolution
        happens before containment, so a symlink planted in the install
        directory that points back into the checked-out PR tree lands
@@ -2153,10 +2245,14 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     # can install-trust anything, so a run with neither variable set (the
     # overwhelmingly common case, and every caller that predates issue
     # #5112) must not pay a subprocess call or perturb a test's git mocks.
+    # A failed probe raises WorkTreeUnavailableError out of this function rather
+    # than degrading to "no install trust"; see that class for why exit 3.
+    # Since the probe now returns a Path or raises, "still None" means
+    # "not yet resolved", so no separate resolved-flag is needed and the
+    # type narrows without an assert.
     work_tree: Path | None = None
-    work_tree_resolved = False
 
-    for root in _declared_plugin_roots():
+    for root in _host_declared_roots():
         # Condition 3: the declared root and the project tree must be
         # DISJOINT, checked in BOTH directions.
         #
@@ -2172,13 +2268,8 @@ def _install_trusted_root(config_arg: str) -> Path | None:
         # /home/user install-trusted
         # /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
         # Found by Copilot review on PR #5329.
-        if not work_tree_resolved:
-            work_tree = _consumer_work_tree()
-            work_tree_resolved = True
-        # Fail closed: with no establishable work tree, nothing can be shown
-        # to lie OUTSIDE PR-controlled content, so nothing install-trusts.
         if work_tree is None:
-            return None
+            work_tree = _consumer_work_tree()
         # Disjoint from the real work tree FIRST: that is the authoritative
         # extent of PR-controlled content and the only one PR content
         # cannot relocate. _PROJECT_ROOT is then checked as well, because
@@ -2199,25 +2290,56 @@ def _install_trusted_root(config_arg: str) -> Path | None:
     return None
 
 
-def _resolve_and_read_config(
-    config_arg: str,
-) -> tuple[Path, bytes, Path | None] | tuple[None, None, None]:
+class ResolvedConfig(NamedTuple):
+    """Outcome of resolving ``--config``.
+
+    ``exit_code`` is set if and only if resolution FAILED, and it carries
+    the code the process must exit with. Callers branch on it rather than
+    on ``path is None``, because the two failure kinds exit differently:
+    2 for a config problem (containment, symlink, unreadable) and 3 for an
+    external one (:exc:`WorkTreeUnavailableError`). The earlier 3-tuple form
+    could express only one of those, which is how a git-probe failure came
+    to be reported as an unsafe path (Copilot review, PR #5329).
+    """
+
+    path: Path | None
+    raw: bytes | None
+    install_root: Path | None
+    exit_code: int | None
+
+
+def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
     """Validate the config path and read it exactly once.
 
-    Returns ``(None, None, None)`` after printing to stderr when the
-    path is unsafe (CWE-22 containment), reaches through a repo-local
-    symlink (CWE-59), or is unreadable; the caller exits 2. The returned
-    buffer is the single read that gets trust-verified and then parsed
-    (CWE-367).
+    On success returns the path, the single read of its bytes, and the
+    install-trusted root or ``None``, with ``exit_code`` unset. That one
+    read is what gets trust-verified AND parsed, so there is no window for
+    the file to change between the two (CWE-367).
 
-    The third element is the install-trusted plugin root
-    (:func:`_install_trusted_root`) or ``None``. It is resolved HERE,
-    once, and threaded to :func:`_enforce_config_trust` rather than
-    recomputed there, so the root that decided containment is provably
-    the root that decides trust. Recomputing invites the two to
-    disagree if the environment changes between the calls.
+    On failure prints to stderr and sets ``exit_code``: **2** when the path
+    is unsafe (CWE-22 containment), reaches through a repo-local symlink
+    (CWE-59), or is unreadable; **3** when the consumer's git work tree
+    could not be established, which is external rather than a config fault.
+
+    ``install_root`` is resolved HERE, once, and threaded to
+    :func:`_enforce_config_trust` rather than recomputed there, so the root
+    that decided containment is provably the root that decides trust.
+    Recomputing invites the two to disagree if the environment changes
+    between the calls.
     """
-    install_root = _install_trusted_root(config_arg)
+    try:
+        install_root = _install_trusted_root(config_arg)
+    except WorkTreeUnavailableError as exc:
+        # Exit 3, never 2: see WorkTreeUnavailableError. Not overridable by
+        # --approve-untrusted-config, matching TRUST_GIT_ERROR, because
+        # there is no inspectable artifact for an approval to be based on.
+        print(
+            f"Refusing to evaluate install trust: {exc}. A plugin root is "
+            f"declared, so the consumer work tree must be known to decide "
+            f"whether that root lies outside it.",
+            file=sys.stderr,
+        )
+        return ResolvedConfig(None, None, None, 3)
 
     if install_root is not None:
         # Do NOT route this through validate_safe_path with install_root
@@ -2248,7 +2370,7 @@ def _resolve_and_read_config(
                 f"{config_arg!r}: {exc}",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
     else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
@@ -2258,7 +2380,7 @@ def _resolve_and_read_config(
                 f"its target and surface that file in the approval diff.",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
         try:
             config_path = validate_safe_path(config_arg, _PROJECT_ROOT)
         except (FileNotFoundError, ValueError) as exc:
@@ -2266,12 +2388,14 @@ def _resolve_and_read_config(
                 f"Refusing to load config from unsafe path {config_arg!r}: {exc}",
                 file=sys.stderr,
             )
-            return None, None, None
+            return ResolvedConfig(None, None, None, 2)
     try:
-        return config_path, _read_config_bytes(config_path), install_root
+        return ResolvedConfig(
+            config_path, _read_config_bytes(config_path), install_root, None,
+        )
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
-        return None, None, None
+        return ResolvedConfig(None, None, None, 2)
 
 
 def _extract_criteria(config: dict[str, Any]) -> list[Any] | None:
@@ -2302,9 +2426,16 @@ def main(argv: list[str] | None = None) -> int:
         print("Pull request number must be positive.", file=sys.stderr)
         return 2
 
-    config_path, raw_config, install_root = _resolve_and_read_config(args.config)
-    if config_path is None or raw_config is None:
-        return 2
+    resolved = _resolve_and_read_config(args.config)
+    if resolved.path is None or resolved.raw is None:
+        # One branch, not two: testing path/raw narrows the types AND
+        # detects failure, since exit_code is set on exactly the paths
+        # that leave them None. The conditional expression is the
+        # unreachable-default; `or 2` would be the falsy-override bug
+        # python.md rejects, even though 0 never occurs here.
+        return 2 if resolved.exit_code is None else resolved.exit_code
+    config_path, raw_config = resolved.path, resolved.raw
+    install_root = resolved.install_root
 
     # CWE-829 trust boundary: no criterion command runs unless the
     # working-tree config is byte-identical to the trusted-ref copy, a

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -513,6 +513,38 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[bytes]:
     )
 
 
+def _require_remote_tracking_ref(
+    trust_anchor_ref: str,
+    cwd: Path,
+) -> TrustCheck | None:
+    """``None`` when the ref anchors trust; a git-error TrustCheck otherwise.
+
+    The ref must resolve to ``refs/remotes/*``. ``HEAD``, a local branch, a
+    tag, and a bare SHA are all refused, because the checked-out PR can move
+    or create them, which would make trust self-referential: the PR's own
+    content would become the thing its content is compared against.
+
+    Extracted so the install-trusted path and :func:`_verify_config_trust`
+    cannot diverge. They did: this check lived only in the latter, which
+    install trust skips, and `--trusted-ref HEAD` then let command trust
+    compare PR-modified verifiers against the PR's own commit and execute
+    them (Copilot review, PR #5329). One implementation, two callers, is
+    what keeps the two paths honest about the same requirement.
+    """
+    proc = _run_git(["rev-parse", "--symbolic-full-name", trust_anchor_ref], cwd)
+    full_name = proc.stdout.decode(errors="replace").strip()
+    if proc.returncode == 0 and full_name.startswith("refs/remotes/"):
+        return None
+    return TrustCheck(
+        TRUST_GIT_ERROR,
+        f"trusted ref {trust_anchor_ref!r} must resolve to a "
+        f"remote-tracking ref (refs/remotes/*), got "
+        f"{full_name or 'a local, detached, or unknown revision'}; "
+        f"HEAD and local branches can be moved by the checked-out "
+        f"PR and cannot anchor trust",
+    )
+
+
 def _verify_config_trust(
     config_path: Path,
     trust_anchor_ref: str,
@@ -588,19 +620,9 @@ def _verify_config_trust(
                 f"config {config_path} resolves outside git work tree {toplevel}",
             )
 
-        proc = _run_git(
-            ["rev-parse", "--symbolic-full-name", trust_anchor_ref], toplevel,
-        )
-        full_name = proc.stdout.decode(errors="replace").strip()
-        if proc.returncode != 0 or not full_name.startswith("refs/remotes/"):
-            return TrustCheck(
-                TRUST_GIT_ERROR,
-                f"trusted ref {trust_anchor_ref!r} must resolve to a "
-                f"remote-tracking ref (refs/remotes/*), got "
-                f"{full_name or 'a local, detached, or unknown revision'}; "
-                f"HEAD and local branches can be moved by the checked-out "
-                f"PR and cannot anchor trust",
-            )
+        anchor_error = _require_remote_tracking_ref(trust_anchor_ref, toplevel)
+        if anchor_error is not None:
+            return anchor_error
 
         proc = _run_git(
             ["rev-parse", "--verify", "--quiet", f"{trust_anchor_ref}^{{commit}}"],
@@ -681,7 +703,7 @@ def _enforce_config_trust(
     trust_anchor_ref: str,
     approved: bool,
     tree_bytes: bytes,
-    install_root: Path | None = None,
+    install: InstallTrust | None = None,
 ) -> tuple[TrustCheck, int | None]:
     """Gate dispatch on config trust; returns ``(trust, exit_code_or_None)``.
 
@@ -695,7 +717,7 @@ def _enforce_config_trust(
     never overridable, because approving with nothing to inspect would
     turn an unverifiable state into an execution path.
 
-    ``install_root``, when not ``None``, is the host-declared plugin root
+    ``install``, when not ``None``, carries the host-declared plugin root
     that install-trusts this config (issue #5112, Option 1). Verification
     is skipped rather than attempted: the config is outside the
     consumer's work tree, so the trusted ref has no copy of it to compare
@@ -706,23 +728,48 @@ def _enforce_config_trust(
     establishes; do not extend this branch to any config the consumer
     repository can write.
     """
-    if install_root is not None:
-        return (
-            TrustCheck(
-                TRUST_INSTALL_TRUSTED,
-                f"config {config_path} is install-trusted: it resides in "
-                f"host-declared plugin root {install_root}, outside the "
-                f"consumer work tree, which PR content cannot write",
-            ),
-            None,
-        )
-
+    # Ref validation runs BEFORE the install-trusted short-circuit, not
+    # after. Both guards on --trusted-ref used to sit on the path install
+    # trust skips: this regex, and the refs/remotes/* requirement inside
+    # _verify_config_trust. _enforce_command_trust repeats neither, so an
+    # install-trusted config left the ref wholly unvalidated while command
+    # trust still consumed it.
+    #
+    # Reproduced before this fix (Copilot review, PR #5329, High):
+    # --trusted-ref HEAD under install trust made command trust compare
+    # every work-tree verifier against the PR's OWN commit, so a
+    # PR-modified verify.sh was declared trusted and EXECUTED (its stderr
+    # marker reached the output). An option-shaped ref likewise reached a
+    # git invocation. Widening the config origin must not widen the
+    # command boundary, and skipping these checks did exactly that.
     if not _TRUSTED_REF_RE.match(trust_anchor_ref):
         print(
             f"Refusing malformed --trusted-ref {trust_anchor_ref!r}",
             file=sys.stderr,
         )
         return TrustCheck(TRUST_MALFORMED_REF, "malformed trusted ref"), 2
+
+    if install is not None:
+        # The regex admits HEAD, so it alone does not close the reproduction
+        # above. The refs/remotes/* requirement is the one that does, and
+        # _verify_config_trust (its usual home) is skipped here, so enforce
+        # it directly, in the work tree the install decision was made
+        # against rather than in some other repository.
+        anchor_error = _require_remote_tracking_ref(
+            trust_anchor_ref, install.work_tree,
+        )
+        if anchor_error is not None:
+            print(anchor_error.detail, file=sys.stderr)
+            return anchor_error, 3
+        return (
+            TrustCheck(
+                TRUST_INSTALL_TRUSTED,
+                f"config {config_path} is install-trusted: it resides in "
+                f"host-declared plugin root {install.root}, outside the "
+                f"consumer work tree, which PR content cannot write",
+            ),
+            None,
+        )
 
     trust = _verify_config_trust(config_path, trust_anchor_ref, tree_bytes)
     if trust.status == TRUST_TRUSTED:
@@ -2134,6 +2181,29 @@ def _absolute_config_candidate(config_arg: str) -> Path:
     return candidate
 
 
+class InstallTrust(NamedTuple):
+    """A config admitted by its ORIGIN, with everything that decision used.
+
+    Three fields, each carried rather than recomputed, because recomputing
+    any of them reopens a hole:
+
+    ``config_path`` is the resolved path :func:`_install_trusted_root`
+    actually approved. Resolving ``--config`` a second time to read it is a
+    TOCTOU window (CWE-367): a repo-controlled symlink swapped between the
+    two calls resolves inside the root for the decision and outside it for
+    the read, while ``root`` stays non-null and byte verification stays
+    skipped. Found by Copilot review on PR #5329.
+
+    ``work_tree`` is the boundary the decision was made against. It is also
+    the repository the trust anchor must be validated in, and validating it
+    somewhere else would answer a different question.
+    """
+
+    root: Path
+    config_path: Path
+    work_tree: Path
+
+
 def _host_declared_roots() -> Iterator[Path]:
     """Existing directories named by the host's plugin-root variables.
 
@@ -2166,7 +2236,7 @@ def _host_declared_roots() -> Iterator[Path]:
             yield root
 
 
-def _install_trusted_root(config_arg: str) -> Path | None:
+def _install_trusted_root(config_arg: str) -> InstallTrust | None:
     """The host-declared plugin root that install-trusts ``config_arg``.
 
     Returns the resolved root when every condition below holds, else
@@ -2285,8 +2355,10 @@ def _install_trusted_root(config_arg: str) -> Path | None:
             return None
         # Condition 4: resolution already followed any symlink, so a
         # link out of the install directory fails this containment.
+        # resolved_config is RETURNED, not recomputed by the caller: it is
+        # the exact path this containment approved (CWE-367).
         if _is_within(resolved_config, root):
-            return root
+            return InstallTrust(root, resolved_config, work_tree)
     return None
 
 
@@ -2304,7 +2376,7 @@ class ResolvedConfig(NamedTuple):
 
     path: Path | None
     raw: bytes | None
-    install_root: Path | None
+    install: InstallTrust | None
     exit_code: int | None
 
 
@@ -2328,7 +2400,7 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
     between the calls.
     """
     try:
-        install_root = _install_trusted_root(config_arg)
+        install = _install_trusted_root(config_arg)
     except WorkTreeUnavailableError as exc:
         # Exit 3, never 2: see WorkTreeUnavailableError. Not overridable by
         # --approve-untrusted-config, matching TRUST_GIT_ERROR, because
@@ -2341,8 +2413,8 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
         )
         return ResolvedConfig(None, None, None, 3)
 
-    if install_root is not None:
-        # Do NOT route this through validate_safe_path with install_root
+    if install is not None:
+        # Do NOT route this through validate_safe_path with the install root
         # as the base. That helper builds its result as
         # (resolved_base / path).resolve(), which would make the
         # environment-declared root a component of the path READ rather
@@ -2362,15 +2434,13 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
         # out-of-tree config it inspects nothing and returns None. The
         # CWE-59 hazard it guards is a PR-CREATED link, and condition 4
         # already refuses any link that escapes the install root.
-        try:
-            config_path = _absolute_config_candidate(config_arg).resolve()
-        except OSError as exc:
-            print(
-                f"Refusing to load config from unresolvable path "
-                f"{config_arg!r}: {exc}",
-                file=sys.stderr,
-            )
-            return ResolvedConfig(None, None, None, 2)
+        #
+        # Reused, never re-resolved. Calling .resolve() again here would
+        # be a second resolution of the same argument, and a repo-controlled
+        # symlink swapped between the two lands inside the root for the
+        # DECISION and outside it for the READ, with verification still
+        # skipped (CWE-367, Copilot review on PR #5329).
+        config_path = install.config_path
     else:
         symlink = _symlinked_config_component(config_arg)
         if symlink is not None:
@@ -2391,7 +2461,10 @@ def _resolve_and_read_config(config_arg: str) -> ResolvedConfig:
             return ResolvedConfig(None, None, None, 2)
     try:
         return ResolvedConfig(
-            config_path, _read_config_bytes(config_path), install_root, None,
+            config_path,
+            _read_config_bytes(config_path),
+            install,
+            None,
         )
     except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
@@ -2435,7 +2508,7 @@ def main(argv: list[str] | None = None) -> int:
         # python.md rejects, even though 0 never occurs here.
         return 2 if resolved.exit_code is None else resolved.exit_code
     config_path, raw_config = resolved.path, resolved.raw
-    install_root = resolved.install_root
+    install = resolved.install
 
     # CWE-829 trust boundary: no criterion command runs unless the
     # working-tree config is byte-identical to the trusted-ref copy, a
@@ -2449,7 +2522,7 @@ def main(argv: list[str] | None = None) -> int:
         args.trust_anchor_ref,
         args.approve_untrusted_config,
         raw_config,
-        install_root,
+        install,
     )
     if halt_code is not None:
         return halt_code

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -18,20 +18,35 @@ sits beside the PR review command.
 
 The bundled copy IS runnable from an installed plugin (issue #5112, Option 1).
 When `resolve_pr_review_config` lands on a config inside a host-declared plugin
-root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) that is itself outside the
-consumer's git work tree, the completion gate treats that origin as
+root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) whose tree is **disjoint
+from** the consumer's git work tree, the completion gate treats that origin as
 install-trusted: the operator installed it and PR content cannot write there, so
 the gate skips the byte-identity check it would otherwise run against the trusted
 ref. This reverses an earlier stance that called the bundled copy a reference
 artifact; under that stance an installed `/pr-review` could not dispatch at all,
 because path containment refused the config before any check ran.
 
-Two limits, because the widening is narrow. The `$repo_root/.claude` fallback in
-the list below gets NO such treatment even if a plugin-root variable points at
-it: that path is written by the checked-out PR and keeps the full trust check.
-And only the config origin widens. The commands the config names are still
+**Disjoint, not merely "outside."** Neither tree may be at or under the other,
+and the difference is not pedantic. A root of `$HOME` with the repository at
+`$HOME/repo` is "outside" the work tree in the loose sense (it is not a
+subdirectory of it) while containing every file the checked-out PR wrote. That
+reading was in an earlier draft of this paragraph, and the matching one-way test
+in the gate admitted exactly that root, so a PR-authored config became
+install-trusted and skipped verification. Both directions are checked now.
+The boundary is the real work tree from `git rev-parse --show-toplevel`,
+because a directory marker inside the repository can be created by the PR and
+therefore cannot anchor trust. If the work tree cannot be established, no root
+install-trusts anything and the gate exits 3.
+
+Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
+in the list below gets NO such treatment even if a plugin-root variable points
+at it: that path is written by the checked-out PR and keeps the full trust
+check. Only the config ORIGIN widens; the commands the config names are still
 verified against the trusted ref, so an install-trusted config cannot execute a
-PR-rewritten verifier script.
+PR-rewritten verifier script. And `--trusted-ref` is validated on this path like
+any other, including the requirement that it resolve to a remote-tracking ref:
+`HEAD` and local branches can be moved by the checked-out PR, so they cannot
+anchor trust and are refused.
 
 ## Context
 

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -14,8 +14,24 @@ Respond to PR review comments for: the problem statement from the conversation (
 
 Load configuration from `pr-review-config.yaml` for scripts, completion criteria,
 error recovery, and failure handling tables. In this repository the live config
-sits beside the PR review command. The bundled Copilot CLI copy is a reference
-artifact, not a runnable completion-gate config.
+sits beside the PR review command.
+
+The bundled copy IS runnable from an installed plugin (issue #5112, Option 1).
+When `resolve_pr_review_config` lands on a config inside a host-declared plugin
+root (`COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT`) that is itself outside the
+consumer's git work tree, the completion gate treats that origin as
+install-trusted: the operator installed it and PR content cannot write there, so
+the gate skips the byte-identity check it would otherwise run against the trusted
+ref. This reverses an earlier stance that called the bundled copy a reference
+artifact; under that stance an installed `/pr-review` could not dispatch at all,
+because path containment refused the config before any check ran.
+
+Two limits, because the widening is narrow. The `$repo_root/.claude` fallback in
+the list below gets NO such treatment even if a plugin-root variable points at
+it: that path is written by the checked-out PR and keeps the full trust check.
+And only the config origin widens. The commands the config names are still
+verified against the trusted ref, so an install-trusted config cannot execute a
+PR-rewritten verifier script.
 
 ## Context
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3767,6 +3767,48 @@ class TestWorkTreeProbeFailure:
         assert code == 3, code
         assert "could not run git" in capsys.readouterr().err
 
+    def test_an_anchor_probe_timeout_exits_3_not_1(self, tmp_path, monkeypatch, capsys):
+        """A git failure DURING anchor validation is exit 3, not a traceback.
+
+        The work-tree probe is already guarded, so this covers the SECOND git
+        call on the install-trusted path, inside
+        ``_require_remote_tracking_ref``. ``_verify_config_trust`` happens to
+        call that helper inside its own try, but the install-trusted caller
+        invokes it directly, so a timeout or a missing binary escaped as a
+        traceback and exit 1 instead of the documented non-overridable exit 3
+        (Copilot review, PR #5329). The catch now lives in the shared helper,
+        which is what keeps the two callers from disagreeing about it.
+        """
+        config = self._plugin_root(tmp_path, monkeypatch)
+        calls: list[list[str]] = []
+
+        def _hang_on_anchor(args, cwd):
+            calls.append(args)
+            if args[:2] == ["rev-parse", "--symbolic-full-name"]:
+                raise subprocess.TimeoutExpired(cmd=["git", *args], timeout=30)
+            # The work-tree probe succeeds, so install trust is granted and
+            # execution reaches the anchor check. Without this the case would
+            # exit 3 from the earlier probe and prove nothing about the second.
+            # It must report a tree DISJOINT from tmp_path/"plugin"; returning
+            # tmp_path itself makes the declared root a subdirectory of the
+            # work tree, which condition 3 refuses, and the case then dies at
+            # containment having never reached the anchor call.
+            return subprocess.CompletedProcess(
+                args, 0, str(tmp_path / "consumer").encode() + b"\n", b"",
+            )
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _hang_on_anchor)
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(config)],
+        )
+
+        assert code == 3, code
+        assert "could not resolve trusted ref" in capsys.readouterr().err
+        # Proof the anchor call was actually reached, so a future change that
+        # short-circuits earlier fails here rather than passing vacuously.
+        assert ["rev-parse", "--symbolic-full-name", "origin/main"] in calls, calls
+
     def test_a_config_problem_still_exits_2(self, tmp_path, monkeypatch, capsys):
         """Discriminating control: 3 must not swallow the config code.
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3281,6 +3281,30 @@ class TestTrackedSubset:
         assert "git ls-files failed" in error
 
 
+def _own_plugin_root(monkeypatch, root: Path) -> None:
+    """Declare `root` the plugin that ships the dispatcher under test.
+
+    Install trust requires the declared root to CONTAIN this dispatcher, so a
+    host variable naming a foreign co-installed plugin cannot trust that
+    plugin's config (CWE-829, reproduced in Copilot review on PR #5329).
+
+    These unit tests import the canonical script from the repository, so its
+    real ``__file__`` is nowhere near their ``tmp_path`` roots. Rebinding the
+    module constant states the arrangement each case assumes: "this
+    dispatcher is the one shipped inside that plugin". It does NOT weaken the
+    condition, because the condition is exercised for real elsewhere:
+    ``_install_plugin`` in tests/test_run_completion_gate_install.py copies
+    the script into the plugin root, so every CLI case satisfies it
+    genuinely, and a dedicated case there drives a foreign root end to end.
+    """
+    monkeypatch.setattr(
+        _dispatcher,
+        "_DISPATCHER_PATH",
+        root.resolve() / "skills" / "github" / "scripts" / "pr"
+        / "run_completion_gate.py",
+    )
+
+
 def _git_work_tree(path: Path) -> Path:
     """Create `path` as a real git work tree and return it.
 
@@ -3336,6 +3360,7 @@ class TestInstallTrustedRoot:
         root = tmp_path / "plugin"
         config = self._config_in(root / "commands")
         monkeypatch.setenv(env_var, str(root))
+        _own_plugin_root(monkeypatch, root)
 
         assert _dispatcher._install_trusted_root(str(config)).root == root.resolve()
 
@@ -3372,6 +3397,7 @@ class TestInstallTrustedRoot:
         config = self._config_in(root / "commands")
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", f"  {root}  ")
+        _own_plugin_root(monkeypatch, root)
 
         assert _dispatcher._install_trusted_root(str(config)).root == root.resolve()
 
@@ -3454,6 +3480,7 @@ class TestInstallTrustedRoot:
         link = root / "commands" / "linked.yaml"
         link.symlink_to(target)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
 
         assert _dispatcher._install_trusted_root(str(link)) is None
 
@@ -3469,6 +3496,7 @@ class TestInstallTrustedRoot:
         link = root / "commands" / "linked.yaml"
         link.symlink_to(target)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
 
         assert _dispatcher._install_trusted_root(str(link)).root == root.resolve()
 
@@ -3487,6 +3515,7 @@ class TestInstallTrustedRoot:
         claude_root.mkdir(parents=True)
         config = self._config_in(copilot_root / "commands")
         monkeypatch.setenv("COPILOT_PLUGIN_ROOT", str(copilot_root))
+        _own_plugin_root(monkeypatch, copilot_root)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(claude_root))
 
         assert _dispatcher._install_trusted_root(str(config)).root == copilot_root.resolve()
@@ -3506,6 +3535,7 @@ class TestInstallTrustedRoot:
         root = tmp_path / "plugin"
         self._config_in(root / "commands")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.chdir(consumer)
 
@@ -3530,6 +3560,7 @@ class TestInstallTrustedRoot:
         self._config_in(root / "commands")
         self._config_in(consumer / "commands")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.chdir(consumer)
 
@@ -3684,6 +3715,7 @@ class TestWorkTreeProbeFailure:
             encoding="utf-8",
         )
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         return config
 
@@ -3875,6 +3907,7 @@ class TestInstallTrustedPathConsistency:
         )
 
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.chdir(consumer)
 
@@ -3916,6 +3949,7 @@ class TestInstallTrustedPathConsistency:
         )
 
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
 
         real = _dispatcher._absolute_config_candidate
@@ -3948,6 +3982,7 @@ class TestInstallTrustedPathConsistency:
             "completion_criteria:\n  - name: absolute\n", encoding="utf-8",
         )
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
 
         resolved = _dispatcher._resolve_and_read_config(
@@ -3969,6 +4004,7 @@ class TestInstallTrustedPathConsistency:
         outside.parent.mkdir(parents=True)
         outside.write_text("completion_criteria: []\n", encoding="utf-8")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        _own_plugin_root(monkeypatch, root)
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
 
         resolved = _dispatcher._resolve_and_read_config(

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3279,3 +3279,190 @@ class TestTrackedSubset:
 
         assert tracked == set()
         assert "git ls-files failed" in error
+
+
+class TestInstallTrustedRoot:
+    """Unit coverage for _install_trusted_root (issue #5112, Option 1).
+
+    The subprocess-level behavior lives in
+    tests/test_run_completion_gate_install.py, which exercises the real
+    installed-plugin layout. These cover the helper's individual
+    conditions, including the ones that arrangement cannot isolate.
+
+    _PROJECT_ROOT is resolved at import time to this repository, so a
+    tmp_path root is outside it, which is exactly condition 3's
+    "not at or under the project root".
+    """
+
+    def _config_in(self, root, name="pr-review-config.yaml"):
+        root.mkdir(parents=True, exist_ok=True)
+        config = root / name
+        config.write_text("completion_criteria: []\n", encoding="utf-8")
+        return config
+
+    def test_unset_environment_install_trusts_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        config = self._config_in(tmp_path / "plugin")
+
+        assert _dispatcher._install_trusted_root(str(config)) is None
+
+    @pytest.mark.parametrize(
+        "env_var", ["CLAUDE_PLUGIN_ROOT", "COPILOT_PLUGIN_ROOT"],
+    )
+    def test_either_host_variable_install_trusts(
+        self, tmp_path, monkeypatch, env_var,
+    ):
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        root = tmp_path / "plugin"
+        config = self._config_in(root / "commands")
+        monkeypatch.setenv(env_var, str(root))
+
+        assert _dispatcher._install_trusted_root(str(config)) == root.resolve()
+
+    def test_empty_and_whitespace_values_are_ignored(self, tmp_path, monkeypatch):
+        """An exported-but-empty variable is not a declaration.
+
+        Hosts and CI commonly export a variable with no value; treating
+        that as a plugin root would resolve Path("") to the cwd.
+        """
+        root = tmp_path / "plugin"
+        config = self._config_in(root / "commands")
+        monkeypatch.setenv("COPILOT_PLUGIN_ROOT", "   ")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "")
+
+        assert _dispatcher._install_trusted_root(str(config)) is None
+
+    def test_a_root_that_is_not_a_directory_is_ignored(self, tmp_path, monkeypatch):
+        root = tmp_path / "plugin"
+        config = self._config_in(root / "commands")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "does-not-exist"))
+
+        assert _dispatcher._install_trusted_root(str(config)) is None
+
+    def test_a_root_inside_the_project_root_is_refused(self, monkeypatch):
+        """Condition 3: the PR-controlled in-repo fallback never widens.
+
+        Uses the live project root, so this asserts the real containment
+        the gate applies rather than a stand-in.
+        """
+        in_repo_root = _dispatcher._PROJECT_ROOT / ".claude"
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(in_repo_root))
+        config = in_repo_root / "commands" / "pr-review-config.yaml"
+
+        assert _dispatcher._install_trusted_root(str(config)) is None
+
+    def test_the_project_root_itself_is_refused(self, monkeypatch):
+        """_is_within is true for root == root, so the repo itself is out."""
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_dispatcher._PROJECT_ROOT))
+        config = _dispatcher._PROJECT_ROOT / "pyproject.toml"
+
+        assert _dispatcher._install_trusted_root(str(config)) is None
+
+    def test_a_config_outside_the_declared_root_is_refused(
+        self, tmp_path, monkeypatch,
+    ):
+        """Condition 4: declaring a root does not bless every path."""
+        root = tmp_path / "plugin"
+        root.mkdir(parents=True)
+        elsewhere = self._config_in(tmp_path / "elsewhere")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        assert _dispatcher._install_trusted_root(str(elsewhere)) is None
+
+    def test_a_symlink_escaping_the_root_is_refused(self, tmp_path, monkeypatch):
+        """Condition 4 resolves before containment (CWE-59)."""
+        root = tmp_path / "plugin"
+        (root / "commands").mkdir(parents=True)
+        target = self._config_in(tmp_path / "outside")
+        link = root / "commands" / "linked.yaml"
+        link.symlink_to(target)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        assert _dispatcher._install_trusted_root(str(link)) is None
+
+    def test_a_symlink_within_the_root_is_still_trusted(self, tmp_path, monkeypatch):
+        """The refusal is about escaping, not about links as such.
+
+        A link whose target is also install-controlled stays inside the
+        operator's own directory, so nothing PR-controlled is reached.
+        """
+        root = tmp_path / "plugin"
+        target = self._config_in(root / "real")
+        (root / "commands").mkdir(parents=True)
+        link = root / "commands" / "linked.yaml"
+        link.symlink_to(target)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        assert _dispatcher._install_trusted_root(str(link)) == root.resolve()
+
+    def test_copilot_root_is_consulted_before_claude_root(
+        self, tmp_path, monkeypatch,
+    ):
+        """Order matches resolve_pr_review_config's own precedence.
+
+        That command reads
+        ${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}, so when
+        both are set and only one contains the config, the Copilot root
+        is the one that decides.
+        """
+        copilot_root = tmp_path / "copilot"
+        claude_root = tmp_path / "claude"
+        claude_root.mkdir(parents=True)
+        config = self._config_in(copilot_root / "commands")
+        monkeypatch.setenv("COPILOT_PLUGIN_ROOT", str(copilot_root))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(claude_root))
+
+        assert _dispatcher._install_trusted_root(str(config)) == copilot_root.resolve()
+
+    def test_a_relative_config_resolves_against_the_cwd(
+        self, tmp_path, monkeypatch,
+    ):
+        """--config may be relative; the gate must resolve it the same way."""
+        root = tmp_path / "plugin"
+        self._config_in(root / "commands")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.chdir(root / "commands")
+
+        assert _dispatcher._install_trusted_root("pr-review-config.yaml") == root.resolve()
+
+
+class TestEnforceConfigTrustInstallTrusted:
+    """_enforce_config_trust short-circuits only on an install-trusted root."""
+
+    def test_install_root_proceeds_without_git_verification(self, tmp_path, monkeypatch):
+        """No _run_git call may happen: there is nothing to verify against."""
+        def _explode(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("git must not run for an install-trusted config")
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _explode)
+
+        trust, halt = _dispatcher._enforce_config_trust(
+            tmp_path / "pr-review-config.yaml",
+            "origin/main",
+            False,
+            b"completion_criteria: []\n",
+            tmp_path,
+        )
+
+        assert halt is None
+        assert trust.status == _dispatcher.TRUST_INSTALL_TRUSTED
+        assert "install-trusted" in trust.detail
+
+    def test_without_install_root_verification_still_runs(self, tmp_path, monkeypatch):
+        """Negative control: the short-circuit is gated on the argument.
+
+        Without it the malformed-ref check is reached and returns exit 2,
+        proving the branch above is not simply always taken.
+        """
+        trust, halt = _dispatcher._enforce_config_trust(
+            tmp_path / "pr-review-config.yaml",
+            "--not-a-ref",
+            False,
+            b"completion_criteria: []\n",
+            None,
+        )
+
+        assert halt == 2
+        assert trust.status == _dispatcher.TRUST_MALFORMED_REF

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3281,6 +3281,24 @@ class TestTrackedSubset:
         assert "git ls-files failed" in error
 
 
+def _git_work_tree(path: Path) -> Path:
+    """Create `path` as a real git work tree and return it.
+
+    _install_trusted_root fails closed when `git rev-parse --show-toplevel`
+    reports nothing, so a bare `.git` directory is not enough: git answers
+    "fatal: not a git repository" for one. Verified before relying on it.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return path
+
+
 class TestInstallTrustedRoot:
     """Unit coverage for _install_trusted_root (issue #5112, Option 1).
 
@@ -3439,13 +3457,48 @@ class TestInstallTrustedRoot:
     def test_a_relative_config_resolves_against_the_cwd(
         self, tmp_path, monkeypatch,
     ):
-        """--config may be relative; the gate must resolve it the same way."""
+        """--config may be relative; the gate resolves it against the cwd.
+
+        The cwd is a real work tree, because _install_trusted_root fails
+        closed when git cannot report a toplevel. A relative arg is only
+        install-trustable when it traverses OUT of that work tree and into
+        the declared root, which is what the host does when it passes the
+        bundled config by a path relative to the consumer repository.
+        """
+        consumer = _git_work_tree(tmp_path / "consumer")
         root = tmp_path / "plugin"
         self._config_in(root / "commands")
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
-        monkeypatch.chdir(root / "commands")
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        monkeypatch.chdir(consumer)
 
-        assert _dispatcher._install_trusted_root("pr-review-config.yaml") == root.resolve()
+        approved = _dispatcher._install_trusted_root(
+            "../plugin/commands/pr-review-config.yaml",
+        )
+
+        assert approved == root.resolve()
+
+    def test_a_relative_config_inside_the_work_tree_is_refused(
+        self, tmp_path, monkeypatch,
+    ):
+        """Discriminating control for the case above.
+
+        Same cwd, same declared root, same relative syntax; only the
+        traversal differs. This one stays inside the consumer work tree, so
+        it is PR-controlled and must keep the byte-identity check. Without
+        it the case above would pass for any relative path at all.
+        """
+        consumer = _git_work_tree(tmp_path / "consumer")
+        root = tmp_path / "plugin"
+        self._config_in(root / "commands")
+        self._config_in(consumer / "commands")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        monkeypatch.chdir(consumer)
+
+        assert _dispatcher._install_trusted_root(
+            "commands/pr-review-config.yaml",
+        ) is None
 
 
 class TestEnforceConfigTrustInstallTrusted:
@@ -3510,29 +3563,34 @@ class TestInstallTrustedPathConsistency:
         Without the fix, validate_safe_path anchored the relative arg on
         the plugin root and loaded the decoy instead.
         """
-        root = tmp_path / "plugin"
-        work = root / "work"
-        work.mkdir(parents=True)
+        consumer = _git_work_tree(tmp_path / "consumer")
+        root = tmp_path / "inst" / "plugin"
+        rel = "../inst/plugin/pr-review-config.yaml"
 
         # The file the cwd-anchored resolution names, and the one
-        # _install_trusted_root approves.
-        approved = work / "pr-review-config.yaml"
+        # _install_trusted_root approves: consumer/../inst/plugin/<name>.
+        approved = root / "pr-review-config.yaml"
+        approved.parent.mkdir(parents=True)
         approved.write_text(
             "completion_criteria:\n  - name: approved\n", encoding="utf-8",
         )
-        # Same relative name, anchored on the plugin root instead.
-        decoy = root / "pr-review-config.yaml"
+        # The file the ROOT-anchored resolution names for the same arg:
+        # tmp/inst/plugin/../inst/plugin/<name> is tmp/inst/inst/plugin/<name>.
+        # The asymmetric nesting is what makes the two resolutions differ;
+        # with the root and the cwd at the same depth they coincide and the
+        # case cannot discriminate. Note this decoy sits OUTSIDE the root
+        # that install trust was granted for, which is the defect exactly.
+        decoy = tmp_path / "inst" / "inst" / "plugin" / "pr-review-config.yaml"
+        decoy.parent.mkdir(parents=True)
         decoy.write_text(
             "completion_criteria:\n  - name: decoy\n", encoding="utf-8",
         )
 
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
-        monkeypatch.chdir(work)
+        monkeypatch.chdir(consumer)
 
-        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
-            "pr-review-config.yaml",
-        )
+        config_path, raw, install_root = _dispatcher._resolve_and_read_config(rel)
 
         assert install_root == root.resolve()
         assert config_path == approved.resolve()

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3578,6 +3578,95 @@ class TestEnforceConfigTrustInstallTrusted:
         assert trust.status == _dispatcher.TRUST_MALFORMED_REF
 
 
+class TestWorkTreeProbeFailure:
+    """A failed work-tree probe is exit 3, and a git hang is caught.
+
+    Copilot review, PR #5329. Two distinct defects behind one finding:
+
+    1. ``subprocess.TimeoutExpired`` is NOT an ``OSError`` (its MRO is
+       TimeoutExpired -> SubprocessError -> Exception), and ``_run_git``
+       passes ``timeout=_GIT_TIMEOUT_SECONDS``, so an ``except OSError``
+       alone let a 30-second git hang escape as an unhandled traceback.
+       The module's two other guarded ``_run_git`` callers already catch
+       the pair.
+    2. A probe failure was collapsed into "no install trust" and fell
+       through to containment, exiting 2 and naming the config path as
+       the problem when the path was fine.
+
+    Driven through ``main()`` so the assertion is on the integer the
+    process exits with, not on a helper's return value (testing.md MUST 8).
+    """
+
+    def _plugin_root(self, tmp_path, monkeypatch):
+        root = tmp_path / "plugin"
+        (root / "commands").mkdir(parents=True)
+        config = root / "commands" / "pr-review-config.yaml"
+        config.write_text(
+            "completion_criteria:\n"
+            "  - name: c\n"
+            "    verification: command\n"
+            '    command: "true"\n'
+            '    pass_when: "exit_code == 0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        return config
+
+    def test_a_git_timeout_exits_3_instead_of_raising(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        config = self._plugin_root(tmp_path, monkeypatch)
+
+        def _hang(args, cwd):
+            raise subprocess.TimeoutExpired(cmd=["git", *args], timeout=30)
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _hang)
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(config)],
+        )
+
+        assert code == 3, code
+        err = capsys.readouterr().err
+        assert "could not run git" in err, err
+        assert "Refusing to load config from unsafe path" not in err, err
+
+    def test_a_missing_git_binary_exits_3(self, tmp_path, monkeypatch, capsys):
+        config = self._plugin_root(tmp_path, monkeypatch)
+
+        def _absent(args, cwd):
+            raise FileNotFoundError(2, "No such file or directory: 'git'")
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _absent)
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(config)],
+        )
+
+        assert code == 3, code
+        assert "could not run git" in capsys.readouterr().err
+
+    def test_a_config_problem_still_exits_2(self, tmp_path, monkeypatch, capsys):
+        """Discriminating control: 3 must not swallow the config code.
+
+        Same declared root, same working git; only the config is wrong (it
+        is outside both the root and the project). Without this, a mutant
+        that returned 3 unconditionally would pass every case above.
+        """
+        self._plugin_root(tmp_path, monkeypatch)
+        outside = tmp_path / "outside" / "pr-review-config.yaml"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("completion_criteria: []\n", encoding="utf-8")
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(outside)],
+        )
+
+        assert code == 2, code
+        assert "Refusing to load config from unsafe path" in capsys.readouterr().err
+
+
 class TestInstallTrustedPathConsistency:
     """The path install-trust approves must be the path that is read.
 
@@ -3627,12 +3716,13 @@ class TestInstallTrustedPathConsistency:
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.chdir(consumer)
 
-        config_path, raw, install_root = _dispatcher._resolve_and_read_config(rel)
+        resolved = _dispatcher._resolve_and_read_config(rel)
 
-        assert install_root == root.resolve()
-        assert config_path == approved.resolve()
-        assert b"approved" in raw
-        assert b"decoy" not in raw
+        assert resolved.exit_code is None, resolved.exit_code
+        assert resolved.install_root == root.resolve()
+        assert resolved.path == approved.resolve()
+        assert b"approved" in resolved.raw
+        assert b"decoy" not in resolved.raw
 
     def test_the_environment_root_cannot_redirect_an_absolute_config(
         self, tmp_path, monkeypatch,
@@ -3647,13 +3737,14 @@ class TestInstallTrustedPathConsistency:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
 
-        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
+        resolved = _dispatcher._resolve_and_read_config(
             str(config),
         )
 
-        assert install_root == root.resolve()
-        assert config_path == config.resolve()
-        assert b"absolute" in raw
+        assert resolved.exit_code is None, resolved.exit_code
+        assert resolved.install_root == root.resolve()
+        assert resolved.path == config.resolve()
+        assert b"absolute" in resolved.raw
 
     def test_a_config_outside_the_root_still_falls_back_to_containment(
         self, tmp_path, monkeypatch,
@@ -3667,10 +3758,14 @@ class TestInstallTrustedPathConsistency:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
 
-        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
+        resolved = _dispatcher._resolve_and_read_config(
             str(outside),
         )
 
-        assert install_root is None
-        assert config_path is None
-        assert raw is None
+        assert resolved.install_root is None
+        assert resolved.path is None
+        assert resolved.raw is None
+        # 2, not 3: the work tree resolved fine and the CONFIG is the
+        # problem. The exit-3 branch is a different failure and has its
+        # own cases; asserting the code here keeps the two from merging.
+        assert resolved.exit_code == 2, resolved.exit_code

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3353,6 +3353,26 @@ class TestInstallTrustedRoot:
 
         assert _dispatcher._install_trusted_root(str(config)) is None
 
+    def test_an_ancestor_of_the_project_root_is_refused(self, monkeypatch):
+        """Condition 3 is disjointness, not one-way containment.
+
+        The bypass Copilot found on PR #5329. Testing only "the root is not
+        below the project" passes a root that is an ANCESTOR of the project,
+        while every PR-controlled file in the repo is inside that root, so
+        condition 4 passes too and a config the checked-out PR wrote becomes
+        install-trusted, skipping byte-identity verification (CWE-829).
+
+        Reproduced before the fix with the live project root: declared root
+        /home/user install-trusted
+        /home/user/ai-agents/.claude/commands/pr-review-config.yaml.
+        """
+        project_root = _dispatcher._PROJECT_ROOT.resolve()
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(project_root.parent))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        pr_controlled = project_root / ".claude" / "commands" / "pr-review-config.yaml"
+
+        assert _dispatcher._install_trusted_root(str(pr_controlled)) is None
+
     def test_the_project_root_itself_is_refused(self, monkeypatch):
         """_is_within is true for root == root, so the repo itself is out."""
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_dispatcher._PROJECT_ROOT))

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3466,3 +3466,96 @@ class TestEnforceConfigTrustInstallTrusted:
 
         assert halt == 2
         assert trust.status == _dispatcher.TRUST_MALFORMED_REF
+
+
+class TestInstallTrustedPathConsistency:
+    """The path install-trust approves must be the path that is read.
+
+    Found by Semgrep's dangerous-subprocess-use-tainted-env-args on
+    PR #5329. validate_safe_path builds its result as
+    (resolved_base / path).resolve(), so handing it the environment-
+    declared root as the base made that root a component of the path
+    READ, not merely the boundary it is CHECKED against. For a relative
+    --config the two resolutions disagree, and the file authorized by
+    _install_trusted_root (cwd-anchored) is not the file loaded
+    (root-anchored). _resolve_and_read_config now reuses the approved
+    path instead.
+    """
+
+    def test_a_relative_config_reads_the_cwd_anchored_file(
+        self, tmp_path, monkeypatch,
+    ):
+        """Two files share a relative name; the cwd-anchored one wins.
+
+        Without the fix, validate_safe_path anchored the relative arg on
+        the plugin root and loaded the decoy instead.
+        """
+        root = tmp_path / "plugin"
+        work = root / "work"
+        work.mkdir(parents=True)
+
+        # The file the cwd-anchored resolution names, and the one
+        # _install_trusted_root approves.
+        approved = work / "pr-review-config.yaml"
+        approved.write_text(
+            "completion_criteria:\n  - name: approved\n", encoding="utf-8",
+        )
+        # Same relative name, anchored on the plugin root instead.
+        decoy = root / "pr-review-config.yaml"
+        decoy.write_text(
+            "completion_criteria:\n  - name: decoy\n", encoding="utf-8",
+        )
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        monkeypatch.chdir(work)
+
+        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
+            "pr-review-config.yaml",
+        )
+
+        assert install_root == root.resolve()
+        assert config_path == approved.resolve()
+        assert b"approved" in raw
+        assert b"decoy" not in raw
+
+    def test_the_environment_root_cannot_redirect_an_absolute_config(
+        self, tmp_path, monkeypatch,
+    ):
+        """An absolute --config is unaffected by the root, as before."""
+        root = tmp_path / "plugin"
+        config = root / "commands" / "pr-review-config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text(
+            "completion_criteria:\n  - name: absolute\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+
+        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
+            str(config),
+        )
+
+        assert install_root == root.resolve()
+        assert config_path == config.resolve()
+        assert b"absolute" in raw
+
+    def test_a_config_outside_the_root_still_falls_back_to_containment(
+        self, tmp_path, monkeypatch,
+    ):
+        """Negative control: the install branch is not always taken."""
+        root = tmp_path / "plugin"
+        root.mkdir(parents=True)
+        outside = tmp_path / "outside" / "pr-review-config.yaml"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("completion_criteria: []\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+
+        config_path, raw, install_root = _dispatcher._resolve_and_read_config(
+            str(outside),
+        )
+
+        assert install_root is None
+        assert config_path is None
+        assert raw is None

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3352,12 +3352,49 @@ class TestInstallTrustedRoot:
 
         assert _dispatcher._install_trusted_root(str(config)) is None
 
-    def test_a_root_that_is_not_a_directory_is_ignored(self, tmp_path, monkeypatch):
+    def test_surrounding_whitespace_is_stripped_from_a_real_root(
+        self, tmp_path, monkeypatch,
+    ):
+        """Discriminating twin for the case above.
+
+        The case above cannot observe the strip(): whitespace-only survives
+        it as a relative path that is not a directory, so the value is
+        dropped either way and the assertion holds against an unstripped
+        implementation. Mutation confirmed it, removing .strip() left the
+        whole file green.
+
+        A real root with stray spaces is the input the two implementations
+        disagree on. Unstripped, Path("  /abs/root") is RELATIVE (its first
+        component is the spaces), so it resolves under the cwd, is not a
+        directory, and nothing is trusted.
+        """
         root = tmp_path / "plugin"
         config = self._config_in(root / "commands")
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "does-not-exist"))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", f"  {root}  ")
 
-        assert _dispatcher._install_trusted_root(str(config)) is None
+        assert _dispatcher._install_trusted_root(str(config)) == root.resolve()
+
+    def test_a_root_that_is_not_a_directory_is_ignored(self, tmp_path, monkeypatch):
+        """A declared root must be a directory, not merely a path.
+
+        The config is placed INSIDE the declared root so containment
+        (condition 4) cannot be what refuses this. Without the is_dir()
+        check a plain FILE would install-trust a config named beneath it:
+        Path.resolve() does not require existence, so the containment test
+        happily succeeds against a path that cannot hold a file at all.
+        An earlier version of this case put the config elsewhere, so
+        containment refused it and the is_dir() check went unobserved;
+        mutation confirmed removing is_dir() left the file green.
+        """
+        not_a_dir = tmp_path / "plugin-root-is-a-file"
+        not_a_dir.write_text("", encoding="utf-8")
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(not_a_dir))
+
+        assert _dispatcher._install_trusted_root(
+            str(not_a_dir / "pr-review-config.yaml"),
+        ) is None
 
     def test_a_root_inside_the_project_root_is_refused(self, monkeypatch):
         """Condition 3: the PR-controlled in-repo fallback never widens.

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3337,7 +3337,7 @@ class TestInstallTrustedRoot:
         config = self._config_in(root / "commands")
         monkeypatch.setenv(env_var, str(root))
 
-        assert _dispatcher._install_trusted_root(str(config)) == root.resolve()
+        assert _dispatcher._install_trusted_root(str(config)).root == root.resolve()
 
     def test_empty_and_whitespace_values_are_ignored(self, tmp_path, monkeypatch):
         """An exported-but-empty variable is not a declaration.
@@ -3373,7 +3373,7 @@ class TestInstallTrustedRoot:
         monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", f"  {root}  ")
 
-        assert _dispatcher._install_trusted_root(str(config)) == root.resolve()
+        assert _dispatcher._install_trusted_root(str(config)).root == root.resolve()
 
     def test_a_root_that_is_not_a_directory_is_ignored(self, tmp_path, monkeypatch):
         """A declared root must be a directory, not merely a path.
@@ -3470,7 +3470,7 @@ class TestInstallTrustedRoot:
         link.symlink_to(target)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
 
-        assert _dispatcher._install_trusted_root(str(link)) == root.resolve()
+        assert _dispatcher._install_trusted_root(str(link)).root == root.resolve()
 
     def test_copilot_root_is_consulted_before_claude_root(
         self, tmp_path, monkeypatch,
@@ -3489,7 +3489,7 @@ class TestInstallTrustedRoot:
         monkeypatch.setenv("COPILOT_PLUGIN_ROOT", str(copilot_root))
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(claude_root))
 
-        assert _dispatcher._install_trusted_root(str(config)) == copilot_root.resolve()
+        assert _dispatcher._install_trusted_root(str(config)).root == copilot_root.resolve()
 
     def test_a_relative_config_resolves_against_the_cwd(
         self, tmp_path, monkeypatch,
@@ -3513,7 +3513,7 @@ class TestInstallTrustedRoot:
             "../plugin/commands/pr-review-config.yaml",
         )
 
-        assert approved == root.resolve()
+        assert approved.root == root.resolve()
 
     def test_a_relative_config_inside_the_work_tree_is_refused(
         self, tmp_path, monkeypatch,
@@ -3541,24 +3541,98 @@ class TestInstallTrustedRoot:
 class TestEnforceConfigTrustInstallTrusted:
     """_enforce_config_trust short-circuits only on an install-trusted root."""
 
-    def test_install_root_proceeds_without_git_verification(self, tmp_path, monkeypatch):
-        """No _run_git call may happen: there is nothing to verify against."""
-        def _explode(*args, **kwargs):  # pragma: no cover - must not run
-            raise AssertionError("git must not run for an install-trusted config")
+    def test_install_root_skips_config_verification_but_not_the_ref_check(
+        self, tmp_path, monkeypatch,
+    ):
+        """Byte verification is skipped; ref validation is NOT.
 
-        monkeypatch.setattr(_dispatcher, "_run_git", _explode)
+        This case previously asserted that _run_git must never be called for
+        an install-trusted config, and stubbed it to raise. That contract was
+        wrong and the assertion enforced the wrong thing: the trust ANCHOR
+        still has to resolve to a remote-tracking ref, which takes a git
+        call, and skipping it let `--trusted-ref HEAD` make command trust
+        compare PR-modified verifiers against the PR's own commit (Copilot
+        review, PR #5329). What is skipped is _verify_config_trust's
+        byte-identity comparison, and only that.
+        """
+        calls: list[list[str]] = []
+
+        def _fake_git(args, cwd):
+            calls.append(args)
+            return subprocess.CompletedProcess(
+                args, 0, b"refs/remotes/origin/main\n", b"",
+            )
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _fake_git)
 
         trust, halt = _dispatcher._enforce_config_trust(
             tmp_path / "pr-review-config.yaml",
             "origin/main",
             False,
             b"completion_criteria: []\n",
-            tmp_path,
+            _dispatcher.InstallTrust(
+                tmp_path, tmp_path / "pr-review-config.yaml", tmp_path,
+            ),
         )
 
         assert halt is None
         assert trust.status == _dispatcher.TRUST_INSTALL_TRUSTED
         assert "install-trusted" in trust.detail
+        # Exactly one git call, and it is the anchor check. `cat-file`
+        # would mean byte verification ran, which install trust exists to
+        # skip; asserting the call list catches either drift.
+        assert calls == [["rev-parse", "--symbolic-full-name", "origin/main"]], calls
+
+    def test_install_root_refuses_a_local_ref(self, tmp_path, monkeypatch):
+        """HEAD passes the regex, so only the remote-tracking check stops it.
+
+        The reproduction behind this: with the ref unvalidated, command
+        trust compared a PR-modified verifier against the PR's own HEAD,
+        declared it trusted, and executed it. Exit 3, matching
+        TRUST_GIT_ERROR, so --approve-untrusted-config cannot override it.
+        """
+        def _fake_git(args, cwd):
+            return subprocess.CompletedProcess(args, 0, b"refs/heads/main\n", b"")
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _fake_git)
+
+        trust, halt = _dispatcher._enforce_config_trust(
+            tmp_path / "pr-review-config.yaml",
+            "HEAD",
+            True,  # approval must NOT rescue this
+            b"completion_criteria: []\n",
+            _dispatcher.InstallTrust(
+                tmp_path, tmp_path / "pr-review-config.yaml", tmp_path,
+            ),
+        )
+
+        assert halt == 3, halt
+        assert trust.status == _dispatcher.TRUST_GIT_ERROR
+        assert "remote-tracking" in trust.detail
+
+    def test_install_root_refuses_an_option_shaped_ref(self, tmp_path, monkeypatch):
+        """The regex guard now runs ahead of the short-circuit.
+
+        Discriminating twin for the case above: this one is stopped by the
+        regex and never reaches git, so _run_git raising proves the order.
+        """
+        def _explode(*args, **kwargs):
+            raise AssertionError("a malformed ref must not reach git")
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _explode)
+
+        trust, halt = _dispatcher._enforce_config_trust(
+            tmp_path / "pr-review-config.yaml",
+            "--upload-pack=touch /tmp/pwned",
+            False,
+            b"completion_criteria: []\n",
+            _dispatcher.InstallTrust(
+                tmp_path, tmp_path / "pr-review-config.yaml", tmp_path,
+            ),
+        )
+
+        assert halt == 2, halt
+        assert trust.status == _dispatcher.TRUST_MALFORMED_REF
 
     def test_without_install_root_verification_still_runs(self, tmp_path, monkeypatch):
         """Negative control: the short-circuit is gated on the argument.
@@ -3719,7 +3793,58 @@ class TestInstallTrustedPathConsistency:
         resolved = _dispatcher._resolve_and_read_config(rel)
 
         assert resolved.exit_code is None, resolved.exit_code
-        assert resolved.install_root == root.resolve()
+        assert resolved.install.root == root.resolve()
+        assert resolved.path == approved.resolve()
+        assert b"approved" in resolved.raw
+        assert b"decoy" not in resolved.raw
+
+    def test_the_approved_path_is_the_path_read(self, tmp_path, monkeypatch):
+        """The config is resolved ONCE, and the read reuses that result.
+
+        Simulates the CWE-367 swap Copilot reported: a repo-controlled
+        symlink changed between the containment decision and the read
+        resolves inside the root for the decision and outside it for the
+        read, with byte verification still skipped.
+
+        The swap is injected at the only place a second resolution could
+        happen, ``_absolute_config_candidate``. Call one is the decision,
+        inside ``_install_trusted_root``. Any call two is the re-resolution
+        the fix removed, and it gets the decoy. With the fix there is no
+        call two, so the decoy is unreachable no matter what it points at.
+
+        Written after mutation showed the earlier cases could not tell the
+        two apart: re-resolving returns the same path in a non-adversarial
+        fixture, so every one of them passed against the unfixed code.
+        """
+        root = tmp_path / "plugin"
+        approved = root / "commands" / "pr-review-config.yaml"
+        approved.parent.mkdir(parents=True)
+        approved.write_text(
+            "completion_criteria:\n  - name: approved\n", encoding="utf-8",
+        )
+        decoy = tmp_path / "decoy.yaml"
+        decoy.write_text(
+            "completion_criteria:\n  - name: decoy\n", encoding="utf-8",
+        )
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+
+        real = _dispatcher._absolute_config_candidate
+        calls: list[str] = []
+
+        def _swapping(config_arg):
+            calls.append(config_arg)
+            if len(calls) == 1:
+                return real(config_arg)
+            return decoy
+
+        monkeypatch.setattr(_dispatcher, "_absolute_config_candidate", _swapping)
+
+        resolved = _dispatcher._resolve_and_read_config(str(approved))
+
+        assert resolved.exit_code is None, resolved.exit_code
+        assert len(calls) == 1, f"resolved {len(calls)} times, expected 1"
         assert resolved.path == approved.resolve()
         assert b"approved" in resolved.raw
         assert b"decoy" not in resolved.raw
@@ -3742,7 +3867,7 @@ class TestInstallTrustedPathConsistency:
         )
 
         assert resolved.exit_code is None, resolved.exit_code
-        assert resolved.install_root == root.resolve()
+        assert resolved.install.root == root.resolve()
         assert resolved.path == config.resolve()
         assert b"absolute" in resolved.raw
 
@@ -3762,7 +3887,7 @@ class TestInstallTrustedPathConsistency:
             str(outside),
         )
 
-        assert resolved.install_root is None
+        assert resolved.install is None
         assert resolved.path is None
         assert resolved.raw is None
         # 2, not 3: the work tree resolved fine and the CONFIG is the

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3706,6 +3706,52 @@ class TestWorkTreeProbeFailure:
         assert "could not run git" in err, err
         assert "Refusing to load config from unsafe path" not in err, err
 
+    def test_a_symlink_loop_in_the_work_tree_path_exits_3(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """RuntimeError from resolve() must not escape as a traceback.
+
+        CPython 3.10, 3.11 and 3.12 raise ``RuntimeError("Symlink loop
+        from ...")`` out of ``Path.resolve()``; 3.14 returns the unresolved
+        path instead. ``RuntimeError`` is not an ``OSError``, so the earlier
+        ``except OSError`` guard let it escape on exactly the interpreters
+        the hook-portability floor targets, and a local run on 3.14 could
+        never reveal that (Copilot review, PR #5329).
+
+        The exception is injected rather than produced with real symlinks,
+        because on the interpreter this suite runs under no real loop raises
+        it. That is the point: the defect is invisible to a same-version
+        reproduction, so the test has to model the other versions' contract.
+        """
+        config = self._plugin_root(tmp_path, monkeypatch)
+
+        real_resolve = Path.resolve
+
+        # Exact match, not a substring: tmp_path contains "loop" because
+        # this test is NAMED for one, and a substring trigger fired on the
+        # config path instead of the work tree.
+        looped = "/looped-work-tree"
+
+        def _looping(self, *a, **kw):
+            if str(self) == looped:
+                raise RuntimeError(f"Symlink loop from {self!r}")
+            return real_resolve(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "resolve", _looping)
+        monkeypatch.setattr(
+            _dispatcher, "_run_git",
+            lambda args, cwd: subprocess.CompletedProcess(
+                args, 0, looped.encode() + b"\n", b"",
+            ),
+        )
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(config)],
+        )
+
+        assert code == 3, code
+        assert "does not resolve" in capsys.readouterr().err
+
     def test_a_missing_git_binary_exits_3(self, tmp_path, monkeypatch, capsys):
         config = self._plugin_root(tmp_path, monkeypatch)
 

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -57,9 +57,20 @@ defect. ``_install_plugin`` now builds a real work tree WITH
 ``refs/remotes/origin/main``, which the install-trusted path requires like any
 other; the version that lacked one passed only because the ref check was being
 skipped, and that skip was itself the security defect (Copilot review,
-PR #5329). And the criterion here names ``printf``, a bare interpreter name
-that command trust classifies as external, so there is no work-tree file to
-byte-compare. Both facts came from running it.
+PR #5329). And the criterion here names ``printf``, which resolves to a path
+inside the work tree that is not a file, so ``_classify_argv_token`` returns
+``_ARGV_SKIP`` and there is no work-tree file to byte-compare.
+
+That second fact is stated the way it is because an earlier version of this
+paragraph got it wrong in a specific way worth naming. It said ``printf`` was
+classified as EXTERNAL, reasoning from "it is a bare interpreter name, so it
+must be outside the tree". Reading ``_classify_argv_token`` shows
+``_ARGV_EXTERNAL`` requires a resolved path outside the tree that IS a file;
+a bare name that resolves to nothing takes the ``_ARGV_SKIP`` branch instead.
+The refutation was already in this file's own end-to-end payload, where
+``skipped_external_files`` is empty, and I did not read it. Both branches
+refuse to compare, so nothing was broken, but the claim would have misled the
+next person reasoning about which tokens get verified.
 """
 
 from __future__ import annotations
@@ -106,8 +117,14 @@ _COMMAND_TRUST_HALT = "HALT: completion-gate verifier files"
 # failing on a schema error rather than on the boundary under test.
 # The criterion emits a JSON object and pass_when reads a key out of it, so a
 # run that reaches dispatch is observable in the payload rather than inferred
-# from an exit code. `printf` is a bare interpreter name, so command trust
-# classifies it as external and there is no work-tree file to byte-compare.
+# from an exit code. `printf` resolves to <cwd>/printf, which is INSIDE the
+# work tree and is not a file, so _classify_argv_token returns _ARGV_SKIP and
+# there is no work-tree file to byte-compare. Not _ARGV_EXTERNAL: that branch
+# needs a resolved path OUTSIDE the tree that IS a file, so
+# `command_trust.skipped_external_files` stays empty here. An earlier comment
+# claimed external; the payload in this file's own end-to-end case shows the
+# list empty, which was the evidence against it sitting in plain sight
+# (Copilot review, PR #5329).
 # `true` (YAML/Python) is not a pass_when literal; the evaluator wants `true`
 # lowercase, and `True` raises "Unrecognized literal in pass_when".
 _CONFIG_BODY = """completion_criteria:
@@ -376,6 +393,11 @@ def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None
     assert criterion["passed"] is True
     assert criterion["exit_code"] == 0
     assert criterion["stdout_json"] == {"gate_ran": True}
+    # `printf` takes the _ARGV_SKIP branch, NOT _ARGV_EXTERNAL: it resolves
+    # inside the work tree and is not a file. Pinned because the reverse was
+    # asserted in prose here and stood for several revisions.
+    assert payload["command_trust"]["skipped_external_files"] == []
+    assert payload["command_trust"]["checked_files"] == []
 
 
 def test_copilot_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -43,11 +43,23 @@ the gate really does print, one on each side of the decision:
     when it did not. That makes it the discriminator these tests turn on,
     falsifiable in both directions.
 
-These fixtures deliberately stop at the config boundary rather than proving a
-criterion executed. Reaching dispatch needs a real remote-tracking trusted ref
-and command-trust verification of every argv file, which is a different
-boundary with its own tests. What issue #5112 reports, and what these pin, is
-whether the gate accepts the bundled config at all.
+These fixtures reach dispatch, and one asserts on it.
+``test_the_bundled_config_runs_its_criteria_end_to_end`` runs the criterion and
+reads the parsed ``--json`` payload, because the absence assertions above
+cannot separate "install trust worked" from "the run died earlier for an
+unrelated reason".
+
+An earlier version of this paragraph claimed the opposite, that the fixtures
+"deliberately stop at the config boundary", on the reasoning that dispatch
+would need a real remote-tracking trusted ref and command-trust verification of
+every argv file. Both halves were wrong, and each was wrong in a way that hid a
+defect. ``_install_plugin`` now builds a real work tree WITH
+``refs/remotes/origin/main``, which the install-trusted path requires like any
+other; the version that lacked one passed only because the ref check was being
+skipped, and that skip was itself the security defect (Copilot review,
+PR #5329). And the criterion here names ``printf``, a bare interpreter name
+that command trust classifies as external, so there is no work-tree file to
+byte-compare. Both facts came from running it.
 """
 
 from __future__ import annotations
@@ -69,8 +81,10 @@ _SCRIPT = (
     / "run_completion_gate.py"
 )
 
-# Quoted verbatim from run_completion_gate so these cannot drift from the
-# messages they assert on (.claude/rules/canonical-source-mirror.md):
+# Quoted verbatim from .claude/skills/github/scripts/pr/run_completion_gate.py
+# (the canonical source; src/copilot-cli/... is its generated mirror) so these
+# cannot drift from the messages they assert on. The rule requires the path,
+# not just the module name (.claude/rules/canonical-source-mirror.md):
 #   _resolve_and_read_config:
 #     f"Refusing to load config from unsafe path {config_arg!r}: {exc}"
 #   _enforce_config_trust:
@@ -105,16 +119,31 @@ _CONFIG_BODY = """completion_criteria:
 
 
 def _git_init(path: Path) -> None:
-    """Make `path` a real git work tree.
+    """Make `path` a real git work tree with a remote-tracking trust anchor.
 
     An empty ``.git`` directory is not enough: ``_consumer_work_tree`` shells
     out to ``git rev-parse --show-toplevel``, which reports
     "fatal: not a git repository" for one. Verified before relying on it.
+
+    ``refs/remotes/origin/main`` is created because the default
+    ``--trusted-ref origin/main`` must resolve to a remote-tracking ref on
+    the install-trusted path too. An earlier fixture omitted it and passed
+    only because that check was being skipped, which was the bug (Copilot
+    review, PR #5329). A fixture that satisfies a guard only when the guard
+    is absent is not a fixture, it is the defect wearing a costume.
     """
-    subprocess.run(
-        ["git", "init", "--quiet"], cwd=path, check=True,
-        capture_output=True, text=True,
+    run = lambda *a: subprocess.run(  # noqa: E731
+        ["git", *a], cwd=path, check=True, capture_output=True, text=True,
     )
+    run("init", "--quiet")
+    run("config", "user.email", "test@example.invalid")
+    run("config", "user.name", "test")
+    run("commit", "--quiet", "--allow-empty", "-m", "base")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=path, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    run("update-ref", "refs/remotes/origin/main", head)
 
 
 def _install_plugin(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -147,6 +176,7 @@ def _run_gate(
     env_var: str | None,
     env_value: str | None = None,
     json_output: bool = False,
+    trusted_ref: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     script = plugin_root / "skills" / "github" / "scripts" / "pr" / "run_completion_gate.py"
     env = dict(os.environ)
@@ -165,6 +195,7 @@ def _run_gate(
             "--config",
             str(config),
             *(["--json"] if json_output else []),
+            *(["--trusted-ref", trusted_ref] if trusted_ref else []),
         ],
         cwd=user_repo,
         capture_output=True,
@@ -264,6 +295,51 @@ def test_install_trust_exits_3_when_git_is_not_on_path(tmp_path: Path) -> None:
     assert result.returncode == 3, (result.returncode, result.stderr)
     assert "could not run git" in result.stderr, result.stderr
     assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+
+
+def test_a_local_trusted_ref_is_refused_for_an_installed_config(
+    tmp_path: Path,
+) -> None:
+    """`--trusted-ref HEAD` cannot anchor trust, install-trusted or not.
+
+    Reproduced before the fix: install trust short-circuited ahead of BOTH
+    ref guards, and `_enforce_command_trust` repeats neither, so command
+    trust compared every work-tree verifier against the PR's OWN commit.
+    A PR-modified verifier was declared trusted and executed. Exit 3, and
+    `--approve-untrusted-config` does not override it.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT", trusted_ref="HEAD",
+    )
+
+    assert result.returncode == 3, (result.returncode, result.stderr)
+    assert "remote-tracking" in result.stderr, result.stderr
+    # Proof no criterion ran: the fixture criterion prints this key.
+    assert "gate_ran" not in result.stdout, result.stdout
+
+
+def test_an_option_shaped_trusted_ref_is_refused_for_an_installed_config(
+    tmp_path: Path,
+) -> None:
+    """The regex guard runs ahead of the install short-circuit.
+
+    Before the fix the raw value reached a git invocation, which is the
+    argument-injection surface `_TRUSTED_REF_RE` exists to close.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT",
+        trusted_ref="--upload-pack=touch /tmp/should-not-exist",
+    )
+
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "Refusing malformed --trusted-ref" in result.stderr, result.stderr
+    assert "gate_ran" not in result.stdout, result.stdout
 
 
 def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None:

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -1,16 +1,31 @@
-"""Runtime test: run_completion_gate imports from an installed-plugin path.
+"""Runtime tests: run_completion_gate under an installed-plugin layout.
 
 Issue #2572: the installed Copilot plugin copy of run_completion_gate.py failed
 with ``ModuleNotFoundError: No module named 'scripts'`` because the repo's
 top-level scripts/ package is not bundled with the skill and the project-root
 walk started from the script location (inside installed-plugins/) instead of
-the user's working directory. This test copies the script to a directory with
-no scripts/ tree above it and runs it from a separate working directory,
+the user's working directory. The first test copies the script to a directory
+with no scripts/ tree above it and runs it from a separate working directory,
 asserting the module loads (``--help`` reaches argparse).
+
+Issue #5112: ``resolve_pr_review_config()`` in ``.claude/commands/pr-review.md``
+offers plugin roots as config sources, but path containment refused any
+``--config`` outside the consumer repository, so an installed ``/pr-review``
+whose config resolved to the bundled copy could not dispatch at all. Option 1
+of that issue admits a config inside a host-declared plugin root OUTSIDE the
+work tree as a second trusted origin. The remaining tests exercise that end to
+end, in the layout the issue describes, rather than only ``--help``.
+
+The install-trust assertions deliberately key on the config-refusal message
+rather than on the exit code. Reaching dispatch needs a PR, a remote-tracking
+ref and ``gh``; the behavior issue #5112 reports is narrower and sits earlier:
+whether the gate refuses the bundled config BEFORE any of that. Asserting the
+absence of that specific refusal isolates the change from the environment.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -25,6 +40,74 @@ _SCRIPT = (
     / "pr"
     / "run_completion_gate.py"
 )
+
+# Quoted verbatim from run_completion_gate._resolve_and_read_config so the
+# test cannot drift from the message it asserts on
+# (.claude/rules/canonical-source-mirror.md):
+#     f"Refusing to load config from unsafe path {config_arg!r}: {exc}"
+_CONTAINMENT_REFUSAL = "Refusing to load config from unsafe path"
+
+_CONFIG_BODY = """completion_criteria:
+  - name: placeholder
+    command: ["true"]
+"""
+
+
+def _install_plugin(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build an installed-plugin layout beside a separate consumer repo.
+
+    Returns ``(plugin_root, bundled_config, user_repo)``. The plugin root
+    sits outside the consumer repo, which is the arrangement a real
+    install produces (``~/.copilot/installed-plugins/...`` against a
+    checkout elsewhere) and the one condition 3 of
+    ``_install_trusted_root`` distinguishes from the in-repo fallback.
+    """
+    plugin_root = tmp_path / "installed-plugins" / "project-toolkit"
+    script_dir = plugin_root / "skills" / "github" / "scripts" / "pr"
+    script_dir.mkdir(parents=True)
+    shutil.copy2(_SCRIPT, script_dir / "run_completion_gate.py")
+
+    bundled_config = plugin_root / "commands" / "pr-review-config.yaml"
+    bundled_config.parent.mkdir(parents=True)
+    bundled_config.write_text(_CONFIG_BODY, encoding="utf-8")
+
+    user_repo = tmp_path / "user_repo"
+    (user_repo / ".git").mkdir(parents=True)
+    return plugin_root, bundled_config, user_repo
+
+
+def _run_gate(
+    plugin_root: Path,
+    config: Path,
+    user_repo: Path,
+    *,
+    env_var: str | None,
+    env_value: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    script = plugin_root / "skills" / "github" / "scripts" / "pr" / "run_completion_gate.py"
+    env = dict(os.environ)
+    # Clear both so an ambient value in the developer's own shell cannot
+    # decide the outcome of a test about these variables.
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
+    env.pop("COPILOT_PLUGIN_ROOT", None)
+    if env_var is not None:
+        env[env_var] = env_value if env_value is not None else str(plugin_root)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--pull-request",
+            "1",
+            "--config",
+            str(config),
+        ],
+        cwd=user_repo,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
 
 
 def test_runs_from_installed_path_without_scripts_tree(tmp_path: Path) -> None:
@@ -50,3 +133,96 @@ def test_runs_from_installed_path_without_scripts_tree(tmp_path: Path) -> None:
     assert "ModuleNotFoundError" not in result.stderr, result.stderr
     assert result.returncode == 0, result.stderr
     assert "run_completion_gate.py" in result.stdout
+
+
+def test_bundled_config_is_refused_without_a_declared_plugin_root(
+    tmp_path: Path,
+) -> None:
+    """Negative control for the two tests below.
+
+    With neither variable set the bundled config is outside the consumer
+    repo and nothing install-trusts it, so containment refuses it. This is
+    the pre-issue-#5112 behavior and it must survive unchanged, otherwise
+    the tests that assert the refusal is ABSENT prove nothing.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(plugin_root, config, user_repo, env_var=None)
+
+    assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
+
+
+def test_claude_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo, env_var="CLAUDE_PLUGIN_ROOT",
+    )
+
+    assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+
+
+def test_copilot_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
+    """Both host variables work, per resolve_pr_review_config's own list."""
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo, env_var="COPILOT_PLUGIN_ROOT",
+    )
+
+    assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+
+
+def test_in_repo_plugin_root_does_not_install_trust_its_config(
+    tmp_path: Path,
+) -> None:
+    """The PR-controlled in-repo fallback root gets no widening.
+
+    ``resolve_pr_review_config`` falls back to ``.claude`` inside the
+    consumer repo. That directory is written by the checked-out PR, so
+    condition 3 of ``_install_trusted_root`` refuses to treat it as an
+    install-trusted origin even when the operator points a plugin-root
+    variable at it. The config then takes the ordinary path: containment
+    passes (it is inside the repo) and trust verification applies.
+    """
+    plugin_root, _, user_repo = _install_plugin(tmp_path)
+    in_repo_root = user_repo / ".claude"
+    in_repo_config = in_repo_root / "commands" / "pr-review-config.yaml"
+    in_repo_config.parent.mkdir(parents=True)
+    in_repo_config.write_text(_CONFIG_BODY, encoding="utf-8")
+
+    result = _run_gate(
+        plugin_root,
+        in_repo_config,
+        user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT",
+        env_value=str(in_repo_root),
+    )
+
+    # Not install-trusted, so the gate reaches trust verification and
+    # halts there: the throwaway repo has no remote-tracking ref. The
+    # point is that it did NOT short-circuit to "install-trusted".
+    assert "install-trusted" not in result.stderr, result.stderr
+    assert result.returncode != 0, result.stdout
+
+
+def test_symlink_out_of_the_plugin_root_is_refused(tmp_path: Path) -> None:
+    """A link planted in the install directory cannot reach into the PR tree.
+
+    Condition 4 of ``_install_trusted_root`` resolves the config before
+    containment, so a symlink whose target is the checked-out repo lands
+    outside the plugin root, is not install-trusted, and is then refused
+    by ordinary containment against the project root as well (CWE-59).
+    """
+    plugin_root, _, user_repo = _install_plugin(tmp_path)
+    attacker_config = user_repo / "evil-config.yaml"
+    attacker_config.write_text(_CONFIG_BODY, encoding="utf-8")
+
+    link = plugin_root / "commands" / "linked-config.yaml"
+    link.symlink_to(attacker_config)
+
+    result = _run_gate(
+        plugin_root, link, user_repo, env_var="CLAUDE_PLUGIN_ROOT",
+    )
+
+    assert "install-trusted" not in result.stderr, result.stderr

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -46,6 +46,7 @@ whether the gate accepts the bundled config at all.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -83,11 +84,17 @@ _COMMAND_TRUST_HALT = "HALT: completion-gate verifier files"
 # asserts on a LATER stage (command trust, dispatch) could observe that stage at
 # all. Found by mutation: removing the work-tree anchor left the bypass case
 # failing on a schema error rather than on the boundary under test.
+# The criterion emits a JSON object and pass_when reads a key out of it, so a
+# run that reaches dispatch is observable in the payload rather than inferred
+# from an exit code. `printf` is a bare interpreter name, so command trust
+# classifies it as external and there is no work-tree file to byte-compare.
+# `true` (YAML/Python) is not a pass_when literal; the evaluator wants `true`
+# lowercase, and `True` raises "Unrecognized literal in pass_when".
 _CONFIG_BODY = """completion_criteria:
   - name: placeholder
     verification: command
-    command: "true"
-    pass_when: "exit_code == 0"
+    command: "printf '{\\"gate_ran\\": true}'"
+    pass_when: "gate_ran == true"
 """
 
 
@@ -133,6 +140,7 @@ def _run_gate(
     *,
     env_var: str | None,
     env_value: str | None = None,
+    json_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     script = plugin_root / "skills" / "github" / "scripts" / "pr" / "run_completion_gate.py"
     env = dict(os.environ)
@@ -150,6 +158,7 @@ def _run_gate(
             "1",
             "--config",
             str(config),
+            *(["--json"] if json_output else []),
         ],
         cwd=user_repo,
         capture_output=True,
@@ -215,6 +224,42 @@ def test_claude_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
     # appear. This is the assertion that fails if the root stops being
     # honored; the containment check above only proves the path was accepted.
     assert _CONFIG_TRUST_HALT not in result.stderr, result.stderr
+
+
+def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None:
+    """Positive control for every absence assertion in this file.
+
+    The other install cases assert that a refusal string is ABSENT, which
+    cannot distinguish "install trust worked" from "the run died earlier for
+    an unrelated reason". This drives the same layout with --json and reads
+    the structured payload, so the claim is what the gate reported rather
+    than what a substring search did not find (testing.md MUST 9).
+
+    Requested in Copilot review on PR #5329: the acceptance criterion for
+    issue #5112 is that an installed /pr-review can DISPATCH its bundled
+    config, and until this case existed nothing observed a criterion running.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT", json_output=True,
+    )
+
+    assert result.returncode == 0, (result.returncode, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["config_trust"]["status"] == "install-trusted"
+    # The config was install-trusted; the FILES its criteria name were still
+    # verified. Widening the config origin must not widen the command
+    # boundary, so this is not incidental detail.
+    assert payload["command_trust"]["status"] == "trusted"
+    assert payload["all_passed"] is True
+    criterion = payload["criteria"][0]
+    # Proof of execution, not of acceptance: the gate ran the command and
+    # parsed what the command printed.
+    assert criterion["passed"] is True
+    assert criterion["exit_code"] == 0
+    assert criterion["stdout_json"] == {"gate_ran": True}
 
 
 def test_copilot_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -163,9 +163,11 @@ def _git_init(path: Path) -> None:
     review, PR #5329). A fixture that satisfies a guard only when the guard
     is absent is not a fixture, it is the defect wearing a costume.
     """
-    run = lambda *a: subprocess.run(  # noqa: E731
-        ["git", *a], cwd=path, check=True, capture_output=True, text=True,
-    )
+    def run(*a: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *a], cwd=path, check=True, capture_output=True, text=True,
+        )
+
     run("init", "--quiet")
     run("config", "user.email", "test@example.invalid")
     run("config", "user.name", "test")
@@ -371,6 +373,64 @@ def test_an_option_shaped_trusted_ref_is_refused_for_an_installed_config(
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "Refusing malformed --trusted-ref" in result.stderr, result.stderr
     assert "gate_ran" not in result.stdout, result.stdout
+
+
+def test_a_foreign_plugin_root_is_not_install_trusted(tmp_path: Path) -> None:
+    """A co-installed plugin's root cannot trust that plugin's config.
+
+    The host variable names *a* plugin root, not necessarily ours. This
+    repository already records that: ``_resolve_lib_dir`` in
+    ``.claude/skills/pr-comment-responder/scripts/cluster_threads.py`` says
+    ``COPILOT_PLUGIN_ROOT`` is "set by the Copilot CLI host, may point to
+    whichever plugin triggered the context-mode hook, not this one", and
+    ``resolve_pr_conflicts.py`` records the same for ``CLAUDE_PLUGIN_ROOT``
+    under issue #4961. Both defend by validating each candidate;
+    ``_install_trusted_root`` checked only ``is_dir()``.
+
+    Reproduced end to end before the fix (Copilot review, PR #5329): the
+    foreign config was install-trusted and its criterion executed. Command
+    trust caught nothing, because a bare ``sh``, an option ``-c``, and an
+    option VALUE are all skipped, so no argv token resolved to a work-tree
+    file (CWE-829).
+
+    The criterion here writes a MARKER to stderr. Asserting the marker is
+    absent is the assertion that matters: a refusal message alone would not
+    distinguish "refused" from "refused after running the command".
+    """
+    plugin_root, _config, user_repo = _install_plugin(tmp_path)
+
+    foreign = tmp_path / "foreign-plugin"
+    (foreign / "commands").mkdir(parents=True)
+    foreign_config = foreign / "commands" / "pr-review-config.yaml"
+    foreign_config.write_text(
+        "completion_criteria:\n"
+        "  - name: pwn\n"
+        "    verification: command\n"
+        "    command: \"sh -c 'echo FOREIGN-PLUGIN-EXECUTION >&2'\"\n"
+        '    pass_when: "exit_code == 0"\n',
+        encoding="utf-8",
+    )
+
+    script = (
+        plugin_root / "skills" / "github" / "scripts" / "pr"
+        / "run_completion_gate.py"
+    )
+    env = dict(os.environ)
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
+    # The foreign root, not the one shipping this dispatcher.
+    env["COPILOT_PLUGIN_ROOT"] = str(foreign)
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--pull-request", "1",
+         "--config", str(foreign_config)],
+        cwd=user_repo, capture_output=True, encoding="utf-8",
+        errors="replace", env=env, check=False,
+    )
+
+    assert "FOREIGN-PLUGIN-EXECUTION" not in result.stderr, result.stderr
+    assert "FOREIGN-PLUGIN-EXECUTION" not in result.stdout, result.stdout
+    assert result.returncode != 0, (result.returncode, result.stdout)
+    assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
 
 
 def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None:

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -14,13 +14,34 @@ offers plugin roots as config sources, but path containment refused any
 whose config resolved to the bundled copy could not dispatch at all. Option 1
 of that issue admits a config inside a host-declared plugin root OUTSIDE the
 work tree as a second trusted origin. The remaining tests exercise that end to
-end, in the layout the issue describes, rather than only ``--help``.
+end, in the layout the issue describes.
 
-The install-trust assertions deliberately key on the config-refusal message
-rather than on the exit code. Reaching dispatch needs a PR, a remote-tracking
-ref and ``gh``; the behavior issue #5112 reports is narrower and sits earlier:
-whether the gate refuses the bundled config BEFORE any of that. Asserting the
-absence of that specific refusal isolates the change from the environment.
+How these tests discriminate, and why the obvious assertion does not
+--------------------------------------------------------------------
+An earlier revision asserted ``"install-trusted" not in result.stderr``. That
+assertion cannot fail: the status reaches the JSON payload on stdout and is
+never written to stderr, so it held whether or not the config was wrongly
+install-trusted (Copilot review, PR #5329). It is replaced by two strings that
+the gate really does print, one on each side of the decision:
+
+``Refusing to load config from unsafe path``
+    Emitted by ``_resolve_and_read_config`` when work-tree containment rejects
+    the path. Present in the pre-issue-#5112 behavior, absent once a root
+    install-trusts the config.
+
+``HALT: completion-gate config``
+    Emitted by ``_enforce_config_trust`` (both its git-error and its untrusted
+    branch), and by nothing else; the command-trust halts read "completion-gate
+    verifier files". An install-trusted config SKIPS verification, so this
+    string is absent exactly when install trust applied and present exactly
+    when it did not. That makes it the discriminator these tests turn on,
+    falsifiable in both directions.
+
+These fixtures deliberately stop at the config boundary rather than proving a
+criterion executed. Reaching dispatch needs a real remote-tracking trusted ref
+and command-trust verification of every argv file, which is a different
+boundary with its own tests. What issue #5112 reports, and what these pin, is
+whether the gate accepts the bundled config at all.
 """
 
 from __future__ import annotations
@@ -41,26 +62,32 @@ _SCRIPT = (
     / "run_completion_gate.py"
 )
 
-# Quoted verbatim from run_completion_gate._resolve_and_read_config so the
-# test cannot drift from the message it asserts on
-# (.claude/rules/canonical-source-mirror.md):
+# Quoted verbatim from run_completion_gate so these cannot drift from the
+# messages they assert on (.claude/rules/canonical-source-mirror.md):
+#   _resolve_and_read_config:
 #     f"Refusing to load config from unsafe path {config_arg!r}: {exc}"
+#   _enforce_config_trust:
+#     f"HALT: completion-gate config {config_path} cannot be "
+#     f"HALT: completion-gate config {config_path} is not trusted "
 _CONTAINMENT_REFUSAL = "Refusing to load config from unsafe path"
+_CONFIG_TRUST_HALT = "HALT: completion-gate config"
 
+# `command` must be a non-empty STRING; _validate_criterion_schema rejects a
+# list ("criterion {name!r}: command must be a non-empty string"). An earlier
+# revision used ["true"] here, which could never have reached dispatch
+# (Copilot review, PR #5329).
 _CONFIG_BODY = """completion_criteria:
   - name: placeholder
-    command: ["true"]
+    command: "true"
 """
 
 
 def _install_plugin(tmp_path: Path) -> tuple[Path, Path, Path]:
     """Build an installed-plugin layout beside a separate consumer repo.
 
-    Returns ``(plugin_root, bundled_config, user_repo)``. The plugin root
-    sits outside the consumer repo, which is the arrangement a real
-    install produces (``~/.copilot/installed-plugins/...`` against a
-    checkout elsewhere) and the one condition 3 of
-    ``_install_trusted_root`` distinguishes from the in-repo fallback.
+    Returns ``(plugin_root, bundled_config, user_repo)``. The plugin root is a
+    SIBLING of the consumer repo, never an ancestor of it, which is the
+    arrangement a real install produces and the only one condition 3 admits.
     """
     plugin_root = tmp_path / "installed-plugins" / "project-toolkit"
     script_dir = plugin_root / "skills" / "github" / "scripts" / "pr"
@@ -140,16 +167,17 @@ def test_bundled_config_is_refused_without_a_declared_plugin_root(
 ) -> None:
     """Negative control for the two tests below.
 
-    With neither variable set the bundled config is outside the consumer
-    repo and nothing install-trusts it, so containment refuses it. This is
-    the pre-issue-#5112 behavior and it must survive unchanged, otherwise
-    the tests that assert the refusal is ABSENT prove nothing.
+    With neither variable set the bundled config is outside the consumer repo
+    and nothing install-trusts it, so containment refuses it. This is the
+    pre-issue-#5112 behavior and it must survive unchanged, otherwise the
+    tests asserting that refusal is ABSENT prove nothing.
     """
     plugin_root, config, user_repo = _install_plugin(tmp_path)
 
     result = _run_gate(plugin_root, config, user_repo, env_var=None)
 
     assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
+    assert result.returncode != 0, result.stdout
 
 
 def test_claude_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
@@ -160,6 +188,10 @@ def test_claude_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
     )
 
     assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+    # Install trust SKIPS verification, so the config-trust halt must not
+    # appear. This is the assertion that fails if the root stops being
+    # honored; the containment check above only proves the path was accepted.
+    assert _CONFIG_TRUST_HALT not in result.stderr, result.stderr
 
 
 def test_copilot_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
@@ -171,6 +203,40 @@ def test_copilot_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
     )
 
     assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+    assert _CONFIG_TRUST_HALT not in result.stderr, result.stderr
+
+
+def test_a_root_that_is_an_ancestor_of_the_repo_does_not_install_trust(
+    tmp_path: Path,
+) -> None:
+    """The bypass Copilot found on PR #5329, pinned.
+
+    Condition 3 originally tested only "the root is not below the project".
+    A root that is an ANCESTOR of the project passes that one-way test while
+    containing every PR-controlled file in the repo, so a config the checked-out
+    PR wrote became install-trusted and skipped byte-identity verification
+    (CWE-829). Condition 3 now requires the two trees to be disjoint.
+
+    The config here lives inside the consumer repo, so containment accepts it;
+    the question is purely whether verification is skipped. The trust halt must
+    be PRESENT, proving install trust did not apply.
+    """
+    plugin_root, _, user_repo = _install_plugin(tmp_path)
+    ancestor = user_repo.parent
+    pr_controlled = user_repo / ".claude" / "commands" / "pr-review-config.yaml"
+    pr_controlled.parent.mkdir(parents=True)
+    pr_controlled.write_text(_CONFIG_BODY, encoding="utf-8")
+
+    result = _run_gate(
+        plugin_root,
+        pr_controlled,
+        user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT",
+        env_value=str(ancestor),
+    )
+
+    assert _CONFIG_TRUST_HALT in result.stderr, result.stderr
+    assert result.returncode != 0, result.stdout
 
 
 def test_in_repo_plugin_root_does_not_install_trust_its_config(
@@ -178,12 +244,11 @@ def test_in_repo_plugin_root_does_not_install_trust_its_config(
 ) -> None:
     """The PR-controlled in-repo fallback root gets no widening.
 
-    ``resolve_pr_review_config`` falls back to ``.claude`` inside the
-    consumer repo. That directory is written by the checked-out PR, so
-    condition 3 of ``_install_trusted_root`` refuses to treat it as an
-    install-trusted origin even when the operator points a plugin-root
-    variable at it. The config then takes the ordinary path: containment
-    passes (it is inside the repo) and trust verification applies.
+    ``resolve_pr_review_config`` falls back to ``.claude`` inside the consumer
+    repo. That directory is written by the checked-out PR, so condition 3
+    refuses it as an install-trusted origin even when the operator points a
+    plugin-root variable at it. The config then takes the ordinary path:
+    containment passes (it is inside the repo) and verification applies.
     """
     plugin_root, _, user_repo = _install_plugin(tmp_path)
     in_repo_root = user_repo / ".claude"
@@ -199,20 +264,24 @@ def test_in_repo_plugin_root_does_not_install_trust_its_config(
         env_value=str(in_repo_root),
     )
 
-    # Not install-trusted, so the gate reaches trust verification and
-    # halts there: the throwaway repo has no remote-tracking ref. The
-    # point is that it did NOT short-circuit to "install-trusted".
-    assert "install-trusted" not in result.stderr, result.stderr
+    assert _CONFIG_TRUST_HALT in result.stderr, result.stderr
     assert result.returncode != 0, result.stdout
 
 
-def test_symlink_out_of_the_plugin_root_is_refused(tmp_path: Path) -> None:
-    """A link planted in the install directory cannot reach into the PR tree.
+def test_symlink_out_of_the_plugin_root_is_not_install_trusted(
+    tmp_path: Path,
+) -> None:
+    """A link planted in the install directory cannot borrow install trust.
 
-    Condition 4 of ``_install_trusted_root`` resolves the config before
-    containment, so a symlink whose target is the checked-out repo lands
-    outside the plugin root, is not install-trusted, and is then refused
-    by ordinary containment against the project root as well (CWE-59).
+    Condition 4 resolves the config before containment, so a symlink whose
+    target is the checked-out repo lands outside the plugin root and does not
+    install-trust (CWE-59).
+
+    It is NOT hard-refused, and that is deliberate: it falls through to the
+    ordinary path, where work-tree containment accepts the in-repo target and
+    byte-identity verification then applies to it. That is strictly more
+    scrutiny than install trust would have given, not less. The assertion is
+    therefore that verification RAN, not that the path was rejected.
     """
     plugin_root, _, user_repo = _install_plugin(tmp_path)
     attacker_config = user_repo / "evil-config.yaml"
@@ -225,4 +294,5 @@ def test_symlink_out_of_the_plugin_root_is_refused(tmp_path: Path) -> None:
         plugin_root, link, user_repo, env_var="CLAUDE_PLUGIN_ROOT",
     )
 
-    assert "install-trusted" not in result.stderr, result.stderr
+    assert _CONFIG_TRUST_HALT in result.stderr, result.stderr
+    assert result.returncode != 0, result.stdout

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -1,3 +1,9 @@
+# taste-lint: ignore file-size, one suite shares the installed-plugin
+# layout fixtures (_install_plugin, _git_init, _run_gate, _CONFIG_BODY)
+# across every install-trust state. Splitting it duplicates the layout
+# builder or moves it to a module that pytest's rootdir insertion does
+# not reliably import from tests/, and each case here is only readable
+# against the same layout. Same rationale as test_why_pr_blocked.py.
 """Runtime tests: run_completion_gate under an installed-plugin layout.
 
 Issue #2572: the installed Copilot plugin copy of run_completion_gate.py failed

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -226,6 +226,40 @@ def test_claude_plugin_root_admits_the_bundled_config(tmp_path: Path) -> None:
     assert _CONFIG_TRUST_HALT not in result.stderr, result.stderr
 
 
+def test_install_trust_exits_3_when_git_is_not_on_path(tmp_path: Path) -> None:
+    """Missing git is external (exit 3), like the non-work-tree case.
+
+    Same layout as the passing case; the only change is an emptied PATH, so
+    ``_run_git`` raises ``FileNotFoundError``. That IS an ``OSError``, so it
+    was already caught, but nothing asserted which code it produced and the
+    old code produced 2.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+    script = (
+        plugin_root / "skills" / "github" / "scripts" / "pr"
+        / "run_completion_gate.py"
+    )
+    env = dict(os.environ)
+    env.pop("COPILOT_PLUGIN_ROOT", None)
+    env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+    # An empty directory as the whole PATH: git cannot be found, but the
+    # interpreter is invoked by absolute path so the run still starts.
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+    env["PATH"] = str(empty_bin)
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--pull-request", "1",
+         "--config", str(config)],
+        cwd=user_repo, capture_output=True, encoding="utf-8",
+        errors="replace", env=env, check=False,
+    )
+
+    assert result.returncode == 3, (result.returncode, result.stderr)
+    assert "could not run git" in result.stderr, result.stderr
+    assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+
+
 def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None:
     """Positive control for every absence assertion in this file.
 
@@ -439,13 +473,19 @@ def test_a_pr_created_nested_claude_cannot_relocate_the_trust_boundary(
 def test_install_trust_fails_closed_outside_a_git_work_tree(
     tmp_path: Path,
 ) -> None:
-    """No establishable work tree means no install trust.
+    """No establishable work tree halts with exit 3, not exit 2.
 
-    ``_consumer_work_tree`` returns ``None`` when git cannot report a
-    toplevel. Nothing can then be shown to lie outside PR-controlled
-    content, so install trust must be withheld rather than granted by
-    default. The layout is otherwise the valid one from ``_install_plugin``,
-    so the only difference from the passing case is the missing work tree.
+    Nothing can be shown to lie outside PR-controlled content, so install
+    trust is withheld. The layout is otherwise the valid one from
+    ``_install_plugin``, so the only difference from the passing case is
+    the missing work tree.
+
+    The CODE is the point, not just the halt. An earlier revision returned
+    ``None`` from the probe and fell through to containment, exiting 2 with
+    "Refusing to load config from unsafe path". It failed closed, but named
+    the wrong cause: the path was fine, the work tree was not establishable.
+    Per ADR-035 and this repo's table (2 config, 3 external) that is a 3.
+    Found by Copilot review on PR #5329.
     """
     plugin_root, config, user_repo = _install_plugin(tmp_path)
     # Remove the marker that makes this look like a work tree. git then
@@ -469,5 +509,8 @@ def test_install_trust_fails_closed_outside_a_git_work_tree(
         plugin_root, config, user_repo, env_var="CLAUDE_PLUGIN_ROOT",
     )
 
-    assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
-    assert result.returncode != 0, result.stdout
+    assert result.returncode == 3, (result.returncode, result.stderr)
+    assert "Refusing to evaluate install trust" in result.stderr, result.stderr
+    # The old exit-2 message must be GONE, not merely accompanied. A
+    # positive-only assertion would pass on a run that printed both.
+    assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -71,15 +71,37 @@ _SCRIPT = (
 #     f"HALT: completion-gate config {config_path} is not trusted "
 _CONTAINMENT_REFUSAL = "Refusing to load config from unsafe path"
 _CONFIG_TRUST_HALT = "HALT: completion-gate config"
+# The command-trust halt, distinct from the config one above:
+#     f"HALT: completion-gate verifier files cannot be verified "
+_COMMAND_TRUST_HALT = "HALT: completion-gate verifier files"
 
-# `command` must be a non-empty STRING; _validate_criterion_schema rejects a
-# list ("criterion {name!r}: command must be a non-empty string"). An earlier
-# revision used ["true"] here, which could never have reached dispatch
-# (Copilot review, PR #5329).
+# Must satisfy _validate_criterion_schema in full, not merely parse as YAML.
+# Required: `name` (non-empty str), `verification: command`, `command` (non-empty
+# STRING; a list raises "command must be a non-empty string"), and exactly one of
+# `pass_when` / `pass_when_python`. An earlier revision used ["true"] with no
+# `verification` key, so every run died at schema validation and no case that
+# asserts on a LATER stage (command trust, dispatch) could observe that stage at
+# all. Found by mutation: removing the work-tree anchor left the bypass case
+# failing on a schema error rather than on the boundary under test.
 _CONFIG_BODY = """completion_criteria:
   - name: placeholder
+    verification: command
     command: "true"
+    pass_when: "exit_code == 0"
 """
+
+
+def _git_init(path: Path) -> None:
+    """Make `path` a real git work tree.
+
+    An empty ``.git`` directory is not enough: ``_consumer_work_tree`` shells
+    out to ``git rev-parse --show-toplevel``, which reports
+    "fatal: not a git repository" for one. Verified before relying on it.
+    """
+    subprocess.run(
+        ["git", "init", "--quiet"], cwd=path, check=True,
+        capture_output=True, text=True,
+    )
 
 
 def _install_plugin(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -99,7 +121,8 @@ def _install_plugin(tmp_path: Path) -> tuple[Path, Path, Path]:
     bundled_config.write_text(_CONFIG_BODY, encoding="utf-8")
 
     user_repo = tmp_path / "user_repo"
-    (user_repo / ".git").mkdir(parents=True)
+    user_repo.mkdir(parents=True)
+    _git_init(user_repo)
     return plugin_root, bundled_config, user_repo
 
 
@@ -295,4 +318,111 @@ def test_symlink_out_of_the_plugin_root_is_not_install_trusted(
     )
 
     assert _CONFIG_TRUST_HALT in result.stderr, result.stderr
+    assert result.returncode != 0, result.stdout
+
+
+def test_a_pr_created_nested_claude_cannot_relocate_the_trust_boundary(
+    tmp_path: Path,
+) -> None:
+    """The second bypass Copilot found on PR #5329, pinned.
+
+    ``_resolve_project_root`` falls back to the nearest ancestor of the cwd
+    holding ``.claude`` OR ``.git``, and PR content can create a ``.claude``
+    directory. With the host started in ``repo/subdir`` and the PR adding
+    ``repo/subdir/.claude``, ``_PROJECT_ROOT`` becomes ``repo/subdir``, so a
+    declared root of ``repo/.claude`` is neither above nor below it. A
+    disjointness test anchored on ``_PROJECT_ROOT`` therefore passed, and a
+    wholly PR-controlled config became install-trusted (CWE-829).
+
+    ``_install_trusted_root`` now anchors on ``git rev-parse --show-toplevel``,
+    which PR content cannot move. Reproduced end to end before the fix: the
+    config-trust halt was absent (verification skipped) and execution reached
+    command trust.
+
+    Asserted here on the containment refusal rather than on the absence of a
+    halt string. Once install trust is correctly withheld the run fails
+    EARLIER, at work-tree containment, so an absence-only assertion would pass
+    for the wrong reason.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git_init(repo)
+
+    # PR-controlled, inside the real work tree.
+    declared_root = repo / ".claude"
+    (declared_root / "commands").mkdir(parents=True)
+    config = declared_root / "commands" / "pr-review-config.yaml"
+    config.write_text(_CONFIG_BODY, encoding="utf-8")
+
+    # The nested .claude the malicious PR adds, in the directory the host
+    # starts from. This is what used to relocate _PROJECT_ROOT.
+    subdir = repo / "subdir"
+    (subdir / ".claude").mkdir(parents=True)
+
+    installed = tmp_path / "plug" / "skills" / "github" / "scripts" / "pr"
+    installed.mkdir(parents=True)
+    shutil.copy2(_SCRIPT, installed / "run_completion_gate.py")
+
+    env = dict(os.environ)
+    env.pop("COPILOT_PLUGIN_ROOT", None)
+    env["CLAUDE_PLUGIN_ROOT"] = str(declared_root)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(installed / "run_completion_gate.py"),
+            "--pull-request",
+            "1",
+            "--config",
+            str(config),
+        ],
+        cwd=subdir,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+
+    assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
+    # Never reached command trust, so no criterion could have run. With the
+    # bypass present this string WAS produced.
+    assert _COMMAND_TRUST_HALT not in result.stderr, result.stderr
+    assert result.returncode == 2, (result.returncode, result.stderr)
+
+
+def test_install_trust_fails_closed_outside_a_git_work_tree(
+    tmp_path: Path,
+) -> None:
+    """No establishable work tree means no install trust.
+
+    ``_consumer_work_tree`` returns ``None`` when git cannot report a
+    toplevel. Nothing can then be shown to lie outside PR-controlled
+    content, so install trust must be withheld rather than granted by
+    default. The layout is otherwise the valid one from ``_install_plugin``,
+    so the only difference from the passing case is the missing work tree.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+    # Remove the marker that makes this look like a work tree. git then
+    # reports no toplevel for this cwd.
+    shutil.rmtree(user_repo / ".git")
+
+    # Precondition, not decoration. If TMPDIR happened to sit inside a
+    # repository, git would walk up and report ITS toplevel, install trust
+    # would be evaluated normally, and the assertions below would pass for
+    # a reason unrelated to the fail-closed branch under test.
+    probe = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=user_repo, capture_output=True, text=True, check=False,
+    )
+    assert probe.returncode != 0, (
+        f"cwd is inside a work tree at {probe.stdout.strip()!r}; "
+        "this case cannot exercise the fail-closed branch"
+    )
+
+    result = _run_gate(
+        plugin_root, config, user_repo, env_var="CLAUDE_PLUGIN_ROOT",
+    )
+
+    assert _CONTAINMENT_REFUSAL in result.stderr, result.stderr
     assert result.returncode != 0, result.stdout

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -57,26 +57,35 @@ defect. ``_install_plugin`` now builds a real work tree WITH
 ``refs/remotes/origin/main``, which the install-trusted path requires like any
 other; the version that lacked one passed only because the ref check was being
 skipped, and that skip was itself the security defect (Copilot review,
-PR #5329). And the criterion here names ``printf``, which resolves to a path
-inside the work tree that is not a file, so ``_classify_argv_token`` returns
-``_ARGV_SKIP`` and there is no work-tree file to byte-compare.
+PR #5329). And the criterion runs this interpreter by absolute path, which is a
+real file OUTSIDE the work tree, so ``_classify_argv_token`` returns
+``_ARGV_EXTERNAL``: recorded in ``skipped_external_files`` and not
+byte-compared. The end-to-end case asserts that classification rather than
+describing it.
 
-That second fact is stated the way it is because an earlier version of this
-paragraph got it wrong in a specific way worth naming. It said ``printf`` was
-classified as EXTERNAL, reasoning from "it is a bare interpreter name, so it
-must be outside the tree". Reading ``_classify_argv_token`` shows
-``_ARGV_EXTERNAL`` requires a resolved path outside the tree that IS a file;
-a bare name that resolves to nothing takes the ``_ARGV_SKIP`` branch instead.
-The refutation was already in this file's own end-to-end payload, where
-``skipped_external_files`` is empty, and I did not read it. Both branches
-refuse to compare, so nothing was broken, but the claim would have misled the
-next person reasoning about which tokens get verified.
+Two corrections are folded into that sentence, both worth naming because each
+was a claim about behavior made without reading the branch.
+
+The command used to be ``printf``, and this paragraph claimed it was classified
+EXTERNAL, reasoning from "it is a bare interpreter name, so it must be outside
+the tree". That was wrong: ``_ARGV_EXTERNAL`` requires a resolved path outside
+the tree that IS a file, while a bare name resolves inside the tree to nothing
+and takes ``_ARGV_SKIP``. The refutation sat in this file's own payload, where
+``skipped_external_files`` was empty. Nothing was broken, since both branches
+decline to compare, but the description was backwards.
+
+``printf`` was then replaced outright because it is POSIX-only and the case
+failed on a Windows checkout. Windows CI runs only ``-m windows_path`` and this
+file carries no marker, so that break would have reached a contributor rather
+than a gate. Running the interpreter instead is portable AND lands on the
+external branch the earlier prose only claimed to cover.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -115,22 +124,27 @@ _COMMAND_TRUST_HALT = "HALT: completion-gate verifier files"
 # asserts on a LATER stage (command trust, dispatch) could observe that stage at
 # all. Found by mutation: removing the work-tree anchor left the bypass case
 # failing on a schema error rather than on the boundary under test.
-# The criterion emits a JSON object and pass_when reads a key out of it, so a
-# run that reaches dispatch is observable in the payload rather than inferred
-# from an exit code. `printf` resolves to <cwd>/printf, which is INSIDE the
-# work tree and is not a file, so _classify_argv_token returns _ARGV_SKIP and
-# there is no work-tree file to byte-compare. Not _ARGV_EXTERNAL: that branch
-# needs a resolved path OUTSIDE the tree that IS a file, so
-# `command_trust.skipped_external_files` stays empty here. An earlier comment
-# claimed external; the payload in this file's own end-to-end case shows the
-# list empty, which was the evidence against it sitting in plain sight
-# (Copilot review, PR #5329).
+#
+# The criterion runs THIS interpreter rather than a shell builtin. An earlier
+# revision used `printf`, which is POSIX-only, so the case failed on a Windows
+# checkout before producing any payload (Copilot review, PR #5329). Windows CI
+# runs only `-m windows_path` and this file carries no such marker, so the
+# breakage would have hit a contributor's local run rather than a gate.
+#
+# Quoting round-trips because both sides use shlex: shlex.quote here,
+# shlex.split in _format_command, and the spawn is a list with no shell, so an
+# interpreter path containing spaces or backslashes survives on any platform.
+#
 # `true` (YAML/Python) is not a pass_when literal; the evaluator wants `true`
 # lowercase, and `True` raises "Unrecognized literal in pass_when".
-_CONFIG_BODY = """completion_criteria:
+_GATE_RAN_PROGRAM = 'import json,sys;sys.stdout.write(json.dumps({"gate_ran": True}))'
+_CRITERION_COMMAND = (
+    f"{shlex.quote(sys.executable)} -c {shlex.quote(_GATE_RAN_PROGRAM)}"
+)
+_CONFIG_BODY = f"""completion_criteria:
   - name: placeholder
     verification: command
-    command: "printf '{\\"gate_ran\\": true}'"
+    command: {json.dumps(_CRITERION_COMMAND)}
     pass_when: "gate_ran == true"
 """
 
@@ -393,10 +407,18 @@ def test_the_bundled_config_runs_its_criteria_end_to_end(tmp_path: Path) -> None
     assert criterion["passed"] is True
     assert criterion["exit_code"] == 0
     assert criterion["stdout_json"] == {"gate_ran": True}
-    # `printf` takes the _ARGV_SKIP branch, NOT _ARGV_EXTERNAL: it resolves
-    # inside the work tree and is not a file. Pinned because the reverse was
-    # asserted in prose here and stood for several revisions.
-    assert payload["command_trust"]["skipped_external_files"] == []
+    # Classification is pinned, not narrated. The interpreter is an absolute
+    # path to a real file OUTSIDE the work tree, which is exactly the
+    # _ARGV_EXTERNAL branch: recorded, not byte-compared. `checked_files`
+    # stays empty because no argv token resolves to a work-tree file.
+    #
+    # An earlier revision ran `printf` and claimed in prose that it was
+    # classified external. It was not: a bare name resolves INSIDE the tree
+    # to nothing, which is _ARGV_SKIP, and the list was empty. Asserting the
+    # list is what stops prose and behavior drifting apart again.
+    external = payload["command_trust"]["skipped_external_files"]
+    assert len(external) == 1, external
+    assert not Path(external[0]).is_relative_to(user_repo.resolve()), external
     assert payload["command_trust"]["checked_files"] == []
 
 


### PR DESCRIPTION
## Summary

Implements **Option 1** of issue #5112, as decided by the repo owner. Six files, **+2472/-89**, across 14 commits (11 authored, plus three merges of `main` into the branch).

Read the security section first. Automated review found **eight** defects in this change after it passed every local gate, four of them trust-boundary bypasses, and one of those defeated this PR's own central claim. All are fixed and each was reproduced before and after.

### What

A completion-gate config that resolves inside a host-declared plugin root (`COPILOT_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT`) whose tree is **disjoint from the consumer's git work tree** becomes a second trusted *origin*. The byte-identity check against the trusted ref is skipped for it. Everything else about the trust model is unchanged, including validation of the trust anchor itself.

### Why

`resolve_pr_review_config()` in the pr-review command offers plugin roots as config sources, but the gate refused any `--config` outside `_PROJECT_ROOT`. An installed `/pr-review` landing on the bundled copy could not dispatch **at all**: it halted before the trust check ran, so the config was *unreachable* rather than *untrusted*. Relaxing containment alone would not fix it either, because `_verify_config_trust` would then return `git-error` (the config is outside the work tree, so the trusted ref has no copy to compare against), and `git-error` is deliberately not overridable. Hence an origin claim rather than a verification outcome.

## Specification References

| Type | Reference | How this PR relates |
|:-----|:----------|:--------------------|
| Issue | #5112 | Implements Option 1. Does not close it; see the closing-keyword note below. |
| Issue | #5099 | Adjacent, untouched. Tracks widening the same boundary to the verifier scripts and dispatcher, plus the ADR-059 amendment. |
| Spec | ADR-059 | The trust model this extends. An amendment writing the model down once is queued on #5099 and deliberately not authored here. |
| Spec | ADR-035 | Exit-code contract. Load-bearing here: a failed git probe is exit 3, not 2. |

## Changes

- **`.claude/skills/github/scripts/pr/run_completion_gate.py`** (+587/-41): the feature and the fixes. Adds `TRUST_INSTALL_TRUSTED`, `_PLUGIN_ROOT_ENV_VARS`, `_install_trusted_root()`, `_consumer_work_tree()`, `_host_declared_roots()`, `_are_disjoint()`, `_absolute_config_candidate()`, `_require_remote_tracking_ref()`, `_resolve_or_none()`, and the `InstallTrust`, `ResolvedConfig` and `WorkTreeUnavailableError` types.
- **`src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py`** (+587/-41): generated mirror, verified byte-identical with `diff -q` after every regeneration, produced by running the library sync before the plugin build (that order matters; the reverse leaves a stale mirror and both steps still exit 0).
- **`tests/skills/github/test_run_completion_gate.py`** (+661/-0): five new classes covering the helper's conditions, the trust short-circuit, path consistency, work-tree probe failure, and trust-anchor validation.
- **`tests/test_run_completion_gate_install.py`** (+571/-3): 1 test to 13, executing a bundled config end to end in a real installed-plugin layout with a real trust anchor.
- **`.claude/commands/pr-review.md`** (+33/-2): reverses the "reference artifact, not a runnable completion-gate config" stance and records the three limits, including that a root must be disjoint from the work tree rather than merely "outside" it.
- **`src/copilot-cli/skills/pr-review/SKILL.md`** (+33/-2): generated mirror of the above.

Neither mirror is hand-edited.

## Security: eight defects found by review, after every local gate passed

Each was reproduced before the fix and re-verified after. Findings 1, 2, 5, 6 and 8 were latent in the original design and surfaced over successive review rounds. Findings 3, 4 and 7 were introduced by fixes to earlier findings, and finding 3 defeated the fix for finding 2 outright, which is the part worth weighing: each repair narrowed the reviewer's attention to the thing just changed, and the next defect was next to it.

### 1. The environment root became part of the path read (Semgrep, fixed in `0948d2430`)

`validate_safe_path` builds its result as `(resolved_base / path).resolve()`, so passing the declared root as that base made the root a component of the path **read**, not merely the boundary it is **checked against**. For a relative `--config` the path authorized was not the path read. The root is now deny-only: it can refuse a config, never construct one.

### 2. An ancestor root install-trusted the whole repo (Copilot, fixed in `a12ae1645`)

Condition 3 tested only that the declared root is not *below* the project. An **ancestor** passes that one-way test while containing every PR-controlled file in the repo. Reproduced: declared root `/home/user`, project at `/home/user/ai-agents`, and a PR-written config became install-trusted, skipping verification (CWE-829). Now disjoint in both directions, via `_are_disjoint`.

### 3. A PR-created nested plugin directory relocated the boundary (Copilot, fixed in `60336e6ea`)

This one defeated fix 2. `_resolve_project_root` stops at the nearest ancestor holding a plugin directory, so a PR that adds one in a subdirectory moves `_PROJECT_ROOT`, and a wholly PR-controlled root then looks *disjoint*. Reproduced end to end: the config-trust halt was absent and the run dispatched the criterion. The boundary now derives from `git rev-parse --show-toplevel`, which PR content cannot move, and fails closed when git cannot report one.

### 4. A failed git probe reported the wrong cause, and a timeout escaped (Copilot, fixed in `ffcaae7fe`)

`subprocess.TimeoutExpired` is not an `OSError` (MRO: `TimeoutExpired -> SubprocessError -> Exception`), so a git hang escaped as an unhandled traceback; the module's two other guarded callers already caught the pair. And returning a sentinel collapsed "the work tree could not be established" into "no install trust", exiting 2 and naming the config path when the path was fine. Per ADR-035 an external git failure is exit 3, non-overridable.

### 5. An install-trusted config left `--trusted-ref` wholly unvalidated (Copilot, High, fixed in `52c62f339`)

**This one defeats the "the command boundary is not widened" claim this PR makes.** Both guards on the ref sat on the path install trust skips: the regex inside `_enforce_config_trust` after the short-circuit, and the `refs/remotes/*` requirement inside `_verify_config_trust`, which install trust never calls. `_enforce_command_trust` repeats neither and consumes the ref anyway.

Reproduced against an installed layout whose "PR" commit had modified a verifier the config names:

```
=== --trusted-ref HEAD under install trust ===
FAIL   c
       command: ./verify.sh
       stdout: {ok: true}
       stderr: PWNED        <-- the PR-modified verifier EXECUTED
```

Command trust compared `verify.sh` against the PR's own commit, matched, and dispatched. An option-shaped ref likewise reached a git invocation, which is the argument-injection surface the regex exists to close.

Ref validation now runs **before** the short-circuit, and the install branch enforces `refs/remotes/*` directly in the work tree the install decision was made against. The regex admits `HEAD`, so the regex alone does not close this; the remote-tracking requirement is what does. Extracted as `_require_remote_tracking_ref` with both call sites on it, because the two paths diverging on the same requirement is exactly how this happened.

Re-verified after the fix, including the control that matters:

```
A  --upload-pack=...   rc=2  Refusing malformed --trusted-ref
B  HEAD                rc=3  must resolve to a remote-tracking ref, got refs/heads/master
C  origin/main         HALT: completion-gate verifier files differ from origin/main
                             Untrusted files: verify.sh
```

C proves the legitimate path still reaches command trust and still catches the PR-modified verifier. The fix closes the hole without disabling the check that was being bypassed.

### 6. The config was resolved twice (Copilot, CWE-367, fixed in `52c62f339`)

Once to decide containment, once to read. A repo-controlled symlink swapped between the two resolves inside the root for the decision and outside it for the read, with verification still skipped. `_install_trusted_root` now returns `InstallTrust(root, config_path, work_tree)` and the reader reuses the approved path. Preserving beats re-checking: a repeated containment check is itself two resolutions with a gap.

### 7. resolve() does not raise one exception family across versions (Copilot, fixed in `bb9badf7a`)

On a symlink loop, CPython 3.10, 3.11 and 3.12 raise `RuntimeError` out of `pathlib`; 3.14 returns the unresolved path without raising. `RuntimeError` is not an `OSError`, so every `except OSError` guard around a `resolve()` in this module let the loop escape as an unhandled traceback on exactly the interpreters the hook-portability floor targets. Skill scripts run under the host's ambient interpreter, so this ships.

Measured, because it cannot be reproduced here:

```
$ grep -rn "RuntimeError" /usr/lib/python3.1{0,1,2}/pathlib.py
3.10:1074  raise RuntimeError("Symlink loop from %r" % e.filename)
3.11:990   raise RuntimeError("Symlink loop from %r" % e.filename)
3.12:1239  raise RuntimeError("Symlink loop from %r" % e.filename)
$ python3.14  -> returned the path, no raise
```

Normalized into `_resolve_or_none` so the four call sites cannot drift apart on the same trap. Writing the regression surfaced a site the finding did not name: `validate_safe_path` resolves unguarded, so the non-install path had the same hole. Caught at this module's call site; the shared helper is left alone and flagged below.

### 8. A false claim about argv classification (Copilot, fixed in `bb9badf7a`)

I wrote that `printf` is classified `_ARGV_EXTERNAL`. It is `_ARGV_SKIP`: `_ARGV_EXTERNAL` requires a resolved path outside the work tree that IS a file, and a bare name resolves inside the tree to nothing. No behavior was wrong, but the claim would have misled anyone reasoning about which tokens get verified.

The part worth recording: the refutation was already in evidence I had pasted into this very PR, where `skipped_external_files` is `[]`, and I did not read it. The end-to-end case now asserts that list is empty rather than narrating it.

## The four conditions, each load-bearing

`_install_trusted_root` returns a root only when all hold:

1. `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` is set and non-empty. An unset environment changes nothing and makes no git subprocess call.
2. It resolves to an existing directory.
3. Its tree, the **git work tree**, and the project tree are **disjoint**, checked in both directions. No establishable work tree exits 3.
4. The **resolved** config is inside the root, and that resolved path is what gets read.

**The command boundary is not widened.** Ref validation applies on every path, and `_enforce_command_trust` still verifies every work-tree file the criteria name. Defect 5 above is what it took to make that sentence true.

## Acceptance criteria

- [x] An installed `/pr-review` with a bundled config dispatches its criteria, not merely passes containment
- [x] The in-repo plugin-directory fallback keeps the full byte-identity check
- [x] A root that is an ancestor of the repo does not install-trust
- [x] A PR-created nested plugin directory cannot relocate the trust boundary
- [x] Install trust exits 3 when the work tree cannot be established
- [x] A symlink escaping the plugin root does not install-trust
- [x] The path install trust approves is the path that is read
- [x] The trust anchor is validated on the install-trusted path, including the remote-tracking requirement
- [x] The command-trust boundary is unchanged
- [x] The environment-declared root can deny but never construct a config path
- [x] The change lands in both trees via the generator, not by hand-editing the mirror

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [x] Documentation update

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

**172 pre-existing tests unchanged and passing; 39 new; 211 total.** The install-layout file went from 1 test to 13. Counts come from `--collect-only` on the current head and on `origin/main` in a detached worktree, not from `grep -c "def test_"`, which undercounts parametrized cases. These figures went stale twice during review; they are re-measured at each body edit rather than incremented.

### Four assertions that could not fail, and one fixture that hid a guard, all mine

Worth reading, because in each case the test actively certified the opposite of what it claimed.

`"install-trusted" not in result.stderr` could never fail: the status reaches the stdout JSON payload and is never written to stderr. Replaced with `HALT: completion-gate config`, falsifiable in both directions.

`test_a_root_that_is_not_a_directory_is_ignored` placed the config outside the declared root, so containment refused it and `is_dir()` was never observed. It now names a config inside a root that is a regular **file**, which `Path.resolve()` happily contains.

`test_empty_and_whitespace_values_are_ignored` cannot observe `.strip()` at all, since whitespace-only survives it as a relative non-directory. Kept, and paired with a discriminating twin on a real root carrying stray spaces.

`test_install_root_proceeds_without_git_verification` asserted that git must **never** run for an install-trusted config, and stubbed `_run_git` to raise. That contract was wrong and the assertion enforced the wrong thing: the trust anchor still has to be validated. It now asserts the exact call list, so both a leaked `cat-file` and a missing anchor check fail it.

And one fixture: `_install_plugin` created no `refs/remotes/origin/main`, so it satisfied the anchor guard exclusively when that guard was absent.

### Mutation results

`__pycache__` cleared between every mutation and rerun (testing rule SHOULD 8), patch application confirmed with `cmp -s` against a backup, byte-identical restore verified after each.

| mutation | expected | result | killed |
|:---|:---|:---|:---|
| drop the work-tree disjointness check | DEAD | DEAD | nested-plugin-dir bypass |
| fail open when no work tree | DEAD | DEAD | fail-closed case |
| report the probe failure as exit 2 | DEAD | DEAD | 4 cases |
| make every resolution failure exit 3 | DEAD | DEAD | 7 cases |
| drop `TimeoutExpired` from the except | DEAD | DEAD | as an unhandled traceback |
| re-anchor the read on `validate_safe_path` | DEAD | DEAD | path-consistency case |
| yield a non-directory root | DEAD | DEAD | is-not-a-directory case |
| drop `.strip()` on the variable | DEAD | DEAD | whitespace case |
| never grant install trust | DEAD | DEAD | 3 cases |
| report install trust as plain `trusted` | DEAD | DEAD | end-to-end case only |
| restore the pre-fix short-circuit order | DEAD | DEAD | 3 cases |
| drop the `refs/remotes/` requirement | DEAD | DEAD | 4 cases |
| re-resolve instead of reusing | DEAD | DEAD | resolution-count case |
| drop `RuntimeError` from `_resolve_or_none` | DEAD | DEAD | as an unhandled traceback |
| return `_ARGV_EXTERNAL` for a non-file | DEAD | DEAD | 3 cases |
| behavior-preserving edit | SURVIVED | SURVIVED | inverted control |

Three of these SURVIVED on first run, and each was a finding about my tests rather than the code (testing rule SHOULD 17: a probe that cannot fail is not a passing probe). The non-directory and `.strip()` cases could not observe the conditions they were named for. The re-resolve mutant survived because re-resolving returns the same path in a non-adversarial fixture, so every existing case passed against the unfixed version; the replacement injects the swap at the only place a second resolution can occur and asserts the resolution **count**, so the mutant now fails on `assert 2 == 1`.

The inverted control is there because a harness whose mutants are all one polarity cannot distinguish "every mutant died" from "the harness fails no matter what" (testing rule MUST 11).

### A CI failure worth recording

`pytest (bulk-nested)` went red on `349050a7c` while a parallel run of the same job went green. Reproduced locally and deterministically, so not a flake: `test_scripts_validate_github_core_before_trusting` selects "bootstrap scripts" by `"_plugin_root" in f.read_text()`, and a helper I named `_declared_plugin_roots` matched that fragment by accident. This module reads those variables to decide config trust and never puts a plugin root on `sys.path`, so it has no `_plugin_root` variable and the literal the guard demands would be dead code. Renamed to `_host_declared_roots`, with the reason in its docstring. The guard is left exactly as strong as it was.

Other gates green: `ruff check`, the ADR lifecycle check, both vendor-portability ratchets, the generated-staleness check, and the taste count ratchet (at baseline). The full lefthook pre-push suite is green on every pushed commit, including `pre-pr-validation`, `python-tests`, `security-scan`, and `plugin-load-e2e`.

## Agent Review

### Security Review

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed authentication/authorization changes

**This moves a trust boundary and should be read as such.** The residual is recorded in the code rather than claimed closed: an actor who can already edit the workflow that invokes this gate can both set these variables and write the directory they name. That actor can run arbitrary commands in the same workflow, so it is a strictly smaller capability than they already hold.

The record above is the argument for a careful human read before this merges. Every local gate passed on the first version, and on each subsequent one; eight defects still got through, four of them bypasses, and three were introduced by fixes to earlier findings. The functions to read closely are `_install_trusted_root`, `_consumer_work_tree`, `_require_remote_tracking_ref`, `_resolve_and_read_config`, and the short-circuit in `_enforce_config_trust`.

### Other Agent Reviews

- [x] Critic validated implementation plan

All 24 review threads have a per-finding response and are resolved.

- [ ] Architect reviewed design changes

Not convened. The `adr-review` gate did not fire because no ADR was edited: the ADR-059 amendment is queued on #5099 and writing it here would duplicate that decision. Given that defect 5 changed where trust-anchor validation happens, an architect read of that amendment when it lands would be worthwhile.

## Author Pre-flight

- [x] Pre-PR validation passed (as `pre-pr-validation` in the pre-push suite)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated
- [x] No new warnings introduced

## Notes for the reviewer

**A correction to my own triage on #5112.** That comment claimed the symlink refusal fires *ahead* of the containment check for `_direct/` install layouts. **That was wrong.** `_first_symlinked_component` skips every component not within `_PROJECT_ROOT`, so it returns `None` for an out-of-tree config and never fires.

**Local Semgrep could not reproduce its own finding.** `semgrep 1.173.0` OSS with the same rule reports 0 findings on the *pre-fix* file as well; the cloud scan runs Pro interfile taint analysis. I did not claim the fix cleared the check until the check itself re-ran green.

**Independent review is thinner than this change deserves.** Codex and Cursor Bugbot are both out on usage limits, Devin's trial is expired, and CodeRabbit is excluded by label, leaving Copilot's reviewer as the only substantive one running. It found seven of the eight across six rounds, four of them bypasses.

**One suppression added, declared.** The install-layout suite crossed 500 lines and took the taste ratchet to 576 against baseline 575. Raising the baseline would loosen the gate repo-wide to accommodate one file, so it carries a reasoned `# taste-lint: ignore file-size` instead, the mechanism the ratchet itself offers (issue #3779) and the same declaration `tests/skills/github/test_why_pr_blocked.py` carries for the same shape. Push back if you would rather see the file split.

**`needs-split` is on this PR and does not block it.** `scripts/validation/pr_commit_count.py:73-75` states the thresholds are advisory only and that neither blocks a push or a merge (issue #5233). 11 authored commits is over the warning threshold of 10 because each review round landed as its own commit rather than being folded into earlier ones, which I judged more useful to read than a squashed history. The merge is a squash anyway.

**Three things I flagged but did not fix, all out of scope.** `validate_safe_path` in `scripts/utils/path_validation.py:55` resolves unguarded and has the same `RuntimeError` hole as finding 7; many scripts call it, so that fix wants its own change and its own review. The bootstrap guard's selector is a bare substring match on `_plugin_root`, so any identifier containing that fragment is pulled into its scope; tightening it affects 40-plus scripts and does not belong in this PR. And three complexity findings in the gate script (`_eval_node` 15, `_validate_criterion_schema` 13, `main` 12) predate this branch; `_install_trusted_root` briefly joined them at 11 and was brought back under the limit in `d37ebafe3`.

Refs #5112

These references do not close their linked items: #5112 offers two mutually exclusive options and this PR implements one of them, but the issue also carries the install-layout test ask (done here) alongside the ADR-059 amendment that #5099 owns. Closing is yours once you are satisfied Option 1 is the settled answer.