### PR TITLE
docs(build): fix stale line-number citations from PR #5327's final review round

### DIFF
--- a/build/model_pin_manifest.py
+++ b/build/model_pin_manifest.py
@@ -97,8 +97,8 @@ _CANONICAL_MAJOR_MINOR_RE = re.compile(
 )
 
 # The two known target shapes a platform's own ``model_tiers`` map spells its
-# tier defaults in today. See templates/platforms/copilot-cli.yaml:107-110
-# (dot form) and templates/platforms/vscode.yaml:18-21 (display form, shared
+# tier defaults in today. See templates/platforms/copilot-cli.yaml:109-112
+# (dot form) and templates/platforms/vscode.yaml:20-23 (display form, shared
 # by visual-studio.yaml). Matching against these rather than hardcoding a
 # per-platform-name template means a platform YAML's spelling stays the one
 # source of truth for its own format.
@@ -380,9 +380,9 @@ def format_model_id_for_platform(
     ``_normalize_id`` treats as canonical), but each platform's
     ``model_tiers`` map spells its OWN default id differently, for example:
 
-        templates/platforms/copilot-cli.yaml:107-110 (dot form):
+        templates/platforms/copilot-cli.yaml:109-112 (dot form):
             opus: "claude-opus-4.6"
-        templates/platforms/vscode.yaml:18-21 (display form, shared by
+        templates/platforms/vscode.yaml:20-23 (display form, shared by
         visual-studio.yaml):
             opus: "Claude Opus 4.6 (copilot)"
 

--- a/build/model_pin_sweep_evidence.py
+++ b/build/model_pin_sweep_evidence.py
@@ -65,7 +65,7 @@ def _normalize_id(model_id: str) -> str:
 def _agent_name_from_unit(unit: object) -> str | None:
     """Derive the agent name ``build_report`` would have recorded for this unit.
 
-    Mirrors ``build/generate_agents.py:265``
+    Mirrors ``build/generate_agents.py:303``
     (``agent_name = shared_file.stem.replace(".shared", "")``) verbatim: the
     unit is ``templates/agents/<name>.shared.md``, and
     ``scripts/eval/_model_sweep_core.py:481``'s ``build_report`` writes that

--- a/tests/test_generate_agents.py
+++ b/tests/test_generate_agents.py
@@ -29,7 +29,7 @@ def _create_test_structure(
     """Create a minimal test directory structure for agent generation.
 
     ``with_model_tiers=True`` adds a ``model_tiers`` map to the vscode
-    platform config, matching real templates/platforms/vscode.yaml:18-21;
+    platform config, matching real templates/platforms/vscode.yaml:20-23;
     the default (False) preserves every existing caller's plain config,
     since a manifest-pin test is the only kind that needs it (a manifest
     entry's id can't reach a formatted output without one -- see

--- a/tests/test_generate_agents_common.py
+++ b/tests/test_generate_agents_common.py
@@ -444,7 +444,7 @@ class TestConvertFrontmatterForPlatform:
                 if isinstance(default_model, str)
                 else "claude-sonnet-4-6"
             )
-            # Matches build/generate_agents.py:265's agent_name derivation
+            # Matches build/generate_agents.py:303's agent_name derivation
             # verbatim; see model_pin_sweep_evidence.py:_agent_name_from_unit.
             agent = Path(str(unit)).stem.replace(".shared", "")
             artifact_path.write_text(

--- a/tests/test_model_pin_manifest.py
+++ b/tests/test_model_pin_manifest.py
@@ -140,7 +140,7 @@ def _keep_pin_entry(
             default_id = (
                 default_model if isinstance(default_model, str) else DEFAULT_MODEL
             )
-            # Matches build/generate_agents.py:265's agent_name derivation
+            # Matches build/generate_agents.py:303's agent_name derivation
             # verbatim, since build_report's own "agent" field records that
             # same value; see model_pin_sweep_evidence.py:_agent_name_from_unit.
             agent = Path(str(unit)).stem.replace(".shared", "")


### PR DESCRIPTION
## Summary

PR #5327 (ADR-080 sidecar-manifest wiring) merged before its final Copilot review round (commit `99bd7b2d5`, review [5033916030](https://github.com/rjmurillo/ai-agents/pull/5327#pullrequestreview-5033916030)) landed a fix locally. That review round caught four canonical-source citations that earlier commits within #5327 had made stale by inserting lines above the cited code. This PR carries that one fix forward onto `main` post-merge.

## Changes

- `build/model_pin_sweep_evidence.py`: the mirror-source citation for the agent_name derivation, per `build/generate_agents.py`, cited line 265; earlier commits within #5327 added the `templates_path`/`output_root` resolution block above it, pushing the real line to 303.
- `tests/test_generate_agents_common.py`: matching test comment had the same stale line-265 citation.
- `build/model_pin_manifest.py`: per `templates/platforms/copilot-cli.yaml` and per `vscode.yaml`, the `model_tiers` block citations (previously lines 107-110 and 18-21) moved to 109-112 and 20-23 after comment expansion earlier in #5327. Two occurrences each (the `format_model_id_for_platform` module comment and its docstring).

Each new line range was verified against the current file content before editing (`grep` confirms the code/YAML block is exactly at the cited lines). No behavior change; citation text only.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5327 | The review round this carries forward |

## Testing

- [x] `uv run pytest tests/test_model_pin_manifest.py tests/test_model_pin_manifest_sweep_evidence.py tests/test_generate_agents_common.py` (142 passed)
- [x] `ruff check` / `mypy` clean on the three touched files
- [x] No testing required beyond the above (documentation/citation-only change, no behavior change)

## Type of Change

- [x] Documentation update

## Notes for reviewers

This PR's branch name and commit content are a direct continuation of #5327 (recreated after that PR merged out from under this one still-unpushed commit; see the branch-restart protocol in this session's git-safety instructions: the original 26-commit history is not replayed, only this one net-new commit). Two other findings from the same review round are deliberately NOT addressed here, with reasoning in the commit message: a manifest-level `schema_version` check (would diverge from canonical `check_model_pins.py`, which also doesn't check it, and ADR-080 defines no v2 shape today) and provider/harness identity in sweep evidence (a real methodological question, but scoped to ADR-080 policy and `scripts/eval/eval-model-sweep.py`, not a defect in the manifest-wiring code).

---
_Generated by [Claude Code](https://claude.ai/code/session_018Wcv2NL3P8zST5jzGTN3af)_
