### PR TITLE
fix(github): correct the missing-PyYAML remediation and pin the contract

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -36,14 +36,16 @@ because a directory marker inside the repository can be created by the PR and
 therefore cannot anchor trust. If the work tree cannot be established, no root
 install-trusts anything and the gate exits 3.
 
-**Runtime prerequisite.** The gate parses YAML, so the environment that
-`uv run python` resolves to must carry PyYAML. The plugin declares no
-dependencies, so a clean consumer environment may not. This is not new (the
-gate has always parsed YAML) but it becomes reachable now that an installed
-`/pr-review` can dispatch at all. The failure is clean rather than silent:
-exit 2 with `PyYAML is required to parse the completion-gate config; install
-it via 'pip install pyyaml'`. It is never reported as a criterion failure,
-because an unparseable config is not a gate verdict.
+**Runtime prerequisite.** The gate parses YAML, and the plugin declares no
+dependencies, so a clean consumer environment may lack PyYAML. Not new (the
+gate has always parsed YAML), but reachable now that an installed
+`/pr-review` can dispatch. The failure is clean, never a criterion failure:
+exit 2, `PyYAML is required to parse the completion-gate config`, and the
+path of the interpreter that failed. Install into THAT interpreter. The
+invocation below uses `uv run python`, so the environment is the consumer
+project's and `uv run --with pyyaml python ...` is the form that works; a
+bare `pip install pyyaml` can modify an environment the next run never
+consults, leaving the failure unchanged.
 
 Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
 in the list below gets NO such treatment even if a plugin-root variable points

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -36,6 +36,15 @@ because a directory marker inside the repository can be created by the PR and
 therefore cannot anchor trust. If the work tree cannot be established, no root
 install-trusts anything and the gate exits 3.
 
+**Runtime prerequisite.** The gate parses YAML, so the environment that
+`uv run python` resolves to must carry PyYAML. The plugin declares no
+dependencies, so a clean consumer environment may not. This is not new (the
+gate has always parsed YAML) but it becomes reachable now that an installed
+`/pr-review` can dispatch at all. The failure is clean rather than silent:
+exit 2 with `PyYAML is required to parse the completion-gate config; install
+it via 'pip install pyyaml'`. It is never reported as a criterion failure,
+because an unparseable config is not a gate verdict.
+
 Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
 in the list below gets NO such treatment even if a plugin-root variable points
 at it: that path is written by the checked-out PR and keeps the full trust

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -404,9 +404,16 @@ def _load_config_bytes(raw: bytes, path: Path) -> dict[str, Any]:
     could not be parsed".
     """
     if not _HAVE_YAML:
+        # Name the interpreter rather than a bare `pip install`. The shipped
+        # skill invokes this through `uv run python`, which resolves to the
+        # consumer project's environment, while a bare `pip` targets whatever
+        # is first on PATH. Those can differ, so the old text could send an
+        # operator to install PyYAML somewhere the next run never looks.
         raise ConfigError(
-            "PyYAML is required to parse the completion-gate config; "
-            "install it via `pip install pyyaml`.",
+            "PyYAML is required to parse the completion-gate config; install "
+            f"it for the interpreter running this script ({sys.executable}). "
+            "Under uv that is `uv run --with pyyaml python ...`; a bare "
+            "`pip install pyyaml` may target a different environment.",
         )
     try:
         text = raw.decode("utf-8")

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -404,9 +404,16 @@ def _load_config_bytes(raw: bytes, path: Path) -> dict[str, Any]:
     could not be parsed".
     """
     if not _HAVE_YAML:
+        # Name the interpreter rather than a bare `pip install`. The shipped
+        # skill invokes this through `uv run python`, which resolves to the
+        # consumer project's environment, while a bare `pip` targets whatever
+        # is first on PATH. Those can differ, so the old text could send an
+        # operator to install PyYAML somewhere the next run never looks.
         raise ConfigError(
-            "PyYAML is required to parse the completion-gate config; "
-            "install it via `pip install pyyaml`.",
+            "PyYAML is required to parse the completion-gate config; install "
+            f"it for the interpreter running this script ({sys.executable}). "
+            "Under uv that is `uv run --with pyyaml python ...`; a bare "
+            "`pip install pyyaml` may target a different environment.",
         )
     try:
         text = raw.decode("utf-8")

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -38,14 +38,16 @@ because a directory marker inside the repository can be created by the PR and
 therefore cannot anchor trust. If the work tree cannot be established, no root
 install-trusts anything and the gate exits 3.
 
