### PR TITLE
fix(validation): never join a Markdown heading to body text as anchor context

### DIFF
--- a/scripts/validation/check_citation_freshness.py
+++ b/scripts/validation/check_citation_freshness.py
@@ -54,6 +54,7 @@ from citation_anchors import (  # noqa: E402
     _URL,
     _anchor_candidates,
     _anchor_matches,
+    _atx_heading,
     _context_lines,
     _continuation_quote,
     _same_line_segment,
@@ -160,7 +161,10 @@ def _citation_anchors(
         _context_lines(citing_lines, line_index, line_text, segment, markdown),
         citation_text,
     )
-    if citing_lines is not None:
+    # A Markdown heading is a complete unit (see _context_lines), so a
+    # heading ending in a colon never harvests the indented body below
+    # it as a continuation quote either.
+    if citing_lines is not None and not (markdown and _atx_heading(line_text)):
         quote = _continuation_quote(citing_lines, line_index)
         if quote is not None:
             anchors.append(quote)

--- a/scripts/validation/check_citation_freshness.py
+++ b/scripts/validation/check_citation_freshness.py
@@ -152,11 +152,13 @@ def _citation_anchors(
     segment: str,
     citing_lines: list[str] | None,
     line_number: int,
+    markdown: bool = False,
 ) -> list[str]:
     """Collect the anchors the citing sentence names for one citation."""
     line_index = line_number - 1
     anchors: list[str] = _anchor_candidates(
-        _context_lines(citing_lines, line_index, line_text, segment), citation_text
+        _context_lines(citing_lines, line_index, line_text, segment, markdown),
+        citation_text,
     )
     if citing_lines is not None:
         quote = _continuation_quote(citing_lines, line_index)
@@ -232,6 +234,7 @@ def _check_citation(
     )
 
     citing_lines = head_files.lines(citing_file)
+    markdown = citing_file.endswith(".md")
     if _has_ignore_marker(citing_lines, line_number, line_text):
         return None
     cited_lines, finding = _resolve_cited_range(
@@ -243,7 +246,7 @@ def _check_citation(
         # mechanical, so it is appended here too.
         if cited_lines is not None:
             anchors = _citation_anchors(
-                citation_text, line_text, segment, citing_lines, line_number
+                citation_text, line_text, segment, citing_lines, line_number, markdown
             )
             hint = _relocation_hint(anchors, cited_lines)
             if hint:
@@ -257,7 +260,9 @@ def _check_citation(
         citing_file,
         line_number,
         citation_text,
-        _citation_anchors(citation_text, line_text, segment, citing_lines, line_number),
+        _citation_anchors(
+            citation_text, line_text, segment, citing_lines, line_number, markdown
+        ),
         cited_lines,
         start,
         end,

--- a/scripts/validation/citation_anchors.py
+++ b/scripts/validation/citation_anchors.py
@@ -139,11 +139,12 @@ def _anchor_matches(anchor: str, cited_text: str) -> bool:
 
 
 # An ATX heading per CommonMark: up to 3 leading spaces (4 is a code
-# block), optional blockquote markers, 1-6 hashes, then whitespace or end
-# of line. This is what "#hashtag" and 7-hash paragraphs fail and a
-# blockquoted "> ## heading" passes; the bare hash-prefix predicate below
-# stays the code-comment classifier.
-_ATX_HEADING = re.compile(r"^ {0,3}(?:> ?)*#{1,6}(?:[ \t]|$)")
+# block), optional blockquote markers each followed by up to 3 spaces,
+# 1-6 hashes, then whitespace or end of line. This is what "#hashtag"
+# and 7-hash paragraphs fail and a blockquoted "> ## heading" passes,
+# indented marker forms (">   ## heading") included; the bare
+# hash-prefix predicate below stays the code-comment classifier.
+_ATX_HEADING = re.compile(r"^ {0,3}(?:> {0,3})*#{1,6}(?:[ \t]|$)")
 
 
 def _atx_heading(line: str) -> bool:

--- a/scripts/validation/citation_anchors.py
+++ b/scripts/validation/citation_anchors.py
@@ -201,7 +201,11 @@ def _sentence_continues(line: str) -> bool:
 
 
 def _context_lines(
-    citing_lines: list[str] | None, line_index: int, line_text: str, segment: str
+    citing_lines: list[str] | None,
+    line_index: int,
+    line_text: str,
+    segment: str,
+    markdown: bool = False,
 ) -> list[str]:
     """Return this citation's slice of its line plus wrapped-sentence neighbors.
 
@@ -215,8 +219,15 @@ def _context_lines(
     context = [segment]
     if citing_lines is None:
         return context
-    own_indent = _indent_width(line_text)
     own_hash = _hash_prefixed(line_text)
+    if markdown and own_hash:
+        # In a Markdown citing file a hash prefix is a heading, and a
+        # heading is a complete unit: it never wraps into any neighbor,
+        # another heading included (the hash-match rule below would let
+        # equal-prefixed headings pool anchors). In code files the same
+        # prefix is a comment, which continues into comment lines.
+        return context
+    own_indent = _indent_width(line_text)
     for offset in (1, 2):
         index = line_index - offset
         if index < 0 or not _sentence_continues(citing_lines[index]):
@@ -224,9 +235,8 @@ def _context_lines(
         # A deeper-indented neighbor is an example or verbatim block
         # belonging to an earlier line (a sibling citation's continuation
         # quote, say), not this sentence wrapping across lines. A hash
-        # prefix must match on both sides too: a Markdown heading is a
-        # complete unit, so it never wraps into body text, while comment
-        # lines still continue into comment lines.
+        # prefix must match on both sides too: a heading never wraps into
+        # body text, while comment lines continue into comment lines.
         if _indent_width(citing_lines[index]) > own_indent:
             break
         if _hash_prefixed(citing_lines[index]) != own_hash:

--- a/scripts/validation/citation_anchors.py
+++ b/scripts/validation/citation_anchors.py
@@ -138,6 +138,11 @@ def _anchor_matches(anchor: str, cited_text: str) -> bool:
     return False
 
 
+def _hash_prefixed(line: str) -> bool:
+    """Return whether a line is a Markdown heading or a comment line."""
+    return line.lstrip().startswith("#")
+
+
 def _indent_width(line: str) -> int:
     """Return the leading-whitespace width after any comment marker."""
     prefix = 0
@@ -211,19 +216,25 @@ def _context_lines(
     if citing_lines is None:
         return context
     own_indent = _indent_width(line_text)
+    own_hash = _hash_prefixed(line_text)
     for offset in (1, 2):
         index = line_index - offset
         if index < 0 or not _sentence_continues(citing_lines[index]):
             break
         # A deeper-indented neighbor is an example or verbatim block
         # belonging to an earlier line (a sibling citation's continuation
-        # quote, say), not this sentence wrapping across lines.
+        # quote, say), not this sentence wrapping across lines. A hash
+        # prefix must match on both sides too: a Markdown heading is a
+        # complete unit, so it never wraps into body text, while comment
+        # lines still continue into comment lines.
         if _indent_width(citing_lines[index]) > own_indent:
+            break
+        if _hash_prefixed(citing_lines[index]) != own_hash:
             break
         context.insert(0, citing_lines[index])
     if _sentence_continues(line_text) and line_index + 1 < len(citing_lines):
         following = citing_lines[line_index + 1]
-        if _indent_width(following) <= own_indent:
+        if _indent_width(following) <= own_indent and _hash_prefixed(following) == own_hash:
             context.append(following)
     return context
 

--- a/scripts/validation/citation_anchors.py
+++ b/scripts/validation/citation_anchors.py
@@ -138,8 +138,21 @@ def _anchor_matches(anchor: str, cited_text: str) -> bool:
     return False
 
 
+# An ATX heading per CommonMark: up to 3 leading spaces (4 is a code
+# block), optional blockquote markers, 1-6 hashes, then whitespace or end
+# of line. This is what "#hashtag" and 7-hash paragraphs fail and a
+# blockquoted "> ## heading" passes; the bare hash-prefix predicate below
+# stays the code-comment classifier.
+_ATX_HEADING = re.compile(r"^ {0,3}(?:> ?)*#{1,6}(?:[ \t]|$)")
+
+
+def _atx_heading(line: str) -> bool:
+    """Return whether a line is a Markdown ATX heading (blockquotes included)."""
+    return bool(_ATX_HEADING.match(line))
+
+
 def _hash_prefixed(line: str) -> bool:
-    """Return whether a line is a Markdown heading or a comment line."""
+    """Return whether a line's first non-blank character is a hash marker."""
     return line.lstrip().startswith("#")
 
 
@@ -219,32 +232,38 @@ def _context_lines(
     context = [segment]
     if citing_lines is None:
         return context
-    own_hash = _hash_prefixed(line_text)
-    if markdown and own_hash:
-        # In a Markdown citing file a hash prefix is a heading, and a
-        # heading is a complete unit: it never wraps into any neighbor,
-        # another heading included (the hash-match rule below would let
-        # equal-prefixed headings pool anchors). In code files the same
-        # prefix is a comment, which continues into comment lines.
+    if markdown and _atx_heading(line_text):
+        # A Markdown heading is a complete unit: it never wraps into any
+        # neighbor, another heading included (an equal-prefix rule would
+        # let adjacent headings pool anchors).
         return context
     own_indent = _indent_width(line_text)
+    own_hash = _hash_prefixed(line_text)
+
+    def _blocks(neighbor: str) -> bool:
+        # In Markdown only a real heading is a hash boundary, so a
+        # hashtag paragraph stays ordinary body text; in code files a
+        # comment marker must match on both sides, so comment lines
+        # continue into comment lines and never into code.
+        if markdown:
+            return _atx_heading(neighbor)
+        return _hash_prefixed(neighbor) != own_hash
+
     for offset in (1, 2):
         index = line_index - offset
         if index < 0 or not _sentence_continues(citing_lines[index]):
             break
         # A deeper-indented neighbor is an example or verbatim block
         # belonging to an earlier line (a sibling citation's continuation
-        # quote, say), not this sentence wrapping across lines. A hash
-        # prefix must match on both sides too: a heading never wraps into
-        # body text, while comment lines continue into comment lines.
+        # quote, say), not this sentence wrapping across lines.
         if _indent_width(citing_lines[index]) > own_indent:
             break
-        if _hash_prefixed(citing_lines[index]) != own_hash:
+        if _blocks(citing_lines[index]):
             break
         context.insert(0, citing_lines[index])
     if _sentence_continues(line_text) and line_index + 1 < len(citing_lines):
         following = citing_lines[line_index + 1]
-        if _indent_width(following) <= own_indent and _hash_prefixed(following) == own_hash:
+        if _indent_width(following) <= own_indent and not _blocks(following):
             context.append(following)
     return context
 

--- a/scripts/validation/citation_anchors.py
+++ b/scripts/validation/citation_anchors.py
@@ -139,12 +139,13 @@ def _anchor_matches(anchor: str, cited_text: str) -> bool:
 
 
 # An ATX heading per CommonMark: up to 3 leading spaces (4 is a code
-# block), optional blockquote markers each followed by up to 3 spaces,
+# block), optional blockquote markers each followed by up to 4 spaces
+# (the marker's own optional space plus the heading's up-to-3 indent),
 # 1-6 hashes, then whitespace or end of line. This is what "#hashtag"
 # and 7-hash paragraphs fail and a blockquoted "> ## heading" passes,
-# indented marker forms (">   ## heading") included; the bare
+# indented marker forms (">    ## heading") included; the bare
 # hash-prefix predicate below stays the code-comment classifier.
-_ATX_HEADING = re.compile(r"^ {0,3}(?:> {0,3})*#{1,6}(?:[ \t]|$)")
+_ATX_HEADING = re.compile(r"^ {0,3}(?:> {0,4})*#{1,6}(?:[ \t]|$)")
 
 
 def _atx_heading(line: str) -> bool:

--- a/tests/validation/test_check_citation_freshness.py
+++ b/tests/validation/test_check_citation_freshness.py
@@ -82,6 +82,21 @@ class TestFreshCitationsPass:
 
         assert code == 0
 
+    def test_heading_with_colon_never_harvests_a_continuation_quote(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot, PR #5341): the markdown flag reached
+        # _context_lines only, so a heading ending in a colon still took
+        # the indented body below it as a required continuation quote and
+        # failed a valid citation. A heading is a complete unit there too.
+        root = _repo(tmp_path)
+        doc = f"## About {TARGET}:2:\n\n    magic_token\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
     def test_indented_continuation_quote_present_in_range_exits_0(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/validation/test_check_citation_freshness.py
+++ b/tests/validation/test_check_citation_freshness.py
@@ -93,9 +93,10 @@ class TestFreshCitationsPass:
         doc = f"## About {TARGET}:2:\n\n    magic_token\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_indented_continuation_quote_present_in_range_exits_0(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/validation/test_check_citation_freshness.py
+++ b/tests/validation/test_check_citation_freshness.py
@@ -292,6 +292,21 @@ class TestCliContract:
         assert code == 0
         assert "[SKIP]" in capsys.readouterr().out
 
+    def test_validate_wrapper_returns_false_on_git_failure(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Spec-validation nit (PR #5338): the boolean wrapper's git-failure
+        # branch is the one pre_pr actually calls; pin it directly.
+        root = _repo(tmp_path)
+        monkeypatch.setattr(
+            checker, "_resolve_default_base_ref", lambda _root: "does-not-exist"
+        )
+
+        assert checker.validate_citation_freshness(root) is False
+
     def test_validate_wrapper_returns_false_on_findings(
         self,
         tmp_path: Path,

--- a/tests/validation/test_check_citation_freshness.py
+++ b/tests/validation/test_check_citation_freshness.py
@@ -162,6 +162,22 @@ class TestStaleCitationsFail:
         assert code == 1
         assert "magic_token" in out
 
+    def test_comment_continuation_anchor_still_joins_in_code_files(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The heading boundary is Markdown-only (Copilot, PR #5341): in a
+        # code file a hash prefix is a comment, and a wrapped comment
+        # sentence still hands its identifier to the citation below, so
+        # this stale citation must keep failing on that anchor.
+        root = _repo(tmp_path)
+        doc = f"# The magic_token helper is defined at\n# {TARGET}:2 in the tree.\n"
+        _add_doc(root, "docs/notes.py", doc)
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert "magic_token" in out
+
     def test_indented_continuation_quote_absent_from_range_fails(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/validation/test_check_citation_freshness_diff.py
+++ b/tests/validation/test_check_citation_freshness_diff.py
@@ -1,0 +1,156 @@
+"""Unified-diff parsing regressions for the citation gate.
+
+Issue #5337; split from the scope test file at the taste file-size
+ceiling, along the class seam. Regression provenance is per comment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.validation.citation_freshness_helpers import (
+    TARGET,
+    _add_doc,
+    _git,
+    _repo,
+    _run,
+)
+
+
+class TestDiffParsing:
+    """The unified-diff parse must use git's LF-only line model."""
+
+    def test_added_content_starting_with_plus_plus_is_not_a_file_header(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot, PR #5338): "+" + "++ heading" renders as
+        # "+++ heading" in the diff, and the old parser read it as a file
+        # header, misattributing every following added line.
+        root = _repo(tmp_path)
+        doc = f"++ heading\nSee `{TARGET}:2` (`magic_token`).\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        # Composed, not literal: a literal expected-finding string is
+        # itself a citation to an untracked path, and the gate flagged
+        # these two assertions when they were first written literally.
+        assert f"{'docs/notes.md'}:2:" in out
+
+    def test_a_configured_textconv_driver_cannot_rewrite_the_parsed_diff(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot round 2, PR #5338): .gitattributes assigns
+        # markdown a diff driver, so a contributor's configured textconv
+        # could rewrite the patch the parser reads. With --no-textconv the
+        # stale citation is still found; without it, the uppercased patch
+        # no longer matches the citation pattern and the gate goes silent.
+        root = _repo(tmp_path)
+        (root / ".gitattributes").write_text("*.md diff=markdown\n", encoding="utf-8")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", "attrs")
+        _git(root, "config", "diff.markdown.textconv", "tr a-z A-Z <")
+        _add_doc(root, "docs/notes.md", f"See `{TARGET}:2` (`magic_token`).\n")
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert "examined 1 citation(s)" in out
+
+    def test_a_type_change_to_regular_file_is_scanned(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot round 6, PR #5338): --diff-filter=ACMR
+        # omitted type changes, so a symlink replaced by a regular file
+        # carried its whole content as unscanned added lines.
+        root = _repo(tmp_path)
+        _git(root, "checkout", "-q", "main")
+        (root / "docs").mkdir(exist_ok=True)
+        (root / "docs" / "link.md").symlink_to("../README.md")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", "link")
+        _git(root, "checkout", "-q", "feature")
+        _git(root, "merge", "-q", "main")
+        (root / "docs" / "link.md").unlink()
+        (root / "docs" / "link.md").write_text(
+            f"See `{TARGET}:2` (`magic_token`).\n", encoding="utf-8"
+        )
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", "replace")
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert "examined 1 citation(s)" in out
+
+    def test_a_pure_rename_does_not_reauthor_its_latent_citations(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot round 4, PR #5338): with a contributor's
+        # diff.renames=false a pure rename degrades to delete-plus-add,
+        # so a stale citation that predates the branch reads as newly
+        # authored and blocks the push. --find-renames pins detection on.
+        root = _repo(tmp_path)
+        _git(root, "checkout", "-q", "main")
+        _add_doc(root, "docs/old.md", f"See `{TARGET}:2` (`magic_token`).\n")
+        _git(root, "checkout", "-q", "feature")
+        _git(root, "merge", "-q", "main")
+        _git(root, "config", "diff.renames", "false")
+        _git(root, "mv", "docs/old.md", "docs/renamed.md")
+        _git(root, "commit", "-q", "-m", "rename")
+
+        code, out = _run(root, capsys)
+
+        assert code == 0
+        assert "examined 0 citation(s)" in out
+
+    def test_c_quoted_citing_path_is_decoded(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot round 5, PR #5338): git C-quotes a header
+        # path carrying a quote even with core.quotePath=false, so the
+        # citing file stopped matching its HEAD path and its stale
+        # citation could pass unread. The shared unquoter decodes it.
+        root = _repo(tmp_path)
+        _add_doc(root, 'docs/od"d.md', f"See `{TARGET}:2` (`magic_token`).\n")
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert 'od"d.md' in out
+
+    def test_non_ascii_citing_path_is_not_octal_escaped(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same round: core.quotePath (default true) octal-escapes a
+        # non-ASCII path in the +++ header, so the citing file stops
+        # matching its HEAD path; pinned off, the finding names the
+        # real file.
+        root = _repo(tmp_path)
+        _add_doc(root, "docs/nötes.md", f"See `{TARGET}:2` (`magic_token`).\n")
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert f"{'docs/nötes.md'}:1:" in out
+
+    def test_unicode_line_separator_does_not_shift_line_numbers(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot, PR #5338): splitlines() breaks on U+2028, so
+        # a separator whose tail begins "+ " minted a phantom added line and
+        # shifted every following line number by one.
+        root = _repo(tmp_path)
+        doc = f"a + x\nSee `{TARGET}:2` (`magic_token`).\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        # Composed, not literal: a literal expected-finding string is
+        # itself a citation to an untracked path, and the gate flagged
+        # these two assertions when they were first written literally.
+        assert f"{'docs/notes.md'}:2:" in out

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -120,9 +120,10 @@ class TestScopeBoundaries:
         doc = f"## About {TARGET}:2\nThe `magic_token` helper is unrelated.\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_adjacent_markdown_headings_never_pool_anchors(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -135,9 +136,10 @@ class TestScopeBoundaries:
         doc = f"## About {TARGET}:2\n## The `magic_token` helper\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_unfinished_heading_above_a_body_citation_adds_no_anchors(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -153,9 +155,10 @@ class TestScopeBoundaries:
         doc = f"## The `magic_token` helper\nDetails in {TARGET}:2 today.\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_blockquoted_heading_is_still_a_complete_unit(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -167,9 +170,10 @@ class TestScopeBoundaries:
         doc = f"> ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_blockquote_marker_spacing_does_not_hide_a_heading(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -183,9 +187,10 @@ class TestScopeBoundaries:
         doc = f">    ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
         _add_doc(root, "docs/notes.md", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_hashtag_paragraph_is_body_text_not_a_heading(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -214,9 +219,10 @@ class TestScopeBoundaries:
         doc = f"magic_token_reader = load()\n# See {TARGET}:2 for the value.\n"
         _add_doc(root, "docs/notes.py", doc)
 
-        code, _out = _run(root, capsys)
+        code, out = _run(root, capsys)
 
         assert code == 0
+        assert "examined 1 citation(s)" in out
 
     def test_finished_previous_sentence_is_not_an_anchor_source(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -1,7 +1,8 @@
-"""Scope boundaries, diff parsing, and wiring for the citation gate.
+"""Scope boundaries for the citation gate.
 
 Issue #5337; split from ``test_check_citation_freshness.py`` at the taste
-file-size ceiling. Regression provenance for each case is in its comment.
+file-size ceiling (diff parsing and wiring live in sibling files).
+Regression provenance for each case is in its comment.
 """
 
 from __future__ import annotations
@@ -20,142 +21,6 @@ from tests.validation.citation_freshness_helpers import (
     checker,
 )
 
-
-class TestDiffParsing:
-    """The unified-diff parse must use git's LF-only line model."""
-
-    def test_added_content_starting_with_plus_plus_is_not_a_file_header(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot, PR #5338): "+" + "++ heading" renders as
-        # "+++ heading" in the diff, and the old parser read it as a file
-        # header, misattributing every following added line.
-        root = _repo(tmp_path)
-        doc = f"++ heading\nSee `{TARGET}:2` (`magic_token`).\n"
-        _add_doc(root, "docs/notes.md", doc)
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        # Composed, not literal: a literal expected-finding string is
-        # itself a citation to an untracked path, and the gate flagged
-        # these two assertions when they were first written literally.
-        assert f"{'docs/notes.md'}:2:" in out
-
-    def test_a_configured_textconv_driver_cannot_rewrite_the_parsed_diff(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot round 2, PR #5338): .gitattributes assigns
-        # markdown a diff driver, so a contributor's configured textconv
-        # could rewrite the patch the parser reads. With --no-textconv the
-        # stale citation is still found; without it, the uppercased patch
-        # no longer matches the citation pattern and the gate goes silent.
-        root = _repo(tmp_path)
-        (root / ".gitattributes").write_text("*.md diff=markdown\n", encoding="utf-8")
-        _git(root, "add", "-A")
-        _git(root, "commit", "-q", "-m", "attrs")
-        _git(root, "config", "diff.markdown.textconv", "tr a-z A-Z <")
-        _add_doc(root, "docs/notes.md", f"See `{TARGET}:2` (`magic_token`).\n")
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        assert "examined 1 citation(s)" in out
-
-    def test_a_type_change_to_regular_file_is_scanned(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot round 6, PR #5338): --diff-filter=ACMR
-        # omitted type changes, so a symlink replaced by a regular file
-        # carried its whole content as unscanned added lines.
-        root = _repo(tmp_path)
-        _git(root, "checkout", "-q", "main")
-        (root / "docs").mkdir(exist_ok=True)
-        (root / "docs" / "link.md").symlink_to("../README.md")
-        _git(root, "add", "-A")
-        _git(root, "commit", "-q", "-m", "link")
-        _git(root, "checkout", "-q", "feature")
-        _git(root, "merge", "-q", "main")
-        (root / "docs" / "link.md").unlink()
-        (root / "docs" / "link.md").write_text(
-            f"See `{TARGET}:2` (`magic_token`).\n", encoding="utf-8"
-        )
-        _git(root, "add", "-A")
-        _git(root, "commit", "-q", "-m", "replace")
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        assert "examined 1 citation(s)" in out
-
-    def test_a_pure_rename_does_not_reauthor_its_latent_citations(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot round 4, PR #5338): with a contributor's
-        # diff.renames=false a pure rename degrades to delete-plus-add,
-        # so a stale citation that predates the branch reads as newly
-        # authored and blocks the push. --find-renames pins detection on.
-        root = _repo(tmp_path)
-        _git(root, "checkout", "-q", "main")
-        _add_doc(root, "docs/old.md", f"See `{TARGET}:2` (`magic_token`).\n")
-        _git(root, "checkout", "-q", "feature")
-        _git(root, "merge", "-q", "main")
-        _git(root, "config", "diff.renames", "false")
-        _git(root, "mv", "docs/old.md", "docs/renamed.md")
-        _git(root, "commit", "-q", "-m", "rename")
-
-        code, out = _run(root, capsys)
-
-        assert code == 0
-        assert "examined 0 citation(s)" in out
-
-    def test_c_quoted_citing_path_is_decoded(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot round 5, PR #5338): git C-quotes a header
-        # path carrying a quote even with core.quotePath=false, so the
-        # citing file stopped matching its HEAD path and its stale
-        # citation could pass unread. The shared unquoter decodes it.
-        root = _repo(tmp_path)
-        _add_doc(root, 'docs/od"d.md', f"See `{TARGET}:2` (`magic_token`).\n")
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        assert 'od"d.md' in out
-
-    def test_non_ascii_citing_path_is_not_octal_escaped(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Same round: core.quotePath (default true) octal-escapes a
-        # non-ASCII path in the +++ header, so the citing file stops
-        # matching its HEAD path; pinned off, the finding names the
-        # real file.
-        root = _repo(tmp_path)
-        _add_doc(root, "docs/nötes.md", f"See `{TARGET}:2` (`magic_token`).\n")
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        assert f"{'docs/nötes.md'}:1:" in out
-
-    def test_unicode_line_separator_does_not_shift_line_numbers(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Regression (Copilot, PR #5338): splitlines() breaks on U+2028, so
-        # a separator whose tail begins "+ " minted a phantom added line and
-        # shifted every following line number by one.
-        root = _repo(tmp_path)
-        doc = f"a + x\nSee `{TARGET}:2` (`magic_token`).\n"
-        _add_doc(root, "docs/notes.md", doc)
-
-        code, out = _run(root, capsys)
-
-        assert code == 1
-        # Composed, not literal: a literal expected-finding string is
-        # itself a citation to an untracked path, and the gate flagged
-        # these two assertions when they were first written literally.
-        assert f"{'docs/notes.md'}:2:" in out
 
 class TestScopeBoundaries:
     def test_ignore_marker_on_the_line_above_suppresses(
@@ -238,6 +103,21 @@ class TestScopeBoundaries:
             f"    second {TARGET}:2 (spelled, shared by\n"
             f"    others):\n"
         )
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
+    def test_markdown_heading_does_not_join_body_text_as_context(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (CodeRabbit, PR #5338): a heading is a complete
+        # unit, but an unterminated one joined the following body line
+        # as a sentence wrap, so a body identifier became an unrelated
+        # required anchor and rejected a valid heading citation.
+        root = _repo(tmp_path)
+        doc = f"## About {TARGET}:2\nThe `magic_token` helper is unrelated.\n"
         _add_doc(root, "docs/notes.md", doc)
 
         code, _out = _run(root, capsys)

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -171,6 +171,21 @@ class TestScopeBoundaries:
 
         assert code == 0
 
+    def test_blockquote_marker_spacing_does_not_hide_a_heading(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # CodeRabbit's residual-risk note (PR #5341): CommonMark allows
+        # up to 3 spaces after a blockquote marker, so ">  ## heading"
+        # must classify as a heading, not as body text that absorbs the
+        # next blockquote line's backtick span.
+        root = _repo(tmp_path)
+        doc = f">  ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
     def test_hashtag_paragraph_is_body_text_not_a_heading(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -174,12 +174,13 @@ class TestScopeBoundaries:
     def test_blockquote_marker_spacing_does_not_hide_a_heading(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        # CodeRabbit's residual-risk note (PR #5341): CommonMark allows
-        # up to 3 spaces after a blockquote marker, so ">  ## heading"
-        # must classify as a heading, not as body text that absorbs the
-        # next blockquote line's backtick span.
+        # CodeRabbit finding (PR #5341): the marker's own optional space
+        # plus the heading's up-to-3 indent means as many as 4 spaces may
+        # separate ">" from the hashes, so ">    ## heading" must
+        # classify as a heading, not as body text that absorbs the next
+        # blockquote line's backtick span.
         root = _repo(tmp_path)
-        doc = f">  ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
+        doc = f">    ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
         _add_doc(root, "docs/notes.md", doc)
 
         code, _out = _run(root, capsys)

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -146,8 +146,8 @@ class TestScopeBoundaries:
         # #5341): a heading with no sentence-ending punctuation reads as
         # a continuing sentence. The shape is guarded twice, by the
         # indent guard (a hash marker counts as indentation, so a heading
-        # sits deeper than unindented body text) and by the hash-prefix
-        # mismatch, so this pins the behavior: only removing both hands
+        # sits deeper than unindented body text) and by the ATX-heading
+        # block, so this pins the behavior: only removing both hands
         # the heading's backtick span to the citation below it.
         root = _repo(tmp_path)
         doc = f"## The `magic_token` helper\nDetails in {TARGET}:2 today.\n"
@@ -156,6 +156,36 @@ class TestScopeBoundaries:
         code, _out = _run(root, capsys)
 
         assert code == 0
+
+    def test_blockquoted_heading_is_still_a_complete_unit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot, PR #5341): the bare hash-prefix predicate
+        # read "> ## heading" as body text, so a blockquoted heading
+        # citation absorbed the next blockquote line's backtick span.
+        root = _repo(tmp_path)
+        doc = f"> ## About {TARGET}:2\n> The `magic_token` helper is here.\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
+    def test_hashtag_paragraph_is_body_text_not_a_heading(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The other direction of the ATX classifier (Copilot, PR #5341):
+        # "#hashtag" is not a heading (no space after the hash), so a
+        # citation on that line keeps its wrapped-sentence anchor and
+        # this stale claim must fail rather than pass anchorless.
+        root = _repo(tmp_path)
+        doc = f"The `magic_token` helper sits\n#hashtag {TARGET}:2 note\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, out = _run(root, capsys)
+
+        assert code == 1
+        assert "magic_token" in out
 
     def test_code_text_never_joins_a_comment_citation_backward(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/validation/test_check_citation_freshness_scope.py
+++ b/tests/validation/test_check_citation_freshness_scope.py
@@ -124,6 +124,54 @@ class TestScopeBoundaries:
 
         assert code == 0
 
+    def test_adjacent_markdown_headings_never_pool_anchors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression (Copilot, PR #5341): two headings share the hash
+        # prefix, so the mismatch guard alone let a cited heading join
+        # the next heading and absorb its backtick span as a required
+        # anchor. A heading joins nothing, another heading included.
+        root = _repo(tmp_path)
+        doc = f"## About {TARGET}:2\n## The `magic_token` helper\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
+    def test_unfinished_heading_above_a_body_citation_adds_no_anchors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The backward direction of the heading boundary (Copilot, PR
+        # #5341): a heading with no sentence-ending punctuation reads as
+        # a continuing sentence. The shape is guarded twice, by the
+        # indent guard (a hash marker counts as indentation, so a heading
+        # sits deeper than unindented body text) and by the hash-prefix
+        # mismatch, so this pins the behavior: only removing both hands
+        # the heading's backtick span to the citation below it.
+        root = _repo(tmp_path)
+        doc = f"## The `magic_token` helper\nDetails in {TARGET}:2 today.\n"
+        _add_doc(root, "docs/notes.md", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
+    def test_code_text_never_joins_a_comment_citation_backward(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The input that isolates the backward hash-mismatch break: a
+        # continuing code line sits at indent 0, below the comment's
+        # marker-inclusive indent, so only the prefix mismatch stops its
+        # identifier becoming this citation's required anchor.
+        root = _repo(tmp_path)
+        doc = f"magic_token_reader = load()\n# See {TARGET}:2 for the value.\n"
+        _add_doc(root, "docs/notes.py", doc)
+
+        code, _out = _run(root, capsys)
+
+        assert code == 0
+
     def test_finished_previous_sentence_is_not_an_anchor_source(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

Follow-up to the citation-freshness gate merged in #5338: a Markdown heading is never joined to any context neighbor as an anchor source (body text, another heading, or an indented continuation quote), plus the regression tests promised in that PR's final review round (the heading boundary, the `validate_citation_freshness` git-failure branch, and the diff-parsing suite split into its own file for the size ratchet).

### Why

PR #5338 merged (squash `2caee96dd`) while these two commits were mid-push; the remote branch was auto-deleted before they landed. The heading fix was confirmed in the resolved CodeRabbit thread on that PR ("Confirmed and fixed in 36c9f8ba4", now rebased as `894464004`): a heading such as `## About path.md:2` followed by body prose let the body line's backtick span become an anchor for the heading's citation, because `_context_lines` treated the heading as a wrapped sentence. A heading is a complete unit; it never wraps into body text. Reviews on this PR then found the remaining holes: adjacent headings could still pool anchors through the shared hash prefix (`36d5188dd`); the bare hash-prefix predicate misclassified blockquoted headings and hashtag paragraphs while the continuation-quote harvest ignored the heading boundary entirely (`cae387cf3`); and blockquote markers can carry CommonMark's marker space plus heading indent, up to 4 spaces before the hashes (`a682cf2a0`, `afbdea779`).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5337 | Citation freshness gate incident record |

These references do not close their linked items: #5337's gate shipped in #5338; this PR hardens one anchor-context boundary in it.

## Changes

- `scripts/validation/citation_anchors.py`: `_atx_heading` classifies real Markdown ATX headings (up to 3 leading spaces, blockquote markers each followed by up to 4 spaces, 1-6 hashes then whitespace), so `> ## heading` and `>    ## heading` are headings and `#hashtag` is body text; `_context_lines` takes a `markdown` flag, and a heading joins no neighbor at all, while code-file comments keep continuing into comment lines under the bare hash-prefix classifier.
- `scripts/validation/check_citation_freshness.py`: `_check_citation` classifies the citing file (`citing_file.endswith(".md")`) and passes the flag through `_citation_anchors`, which also skips the continuation-quote harvest when the citing line is a Markdown heading.
- `tests/validation/test_check_citation_freshness_scope.py`: mutation-verified pins for the heading boundary in every direction: adjacent headings, blockquoted headings, marker-spacing forms, hashtag paragraphs, an unfinished heading above a body citation (doubly guarded; the comment names both guards), code text never joining a comment citation backward, plus the original heading-to-body test; `TestDiffParsing` extracted to keep the file under the size ratchet.
- `tests/validation/test_check_citation_freshness_diff.py`: new home for the extracted `TestDiffParsing` suite (C-quoted header paths, non-ASCII paths, U+2028, type-change, pure-rename cases), unchanged in behavior.
- `tests/validation/test_check_citation_freshness.py`: `test_validate_wrapper_returns_false_on_git_failure` pins the boolean wrapper's git-failure branch, the one `pre_pr` actually calls; `test_heading_with_colon_never_harvests_a_continuation_quote` pins the colon-plus-indented-body case; `test_comment_continuation_anchor_still_joins_in_code_files` pins that a wrapped comment sentence still hands its identifier anchor to a stale citation.

## Acceptance criteria

- [x] A Markdown heading citation is not judged against anchors harvested from the following body line
- [x] Two adjacent Markdown headings never pool anchors
- [x] A heading ending in a colon never harvests the indented body below it as a continuation quote
- [x] Blockquoted headings are headings, marker spacing up to CommonMark's 4-space maximum included; hashtag paragraphs are body text
- [x] Comment lines still join comment lines as wrapped-sentence context
- [x] The heading boundary tests fail when their guards are removed (mutation-verified)
- [x] `validate_citation_freshness` returns False when git fails mid-run

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, no rush

**Focus areas**: the heading classification in `_context_lines` and the flag threading in `_check_citation`; everything else is test relocation and new pins.

## Testing

Deliverables in this PR:

- [x] Tests added/updated

All 66 gate tests pass locally (`uv run pytest tests/validation/test_check_citation_freshness*.py`); each new guard was verified discriminating by mutation (the matching test fails with the guard removed, byte-identical restore confirmed after each probe).

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5337

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSEWmJo3dWpBW4xKBvQxwp