-**Runtime prerequisite.** The gate parses YAML, so the environment that
-`uv run python` resolves to must carry PyYAML. The plugin declares no
-dependencies, so a clean consumer environment may not. This is not new (the
-gate has always parsed YAML) but it becomes reachable now that an installed
-`/pr-review` can dispatch at all. The failure is clean rather than silent:
-exit 2 with `PyYAML is required to parse the completion-gate config; install
-it via 'pip install pyyaml'`. It is never reported as a criterion failure,
-because an unparseable config is not a gate verdict.
+**Runtime prerequisite.** The gate parses YAML, and the plugin declares no
+dependencies, so a clean consumer environment may lack PyYAML. Not new (the
+gate has always parsed YAML), but reachable now that an installed
+`/pr-review` can dispatch. The failure is clean, never a criterion failure:
+exit 2, `PyYAML is required to parse the completion-gate config`, and the
+path of the interpreter that failed. Install into THAT interpreter. The
+invocation below uses `uv run python`, so the environment is the consumer
+project's and `uv run --with pyyaml python ...` is the form that works; a
+bare `pip install pyyaml` can modify an environment the next run never
+consults, leaving the failure unchanged.
 
 Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
 in the list below gets NO such treatment even if a plugin-root variable points

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -38,6 +38,15 @@ because a directory marker inside the repository can be created by the PR and
 therefore cannot anchor trust. If the work tree cannot be established, no root
 install-trusts anything and the gate exits 3.
 
+**Runtime prerequisite.** The gate parses YAML, so the environment that
+`uv run python` resolves to must carry PyYAML. The plugin declares no
+dependencies, so a clean consumer environment may not. This is not new (the
+gate has always parsed YAML) but it becomes reachable now that an installed
+`/pr-review` can dispatch at all. The failure is clean rather than silent:
+exit 2 with `PyYAML is required to parse the completion-gate config; install
+it via 'pip install pyyaml'`. It is never reported as a criterion failure,
+because an unparseable config is not a gate verdict.
+
 Three limits, because the widening is narrow. The `$repo_root/.claude` fallback
 in the list below gets NO such treatment even if a plugin-root variable points
 at it: that path is written by the checked-out PR and keeps the full trust

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3861,6 +3861,60 @@ class TestWorkTreeProbeFailure:
         assert "Refusing to load config from unsafe path" in capsys.readouterr().err
 
 
+class TestInstalledRuntimePrerequisites:
+    """What a consumer whose environment lacks PyYAML actually gets.
+
+    Copilot review, PR #5329: the shipped skill runs ``uv run python`` from
+    the consumer's cwd and the plugin declares no dependencies, so a clean
+    consumer environment may not carry PyYAML. That is a PRE-EXISTING
+    condition (this gate has always parsed YAML), but this PR is what makes
+    installed dispatch reachable at all, so the prerequisite becomes visible
+    here for the first time.
+
+    Packaging the dependency, or replacing the parser, is a plugin-wide
+    decision and is deliberately not made in this PR. What IS pinned is that
+    the failure is clean: exit 2 with an actionable message, not a traceback
+    (exit 1) and not a silently skipped criterion. A gate that cannot parse
+    its config must not look like a gate that passed.
+    """
+
+    def test_missing_pyyaml_exits_2_with_an_actionable_message(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        root = tmp_path / "plugin"
+        (root / "commands").mkdir(parents=True)
+        config = root / "commands" / "pr-review-config.yaml"
+        config.write_text("completion_criteria: []\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+        monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
+        _own_plugin_root(monkeypatch, root)
+
+        def _fake_git(args, cwd):
+            if args[:2] == ["rev-parse", "--symbolic-full-name"]:
+                return subprocess.CompletedProcess(
+                    args, 0, b"refs/remotes/origin/main\n", b"",
+                )
+            return subprocess.CompletedProcess(
+                args, 0, str(tmp_path / "consumer").encode() + b"\n", b"",
+            )
+
+        monkeypatch.setattr(_dispatcher, "_run_git", _fake_git)
+        monkeypatch.setattr(_dispatcher, "_HAVE_YAML", False)
+
+        code = _dispatcher.main(
+            ["--pull-request", "1", "--config", str(config)],
+        )
+
+        # 2, not 1: a config that cannot be parsed is a config error under
+        # ADR-035. Exit 1 is reserved for "a criterion failed", and reporting
+        # an unparseable config that way would read as a real gate verdict.
+        assert code == 2, code
+        err = capsys.readouterr().err
+        assert "PyYAML is required" in err, err
+        # Actionable, not merely present: the operator is told what to do.
+        assert "pip install pyyaml" in err, err
+
+
 class TestInstallTrustedPathConsistency:
     """The path install-trust approves must be the path that is read.
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -3911,8 +3911,12 @@ class TestInstalledRuntimePrerequisites:
         assert code == 2, code
         err = capsys.readouterr().err
         assert "PyYAML is required" in err, err
-        # Actionable, not merely present: the operator is told what to do.
-        assert "pip install pyyaml" in err, err
+        # Actionable AND correctly targeted. Naming the interpreter is the
+        # point: the shipped skill runs this through `uv run python`, so a
+        # bare `pip install` can modify an environment the next run never
+        # consults. Raised by Copilot on PR #5331.
+        assert sys.executable in err, err
+        assert "uv run --with pyyaml" in err, err
 
 
 class TestInstallTrustedPathConsistency:

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -764,6 +764,11 @@ def test_a_consumer_without_pyyaml_exits_2_rather_than_crashing(
     # as 1 would read as a real gate verdict on a gate that never ran.
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "PyYAML is required" in result.stderr, result.stderr
+    # The remediation must name the interpreter that actually failed, not a
+    # bare `pip`. This subprocess ran under sys.executable, so that exact
+    # path appearing in stderr is what proves the message is targeted rather
+    # than merely worded well.
+    assert sys.executable in result.stderr, result.stderr
     # Absence assertion with a live positive control: the end-to-end case
     # above drives this same layout WITHOUT the overlay and reaches exit 0,
     # so a traceback here would be this overlay's doing and nothing else.

--- a/tests/test_run_completion_gate_install.py
+++ b/tests/test_run_completion_gate_install.py
@@ -210,6 +210,7 @@ def _run_gate(
     env_value: str | None = None,
     json_output: bool = False,
     trusted_ref: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     script = plugin_root / "skills" / "github" / "scripts" / "pr" / "run_completion_gate.py"
     env = dict(os.environ)
@@ -219,6 +220,8 @@ def _run_gate(
     env.pop("COPILOT_PLUGIN_ROOT", None)
     if env_var is not None:
         env[env_var] = env_value if env_value is not None else str(plugin_root)
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [
             sys.executable,
@@ -700,3 +703,68 @@ def test_install_trust_fails_closed_outside_a_git_work_tree(
     # The old exit-2 message must be GONE, not merely accompanied. A
     # positive-only assertion would pass on a run that printed both.
     assert _CONTAINMENT_REFUSAL not in result.stderr, result.stderr
+
+
+def _without_pyyaml(tmp_path: Path) -> dict[str, str]:
+    """Environment overlay that makes ``import yaml`` fail in a subprocess.
+
+    A ``sitecustomize`` module on ``PYTHONPATH`` is imported by ``site`` at
+    interpreter startup, so this lands BEFORE the dispatcher's own import
+    runs. Setting the entry to ``None`` is what CPython's import machinery
+    treats as a halted import; measured on this interpreter it raises
+    ``ImportError: import of yaml halted; None in sys.modules``, which is the
+    same exception class a genuinely absent PyYAML raises.
+
+    Prepends rather than replaces, so a PYTHONPATH the caller's environment
+    already sets is preserved.
+    """
+    blocker = tmp_path / "no_pyyaml"
+    blocker.mkdir()
+    (blocker / "sitecustomize.py").write_text(
+        "import sys\nsys.modules['yaml'] = None\n", encoding="utf-8",
+    )
+    existing = os.environ.get("PYTHONPATH")
+    path = str(blocker) if not existing else f"{blocker}{os.pathsep}{existing}"
+    return {"PYTHONPATH": path}
+
+
+def test_a_consumer_without_pyyaml_exits_2_rather_than_crashing(
+    tmp_path: Path,
+) -> None:
+    """The missing-dependency contract, exercised as a real process.
+
+    The sibling case in ``tests/skills/github/test_run_completion_gate.py``
+    monkeypatches ``_HAVE_YAML`` to False. That pins the BRANCH given the
+    flag, but not the ``try``/``except ImportError`` guard that sets it: the
+    dispatcher is already imported under the repository environment, which
+    has PyYAML, so replacing the guard with a bare ``import yaml`` leaves
+    that case green. Measured, not assumed: with the guard removed that test
+    still reported ``1 passed``.
+
+    This case cannot be fooled the same way, because the import happens
+    inside a subprocess that genuinely cannot import yaml. Under a bare
+    import the process dies at module load, which is exit 1 and a traceback,
+    and every assertion below fails.
+
+    Raised by Copilot on PR #5331. Its stated failure mode ("a clean
+    installed consumer exits with a traceback") is not what the shipped code
+    does, because the guard is present; the gap it identified in the test is
+    real regardless.
+    """
+    plugin_root, config, user_repo = _install_plugin(tmp_path)
+
+    result = _run_gate(
+        plugin_root, config, user_repo,
+        env_var="CLAUDE_PLUGIN_ROOT",
+        extra_env=_without_pyyaml(tmp_path),
+    )
+
+    # 2, not 1: a config that cannot be parsed is a config error under
+    # ADR-035, and exit 1 is reserved for "a criterion failed". Reporting it
+    # as 1 would read as a real gate verdict on a gate that never ran.
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "PyYAML is required" in result.stderr, result.stderr
+    # Absence assertion with a live positive control: the end-to-end case
+    # above drives this same layout WITHOUT the overlay and reaches exit 0,
+    # so a traceback here would be this overlay's doing and nothing else.
+    assert "Traceback" not in result.stderr, result.stderr


### PR DESCRIPTION
## Summary

Follow-up to #5329, which merged as `dda522378` while this was in flight. Four commits, six files, **+171/-4**.

Started as a single test pinning the missing-PyYAML contract. Copilot review then found two real defects in that test and in the message it asserted, so the PR now also corrects the shipped error text. Both rounds are described below rather than folded away, because the second round found a defect in the fix to the first.

### Round 1 (`d0ca328c0`): the original finding

The shipped skill runs `uv run python` from the consumer's cwd (`SKILL.md:162`), the plugin declares no dependencies, and the gate raises `PyYAML is required` when the module is absent. A clean consumer environment can fail before dispatch while #5329's end-to-end case passes, because the ai-agents venv supplies PyYAML.

Verified each half rather than taking the report on faith: the raise exists in `_load_config_bytes`, no requirements or pyproject ships under `src/copilot-cli`, and `SKILL.md` does invoke `uv run python`.

### Round 2 (`24627b23b`): the test could not detect its own bug

Copilot: the round-1 test monkeypatches `_HAVE_YAML = False`, which pins the branch *given* the flag but not the `try`/`except ImportError` guard that sets it.

Confirmed by mutation, not by reading. Replacing the guard with a bare `import yaml` and rerunning reported `1 passed`. **SURVIVED.**

The replacement runs the copied shipped dispatcher as a subprocess whose interpreter genuinely cannot import yaml, via a `sitecustomize` on `PYTHONPATH` setting `sys.modules["yaml"] = None`. That mechanism was verified against a control before use:

```
--- with block ---    ImportError: import of yaml halted; None in sys.modules
--- without block --- imported ok, version 6.0.3
```

Under the same mutation the new case **fails** with exit 1 and `ModuleNotFoundError` at module load. It discriminates where the old one could not.

**One correction to that report.** It stated a clean consumer "exits with a traceback before `main()`". It does not: the guard at `run_completion_gate.py:335` is present, so absence yields exit 2 and a clean message. The gap in the *test* was real; the claim about current behavior was not. Implementing the sentence as written would have meant adding a guard that already exists.

### Round 2 (`25e4c4d02`, `e22fdc414`): the remediation pointed at the wrong environment

Copilot: `pip install pyyaml` is unreliable here, because `uv run python` resolves to the consumer project's environment while a bare `pip` targets whatever is first on PATH.

This was worse than wording. The round-1 test asserted the message was **actionable**; a remediation that can send the operator elsewhere does not meet that claim. The test and the message were wrong together.

The message now names `sys.executable`, which is correct however the script was invoked:

```
PyYAML is required to parse the completion-gate config; install it for the
interpreter running this script (/home/user/ai-agents/.venv/bin/python3).
Under uv that is `uv run --with pyyaml python ...`; a bare `pip install
pyyaml` may target a different environment.
```

Rendered from the shipped code. The bare-pip form is kept as an explicit caveat rather than deleted, since an operator on a system Python still reaches for it.

## Specification References

| Type | Reference | How this PR relates |
|:-----|:----------|:--------------------|
| Issue | #5112 | Follow-up to the Option 1 implementation merged in #5329. Does not close it. |
| PR | #5329 | Merged as `dda522378`. This carries over its last review finding. |
| Spec | ADR-035 | Exit-code contract. Load-bearing: an unparseable config is 2, never 1. |

## Changes

- **`tests/test_run_completion_gate_install.py`** (+73): `_without_pyyaml` overlay and a subprocess case asserting exit 2, the message, the interpreter path, and no traceback. `_run_gate` gains an `extra_env` parameter.
- **`tests/skills/github/test_run_completion_gate.py`** (+58): `TestInstalledRuntimePrerequisites`, kept as the cheap branch-level pin, with assertions retargeted from `pip install pyyaml` to `sys.executable` and `uv run --with pyyaml`.
- **`.claude/skills/github/scripts/pr/run_completion_gate.py`** (+10/-2): the remediation text.
- **`.claude/commands/pr-review.md`** (+11): the runtime prerequisite and how to install into the right interpreter.
- Two generated mirrors under `src/copilot-cli/`. Regenerated, not hand-edited.

## What this deliberately does not do

**It does not package the dependency, and it does not replace the parser.** Copilot suggested `uv run --with pyyaml python` in the invocation, which would make the failure impossible rather than legible. I did not take it: `--with` resolves at run time, so an offline or restricted-index consumer would newly fail at *invocation* instead of getting today's clean exit 2 at *parse*. That converts a documented prerequisite into a per-run network dependency. Owner's call, options ranked in the thread.

**It does not pretend the condition is new.** This gate has always parsed YAML. What #5329 changed is that installed dispatch became *reachable*, so the prerequisite became visible for the first time.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change adding functionality)

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

```
$ uv run --frozen pytest tests/skills/github/test_run_completion_gate.py \
                        tests/test_run_completion_gate_install.py -q
215 passed
```

Measured with `--collect-only`, not `grep -c "def test_"`, which undercounts parametrized cases. 222 pass with `tests/skills/github/test_bootstrap_fallback.py` added.

`pre_pr.py` reports `RESULT: All validations passed`. `ruff check` clean. Taste count ratchet at baseline 575. Both mirrors byte-identical to their canonical sources.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed authentication/authorization changes

No boundary moves. The trust-boundary work, and the eleven review-found defects it went through, are in #5329.

### Other Agent Reviews

- [x] Critic validated implementation plan
- [ ] Architect reviewed design changes

Not convened. Packaging the dependency would be architecture and is explicitly out of scope above.

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated
- [x] No new warnings introduced

## Notes for the reviewer

**Why a new PR rather than a push to the old one.** #5329 merged at 19:04 with head `4694e8ddb`; the first commit here came after. A merged PR cannot track new work, so the branch was restarted from `main`.

**`.claude/commands/pr-review.md` is now at 199 lines against a 200-line ceiling.** My first attempt at the doc change tripped `command-size` at 203. I tightened my own prose rather than claim a size exception, but the next addition to that file forces a choice: convert to a skill, or justify an exception.

**One item from #5329 remains open.** `semgrep-cloud-platform/scan` was red on that PR's last three heads with no finding text ever posted. It passes here, but I do not know whether that project scans the diff or the full repo, so I am not treating the pass as exoneration.

Refs #5112, Refs #5329

These references do not close their linked items: #5112 still carries the ADR-059 amendment that #5099 owns, and #5329 is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)