### PR TITLE
feat(validation): detect a repository flagged bare while it has a work tree

### DIFF
--- a/.agents/governance/GOTCHAS.md
+++ b/.agents/governance/GOTCHAS.md
@@ -481,6 +481,18 @@ is bad. Check `git config core.bare` before believing a push failure, and
 re-verify against a repaired repository before attributing anything to your
 change. Tracked in issue #4698.
 
+Detection now exists. `scripts/validation/check_repo_health.py` runs as the
+first `pre-commit` and `pre-push` job and fails with a repair named for the
+config scope that carries the value. It reads every scope rather than the
+effective answer, because the immunization above makes a repaired worktree
+report itself healthy while its siblings are still dead. It cannot help from a
+worktree git already refuses: lefthook resolves the top level before its first
+job and exits 128 there, so run the script by hand in that case:
+
+```
+uv run --frozen python scripts/validation/check_repo_health.py
+```
+
 ## When several unrelated checks fail at once, suspect the substrate
 
 The `core.bare` incident above produced four plausible and independent-looking

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,12 +23,19 @@ pre-commit:
     # It runs first because the failures it causes name the wrong component:
     # the incident produced four unrelated-looking diagnoses before the shared
     # cause was found. One accurate message has to precede all of them.
-    # Cap sized from the script's own watchdog, not from a default. The healthy
-    # path is one `git config --show-scope` read under GIT_TIMEOUT_SECONDS = 5,
-    # so 10s is that watchdog plus 5s of interpreter headroom. Measured on this
-    # checkout: 0.077s and 0.130s warm, 0.944s on the run that also built the
-    # venv. The pair below is funded from one allocation (see repair-packed-refs)
-    # so the stage's declared worst case does not rise; ADR-104 rule 7 and
+    # Cap sized from the script's own budget, not from a default. The script
+    # holds GIT_BUDGET_SECONDS = 7 across the whole evaluation and exits 3 when
+    # it runs out, so this 10s cap is that budget plus 3s of interpreter
+    # headroom and is never what stops the job. Measured on this checkout:
+    # 0.077s and 0.130s warm, 0.944s on the run that also built the venv.
+    # The per-call GIT_TIMEOUT_SECONDS = 5 watchdog does NOT bound the run: the
+    # corrupted path issues five sequential git calls, so the watchdog alone
+    # allows 25s and lefthook would kill the job before it printed the repair,
+    # which is the one message this gate exists to deliver.
+    # `tests/validation/test_check_repo_health_budget.py` parses this cap and
+    # fails if either number moves without the other. The pair below is funded
+    # from one allocation (see repair-packed-refs) so the stage's declared worst
+    # case does not rise; ADR-104 rule 7 and
     # `tests/ci/test_lefthook_declared_budget.py` both refuse a cap that does.
     - name: repo-health
       timeout: 10s
@@ -434,10 +441,12 @@ pre-push:
     # repository it is validating, so this runs before every job whose failure
     # the corruption would otherwise be blamed for.
     # Same 10s as pre-commit, and for the same reason: the cap tracks the
-    # script's GIT_TIMEOUT_SECONDS = 5 watchdog plus interpreter headroom, not
-    # the stage it runs in. This job is a leading serial singleton, ahead of the
-    # parallel group, so the loaded-machine contention ci-scripts.md MUST-16
-    # measures on a group member does not apply to it.
+    # script's GIT_BUDGET_SECONDS = 7 shared deadline plus interpreter headroom,
+    # not the stage it runs in. The script reports first whatever the machine is
+    # doing, so a slow run yields exit 3 naming the git call that ran out rather
+    # than a lefthook kill with no diagnosis. This job is a leading serial
+    # singleton, ahead of the parallel group, so the loaded-machine contention
+    # ci-scripts.md MUST-16 measures on a group member does not apply to it.
     - name: repo-health
       timeout: 10s
       run: uv run --frozen python scripts/validation/check_repo_health.py

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,8 +23,15 @@ pre-commit:
     # It runs first because the failures it causes name the wrong component:
     # the incident produced four unrelated-looking diagnoses before the shared
     # cause was found. One accurate message has to precede all of them.
+    # Cap sized from the script's own watchdog, not from a default. The healthy
+    # path is one `git config --show-scope` read under GIT_TIMEOUT_SECONDS = 5,
+    # so 10s is that watchdog plus 5s of interpreter headroom. Measured on this
+    # checkout: 0.077s and 0.130s warm, 0.944s on the run that also built the
+    # venv. The pair below is funded from one allocation (see repair-packed-refs)
+    # so the stage's declared worst case does not rise; ADR-104 rule 7 and
+    # `tests/ci/test_lefthook_declared_budget.py` both refuse a cap that does.
     - name: repo-health
-      timeout: 20s
+      timeout: 10s
       run: uv run --frozen python scripts/validation/check_repo_health.py
 
     - name: repair-packed-refs
@@ -45,8 +52,12 @@ pre-commit:
     # test whose fixture reads live git state. Reuses the existing per-branch
     # push-lock file (push-lock.md) rather than a second scheme; blocks only
     # when that lock is currently held. Bypass: SKIP_PUSH_LOCK_COMMIT_GUARD=1.
+    # 30s -> 20s pays for repo-health's 10s above, so the pre-commit declared
+    # worst case is unchanged. This job's own bound is one subprocess under a
+    # `timeout=10` plus a non-blocking flock probe, and it measured 0.087s here,
+    # so 20s is still twice its internal ceiling.
     - name: push-lock-commit-guard
-      timeout: 30s
+      timeout: 20s
       run: uv run --frozen python scripts/validation/check_push_lock_before_commit.py
 
     - group:
@@ -422,12 +433,20 @@ pre-push:
     # five linked worktrees. The pre-push hook can therefore corrupt the
     # repository it is validating, so this runs before every job whose failure
     # the corruption would otherwise be blamed for.
+    # Same 10s as pre-commit, and for the same reason: the cap tracks the
+    # script's GIT_TIMEOUT_SECONDS = 5 watchdog plus interpreter headroom, not
+    # the stage it runs in. This job is a leading serial singleton, ahead of the
+    # parallel group, so the loaded-machine contention ci-scripts.md MUST-16
+    # measures on a group member does not apply to it.
     - name: repo-health
-      timeout: 1m
+      timeout: 10s
       run: uv run --frozen python scripts/validation/check_repo_health.py
 
+    # 1m -> 50s pays for repo-health's 10s above, so the pre-push declared worst
+    # case is unchanged. This job's single git call runs under a 15s watchdog, so
+    # 50s is still more than three times its internal ceiling.
     - name: repair-packed-refs
-      timeout: 1m
+      timeout: 50s
       run: uv run --frozen python scripts/maintenance/repair_packed_refs.py
 
     - name: mutation-safety

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,15 @@ pre-merge-commit:
 pre-commit:
   piped: true
   jobs:
+    # Issue #4698: a push can write core.bare=true into the shared .git/config,
+    # which leaves every worktree unable to run a command needing a work tree.
+    # It runs first because the failures it causes name the wrong component:
+    # the incident produced four unrelated-looking diagnoses before the shared
+    # cause was found. One accurate message has to precede all of them.
+    - name: repo-health
+      timeout: 20s
+      run: uv run --frozen python scripts/validation/check_repo_health.py
+
     - name: repair-packed-refs
       timeout: 20s
       run: uv run --frozen python scripts/maintenance/repair_packed_refs.py
@@ -392,7 +401,7 @@ pre-commit:
 # everything after it (verified empirically on lefthook 2.1.10: a failing job
 # inside a `parallel: true` group makes later top-level jobs report
 # "(skip) broken pipe"). Stage order:
-#   1. Singleton guards (repair-packed-refs, mutation-safety,
+#   1. Singleton guards (repo-health, repair-packed-refs, mutation-safety,
 #      push-ref-staleness).
 #   2. Fast stage, stdin half: the piped group of cheap ref-payload policies.
 #   3. Fast stage, parallel half: ratchets and policy gates that each finish
@@ -408,6 +417,15 @@ pre-commit:
 pre-push:
   piped: true
   jobs:
+    # Issue #4698: measured twice in one session, a push wrote core.bare=true
+    # into the shared .git/config and broke the main checkout plus three of
+    # five linked worktrees. The pre-push hook can therefore corrupt the
+    # repository it is validating, so this runs before every job whose failure
+    # the corruption would otherwise be blamed for.
+    - name: repo-health
+      timeout: 1m
+      run: uv run --frozen python scripts/validation/check_repo_health.py
+
     - name: repair-packed-refs
       timeout: 1m
       run: uv run --frozen python scripts/maintenance/repair_packed_refs.py

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -47,15 +47,52 @@ alone would report the immunized checkout healthy while three of its siblings
 were dead.
 
 Bareness is only a defect where a work tree is meant to exist, and a genuine
-bare repository answers ``local\ttrue`` as well. The discriminator is a
-``.git`` marker naming *this* repository's git directory at the working
-directory or an ancestor: a directory in a normal checkout, a ``gitdir:`` file
-in a linked worktree or a ``git init --separate-git-dir`` checkout. Comparing
-the marker's target with ``git rev-parse --absolute-git-dir`` keeps a bare
-repository nested inside an unrelated checkout out of scope.
-``git worktree list --porcelain`` was probed as an alternative and rejected: it
-prints ``bare`` for the corrupted checkout, the separate-git-dir checkout, and
-the genuine bare repository alike.
+bare repository answers ``local\ttrue`` as well. The question the discriminator
+has to answer is whether the repository's **main** work tree is meant to exist,
+not whether the checkout being read has one.
+
+The two are not the same, and reading the second is what made this gate print
+destructive advice for a healthy layout. ``git clone --bare seed bareA.git``
+followed by ``git -C bareA.git worktree add wtA master`` is an ordinary git
+setup. ``wtA`` is a live checkout, ``git -C wtA status`` works, and ``wtA``
+carries a ``gitdir:`` marker naming its own private git directory, so anchoring
+on ``git rev-parse --absolute-git-dir`` finds a marker and calls the repository
+corrupted. It is not: ``local\ttrue`` there is the bare parent's config, read
+through the worktree, exactly as designed. Running the ``git config core.bare
+false`` the gate printed writes into that shared config and breaks the bare
+parent (``git -C bareA.git status`` then fails) along with every sibling
+worktree.
+
+So the anchor is ``git rev-parse --path-format=absolute --git-common-dir``,
+which answers the same shared path from the main checkout and from every linked
+worktree, and the main work tree is whichever of these names it:
+
+* a checkout at the working directory or an ancestor whose ``.git`` marker
+  resolves to the common directory. A ``.git`` directory in a normal checkout,
+  or a ``gitdir:`` file in a ``git init --separate-git-dir`` checkout, which
+  ``git worktree list`` no longer reports once the value is set.
+* otherwise the first ``worktree`` line of ``git worktree list --porcelain``,
+  which is the main worktree. This is the case a linked worktree needs, since
+  the main checkout is usually not one of its ancestors. Only that path is read
+  from the listing: its ``bare`` attribute is printed for the corrupted
+  checkout, the separate-git-dir checkout, and the genuine bare repository
+  alike, so it cannot carry the verdict.
+
+That path still needs one filesystem read, because git derives a bare
+repository's main-worktree path by stripping a trailing ``.git`` component:
+measured on git 2.43.0, a bare repository at ``dirD/.git`` reports ``worktree
+dirD`` and a poisoned checkout at ``corrupt/seed`` reports ``worktree
+corrupt/seed``, so the reported path is a pure function of the common directory
+and carries no evidence of its own. What separates them is content: the
+poisoned checkout holds its tracked files, ``dirD`` holds ``.git`` and nothing
+else. A directory that holds nothing but its own ``.git`` entry is a bare
+repository's phantom work tree, not a work tree.
+
+Ambiguity resolves toward "bare by design" on purpose. A miss leaves the reader
+with the four confusing failures this gate front-runs, which is the pre-gate
+status quo; a false alarm hands the reader a command that destroys a healthy
+repository. Only the second is irreversible, so a main work tree that holds no
+content is treated as absent.
 
 Where it runs: first in the ``pre-commit`` and ``pre-push`` job lists, ahead of
 ``repair-packed-refs``. The incident produced four plausible and independent
@@ -118,6 +155,7 @@ _DEFAULT_REPAIR = _SCOPE_REPAIRS["local"]
 _IMMUNIZATION = "git config --worktree core.bare false"
 
 _WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
+
 
 
 class GitExecutionError(RuntimeError):
@@ -213,22 +251,88 @@ def _marker_git_dir(marker: Path) -> Path | None:
     return None
 
 
-def _work_tree_root(start: Path, git_dir: Path) -> Path | None:
-    """Return the checkout whose ``.git`` marker names ``git_dir``, or None.
+def _work_tree_root(start: Path, common_dir: Path) -> Path | None:
+    """Return the checkout whose ``.git`` marker names ``common_dir``, or None.
 
     Ancestors are walked so an invocation from a subdirectory still finds the
-    checkout. The marker's target is compared with the repository's own git
-    directory so a bare repository sitting inside an unrelated checkout is not
-    attributed to that checkout.
+    checkout. Two comparisons matter and both are against the *common* git
+    directory, never against this checkout's own ``--absolute-git-dir``:
+
+    * a linked worktree's marker names its private git directory under
+      ``<common>/worktrees/<name>``, so it does not match, which is what stops a
+      healthy linked worktree of a genuinely bare repository being read as
+      evidence that a main work tree exists.
+    * a bare repository sitting inside an unrelated checkout does not match that
+      checkout's marker either, so it is not attributed to it.
+
+    A ``git init --separate-git-dir`` checkout does match, because its
+    ``gitdir:`` file names the common directory itself. That case needs the
+    walk: once ``core.bare`` is true, ``git worktree list`` names the git
+    directory as the main worktree and never mentions the real checkout.
     """
     for candidate in (start, *start.parents):
         marker = candidate / ".git"
         if not marker.exists():
             continue
         target = marker.resolve() if marker.is_dir() else _marker_git_dir(marker)
-        if target == git_dir:
+        if target == common_dir:
             return candidate
     return None
+
+
+def _common_git_dir(repo_root: Path) -> Path:
+    """Return the repository's shared git directory, absolute.
+
+    ``--path-format=absolute`` because the bare answer is relative to the
+    working directory (``.git`` from a checkout's top level, ``.`` inside a bare
+    repository), and lefthook already requires that flag of the git it runs.
+    """
+    raw = _git(repo_root, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if not raw:
+        raise GitExecutionError("git returned an empty git directory")
+    return Path(raw).resolve()
+
+
+def _reported_main_worktree(repo_root: Path) -> Path | None:
+    """Return the path on the first ``worktree`` line of the porcelain listing.
+
+    That first entry is the main worktree. Later entries are linked worktrees,
+    whose own health this gate does not decide.
+    """
+    raw = _git(repo_root, "worktree", "list", "--porcelain")
+    for line in (raw or "").splitlines():
+        before, separator, path = line.partition("worktree ")
+        if separator and not before and path:
+            return Path(path).resolve()
+    return None
+
+
+def _holds_checked_out_content(work_tree: Path) -> bool:
+    """Report whether a directory holds anything besides its own ``.git`` entry.
+
+    Measured on git 2.43.0: ``git clone --bare seed dirD/.git`` leaves ``dirD``
+    holding ``.git`` and nothing else while git names ``dirD`` as the main
+    worktree, which is indistinguishable by path from a poisoned checkout whose
+    git directory sits at the same place. A checkout holds its tracked files.
+    """
+    try:
+        with os.scandir(work_tree) as entries:
+            return any(entry.name != ".git" for entry in entries)
+    except OSError:
+        return False
+
+
+def _main_work_tree(repo_root: Path, common_dir: Path) -> Path | None:
+    """Return the main work tree this repository is meant to have, or None.
+
+    None is the "bare by design" verdict, and it is where every ambiguity
+    lands: see the module docstring for why a false alarm costs more than a
+    miss here.
+    """
+    candidate = _work_tree_root(repo_root, common_dir) or _reported_main_worktree(repo_root)
+    if candidate is None or candidate.resolve() == common_dir:
+        return None
+    return candidate if _holds_checked_out_content(candidate) else None
 
 
 def _worktree_config_enabled(repo_root: Path) -> bool:
@@ -246,11 +350,7 @@ def diagnose(repo_root: Path) -> RepoHealth:
     if not bare_scopes:
         return RepoHealth("usable", scopes_read=len(scoped))
 
-    raw_git_dir = _git(repo_root, "rev-parse", "--absolute-git-dir")
-    if not raw_git_dir:
-        raise GitExecutionError("git returned an empty git directory")
-
-    work_tree = _work_tree_root(repo_root, Path(raw_git_dir).resolve())
+    work_tree = _main_work_tree(repo_root, _common_git_dir(repo_root))
     if work_tree is None:
         return RepoHealth("bare_by_design", bare_scopes=bare_scopes, scopes_read=len(scoped))
 
@@ -336,8 +436,9 @@ def _evaluate(repo_root: Path) -> int:
         return 0
     if health.status == "bare_by_design":
         print(
-            f"repo health: skipped, {repo_root} is a bare repository with no "
-            "work tree (1 of 1 read scope expected to be bare)"
+            f"repo health: skipped, {repo_root} belongs to a bare repository "
+            f"with no work tree ({len(health.bare_scopes)} of "
+            f"{health.scopes_read} read scope(s) bare by design)"
         )
         return 0
 

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -5,133 +5,68 @@ Something during ``git push`` writes ``core.bare = true`` into the shared
 ``.git/config``. A bare repository cannot have a work tree, so every git
 command needing one fails with ``fatal: this operation must be run in a work
 tree``. Issue #4698 measured it twice in one session: it broke the main
-checkout and three of five linked worktrees at once, and surfaced as four
-unrelated-looking failures (two portability checks in the pre-PR gate, a
-lefthook integration test, and plain ``git status``). Three wrong diagnoses
-were attempted before the shared cause was found, including one issue filed
-and retracted.
-
-``.agents/governance/GOTCHAS.md`` records the same incident and the same
-repair, quoted verbatim from its "Repair" and "Immunize" lines::
+checkout and three of five linked worktrees at once and surfaced as four
+unrelated-looking failures, and three wrong diagnoses were attempted before the
+shared cause was found. ``.agents/governance/GOTCHAS.md`` records the incident
+and the repair, quoted verbatim from its "Repair" and "Immunize" lines::
 
     git config core.bare false
 
     git config --worktree core.bare false          # in the main checkout
     git -C <each linked worktree> config --worktree core.bare false
 
-What the gate reads, and why it is not ``--is-bare-repository``
---------------------------------------------------------------
+Three questions decide the verdict, and each has a counterintuitive answer.
 
-The obvious probe is whether *this* checkout resolves bare. It is the wrong
-one, because in that state nothing local can report anything: measured on
-lefthook 2.1.10, lefthook runs ``git rev-parse --path-format=absolute
---show-toplevel ...`` before its first job and exits 128 on the same fatal
-text, so a hook job can never speak from a bare-flagged worktree, and ``git
-commit`` refuses before reaching a hook at all.
+**Which value counts.** Not ``--is-bare-repository``. In the state that answer
+reports bare, nothing local can report anything: measured on lefthook 2.1.10,
+lefthook runs ``git rev-parse --path-format=absolute --show-toplevel`` before
+its first job and exits 128 on the same fatal text, and ``git commit`` refuses
+even earlier. The state a hook CAN speak from is the mixed one GOTCHAS
+prescribes, where the shared config says true and this worktree carries a
+worktree-scoped false; there the effective answer calls this checkout healthy
+while its siblings are dead. So the gate reads ``--show-scope`` and asks
+:func:`_effective_pair` twice, once for here and once for what a sibling
+without an override sees. Presence of a ``true`` is not the test either, since
+git overrides one scope with another: see :func:`_active_bare_scopes`.
 
-The state a hook CAN speak from is the mixed one GOTCHAS prescribes, and it is
-also the state the incident left behind: the shared config says true while
-this worktree carries a worktree-scoped false. Measured on git 2.43.0 with
-``extensions.worktreeConfig`` enabled, an immunized checkout and its poisoned
-linked worktree answer the same repository differently::
+**Whether a work tree is meant to exist.** A genuine bare repository answers
+``local true`` as well, so bareness alone is not the defect. The question is
+about the repository's *main* work tree, not about the checkout being read, and
+conflating the two made an earlier version of this gate print destructive
+advice: ``git clone --bare seed bareA.git`` then ``git -C bareA.git worktree
+add wtA`` is ordinary git, ``wtA`` is a live checkout carrying a ``gitdir:``
+marker, and running the ``git config core.bare false`` the gate printed writes
+into the bare parent's shared config and breaks it and every sibling at once.
+The anchor is therefore ``rev-parse --path-format=absolute --git-common-dir``,
+which answers the same shared path from every worktree, corroborated by the
+staged index. :func:`_main_work_tree` carries the measurements.
 
-    immunized main    git config --show-scope --get-all core.bare
-                      -> local\ttrue
-                         worktree\tfalse
-    poisoned linked   -> local\ttrue
-    healthy clone     -> local\tfalse
+Ambiguity resolves toward "bare by design" on purpose. A miss returns the
+reader to the pre-gate status quo; a false alarm hands them a command that
+destroys a healthy repository, and only the second is irreversible.
 
-So one scoped read answers for the whole repository, from any worktree that
-still works, and it keeps working in a worktree that does not. Effective value
-alone would report the immunized checkout healthy while three of its siblings
-were dead.
-
-Bareness is only a defect where a work tree is meant to exist, and a genuine
-bare repository answers ``local\ttrue`` as well. The question the discriminator
-has to answer is whether the repository's **main** work tree is meant to exist,
-not whether the checkout being read has one.
-
-The two are not the same, and reading the second is what made this gate print
-destructive advice for a healthy layout. ``git clone --bare seed bareA.git``
-followed by ``git -C bareA.git worktree add wtA master`` is an ordinary git
-setup. ``wtA`` is a live checkout, ``git -C wtA status`` works, and ``wtA``
-carries a ``gitdir:`` marker naming its own private git directory, so anchoring
-on ``git rev-parse --absolute-git-dir`` finds a marker and calls the repository
-corrupted. It is not: ``local\ttrue`` there is the bare parent's config, read
-through the worktree, exactly as designed. Running the ``git config core.bare
-false`` the gate printed writes into that shared config and breaks the bare
-parent (``git -C bareA.git status`` then fails) along with every sibling
-worktree.
-
-So the anchor is ``git rev-parse --path-format=absolute --git-common-dir``,
-which answers the same shared path from the main checkout and from every linked
-worktree, and the main work tree is whichever of these names it:
-
-* a checkout at the working directory or an ancestor whose ``.git`` marker
-  resolves to the common directory. A ``.git`` directory in a normal checkout,
-  or a ``gitdir:`` file in a ``git init --separate-git-dir`` checkout, which
-  ``git worktree list`` no longer reports once the value is set.
-* otherwise the first ``worktree`` line of ``git worktree list --porcelain``,
-  which is the main worktree. This is the case a linked worktree needs, since
-  the main checkout is usually not one of its ancestors. Only that path is read
-  from the listing: its ``bare`` attribute is printed for the corrupted
-  checkout, the separate-git-dir checkout, and the genuine bare repository
-  alike, so it cannot carry the verdict.
-
-That path still needs corroboration, because git derives a bare repository's
-main-worktree path by stripping a trailing ``.git`` component: measured on git
-2.43.0, a bare repository at ``dirD/.git`` reports ``worktree dirD`` and a
-poisoned checkout at ``corrupt/seed`` reports ``worktree corrupt/seed``, so the
-reported path is a pure function of the common directory and carries no
-evidence of its own.
-
-What separates them is repository metadata, not a directory listing. A checkout
-has a staged index; a bare repository has none. Measured on git 2.43.0::
-
-    seed/.git/index                    True    ordinary checkout
-    corrupt/.git/index                 True    checkout later flagged bare
-    dirD/.git/index                    False   git clone --bare seed dirD/.git
-    holder/.git/index                  False   the same, with an unrelated
-                                               README sitting beside it
-    bareA.git/index                    False   bare repository that has handed
-                                               out a linked worktree
-    bareA.git/worktrees/wtA/index      True    that worktree's own index
-
-The listing read stays as a second, independent condition, because a bare
-repository that someone has run ``git read-tree`` inside does acquire an index
-while its phantom work tree still holds nothing but ``.git``. Both conditions
-have to hold: metadata proving a main work tree was ever staged, and content
-proving one is there now. A directory holding files beside a bare repository's
-``.git`` is neither, and reading content alone called that corrupted.
-
-Ambiguity resolves toward "bare by design" on purpose. A miss leaves the reader
-with the four confusing failures this gate front-runs, which is the pre-gate
-status quo; a false alarm hands the reader a command that destroys a healthy
-repository. Only the second is irreversible, so a main work tree that holds no
-content is treated as absent.
+**How long the gate may take.** Long enough to finish, and less than lefthook
+allows, or the diagnosis is replaced by a timeout line. See
+``GIT_BUDGET_SECONDS``.
 
 Where it runs: first in the ``pre-commit`` and ``pre-push`` job lists, ahead of
-``repair-packed-refs``. The incident produced four plausible and independent
-diagnoses before the shared cause was found, so the value is one accurate
-message arriving before any of the failures the corruption would otherwise be
-blamed for. Run it by hand against a worktree that git already refuses; a hook
-cannot, for the lefthook reason above.
+``repair-packed-refs``, so one accurate message precedes every failure the
+corruption would otherwise be blamed for. Run it by hand against a worktree git
+already refuses; a hook cannot, for the lefthook reason above.
 
-Stricter/looser/different than canonical: GOTCHAS names one repair,
-``git config core.bare false``. This gate reads ``--show-scope`` and names a
-repair per scope that actually carries the value, because that one command
-writes to the local config and cannot clear a worktree-scoped, global, or
-system value. It adds the worktree-scoped immunization line only when
+Stricter/looser/different than canonical: GOTCHAS names one repair, ``git
+config core.bare false``. That command writes to the local config and cannot
+clear a worktree-scoped, global, or system value, so this gate names a repair
+per scope that carries the value. It adds the immunization line only when
 ``extensions.worktreeConfig`` is enabled: measured, ``git config --worktree``
 otherwise exits 128 with ``--worktree cannot be used with multiple working
-trees unless the config extension worktreeConfig is enabled``, so printing it
-unconditionally would hand the reader a command that fails.
+trees unless the config extension worktreeConfig is enabled``.
 
 Exit codes (ADR-035):
     0 - Success (no scope flags this work tree bare, or none applies here)
     1 - Logic error (a config scope flags a repository that has a work tree)
     2 - Config error (invalid repository root)
-    3 - External failure (git missing, timed out, or failed unexpectedly)
+    3 - External failure (git missing, timed out, budget exhausted, or failed)
 """
 
 from __future__ import annotations
@@ -140,50 +75,77 @@ import os
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
+
+# Flat import, not `scripts.validation.*`: lefthook and the docs invoke this by
+# file path, so `sys.path[0]` is this directory and an absolute import fails.
+# `tests/validation/test_validation_entry_point_imports.py` reproduces that.
+from check_repo_health_report import (
+    RepoHealth,
+    report_bare_by_design,
+    report_corruption,
+    report_invalid_root,
+    report_not_a_repository,
+    report_unreadable,
+    report_unverifiable,
+    report_usable,
+)
 
 # A hung git must not stall a commit or a push. Local config and rev-parse
 # reads answer in milliseconds, so this only trips on a genuine hang, and the
 # gate then fails closed with exit 3 rather than reporting a verified pass.
 GIT_TIMEOUT_SECONDS = 5
 
+# One deadline for the whole evaluation, because the per-call watchdog does not
+# bound the run: the corrupted path issues five sequential git calls, so it
+# allows 25s against the 10s `timeout:` the `repo-health` job declares in
+# `lefthook.yml`. Which cap fires decides what the reader gets. Measured on
+# lefthook 2.1.10 (`.claude/rules/ci-scripts.md` MUST-19), a `timeout:` kill
+# lands on the job's shell before any guard runs, replacing the repair guidance
+# with a generic timeout line, which is the one failure this gate exists to
+# prevent. So 7s here, plus `uv run` startup measured at 0.077s and 0.130s warm
+# and 0.944s cold, leaves the 10s cap unreached. Exhausting the budget still
+# blocks, with exit 3 naming the command that ran out.
+# `tests/validation/test_check_repo_health_budget.py` pins the two together.
+GIT_BUDGET_SECONDS = 7
+
 # git refuses every command, including `git config --unset-all`, when core.bare
 # holds a value it cannot parse as a boolean. Measured with core.bare=notabool:
 # `git config --show-scope --get-all core.bare` exits 128 with this text.
 _BAD_BOOLEAN_MARKER = "bad boolean config value"
 
-_SCOPE_REPAIRS = {
-    "worktree": "git config --worktree core.bare false",
-    "local": "git config core.bare false",
-    "global": "git config --global --unset-all core.bare",
-    "system": "git config --system --unset-all core.bare",
-    "command": (
-        "remove the command-scoped core.bare override "
-        "(git -c core.bare=..., GIT_CONFIG_PARAMETERS, or GIT_CONFIG_KEY_n)"
-    ),
-}
-_DEFAULT_REPAIR = _SCOPE_REPAIRS["local"]
-
-_IMMUNIZATION = "git config --worktree core.bare false"
-
-_WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
-
-# git resolves the repository's location from the environment before it reads
-# any config, so an inherited value here makes every answer below describe a
-# different repository than the one the gate was pointed at. Measured on git
-# 2.43.0 against a corrupted checkout with GIT_DIR naming an unrelated bare
-# repository: `rev-parse --git-common-dir` and `worktree list --porcelain` both
-# answered for that other repository, turning live corruption into a verified
-# pass. GIT_COMMON_DIR redirects the anchor the same way. GIT_CONFIG_KEY_n and
-# its siblings are deliberately kept: a command-scoped core.bare arrives that
-# way and this gate exists to report it.
+# git resolves the repository's location from the environment before reading
+# any config, so an inherited value makes every answer below describe a
+# different repository. Measured on git 2.43.0 against a corrupted checkout with
+# GIT_DIR naming an unrelated bare repository: `rev-parse --git-common-dir` and
+# `worktree list --porcelain` both answered for that other repository, turning
+# live corruption into a verified pass. GIT_COMMON_DIR redirects the anchor the
+# same way. GIT_CONFIG_KEY_n and its siblings are deliberately kept: a
+# command-scoped core.bare arrives that way and this gate reports it.
 _LOCATION_OVERRIDES = ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR")
 
 # A `.git` marker file holds one short `gitdir:` line. Reading it unbounded lets
 # a marker symlinked at a character device such as /dev/zero stream forever,
 # which hangs the commit or push this gate runs inside.
 _MAX_MARKER_BYTES = 8192
+
+
+@dataclass(slots=True)
+class GitBudget:
+    """The shared deadline every git call in one evaluation draws down.
+
+    Threaded rather than read from module state, so two evaluations in one
+    process do not share a clock.
+    """
+
+    total: float = field(default_factory=lambda: float(GIT_BUDGET_SECONDS))
+    started: float = field(default_factory=time.monotonic)
+
+    def remaining(self) -> float:
+        """Seconds left before the gate must report rather than run more git."""
+        return self.total - (time.monotonic() - self.started)
 
 
 class GitExecutionError(RuntimeError):
@@ -198,24 +160,20 @@ class UnreadableCoreBareError(RuntimeError):
     """core.bare holds a value git refuses to parse, so no git command runs."""
 
 
-@dataclass(frozen=True, slots=True)
-class RepoHealth:
-    """One health verdict for one repository."""
+def _git(
+    repo_root: Path, budget: GitBudget, *args: str, missing_ok: bool = False
+) -> str | None:
+    """Return stdout, preserving each failure mode as its own exception.
 
-    status: str
-    work_tree: Path | None = None
-    bare_scopes: tuple[tuple[str, str], ...] = ()
-    scopes_read: int = 0
-    effective_bare: bool = False
-    worktree_config: bool = False
-    # A `true` a later scope overrides. Reported so a usable verdict on a
-    # repository whose config does contain `true` says which value was masked,
-    # rather than the flat "none set true" that would read as a wrong summary.
-    masked_scopes: tuple[tuple[str, str], ...] = ()
-
-
-def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
-    """Return stdout, preserving each failure mode as its own exception."""
+    The per-call watchdog is clamped by what the shared budget has left, so slow
+    successful calls report rather than being killed. See ``GIT_BUDGET_SECONDS``.
+    """
+    remaining = budget.remaining()
+    if remaining <= 0:
+        raise GitExecutionError(
+            f"the {budget.total:.0f}s git budget ran out before `git "
+            f"{' '.join(args)}`; see GIT_BUDGET_SECONDS in this script"
+        )
     git = shutil.which("git")
     if git is None:
         raise GitExecutionError("git executable not found")
@@ -231,7 +189,7 @@ def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
             capture_output=True,
             encoding="utf-8",
             errors="replace",
-            timeout=GIT_TIMEOUT_SECONDS,
+            timeout=min(GIT_TIMEOUT_SECONDS, remaining),
             check=False,
         )
     except (OSError, subprocess.SubprocessError) as exc:
@@ -248,25 +206,21 @@ def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
     raise GitExecutionError(f"git {' '.join(args)} exited {result.returncode}: {stderr}")
 
 
-def _scoped_core_bare(repo_root: Path) -> tuple[tuple[str, str], ...]:
+def _scoped_core_bare(repo_root: Path, budget: GitBudget) -> tuple[tuple[str, str], ...]:
     """Return every ``(scope, value)`` pair git holds for ``core.bare``.
 
-    ``--type=bool`` makes git do the parsing, so each value arrives already
-    normalized to ``true`` or ``false``. Reimplementing that reading here is
-    what a membership test over a fixed list of spellings got wrong in both
-    directions, measured on git 2.43.0: ``git_parse_maybe_bool`` falls through
-    to integer parsing, so every nonzero integer is true and a repository whose
-    ``git status`` already fatals on ``bare = 2`` passed the gate, while a
-    healthy ``bare = `` (explicitly empty, which git reads as false) blocked
-    every commit and push. The flag also separates the two spellings the untyped
-    listing renders identically, since ``--get-all`` prints an empty field for
-    both a valueless variable (``bare``, true) and an empty one (``bare = ``,
-    false). Unset still exits 1 and an unparseable value still exits 128 with
-    ``bad boolean config value``, leaving ``missing_ok`` and
-    ``UnreadableCoreBareError`` untouched.
+    ``--type=bool`` makes git parse, so values arrive normalized. Reimplementing
+    that was wrong in both directions, measured on git 2.43.0:
+    ``git_parse_maybe_bool`` falls through to integer parsing, so ``bare = 2`` is
+    true to git and passed a spelling-list gate whose repository already fataled,
+    while an explicitly empty ``bare = `` is false to git and blocked every
+    commit. The flag also separates the two spellings ``--get-all`` prints
+    identically, a valueless ``bare`` (true) and an empty one (false). Unset
+    still exits 1 and an unparseable value still exits 128, leaving ``missing_ok``
+    and ``UnreadableCoreBareError`` untouched.
     """
     read = ("config", "--show-scope", "--type=bool", "--get-all", "core.bare")
-    raw = _git(repo_root, *read, missing_ok=True)
+    raw = _git(repo_root, budget, *read, missing_ok=True)
     if not raw:
         return ()
     pairs = []
@@ -281,9 +235,8 @@ def _marker_git_dir(marker: Path) -> Path | None:
     """Resolve the git directory a ``.git`` file points at, or None.
 
     Only a regular file of plausible size is read. ``is_file`` follows the
-    symlink, so a ``.git`` symlinked at ``/dev/zero`` is rejected as a character
-    device rather than read until the gate is killed, and an oversized regular
-    file is refused before any of it reaches memory.
+    symlink, so a ``.git`` symlinked at ``/dev/zero`` is refused as a character
+    device rather than streamed until the gate is killed.
     """
     try:
         if not marker.is_file() or marker.stat().st_size > _MAX_MARKER_BYTES:
@@ -307,20 +260,14 @@ def _work_tree_root(start: Path, common_dir: Path) -> Path | None:
     """Return the checkout whose ``.git`` marker names ``common_dir``, or None.
 
     Ancestors are walked so an invocation from a subdirectory still finds the
-    checkout. Two comparisons matter and both are against the *common* git
-    directory, never against this checkout's own ``--absolute-git-dir``:
-
-    * a linked worktree's marker names its private git directory under
-      ``<common>/worktrees/<name>``, so it does not match, which is what stops a
-      healthy linked worktree of a genuinely bare repository being read as
-      evidence that a main work tree exists.
-    * a bare repository sitting inside an unrelated checkout does not match that
-      checkout's marker either, so it is not attributed to it.
-
-    A ``git init --separate-git-dir`` checkout does match, because its
-    ``gitdir:`` file names the common directory itself. That case needs the
-    walk: once ``core.bare`` is true, ``git worktree list`` names the git
-    directory as the main worktree and never mentions the real checkout.
+    checkout. The comparison is against the *common* git directory, never this
+    checkout's own ``--absolute-git-dir``, which is what keeps two healthy
+    layouts out: a linked worktree's marker names a private directory under
+    ``<common>/worktrees/<name>``, and a bare repository nested inside an
+    unrelated checkout does not match that checkout's marker. A ``git init
+    --separate-git-dir`` checkout does match, and needs this walk, because once
+    ``core.bare`` is true ``git worktree list`` names the git directory as the
+    main worktree and never mentions the real checkout.
     """
     for candidate in (start, *start.parents):
         marker = candidate / ".git"
@@ -332,26 +279,26 @@ def _work_tree_root(start: Path, common_dir: Path) -> Path | None:
     return None
 
 
-def _common_git_dir(repo_root: Path) -> Path:
+def _common_git_dir(repo_root: Path, budget: GitBudget) -> Path:
     """Return the repository's shared git directory, absolute.
 
     ``--path-format=absolute`` because the bare answer is relative to the
-    working directory (``.git`` from a checkout's top level, ``.`` inside a bare
-    repository), and lefthook already requires that flag of the git it runs.
+    working directory: ``.git`` from a checkout's top level, ``.`` inside a bare
+    repository.
     """
-    raw = _git(repo_root, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    raw = _git(repo_root, budget, "rev-parse", "--path-format=absolute", "--git-common-dir")
     if not raw:
         raise GitExecutionError("git returned an empty git directory")
     return Path(raw).resolve()
 
 
-def _reported_main_worktree(repo_root: Path) -> Path | None:
+def _reported_main_worktree(repo_root: Path, budget: GitBudget) -> Path | None:
     """Return the path on the first ``worktree`` line of the porcelain listing.
 
-    That first entry is the main worktree. Later entries are linked worktrees,
+    The first entry is the main worktree; later entries are linked worktrees,
     whose own health this gate does not decide.
     """
-    raw = _git(repo_root, "worktree", "list", "--porcelain")
+    raw = _git(repo_root, budget, "worktree", "list", "--porcelain")
     for line in (raw or "").splitlines():
         before, separator, path = line.partition("worktree ")
         if separator and not before and path:
@@ -363,9 +310,8 @@ def _holds_checked_out_content(work_tree: Path) -> bool:
     """Report whether a directory holds anything besides its own ``.git`` entry.
 
     Measured on git 2.43.0: ``git clone --bare seed dirD/.git`` leaves ``dirD``
-    holding ``.git`` and nothing else while git names ``dirD`` as the main
-    worktree, which is indistinguishable by path from a poisoned checkout whose
-    git directory sits at the same place. A checkout holds its tracked files.
+    holding ``.git`` alone while git names ``dirD`` the main worktree, which by
+    path is indistinguishable from a poisoned checkout. A checkout holds files.
     """
     try:
         with os.scandir(work_tree) as entries:
@@ -375,17 +321,22 @@ def _holds_checked_out_content(work_tree: Path) -> bool:
 
 
 def _has_main_work_tree_index(common_dir: Path) -> bool:
-    """Report whether git holds a staged index for this repository's main work tree.
+    """Report whether git holds a staged index for the main work tree.
 
     Repository metadata, which a directory listing is not. Measured on git
-    2.43.0: ``git init --bare`` and ``git clone --bare`` create no ``index``
-    entry, every checkout gains one from its first ``git add``, and a linked
-    worktree keeps its own under ``<common>/worktrees/<name>/index``, so a bare
-    repository that has handed out worktrees still has none of its own. The
-    module docstring carries the full measurement table.
+    2.43.0::
 
-    Answering ``False`` for an unreadable path keeps ambiguity resolving toward
-    "bare by design", which is the direction the module docstring justifies.
+        seed/.git/index                True   ordinary checkout
+        corrupt/.git/index             True   checkout later flagged bare
+        dirD/.git/index                False  git clone --bare seed dirD/.git
+        holder/.git/index              False  the same, with an unrelated
+                                              README sitting beside it
+        bareA.git/index                False  bare repository that handed out
+                                              a linked worktree
+        bareA.git/worktrees/wtA/index  True   that worktree's own index
+
+    An unreadable path answers ``False``, keeping ambiguity on the
+    bare-by-design side the module docstring justifies.
     """
     try:
         return (common_dir / "index").is_file()
@@ -393,18 +344,18 @@ def _has_main_work_tree_index(common_dir: Path) -> bool:
         return False
 
 
-def _main_work_tree(repo_root: Path, common_dir: Path) -> Path | None:
+def _main_work_tree(repo_root: Path, common_dir: Path, budget: GitBudget) -> Path | None:
     """Return the main work tree this repository is meant to have, or None.
 
-    None is the "bare by design" verdict, and it is where every ambiguity
-    lands: see the module docstring for why a false alarm costs more than a
-    miss here. A candidate has to clear both the metadata condition and the
-    content condition, because either alone admits a healthy layout: a file
-    sitting beside a bare repository's ``.git`` passes the content read, and a
-    bare repository someone ran ``git read-tree`` inside passes the metadata
-    read.
+    None is the "bare by design" verdict, where every ambiguity lands. A
+    candidate clears both the metadata and the content condition, because either
+    alone admits a healthy layout: an unrelated file beside a bare repository's
+    ``.git`` passes the content read, and a bare repository someone ran ``git
+    read-tree`` inside passes the metadata read.
     """
-    candidate = _work_tree_root(repo_root, common_dir) or _reported_main_worktree(repo_root)
+    candidate = _work_tree_root(repo_root, common_dir) or _reported_main_worktree(
+        repo_root, budget
+    )
     if candidate is None or candidate.resolve() == common_dir:
         return None
     if not _has_main_work_tree_index(common_dir):
@@ -412,10 +363,11 @@ def _main_work_tree(repo_root: Path, common_dir: Path) -> Path | None:
     return candidate if _holds_checked_out_content(candidate) else None
 
 
-def _worktree_config_enabled(repo_root: Path) -> bool:
+def _worktree_config_enabled(repo_root: Path, budget: GitBudget) -> bool:
     """Report whether ``extensions.worktreeConfig`` permits a worktree-scoped fix."""
     value = _git(
         repo_root,
+        budget,
         "config",
         "--type=bool",
         "--get",
@@ -430,23 +382,19 @@ def _effective_pair(
 ) -> tuple[str, str] | None:
     """Return the ``(scope, value)`` pair git resolves as effective, or None.
 
-    ``core.bare`` is single-valued, so git answers it with one value however
-    many scopes carry it: the last one wins. ``--show-scope --get-all`` emits
-    values in git's own precedence order, system through command, and
-    ``git config --get`` returns the final line. Measured on git 2.43.0, where
-    the ``--get`` column is the fact this function reproduces::
+    ``core.bare`` is single-valued: however many scopes carry it, the last one
+    wins. ``--show-scope --get-all`` emits in git's precedence order, system
+    through command, and ``git config --get`` returns the final line. Measured
+    on git 2.43.0, where ``--get`` is the column this reproduces::
 
-        get-all                             --get    --is-bare-repository
-        global true, local false            false    false
-        local true, local false             false    false
-        local false, local true             true     true
-        local true, worktree false          false    false
-        local true, worktree false,
-          command false                     false    -
+        get-all                       --get   --is-bare-repository
+        global true, local false      false   false
+        local true, local false       false   false
+        local false, local true       true    true
+        local true, worktree false    false   false
 
-    ``ignore_worktree`` answers the second question this gate needs: what a
-    sibling worktree carrying no override of its own sees. That is why the gate
-    cannot simply read ``--is-bare-repository``; see the module docstring.
+    ``ignore_worktree`` answers the gate's second question: what a sibling
+    worktree carrying no override of its own sees.
     """
     considered = [pair for pair in scoped if not (ignore_worktree and pair[0] == "worktree")]
     return considered[-1] if considered else None
@@ -457,21 +405,14 @@ def _active_bare_scopes(scoped: tuple[tuple[str, str], ...]) -> tuple[tuple[str,
 
     A ``true`` git has already overridden is not a defect. ``global true`` under
     a ``local false``, or a stale ``local true`` followed by ``local false``,
-    leaves every worktree of the repository usable, so reporting it would print
-    a repair for a condition nobody has. Presence of the token is therefore not
-    the test; the effective value is.
+    leaves every worktree usable, so reporting it prints a repair for a condition
+    nobody has. Presence is not the test; the effective value is.
 
-    Two effective values matter, because neither alone covers the incident:
-
-    * this vantage point's own value, so a worktree-scoped ``true`` is caught.
-    * the shared value a sibling without an override sees. The state issue
-      #4698 left behind is ``local true`` plus the worktree-scoped ``false``
-      GOTCHAS prescribes, where this checkout resolves usable while its
-      siblings are dead.
-
-    Every true-carrying scope is then reported, not only the governing one,
-    because clearing the top scope can expose a lower one and the reader is
-    better served seeing both repairs at once.
+    Two effective values matter, because neither alone covers the incident: this
+    vantage point's own, so a worktree-scoped ``true`` is caught, and the shared
+    value a sibling without an override sees, which is the state issue #4698 left
+    behind. Every true-carrying scope is then reported, not only the governing
+    one, because clearing the top scope can expose a lower one.
     """
     here = _effective_pair(scoped)
     shared = _effective_pair(scoped, ignore_worktree=True)
@@ -483,9 +424,10 @@ def _active_bare_scopes(scoped: tuple[tuple[str, str], ...]) -> tuple[tuple[str,
     return tuple((scope, value) for scope, value in scoped if value == "true")
 
 
-def diagnose(repo_root: Path) -> RepoHealth:
-    """Classify the repository. Raises the typed errors above on failure."""
-    scoped = _scoped_core_bare(repo_root)
+def diagnose(repo_root: Path, budget: GitBudget | None = None) -> RepoHealth:
+    """Classify the repository, on a fresh budget unless one is supplied."""
+    budget = budget or GitBudget()
+    scoped = _scoped_core_bare(repo_root, budget)
     bare_scopes = _active_bare_scopes(scoped)
     if not bare_scopes:
         return RepoHealth(
@@ -494,7 +436,7 @@ def diagnose(repo_root: Path) -> RepoHealth:
             masked_scopes=tuple(pair for pair in scoped if pair[1] == "true"),
         )
 
-    work_tree = _main_work_tree(repo_root, _common_git_dir(repo_root))
+    work_tree = _main_work_tree(repo_root, _common_git_dir(repo_root, budget), budget)
     if work_tree is None:
         return RepoHealth("bare_by_design", bare_scopes=bare_scopes, scopes_read=len(scoped))
 
@@ -503,58 +445,8 @@ def diagnose(repo_root: Path) -> RepoHealth:
         work_tree=work_tree,
         bare_scopes=bare_scopes,
         scopes_read=len(scoped),
-        effective_bare=_git(repo_root, "rev-parse", "--is-bare-repository") == "true",
-        worktree_config=_worktree_config_enabled(repo_root),
-    )
-
-
-def _repair_lines(health: RepoHealth) -> list[str]:
-    """One repair per scope that carries the value, plus the immunization."""
-    lines = [
-        _SCOPE_REPAIRS.get(scope, _DEFAULT_REPAIR) for scope, _value in health.bare_scopes
-    ]
-    if health.worktree_config and not any(
-        scope == "worktree" for scope, _value in health.bare_scopes
-    ):
-        lines.append(
-            f"{_IMMUNIZATION}   (in every worktree, so a later flip cannot break it)"
-        )
-    return lines
-
-
-def _report_corruption(health: RepoHealth) -> None:
-    """Name the condition, its blast radius, and a repair per poisoned scope."""
-    scopes = ", ".join(f"{scope}={value}" for scope, value in health.bare_scopes)
-    print(
-        f"[FAIL] core.bare is set true ({scopes}) for a repository whose work "
-        f"tree is {health.work_tree}.",
-        file=sys.stderr,
-    )
-    print(f"Every git command needing a work tree fails with: {_WORK_TREE_FATAL}.", file=sys.stderr)
-    if not health.effective_bare:
-        print(
-            "This worktree still resolves usable, so the damage is in a config "
-            "it overrides: any worktree without that override is already broken.",
-            file=sys.stderr,
-        )
-    for line in _repair_lines(health):
-        print(f"Fix: {line}", file=sys.stderr)
-    print(
-        "A push can write this value, so a rejected push is not by itself "
-        "evidence that the branch is bad. Refs issue #4698 and "
-        ".agents/governance/GOTCHAS.md.",
-        file=sys.stderr,
-    )
-
-
-def _report_unreadable(repo_root: Path, detail: str) -> None:
-    """Report a core.bare value git cannot parse, which no git command can clear."""
-    print(f"[FAIL] {repo_root} has an unusable core.bare value: {detail}", file=sys.stderr)
-    print(
-        "git refuses every command in this repository, `git config --unset-all "
-        "core.bare` included, so edit the core.bare line out of the config file "
-        "by hand. Refs issue #4698.",
-        file=sys.stderr,
+        effective_bare=_git(repo_root, budget, "rev-parse", "--is-bare-repository") == "true",
+        worktree_config=_worktree_config_enabled(repo_root, budget),
     )
 
 
@@ -563,32 +455,23 @@ def _evaluate(repo_root: Path) -> int:
     try:
         health = diagnose(repo_root)
     except NotGitRepositoryError:
-        print(f"repo health: skipped, {repo_root} is not a git repository (0 scopes read)")
+        report_not_a_repository(repo_root)
         return 0
     except UnreadableCoreBareError as exc:
-        _report_unreadable(repo_root, str(exc))
+        report_unreadable(repo_root, str(exc))
         return 1
     except GitExecutionError as exc:
-        print(f"[ERROR] Repository health could not be verified: {exc}", file=sys.stderr)
+        report_unverifiable(str(exc))
         return 3
 
     if health.status == "usable":
-        masked = ", ".join(f"{scope}={value}" for scope, value in health.masked_scopes)
-        detail = f"{masked} overridden by a later scope" if masked else "none set true"
-        print(
-            f"repo health: core.bare read in {health.scopes_read} config scope(s), "
-            f"{detail}, for {repo_root}"
-        )
+        report_usable(repo_root, health)
         return 0
     if health.status == "bare_by_design":
-        print(
-            f"repo health: skipped, {repo_root} belongs to a bare repository "
-            f"with no work tree ({len(health.bare_scopes)} of "
-            f"{health.scopes_read} read scope(s) bare by design)"
-        )
+        report_bare_by_design(repo_root, health)
         return 0
 
-    _report_corruption(health)
+    report_corruption(health)
     return 1
 
 
@@ -597,7 +480,7 @@ def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     repo_root = Path(args[0]).resolve() if args else Path(__file__).resolve().parents[2]
     if not repo_root.is_dir():
-        print(f"[FAIL] Invalid repository root: {repo_root}", file=sys.stderr)
+        report_invalid_root(repo_root)
         return 2
     return _evaluate(repo_root)
 

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+r"""Gate: no config scope flags a repository bare while it has a work tree.
+
+Something during ``git push`` writes ``core.bare = true`` into the shared
+``.git/config``. A bare repository cannot have a work tree, so every git
+command needing one fails with ``fatal: this operation must be run in a work
+tree``. Issue #4698 measured it twice in one session: it broke the main
+checkout and three of five linked worktrees at once, and surfaced as four
+unrelated-looking failures (two portability checks in the pre-PR gate, a
+lefthook integration test, and plain ``git status``). Three wrong diagnoses
+were attempted before the shared cause was found, including one issue filed
+and retracted.
+
+``.agents/governance/GOTCHAS.md`` records the same incident and the same
+repair, quoted verbatim from its "Repair" and "Immunize" lines::
+
+    git config core.bare false
+
+    git config --worktree core.bare false          # in the main checkout
+    git -C <each linked worktree> config --worktree core.bare false
+
+What the gate reads, and why it is not ``--is-bare-repository``
+--------------------------------------------------------------
+
+The obvious probe is whether *this* checkout resolves bare. It is the wrong
+one, because in that state nothing local can report anything: measured on
+lefthook 2.1.10, lefthook runs ``git rev-parse --path-format=absolute
+--show-toplevel ...`` before its first job and exits 128 on the same fatal
+text, so a hook job can never speak from a bare-flagged worktree, and ``git
+commit`` refuses before reaching a hook at all.
+
+The state a hook CAN speak from is the mixed one GOTCHAS prescribes, and it is
+also the state the incident left behind: the shared config says true while
+this worktree carries a worktree-scoped false. Measured on git 2.43.0 with
+``extensions.worktreeConfig`` enabled, an immunized checkout and its poisoned
+linked worktree answer the same repository differently::
+
+    immunized main    git config --show-scope --get-all core.bare
+                      -> local\ttrue
+                         worktree\tfalse
+    poisoned linked   -> local\ttrue
+    healthy clone     -> local\tfalse
+
+So one scoped read answers for the whole repository, from any worktree that
+still works, and it keeps working in a worktree that does not. Effective value
+alone would report the immunized checkout healthy while three of its siblings
+were dead.
+
+Bareness is only a defect where a work tree is meant to exist, and a genuine
+bare repository answers ``local\ttrue`` as well. The discriminator is a
+``.git`` marker naming *this* repository's git directory at the working
+directory or an ancestor: a directory in a normal checkout, a ``gitdir:`` file
+in a linked worktree or a ``git init --separate-git-dir`` checkout. Comparing
+the marker's target with ``git rev-parse --absolute-git-dir`` keeps a bare
+repository nested inside an unrelated checkout out of scope.
+``git worktree list --porcelain`` was probed as an alternative and rejected: it
+prints ``bare`` for the corrupted checkout, the separate-git-dir checkout, and
+the genuine bare repository alike.
+
+Where it runs: first in the ``pre-commit`` and ``pre-push`` job lists, ahead of
+``repair-packed-refs``. The incident produced four plausible and independent
+diagnoses before the shared cause was found, so the value is one accurate
+message arriving before any of the failures the corruption would otherwise be
+blamed for. Run it by hand against a worktree that git already refuses; a hook
+cannot, for the lefthook reason above.
+
+Stricter/looser/different than canonical: GOTCHAS names one repair,
+``git config core.bare false``. This gate reads ``--show-scope`` and names a
+repair per scope that actually carries the value, because that one command
+writes to the local config and cannot clear a worktree-scoped, global, or
+system value. It adds the worktree-scoped immunization line only when
+``extensions.worktreeConfig`` is enabled: measured, ``git config --worktree``
+otherwise exits 128 with ``--worktree cannot be used with multiple working
+trees unless the config extension worktreeConfig is enabled``, so printing it
+unconditionally would hand the reader a command that fails.
+
+Exit codes (ADR-035):
+    0 - Success (no scope flags this work tree bare, or none applies here)
+    1 - Logic error (a config scope flags a repository that has a work tree)
+    2 - Config error (invalid repository root)
+    3 - External failure (git missing, timed out, or failed unexpectedly)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# A hung git must not stall a commit or a push. Local config and rev-parse
+# reads answer in milliseconds, so this only trips on a genuine hang, and the
+# gate then fails closed with exit 3 rather than reporting a verified pass.
+GIT_TIMEOUT_SECONDS = 5
+
+# git refuses every command, including `git config --unset-all`, when core.bare
+# holds a value it cannot parse as a boolean. Measured with core.bare=notabool:
+# `git config --show-scope --get-all core.bare` exits 128 with this text.
+_BAD_BOOLEAN_MARKER = "bad boolean config value"
+
+# git reads a variable with no value as true, so an empty string belongs here.
+_TRUE_VALUES = frozenset({"", "true", "yes", "on", "1"})
+
+_SCOPE_REPAIRS = {
+    "worktree": "git config --worktree core.bare false",
+    "local": "git config core.bare false",
+    "global": "git config --global --unset-all core.bare",
+    "system": "git config --system --unset-all core.bare",
+    "command": (
+        "remove the command-scoped core.bare override "
+        "(git -c core.bare=..., GIT_CONFIG_PARAMETERS, or GIT_CONFIG_KEY_n)"
+    ),
+}
+_DEFAULT_REPAIR = _SCOPE_REPAIRS["local"]
+
+_IMMUNIZATION = "git config --worktree core.bare false"
+
+_WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
+
+
+class GitExecutionError(RuntimeError):
+    """Git was unavailable or failed before the gate could establish a fact."""
+
+
+class NotGitRepositoryError(RuntimeError):
+    """The target is explicitly outside a Git repository."""
+
+
+class UnreadableCoreBareError(RuntimeError):
+    """core.bare holds a value git refuses to parse, so no git command runs."""
+
+
+@dataclass(frozen=True, slots=True)
+class RepoHealth:
+    """One health verdict for one repository."""
+
+    status: str
+    work_tree: Path | None = None
+    bare_scopes: tuple[tuple[str, str], ...] = ()
+    scopes_read: int = 0
+    effective_bare: bool = False
+    worktree_config: bool = False
+
+
+def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
+    """Return stdout, preserving each failure mode as its own exception."""
+    git = shutil.which("git")
+    if git is None:
+        raise GitExecutionError("git executable not found")
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    try:
+        result = subprocess.run(
+            [git, *args],
+            cwd=str(repo_root),
+            env=env,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise GitExecutionError(f"git command failed to execute: {exc}") from exc
+    if result.returncode == 0:
+        return result.stdout.strip("\n")
+    stderr = result.stderr.strip()
+    if missing_ok and result.returncode == 1:
+        return None
+    if _BAD_BOOLEAN_MARKER in stderr and "core.bare" in stderr:
+        raise UnreadableCoreBareError(stderr)
+    if "not a git repository" in stderr.lower():
+        raise NotGitRepositoryError(stderr)
+    raise GitExecutionError(f"git {' '.join(args)} exited {result.returncode}: {stderr}")
+
+
+def _is_true(value: str) -> bool:
+    """Apply git's boolean reading, where a valueless variable means true."""
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _scoped_core_bare(repo_root: Path) -> tuple[tuple[str, str], ...]:
+    """Return every ``(scope, value)`` pair git holds for ``core.bare``."""
+    raw = _git(
+        repo_root, "config", "--show-scope", "--get-all", "core.bare", missing_ok=True
+    )
+    if not raw:
+        return ()
+    pairs = []
+    for line in raw.splitlines():
+        scope, separator, value = line.partition("\t")
+        if separator:
+            pairs.append((scope, value))
+    return tuple(pairs)
+
+
+def _marker_git_dir(marker: Path) -> Path | None:
+    """Resolve the git directory a ``.git`` file points at, or None."""
+    try:
+        text = marker.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        before, separator, target = line.partition("gitdir:")
+        if not separator or before.strip():
+            continue
+        path = Path(target.strip())
+        if not path.is_absolute():
+            path = marker.parent / path
+        return path.resolve()
+    return None
+
+
+def _work_tree_root(start: Path, git_dir: Path) -> Path | None:
+    """Return the checkout whose ``.git`` marker names ``git_dir``, or None.
+
+    Ancestors are walked so an invocation from a subdirectory still finds the
+    checkout. The marker's target is compared with the repository's own git
+    directory so a bare repository sitting inside an unrelated checkout is not
+    attributed to that checkout.
+    """
+    for candidate in (start, *start.parents):
+        marker = candidate / ".git"
+        if not marker.exists():
+            continue
+        target = marker.resolve() if marker.is_dir() else _marker_git_dir(marker)
+        if target == git_dir:
+            return candidate
+    return None
+
+
+def _worktree_config_enabled(repo_root: Path) -> bool:
+    """Report whether ``extensions.worktreeConfig`` permits a worktree-scoped fix."""
+    value = _git(
+        repo_root, "config", "--get", "extensions.worktreeConfig", missing_ok=True
+    )
+    return value is not None and _is_true(value)
+
+
+def diagnose(repo_root: Path) -> RepoHealth:
+    """Classify the repository. Raises the typed errors above on failure."""
+    scoped = _scoped_core_bare(repo_root)
+    bare_scopes = tuple((scope, value) for scope, value in scoped if _is_true(value))
+    if not bare_scopes:
+        return RepoHealth("usable", scopes_read=len(scoped))
+
+    raw_git_dir = _git(repo_root, "rev-parse", "--absolute-git-dir")
+    if not raw_git_dir:
+        raise GitExecutionError("git returned an empty git directory")
+
+    work_tree = _work_tree_root(repo_root, Path(raw_git_dir).resolve())
+    if work_tree is None:
+        return RepoHealth("bare_by_design", bare_scopes=bare_scopes, scopes_read=len(scoped))
+
+    return RepoHealth(
+        "corrupted",
+        work_tree=work_tree,
+        bare_scopes=bare_scopes,
+        scopes_read=len(scoped),
+        effective_bare=_git(repo_root, "rev-parse", "--is-bare-repository") == "true",
+        worktree_config=_worktree_config_enabled(repo_root),
+    )
+
+
+def _repair_lines(health: RepoHealth) -> list[str]:
+    """One repair per scope that carries the value, plus the immunization."""
+    lines = [
+        _SCOPE_REPAIRS.get(scope, _DEFAULT_REPAIR) for scope, _value in health.bare_scopes
+    ]
+    if health.worktree_config and not any(
+        scope == "worktree" for scope, _value in health.bare_scopes
+    ):
+        lines.append(
+            f"{_IMMUNIZATION}   (in every worktree, so a later flip cannot break it)"
+        )
+    return lines
+
+
+def _report_corruption(health: RepoHealth) -> None:
+    """Name the condition, its blast radius, and a repair per poisoned scope."""
+    scopes = ", ".join(f"{scope}={value or 'true'}" for scope, value in health.bare_scopes)
+    print(
+        f"[FAIL] core.bare is set true ({scopes}) for a repository whose work "
+        f"tree is {health.work_tree}.",
+        file=sys.stderr,
+    )
+    print(f"Every git command needing a work tree fails with: {_WORK_TREE_FATAL}.", file=sys.stderr)
+    if not health.effective_bare:
+        print(
+            "This worktree still resolves usable, so the damage is in a config "
+            "it overrides: any worktree without that override is already broken.",
+            file=sys.stderr,
+        )
+    for line in _repair_lines(health):
+        print(f"Fix: {line}", file=sys.stderr)
+    print(
+        "A push can write this value, so a rejected push is not by itself "
+        "evidence that the branch is bad. Refs issue #4698 and "
+        ".agents/governance/GOTCHAS.md.",
+        file=sys.stderr,
+    )
+
+
+def _report_unreadable(repo_root: Path, detail: str) -> None:
+    """Report a core.bare value git cannot parse, which no git command can clear."""
+    print(f"[FAIL] {repo_root} has an unusable core.bare value: {detail}", file=sys.stderr)
+    print(
+        "git refuses every command in this repository, `git config --unset-all "
+        "core.bare` included, so edit the core.bare line out of the config file "
+        "by hand. Refs issue #4698.",
+        file=sys.stderr,
+    )
+
+
+def _evaluate(repo_root: Path) -> int:
+    """Evaluate once and return the ADR-035 exit code."""
+    try:
+        health = diagnose(repo_root)
+    except NotGitRepositoryError:
+        print(f"repo health: skipped, {repo_root} is not a git repository (0 scopes read)")
+        return 0
+    except UnreadableCoreBareError as exc:
+        _report_unreadable(repo_root, str(exc))
+        return 1
+    except GitExecutionError as exc:
+        print(f"[ERROR] Repository health could not be verified: {exc}", file=sys.stderr)
+        return 3
+
+    if health.status == "usable":
+        print(
+            f"repo health: core.bare read in {health.scopes_read} config scope(s), "
+            f"none set true, for {repo_root}"
+        )
+        return 0
+    if health.status == "bare_by_design":
+        print(
+            f"repo health: skipped, {repo_root} is a bare repository with no "
+            "work tree (1 of 1 read scope expected to be bare)"
+        )
+        return 0
+
+    _report_corruption(health)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns an ADR-035 exit code."""
+    args = argv if argv is not None else sys.argv[1:]
+    repo_root = Path(args[0]).resolve() if args else Path(__file__).resolve().parents[2]
+    if not repo_root.is_dir():
+        print(f"[FAIL] Invalid repository root: {repo_root}", file=sys.stderr)
+        return 2
+    return _evaluate(repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -321,7 +321,7 @@ def _holds_checked_out_content(work_tree: Path) -> bool:
 
 
 def _has_main_work_tree_index(common_dir: Path) -> bool:
-    """Report whether git holds a staged index for the main work tree.
+    """Report whether git holds a non-empty staged index for the main work tree.
 
     Repository metadata, which a directory listing is not. Measured on git
     2.43.0::
@@ -337,9 +337,20 @@ def _has_main_work_tree_index(common_dir: Path) -> bool:
 
     An unreadable path answers ``False``, keeping ambiguity on the
     bare-by-design side the module docstring justifies.
+
+    Requires a non-trivial index size (> 12 bytes): a bare repository after
+    ``git read-tree`` has an index file, but with an empty entry table the
+    12-byte header is all it holds. A real checkout's index is always larger.
+    This prevents a false positive where ``_maybe_checkout_root`` would
+    otherwise suggest the destructive ``core.bare false`` repair for a bare
+    repository that merely had ``git read-tree`` run inside it.
     """
     try:
-        return (common_dir / "index").is_file()
+        index = common_dir / "index"
+        # The git index header is 12 bytes (4-byte magic + 4-byte version +
+        # 4-byte entry count). An empty index has exactly that + 20 bytes of
+        # SHA checksum = 32 bytes. Anything <= 32 bytes is effectively empty.
+        return index.is_file() and index.stat().st_size > 32
     except OSError:
         return False
 

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -208,6 +208,10 @@ class RepoHealth:
     scopes_read: int = 0
     effective_bare: bool = False
     worktree_config: bool = False
+    # A `true` a later scope overrides. Reported so a usable verdict on a
+    # repository whose config does contain `true` says which value was masked,
+    # rather than the flat "none set true" that would read as a wrong summary.
+    masked_scopes: tuple[tuple[str, str], ...] = ()
 
 
 def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
@@ -421,12 +425,74 @@ def _worktree_config_enabled(repo_root: Path) -> bool:
     return value == "true"
 
 
+def _effective_pair(
+    scoped: tuple[tuple[str, str], ...], *, ignore_worktree: bool = False
+) -> tuple[str, str] | None:
+    """Return the ``(scope, value)`` pair git resolves as effective, or None.
+
+    ``core.bare`` is single-valued, so git answers it with one value however
+    many scopes carry it: the last one wins. ``--show-scope --get-all`` emits
+    values in git's own precedence order, system through command, and
+    ``git config --get`` returns the final line. Measured on git 2.43.0, where
+    the ``--get`` column is the fact this function reproduces::
+
+        get-all                             --get    --is-bare-repository
+        global true, local false            false    false
+        local true, local false             false    false
+        local false, local true             true     true
+        local true, worktree false          false    false
+        local true, worktree false,
+          command false                     false    -
+
+    ``ignore_worktree`` answers the second question this gate needs: what a
+    sibling worktree carrying no override of its own sees. That is why the gate
+    cannot simply read ``--is-bare-repository``; see the module docstring.
+    """
+    considered = [pair for pair in scoped if not (ignore_worktree and pair[0] == "worktree")]
+    return considered[-1] if considered else None
+
+
+def _active_bare_scopes(scoped: tuple[tuple[str, str], ...]) -> tuple[tuple[str, str], ...]:
+    """Return the true-carrying scopes, but only when one of them is in force.
+
+    A ``true`` git has already overridden is not a defect. ``global true`` under
+    a ``local false``, or a stale ``local true`` followed by ``local false``,
+    leaves every worktree of the repository usable, so reporting it would print
+    a repair for a condition nobody has. Presence of the token is therefore not
+    the test; the effective value is.
+
+    Two effective values matter, because neither alone covers the incident:
+
+    * this vantage point's own value, so a worktree-scoped ``true`` is caught.
+    * the shared value a sibling without an override sees. The state issue
+      #4698 left behind is ``local true`` plus the worktree-scoped ``false``
+      GOTCHAS prescribes, where this checkout resolves usable while its
+      siblings are dead.
+
+    Every true-carrying scope is then reported, not only the governing one,
+    because clearing the top scope can expose a lower one and the reader is
+    better served seeing both repairs at once.
+    """
+    here = _effective_pair(scoped)
+    shared = _effective_pair(scoped, ignore_worktree=True)
+    in_force = (here is not None and here[1] == "true") or (
+        shared is not None and shared[1] == "true"
+    )
+    if not in_force:
+        return ()
+    return tuple((scope, value) for scope, value in scoped if value == "true")
+
+
 def diagnose(repo_root: Path) -> RepoHealth:
     """Classify the repository. Raises the typed errors above on failure."""
     scoped = _scoped_core_bare(repo_root)
-    bare_scopes = tuple((scope, value) for scope, value in scoped if value == "true")
+    bare_scopes = _active_bare_scopes(scoped)
     if not bare_scopes:
-        return RepoHealth("usable", scopes_read=len(scoped))
+        return RepoHealth(
+            "usable",
+            scopes_read=len(scoped),
+            masked_scopes=tuple(pair for pair in scoped if pair[1] == "true"),
+        )
 
     work_tree = _main_work_tree(repo_root, _common_git_dir(repo_root))
     if work_tree is None:
@@ -507,9 +573,11 @@ def _evaluate(repo_root: Path) -> int:
         return 3
 
     if health.status == "usable":
+        masked = ", ".join(f"{scope}={value}" for scope, value in health.masked_scopes)
+        detail = f"{masked} overridden by a later scope" if masked else "none set true"
         print(
             f"repo health: core.bare read in {health.scopes_read} config scope(s), "
-            f"none set true, for {repo_root}"
+            f"{detail}, for {repo_root}"
         )
         return 0
     if health.status == "bare_by_design":

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -137,9 +137,6 @@ GIT_TIMEOUT_SECONDS = 5
 # `git config --show-scope --get-all core.bare` exits 128 with this text.
 _BAD_BOOLEAN_MARKER = "bad boolean config value"
 
-# git reads a variable with no value as true, so an empty string belongs here.
-_TRUE_VALUES = frozenset({"", "true", "yes", "on", "1"})
-
 _SCOPE_REPAIRS = {
     "worktree": "git config --worktree core.bare false",
     "local": "git config core.bare false",
@@ -231,16 +228,25 @@ def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
     raise GitExecutionError(f"git {' '.join(args)} exited {result.returncode}: {stderr}")
 
 
-def _is_true(value: str) -> bool:
-    """Apply git's boolean reading, where a valueless variable means true."""
-    return value.strip().lower() in _TRUE_VALUES
-
-
 def _scoped_core_bare(repo_root: Path) -> tuple[tuple[str, str], ...]:
-    """Return every ``(scope, value)`` pair git holds for ``core.bare``."""
-    raw = _git(
-        repo_root, "config", "--show-scope", "--get-all", "core.bare", missing_ok=True
-    )
+    """Return every ``(scope, value)`` pair git holds for ``core.bare``.
+
+    ``--type=bool`` makes git do the parsing, so each value arrives already
+    normalized to ``true`` or ``false``. Reimplementing that reading here is
+    what a membership test over a fixed list of spellings got wrong in both
+    directions, measured on git 2.43.0: ``git_parse_maybe_bool`` falls through
+    to integer parsing, so every nonzero integer is true and a repository whose
+    ``git status`` already fatals on ``bare = 2`` passed the gate, while a
+    healthy ``bare = `` (explicitly empty, which git reads as false) blocked
+    every commit and push. The flag also separates the two spellings the untyped
+    listing renders identically, since ``--get-all`` prints an empty field for
+    both a valueless variable (``bare``, true) and an empty one (``bare = ``,
+    false). Unset still exits 1 and an unparseable value still exits 128 with
+    ``bad boolean config value``, leaving ``missing_ok`` and
+    ``UnreadableCoreBareError`` untouched.
+    """
+    read = ("config", "--show-scope", "--type=bool", "--get-all", "core.bare")
+    raw = _git(repo_root, *read, missing_ok=True)
     if not raw:
         return ()
     pairs = []
@@ -364,15 +370,20 @@ def _main_work_tree(repo_root: Path, common_dir: Path) -> Path | None:
 def _worktree_config_enabled(repo_root: Path) -> bool:
     """Report whether ``extensions.worktreeConfig`` permits a worktree-scoped fix."""
     value = _git(
-        repo_root, "config", "--get", "extensions.worktreeConfig", missing_ok=True
+        repo_root,
+        "config",
+        "--type=bool",
+        "--get",
+        "extensions.worktreeConfig",
+        missing_ok=True,
     )
-    return value is not None and _is_true(value)
+    return value == "true"
 
 
 def diagnose(repo_root: Path) -> RepoHealth:
     """Classify the repository. Raises the typed errors above on failure."""
     scoped = _scoped_core_bare(repo_root)
-    bare_scopes = tuple((scope, value) for scope, value in scoped if _is_true(value))
+    bare_scopes = tuple((scope, value) for scope, value in scoped if value == "true")
     if not bare_scopes:
         return RepoHealth("usable", scopes_read=len(scoped))
 
@@ -406,7 +417,7 @@ def _repair_lines(health: RepoHealth) -> list[str]:
 
 def _report_corruption(health: RepoHealth) -> None:
     """Name the condition, its blast radius, and a repair per poisoned scope."""
-    scopes = ", ".join(f"{scope}={value or 'true'}" for scope, value in health.bare_scopes)
+    scopes = ", ".join(f"{scope}={value}" for scope, value in health.bare_scopes)
     print(
         f"[FAIL] core.bare is set true ({scopes}) for a repository whose work "
         f"tree is {health.work_tree}.",

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -156,6 +156,21 @@ _IMMUNIZATION = "git config --worktree core.bare false"
 
 _WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
 
+# git resolves the repository's location from the environment before it reads
+# any config, so an inherited value here makes every answer below describe a
+# different repository than the one the gate was pointed at. Measured on git
+# 2.43.0 against a corrupted checkout with GIT_DIR naming an unrelated bare
+# repository: `rev-parse --git-common-dir` and `worktree list --porcelain` both
+# answered for that other repository, turning live corruption into a verified
+# pass. GIT_COMMON_DIR redirects the anchor the same way. GIT_CONFIG_KEY_n and
+# its siblings are deliberately kept: a command-scoped core.bare arrives that
+# way and this gate exists to report it.
+_LOCATION_OVERRIDES = ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR")
+
+# A `.git` marker file holds one short `gitdir:` line. Reading it unbounded lets
+# a marker symlinked at a character device such as /dev/zero stream forever,
+# which hangs the commit or push this gate runs inside.
+_MAX_MARKER_BYTES = 8192
 
 
 class GitExecutionError(RuntimeError):
@@ -189,6 +204,8 @@ def _git(repo_root: Path, *args: str, missing_ok: bool = False) -> str | None:
         raise GitExecutionError("git executable not found")
     env = os.environ.copy()
     env["LC_ALL"] = "C"
+    for name in _LOCATION_OVERRIDES:
+        env.pop(name, None)
     try:
         result = subprocess.run(
             [git, *args],
@@ -235,9 +252,18 @@ def _scoped_core_bare(repo_root: Path) -> tuple[tuple[str, str], ...]:
 
 
 def _marker_git_dir(marker: Path) -> Path | None:
-    """Resolve the git directory a ``.git`` file points at, or None."""
+    """Resolve the git directory a ``.git`` file points at, or None.
+
+    Only a regular file of plausible size is read. ``is_file`` follows the
+    symlink, so a ``.git`` symlinked at ``/dev/zero`` is rejected as a character
+    device rather than read until the gate is killed, and an oversized regular
+    file is refused before any of it reaches memory.
+    """
     try:
-        text = marker.read_text(encoding="utf-8", errors="replace")
+        if not marker.is_file() or marker.stat().st_size > _MAX_MARKER_BYTES:
+            return None
+        with marker.open(encoding="utf-8", errors="replace") as handle:
+            text = handle.read(_MAX_MARKER_BYTES)
     except OSError:
         return None
     for line in text.splitlines():

--- a/scripts/validation/check_repo_health.py
+++ b/scripts/validation/check_repo_health.py
@@ -78,15 +78,31 @@ worktree, and the main work tree is whichever of these names it:
   checkout, the separate-git-dir checkout, and the genuine bare repository
   alike, so it cannot carry the verdict.
 
-That path still needs one filesystem read, because git derives a bare
-repository's main-worktree path by stripping a trailing ``.git`` component:
-measured on git 2.43.0, a bare repository at ``dirD/.git`` reports ``worktree
-dirD`` and a poisoned checkout at ``corrupt/seed`` reports ``worktree
-corrupt/seed``, so the reported path is a pure function of the common directory
-and carries no evidence of its own. What separates them is content: the
-poisoned checkout holds its tracked files, ``dirD`` holds ``.git`` and nothing
-else. A directory that holds nothing but its own ``.git`` entry is a bare
-repository's phantom work tree, not a work tree.
+That path still needs corroboration, because git derives a bare repository's
+main-worktree path by stripping a trailing ``.git`` component: measured on git
+2.43.0, a bare repository at ``dirD/.git`` reports ``worktree dirD`` and a
+poisoned checkout at ``corrupt/seed`` reports ``worktree corrupt/seed``, so the
+reported path is a pure function of the common directory and carries no
+evidence of its own.
+
+What separates them is repository metadata, not a directory listing. A checkout
+has a staged index; a bare repository has none. Measured on git 2.43.0::
+
+    seed/.git/index                    True    ordinary checkout
+    corrupt/.git/index                 True    checkout later flagged bare
+    dirD/.git/index                    False   git clone --bare seed dirD/.git
+    holder/.git/index                  False   the same, with an unrelated
+                                               README sitting beside it
+    bareA.git/index                    False   bare repository that has handed
+                                               out a linked worktree
+    bareA.git/worktrees/wtA/index      True    that worktree's own index
+
+The listing read stays as a second, independent condition, because a bare
+repository that someone has run ``git read-tree`` inside does acquire an index
+while its phantom work tree still holds nothing but ``.git``. Both conditions
+have to hold: metadata proving a main work tree was ever staged, and content
+proving one is there now. A directory holding files beside a bare repository's
+``.git`` is neither, and reading content alone called that corrupted.
 
 Ambiguity resolves toward "bare by design" on purpose. A miss leaves the reader
 with the four confusing failures this gate front-runs, which is the pre-gate
@@ -354,15 +370,40 @@ def _holds_checked_out_content(work_tree: Path) -> bool:
         return False
 
 
+def _has_main_work_tree_index(common_dir: Path) -> bool:
+    """Report whether git holds a staged index for this repository's main work tree.
+
+    Repository metadata, which a directory listing is not. Measured on git
+    2.43.0: ``git init --bare`` and ``git clone --bare`` create no ``index``
+    entry, every checkout gains one from its first ``git add``, and a linked
+    worktree keeps its own under ``<common>/worktrees/<name>/index``, so a bare
+    repository that has handed out worktrees still has none of its own. The
+    module docstring carries the full measurement table.
+
+    Answering ``False`` for an unreadable path keeps ambiguity resolving toward
+    "bare by design", which is the direction the module docstring justifies.
+    """
+    try:
+        return (common_dir / "index").is_file()
+    except OSError:
+        return False
+
+
 def _main_work_tree(repo_root: Path, common_dir: Path) -> Path | None:
     """Return the main work tree this repository is meant to have, or None.
 
     None is the "bare by design" verdict, and it is where every ambiguity
     lands: see the module docstring for why a false alarm costs more than a
-    miss here.
+    miss here. A candidate has to clear both the metadata condition and the
+    content condition, because either alone admits a healthy layout: a file
+    sitting beside a bare repository's ``.git`` passes the content read, and a
+    bare repository someone ran ``git read-tree`` inside passes the metadata
+    read.
     """
     candidate = _work_tree_root(repo_root, common_dir) or _reported_main_worktree(repo_root)
     if candidate is None or candidate.resolve() == common_dir:
+        return None
+    if not _has_main_work_tree_index(common_dir):
         return None
     return candidate if _holds_checked_out_content(candidate) else None
 

--- a/scripts/validation/check_repo_health_report.py
+++ b/scripts/validation/check_repo_health_report.py
@@ -1,0 +1,151 @@
+"""What the repo-health gate tells the reader, and the verdict it says it about.
+
+Split from ``check_repo_health.py`` so that file stays under the 500-line taste
+ceiling, but the seam is a real one: this module decides nothing and reads no
+git, and that file spawns no output. Issue #4698 is a diagnosis problem before
+it is a detection problem. The corruption surfaced as four unrelated-looking
+failures and drew three wrong diagnoses, so what the gate prints is the whole
+deliverable and deserves to be readable and testable on its own.
+
+Every line goes to the stream its severity belongs on: a verdict the reader must
+act on to stderr, an all-clear to stdout. Each all-clear carries the number of
+config scopes actually read, so "nothing is wrong" cannot be confused with
+"nothing was examined" (`.claude/rules/ci-scripts.md` MUST-12).
+
+Stricter/looser/different than canonical: `.agents/governance/GOTCHAS.md` names
+one repair, quoted verbatim from its "Repair" and "Immunize" lines::
+
+    git config core.bare false
+
+    git config --worktree core.bare false          # in the main checkout
+    git -C <each linked worktree> config --worktree core.bare false
+
+That first command writes to the local config and cannot clear a
+worktree-scoped, global, or system value, so `_SCOPE_REPAIRS` below names one
+repair per scope that carries the value. The immunization line is added only
+when `extensions.worktreeConfig` is enabled: measured on git 2.43.0,
+`git config --worktree` otherwise exits 128 with `--worktree cannot be used
+with multiple working trees unless the config extension worktreeConfig is
+enabled`, so printing it unconditionally hands the reader a failing command.
+
+Refs #4698.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_SCOPE_REPAIRS = {
+    "worktree": "git config --worktree core.bare false",
+    "local": "git config core.bare false",
+    "global": "git config --global --unset-all core.bare",
+    "system": "git config --system --unset-all core.bare",
+    "command": (
+        "remove the command-scoped core.bare override "
+        "(git -c core.bare=..., GIT_CONFIG_PARAMETERS, or GIT_CONFIG_KEY_n)"
+    ),
+}
+_DEFAULT_REPAIR = _SCOPE_REPAIRS["local"]
+
+_IMMUNIZATION = "git config --worktree core.bare false"
+
+_WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
+
+
+@dataclass(frozen=True, slots=True)
+class RepoHealth:
+    """One health verdict for one repository."""
+
+    status: str
+    work_tree: Path | None = None
+    bare_scopes: tuple[tuple[str, str], ...] = ()
+    scopes_read: int = 0
+    effective_bare: bool = False
+    worktree_config: bool = False
+    # A `true` a later scope overrides, reported so a usable verdict names it
+    # instead of the flat "none set true" that would misdescribe the config.
+    masked_scopes: tuple[tuple[str, str], ...] = ()
+
+
+def _repair_lines(health: RepoHealth) -> list[str]:
+    """One repair per scope that carries the value, plus the immunization."""
+    lines = [
+        _SCOPE_REPAIRS.get(scope, _DEFAULT_REPAIR) for scope, _value in health.bare_scopes
+    ]
+    if health.worktree_config and not any(
+        scope == "worktree" for scope, _value in health.bare_scopes
+    ):
+        lines.append(f"{_IMMUNIZATION}   (in every worktree, so a later flip cannot break it)")
+    return lines
+
+
+def report_corruption(health: RepoHealth) -> None:
+    """Name the condition, its blast radius, and a repair per poisoned scope."""
+    scopes = ", ".join(f"{scope}={value}" for scope, value in health.bare_scopes)
+    print(
+        f"[FAIL] core.bare is set true ({scopes}) for a repository whose work "
+        f"tree is {health.work_tree}.",
+        file=sys.stderr,
+    )
+    print(f"Every git command needing a work tree fails with: {_WORK_TREE_FATAL}.", file=sys.stderr)
+    if not health.effective_bare:
+        print(
+            "This worktree still resolves usable, so the damage is in a config "
+            "it overrides: any worktree without that override is already broken.",
+            file=sys.stderr,
+        )
+    for line in _repair_lines(health):
+        print(f"Fix: {line}", file=sys.stderr)
+    print(
+        "A push can write this value, so a rejected push is not by itself "
+        "evidence that the branch is bad. Refs issue #4698 and "
+        ".agents/governance/GOTCHAS.md.",
+        file=sys.stderr,
+    )
+
+
+def report_unreadable(repo_root: Path, detail: str) -> None:
+    """Report a core.bare value git cannot parse, which no git command can clear."""
+    print(f"[FAIL] {repo_root} has an unusable core.bare value: {detail}", file=sys.stderr)
+    print(
+        "git refuses every command in this repository, `git config --unset-all "
+        "core.bare` included, so edit the core.bare line out of the config file "
+        "by hand. Refs issue #4698.",
+        file=sys.stderr,
+    )
+
+
+def report_unverifiable(detail: str) -> None:
+    """Report a state the gate could not read, which is not a verified pass."""
+    print(f"[ERROR] Repository health could not be verified: {detail}", file=sys.stderr)
+
+
+def report_usable(repo_root: Path, health: RepoHealth) -> None:
+    """Say what was read, and name any true a later scope overrode."""
+    masked = ", ".join(f"{scope}={value}" for scope, value in health.masked_scopes)
+    detail = f"{masked} overridden by a later scope" if masked else "none set true"
+    print(
+        f"repo health: core.bare read in {health.scopes_read} config scope(s), "
+        f"{detail}, for {repo_root}"
+    )
+
+
+def report_bare_by_design(repo_root: Path, health: RepoHealth) -> None:
+    """Say the value is correct here, and never print a repair for it."""
+    print(
+        f"repo health: skipped, {repo_root} belongs to a bare repository "
+        f"with no work tree ({len(health.bare_scopes)} of "
+        f"{health.scopes_read} read scope(s) bare by design)"
+    )
+
+
+def report_not_a_repository(repo_root: Path) -> None:
+    """Say nothing was examined, explicitly, rather than reporting an all-clear."""
+    print(f"repo health: skipped, {repo_root} is not a git repository (0 scopes read)")
+
+
+def report_invalid_root(repo_root: Path) -> None:
+    """Report a root the caller named that is not a directory."""
+    print(f"[FAIL] Invalid repository root: {repo_root}", file=sys.stderr)

--- a/scripts/validation/check_repo_health_report.py
+++ b/scripts/validation/check_repo_health_report.py
@@ -38,8 +38,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 _SCOPE_REPAIRS = {
-    "worktree": "git config --worktree core.bare false",
-    "local": "git config core.bare false",
+    "worktree": "git config --worktree --replace-all core.bare false",
+    "local": "git config --replace-all core.bare false",
     "global": "git config --global --unset-all core.bare",
     "system": "git config --system --unset-all core.bare",
     "command": (
@@ -49,7 +49,7 @@ _SCOPE_REPAIRS = {
 }
 _DEFAULT_REPAIR = _SCOPE_REPAIRS["local"]
 
-_IMMUNIZATION = "git config --worktree core.bare false"
+_IMMUNIZATION = "git config --worktree --replace-all core.bare false"
 
 _WORK_TREE_FATAL = "fatal: this operation must be run in a work tree"
 

--- a/tests/bare_repo_scan.py
+++ b/tests/bare_repo_scan.py
@@ -5,214 +5,51 @@ bare repositories only under a temporary path." The gate added for criteria 1
 and 2 (``scripts/validation/check_repo_health.py``) reports the damage after it
 lands; this reports the shape that produces it before it merges.
 
-The mechanism the issue names: ``core.bare`` is worktree-specific once
-``extensions.worktreeConfig`` is on, so a ``git init --bare`` or a
-``git config core.bare true`` that resolves against an inherited working
-directory instead of a fixture path writes into the developer's shared
-``.git/config`` and breaks the main worktree and every linked worktree at once.
+``tests/bare_repo_sites.py`` reads each module and answers what tokens are
+written there. This module answers whether the corpus is safe, which takes two
+things that file cannot see on its own:
 
-Kept out of ``conftest.py`` deliberately: these helpers are specific to one
-assertion, and a package-wide conftest name would be visible to every test
-module. ``tests/gh_base_ref_test_helpers.py`` carries the same reasoning.
+* **The call graph.** A helper such as ``_init_git_repo`` in
+  ``tests/gh_base_ref_test_helpers.py`` takes its target as a parameter, so it
+  is safe exactly when every caller reached through the graph is temp-rooted.
+  Callers live in other modules, which is what ``resolve_more`` pulls in.
+* **The target trace.** Acceptance of the enclosing function is necessary and
+  not sufficient: ``def test_x(tmp_path): subprocess.run(["git", "init",
+  "--bare", "/home/user/live.git"])`` roots the function and writes a bare
+  repository into a live checkout. :func:`_target_is_temp_rooted` follows the
+  command's own argument, ``cwd=``, or command vector back to the root.
+
+Both counts are reported next to the violations, because a violation count
+alone cannot distinguish "nothing is wrong" from "nothing was examined"
+(``.claude/rules/ci-scripts.md`` MUST-12).
 
 Refs #4698, #4717, #4287.
 """
 
 from __future__ import annotations
 
-import ast
 from collections.abc import Callable, Iterator, Mapping
-from dataclasses import dataclass, field
-from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-TESTS_ROOT = PROJECT_ROOT / "tests"
-
-FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
-
-# The only two spellings by which a git argument vector reaches a bare
-# repository. `git init --bare`, `git clone --bare`, and
-# `git config core.bare <value>` all carry one of them as a literal argument.
-BARE_TOKENS = ("--bare", "core.bare")
-
-# pytest's own temp fixtures. Requesting one roots every path the body derives
-# from it under the session temp directory, outside every checkout.
-_PYTEST_TEMP_PARAMS = frozenset(
-    {"tmp_path", "tmp_path_factory", "tmpdir", "tmpdir_factory"}
-)
-
-# stdlib temp factories, matched on the attribute or the bare name so both
-# `tempfile.TemporaryDirectory()` and an imported `TemporaryDirectory()` count.
-_TEMPFILE_FACTORIES = frozenset(
-    {"TemporaryDirectory", "mkdtemp", "mkstemp", "NamedTemporaryFile"}
-)
-
-# This repository's durable fixture root, required by `.claude/rules/testing.md`
-# MUST NOT 4 for fixtures that must outlive one test. `.gitignore` covers it and
-# `validate_plugin_manifests.py` prunes it, so it is a temporary path in the
-# sense the acceptance criterion means even though it sits inside the checkout.
-_REPO_TEMP_ROOT = ".pytest_tmp"
-
-# The scanner's own two modules hold the tokens as data rather than as git
-# arguments, so scanning them reports the token table above and the negative
-# controls in the test module. `TestTheScannerRunsNoGitCommand` keeps the
-# exclusion honest by failing if either file ever spawns a process.
-SCANNER_MODULES = frozenset(
-    {
-        "tests.bare_repo_scan",
-        "tests.test_bare_repo_fixtures_are_temp_rooted",
-    }
+from tests.bare_repo_sites import (
+    BARE_TOKENS,
+    PROJECT_ROOT,
+    SCANNER_MODULES,
+    TESTS_ROOT,
+    FunctionNode,
+    ScanResult,
+    Site,
+    Violation,
+    _has_fixture_decorator,
+    _is_directly_temp_rooted,
+    _ModuleFacts,
+    _parameter_names,
+    _temp_rooted_names,
 )
 
 # Bound above the depth of any helper chain in the suite. Each round pulls the
 # callers of one more level of unaccepted helpers. Exceeding it raises rather
 # than reporting a clean scan of a call graph the walk never finished.
 _MAX_ROUNDS = 8
-
-
-@dataclass(frozen=True)
-class Violation:
-    """One bare-repository literal whose enclosing scope is not temp-rooted."""
-
-    module: str
-    lineno: int
-    token: str
-    scope: str
-    reason: str
-
-    def __str__(self) -> str:
-        return f"{self.module}:{self.lineno}: {self.token!r} in {self.scope} -- {self.reason}"
-
-
-@dataclass
-class ScanResult:
-    """What the scan examined and what it found. Both halves are required.
-
-    A violation count alone cannot distinguish "nothing is wrong" from "nothing
-    was examined" (`.claude/rules/ci-scripts.md` MUST 12), so callers assert on
-    the examined counts too.
-    """
-
-    violations: list[Violation] = field(default_factory=list)
-    modules_parsed: int = 0
-    sites_examined: int = 0
-    functions_accepted: int = 0
-    functions_seen: int = 0
-
-
-class _ModuleFacts:
-    """The AST facts one module contributes to the scan."""
-
-    def __init__(self, module: str, source: str) -> None:
-        self.module = module
-        self.functions: list[FunctionNode] = []
-        self.calls: list[tuple[str, FunctionNode | None]] = []
-        self.sites: list[tuple[str, int, FunctionNode | None, tuple[str, ...]]] = []
-        self.imports: dict[str, tuple[str, str]] = {}
-        self.name_reads: dict[str, set[FunctionNode]] = {}
-        tree = ast.parse(source, filename=module)
-        parents: dict[ast.AST, ast.AST] = {
-            child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)
-        }
-        self._walk(tree, [], parents)
-
-    def _walk(
-        self,
-        node: ast.AST,
-        stack: list[FunctionNode],
-        parents: Mapping[ast.AST, ast.AST],
-    ) -> None:
-        pushed = self._record(node, stack, parents)
-        for child in ast.iter_child_nodes(node):
-            self._walk(child, stack, parents)
-        if pushed:
-            stack.pop()
-
-    def _record(
-        self,
-        node: ast.AST,
-        stack: list[FunctionNode],
-        parents: Mapping[ast.AST, ast.AST],
-    ) -> bool:
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            self.functions.append(node)
-            stack.append(node)
-            return True
-        if isinstance(node, ast.ImportFrom) and node.module:
-            for alias in node.names:
-                self.imports[alias.asname or alias.name] = (node.module, alias.name)
-        elif isinstance(node, ast.Call):
-            name = _callee_name(node)
-            if name:
-                self.calls.append((name, stack[-1] if stack else None))
-        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and stack:
-            self.name_reads.setdefault(node.id, set()).add(stack[-1])
-        elif isinstance(node, ast.Constant) and node.value in BARE_TOKENS:
-            enclosing = stack[-1] if stack else None
-            bindings = () if enclosing else _binding_names(node, parents)
-            self.sites.append((node.value, node.lineno, enclosing, bindings))
-        return False
-
-
-def _callee_name(node: ast.Call) -> str | None:
-    if isinstance(node.func, ast.Name):
-        return node.func.id
-    if isinstance(node.func, ast.Attribute):
-        return node.func.attr
-    return None
-
-
-def _binding_names(node: ast.AST, parents: Mapping[ast.AST, ast.AST]) -> tuple[str, ...]:
-    """Names a module-scope literal is assigned to, walking up to the statement.
-
-    A token at module scope runs no git command by itself. ``_HOSTILE_CONFIG``
-    in ``tests/test_git_isolation_blast_radius.py`` is the live example: it
-    holds ``core.bare`` as the payload a negative control injects into a child
-    process. Attributing the site to the functions that read the binding follows
-    the data to where a git command could actually see it.
-    """
-    current: ast.AST | None = node
-    while current is not None:
-        if isinstance(current, ast.Assign):
-            return tuple(t.id for t in current.targets if isinstance(t, ast.Name))
-        if isinstance(current, ast.AnnAssign) and isinstance(current.target, ast.Name):
-            return (current.target.id,)
-        current = parents.get(current)
-    return ()
-
-
-def _parameter_names(node: FunctionNode) -> list[str]:
-    args = node.args
-    names = [arg.arg for arg in args.posonlyargs + args.args + args.kwonlyargs]
-    if args.vararg:
-        names.append(args.vararg.arg)
-    if args.kwarg:
-        names.append(args.kwarg.arg)
-    return names
-
-
-def _is_directly_temp_rooted(node: FunctionNode) -> bool:
-    """True when the function establishes a temp root without help from callers."""
-    if _PYTEST_TEMP_PARAMS.intersection(_parameter_names(node)):
-        return True
-    for sub in ast.walk(node):
-        if isinstance(sub, ast.Call):
-            name = _callee_name(sub)
-            if name in _TEMPFILE_FACTORIES:
-                return True
-        if isinstance(sub, ast.Constant) and sub.value == _REPO_TEMP_ROOT:
-            return True
-    return False
-
-
-def _has_fixture_decorator(node: FunctionNode) -> bool:
-    for decorator in node.decorator_list:
-        target = decorator.func if isinstance(decorator, ast.Call) else decorator
-        if isinstance(target, ast.Attribute) and target.attr == "fixture":
-            return True
-        if isinstance(target, ast.Name) and target.id == "fixture":
-            return True
-    return False
 
 
 class _Graph:
@@ -277,6 +114,26 @@ class _Graph:
                     accepted.add(node)
                     changed = True
         return accepted
+
+    def vetted_parameters(self, node: FunctionNode, module: str) -> frozenset[str]:
+        """Parameters whose values a caller or a fixture has already rooted.
+
+        A function admitted by :meth:`accepted` because every caller is
+        temp-rooted receives temp-rooted arguments, so its parameters carry the
+        root inward. A function that roots itself does not get that credit for
+        arbitrary parameters, or ``def test_x(tmp_path)`` would launder any
+        literal path it also passes: there only the fixture parameters count.
+        """
+        parameters = _parameter_names(node)
+        fixtures = frozenset(
+            param
+            for param in parameters
+            for candidate in self.resolve(module, param)
+            if _has_fixture_decorator(candidate)
+        )
+        if _is_directly_temp_rooted(node):
+            return fixtures
+        return fixtures | frozenset(parameters)
 
     def _takes_an_accepted_fixture(
         self, node: FunctionNode, module: str, accepted: set[FunctionNode]
@@ -345,11 +202,11 @@ def _site_scopes(graph: _Graph) -> set[FunctionNode]:
     """Functions that must be temp-rooted: site bodies, plus constant readers."""
     scopes: set[FunctionNode] = set()
     for facts in graph.facts.values():
-        for _token, _lineno, enclosing, bindings in facts.sites:
-            if enclosing is not None:
-                scopes.add(enclosing)
+        for site in facts.sites:
+            if site.enclosing is not None:
+                scopes.add(site.enclosing)
                 continue
-            for binding in bindings:
+            for binding in site.bindings:
                 scopes |= facts.name_reads.get(binding, set())
     return scopes
 
@@ -360,6 +217,17 @@ _NO_TEMP_ROOT = (
     "itself not temp-rooted"
 )
 
+_TARGET_NOT_TRACED = (
+    "the function is temp-rooted but this command's target is not: no argument "
+    "of the git call, and no cwd= it is given, resolves back to a temp root"
+)
+
+_MODULE_LEVEL_CALL = (
+    "a bare-repository command at module scope runs during import, against "
+    "whatever directory collection happens to be in; bind it inside a "
+    "temp-rooted function"
+)
+
 
 def _report(graph: _Graph, accepted: set[FunctionNode]) -> ScanResult:
     result = ScanResult(
@@ -368,42 +236,91 @@ def _report(graph: _Graph, accepted: set[FunctionNode]) -> ScanResult:
         functions_seen=len(graph.owner),
     )
     for module, facts in sorted(graph.facts.items()):
-        for token, lineno, enclosing, bindings in facts.sites:
+        for site in facts.sites:
             result.sites_examined += 1
-            if enclosing is None:
-                result.violations.extend(
-                    _constant_violations(facts, module, token, lineno, bindings, accepted)
-                )
-            elif enclosing not in accepted:
-                result.violations.append(
-                    Violation(
-                        module=module,
-                        lineno=lineno,
-                        token=token,
-                        scope=f"{enclosing.name}()",
-                        reason=_NO_TEMP_ROOT,
-                    )
-                )
+            result.violations.extend(_site_violations(graph, facts, module, site, accepted))
     return result
 
 
-def _constant_violations(
+def _site_violations(
+    graph: _Graph,
     facts: _ModuleFacts,
     module: str,
-    token: str,
-    lineno: int,
-    bindings: tuple[str, ...],
+    site: Site,
     accepted: set[FunctionNode],
 ) -> Iterator[Violation]:
-    readers = {r for b in bindings for r in facts.name_reads.get(b, set())}
-    label = "/".join(bindings) or "<unbound>"
+    """Every reason this one token is not shown to write under a temp root."""
+    if site.enclosing is None:
+        yield from _module_scope_violations(facts, module, site, accepted)
+        return
+    if site.enclosing not in accepted:
+        yield Violation(
+            module=module,
+            lineno=site.lineno,
+            token=site.token,
+            scope=f"{site.enclosing.name}()",
+            reason=_NO_TEMP_ROOT,
+        )
+        return
+    if not site.environment and not _target_is_temp_rooted(graph, facts, module, site):
+        yield Violation(
+            module=module,
+            lineno=site.lineno,
+            token=site.token,
+            scope=f"{site.enclosing.name}()",
+            reason=_TARGET_NOT_TRACED,
+        )
+
+
+def _target_is_temp_rooted(
+    graph: _Graph, facts: _ModuleFacts, module: str, site: Site
+) -> bool:
+    """Trace this command's target, or the vector carrying it, to a temp root."""
+    scope = site.enclosing
+    assert scope is not None
+    rooted = _temp_rooted_names(scope, graph.vetted_parameters(scope, module))
+    if site.references & rooted:
+        return True
+    # The build-then-run shape: the token was appended to a vector, so the
+    # target travels with a later call that receives that vector.
+    consumers = facts.call_references.get(scope, [])
+    return any(
+        site.carriers & names and names & rooted for names in consumers
+    )
+
+
+def _module_scope_violations(
+    facts: _ModuleFacts,
+    module: str,
+    site: Site,
+    accepted: set[FunctionNode],
+) -> Iterator[Violation]:
+    """A module-scope token is data until some function reads it, or a call.
+
+    An unbound one is a call: ``subprocess.run(["git", "init", "--bare",
+    "remote.git"])`` at module scope executes at import, during pytest
+    collection, against the ambient working directory. It binds no name, so
+    following bindings to their readers finds nothing and the old walk reported
+    it clean. It is a violation on sight.
+    """
+    if not site.bindings:
+        yield Violation(
+            module=module,
+            lineno=site.lineno,
+            token=site.token,
+            scope="module scope",
+            reason=_MODULE_LEVEL_CALL,
+        )
+        return
+    readers = {r for b in site.bindings for r in facts.name_reads.get(b, set())}
+    label = "/".join(site.bindings)
     for reader in sorted(readers, key=lambda node: node.lineno):
         if reader in accepted:
             continue
         yield Violation(
             module=module,
-            lineno=lineno,
-            token=token,
+            lineno=site.lineno,
+            token=site.token,
             scope=f"module constant {label} read by {reader.name}()",
             reason="the function that reads this constant is not temp-rooted",
         )

--- a/tests/bare_repo_scan.py
+++ b/tests/bare_repo_scan.py
@@ -1,0 +1,458 @@
+"""Static scan: which test functions can create a bare git repository, and where.
+
+Issue #4698 acceptance criterion 3, "Fixture-creating tests are shown to write
+bare repositories only under a temporary path." The gate added for criteria 1
+and 2 (``scripts/validation/check_repo_health.py``) reports the damage after it
+lands; this reports the shape that produces it before it merges.
+
+The mechanism the issue names: ``core.bare`` is worktree-specific once
+``extensions.worktreeConfig`` is on, so a ``git init --bare`` or a
+``git config core.bare true`` that resolves against an inherited working
+directory instead of a fixture path writes into the developer's shared
+``.git/config`` and breaks the main worktree and every linked worktree at once.
+
+Kept out of ``conftest.py`` deliberately: these helpers are specific to one
+assertion, and a package-wide conftest name would be visible to every test
+module. ``tests/gh_base_ref_test_helpers.py`` carries the same reasoning.
+
+Refs #4698, #4717, #4287.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = PROJECT_ROOT / "tests"
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+# The only two spellings by which a git argument vector reaches a bare
+# repository. `git init --bare`, `git clone --bare`, and
+# `git config core.bare <value>` all carry one of them as a literal argument.
+BARE_TOKENS = ("--bare", "core.bare")
+
+# pytest's own temp fixtures. Requesting one roots every path the body derives
+# from it under the session temp directory, outside every checkout.
+_PYTEST_TEMP_PARAMS = frozenset(
+    {"tmp_path", "tmp_path_factory", "tmpdir", "tmpdir_factory"}
+)
+
+# stdlib temp factories, matched on the attribute or the bare name so both
+# `tempfile.TemporaryDirectory()` and an imported `TemporaryDirectory()` count.
+_TEMPFILE_FACTORIES = frozenset(
+    {"TemporaryDirectory", "mkdtemp", "mkstemp", "NamedTemporaryFile"}
+)
+
+# This repository's durable fixture root, required by `.claude/rules/testing.md`
+# MUST NOT 4 for fixtures that must outlive one test. `.gitignore` covers it and
+# `validate_plugin_manifests.py` prunes it, so it is a temporary path in the
+# sense the acceptance criterion means even though it sits inside the checkout.
+_REPO_TEMP_ROOT = ".pytest_tmp"
+
+# The scanner's own two modules hold the tokens as data rather than as git
+# arguments, so scanning them reports the token table above and the negative
+# controls in the test module. `TestTheScannerRunsNoGitCommand` keeps the
+# exclusion honest by failing if either file ever spawns a process.
+SCANNER_MODULES = frozenset(
+    {
+        "tests.bare_repo_scan",
+        "tests.test_bare_repo_fixtures_are_temp_rooted",
+    }
+)
+
+# Bound above the depth of any helper chain in the suite. Each round pulls the
+# callers of one more level of unaccepted helpers. Exceeding it raises rather
+# than reporting a clean scan of a call graph the walk never finished.
+_MAX_ROUNDS = 8
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One bare-repository literal whose enclosing scope is not temp-rooted."""
+
+    module: str
+    lineno: int
+    token: str
+    scope: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.module}:{self.lineno}: {self.token!r} in {self.scope} -- {self.reason}"
+
+
+@dataclass
+class ScanResult:
+    """What the scan examined and what it found. Both halves are required.
+
+    A violation count alone cannot distinguish "nothing is wrong" from "nothing
+    was examined" (`.claude/rules/ci-scripts.md` MUST 12), so callers assert on
+    the examined counts too.
+    """
+
+    violations: list[Violation] = field(default_factory=list)
+    modules_parsed: int = 0
+    sites_examined: int = 0
+    functions_accepted: int = 0
+    functions_seen: int = 0
+
+
+class _ModuleFacts:
+    """The AST facts one module contributes to the scan."""
+
+    def __init__(self, module: str, source: str) -> None:
+        self.module = module
+        self.functions: list[FunctionNode] = []
+        self.calls: list[tuple[str, FunctionNode | None]] = []
+        self.sites: list[tuple[str, int, FunctionNode | None, tuple[str, ...]]] = []
+        self.imports: dict[str, tuple[str, str]] = {}
+        self.name_reads: dict[str, set[FunctionNode]] = {}
+        tree = ast.parse(source, filename=module)
+        parents: dict[ast.AST, ast.AST] = {
+            child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)
+        }
+        self._walk(tree, [], parents)
+
+    def _walk(
+        self,
+        node: ast.AST,
+        stack: list[FunctionNode],
+        parents: Mapping[ast.AST, ast.AST],
+    ) -> None:
+        pushed = self._record(node, stack, parents)
+        for child in ast.iter_child_nodes(node):
+            self._walk(child, stack, parents)
+        if pushed:
+            stack.pop()
+
+    def _record(
+        self,
+        node: ast.AST,
+        stack: list[FunctionNode],
+        parents: Mapping[ast.AST, ast.AST],
+    ) -> bool:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            self.functions.append(node)
+            stack.append(node)
+            return True
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                self.imports[alias.asname or alias.name] = (node.module, alias.name)
+        elif isinstance(node, ast.Call):
+            name = _callee_name(node)
+            if name:
+                self.calls.append((name, stack[-1] if stack else None))
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and stack:
+            self.name_reads.setdefault(node.id, set()).add(stack[-1])
+        elif isinstance(node, ast.Constant) and node.value in BARE_TOKENS:
+            enclosing = stack[-1] if stack else None
+            bindings = () if enclosing else _binding_names(node, parents)
+            self.sites.append((node.value, node.lineno, enclosing, bindings))
+        return False
+
+
+def _callee_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _binding_names(node: ast.AST, parents: Mapping[ast.AST, ast.AST]) -> tuple[str, ...]:
+    """Names a module-scope literal is assigned to, walking up to the statement.
+
+    A token at module scope runs no git command by itself. ``_HOSTILE_CONFIG``
+    in ``tests/test_git_isolation_blast_radius.py`` is the live example: it
+    holds ``core.bare`` as the payload a negative control injects into a child
+    process. Attributing the site to the functions that read the binding follows
+    the data to where a git command could actually see it.
+    """
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, ast.Assign):
+            return tuple(t.id for t in current.targets if isinstance(t, ast.Name))
+        if isinstance(current, ast.AnnAssign) and isinstance(current.target, ast.Name):
+            return (current.target.id,)
+        current = parents.get(current)
+    return ()
+
+
+def _parameter_names(node: FunctionNode) -> list[str]:
+    args = node.args
+    names = [arg.arg for arg in args.posonlyargs + args.args + args.kwonlyargs]
+    if args.vararg:
+        names.append(args.vararg.arg)
+    if args.kwarg:
+        names.append(args.kwarg.arg)
+    return names
+
+
+def _is_directly_temp_rooted(node: FunctionNode) -> bool:
+    """True when the function establishes a temp root without help from callers."""
+    if _PYTEST_TEMP_PARAMS.intersection(_parameter_names(node)):
+        return True
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            name = _callee_name(sub)
+            if name in _TEMPFILE_FACTORIES:
+                return True
+        if isinstance(sub, ast.Constant) and sub.value == _REPO_TEMP_ROOT:
+            return True
+    return False
+
+
+def _has_fixture_decorator(node: FunctionNode) -> bool:
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Attribute) and target.attr == "fixture":
+            return True
+        if isinstance(target, ast.Name) and target.id == "fixture":
+            return True
+    return False
+
+
+class _Graph:
+    """The call graph over the modules loaded so far."""
+
+    def __init__(self) -> None:
+        self.facts: dict[str, _ModuleFacts] = {}
+        self.owner: dict[FunctionNode, tuple[str, str]] = {}
+        self._by_qualified: dict[tuple[str, str], list[FunctionNode]] = {}
+        self._by_name: dict[str, list[FunctionNode]] = {}
+
+    def add(self, module: str, source: str) -> None:
+        facts = _ModuleFacts(module, source)
+        self.facts[module] = facts
+        for node in facts.functions:
+            self.owner[node] = (module, node.name)
+            self._by_qualified.setdefault((module, node.name), []).append(node)
+            self._by_name.setdefault(node.name, []).append(node)
+
+    def resolve(self, module: str, name: str) -> list[FunctionNode]:
+        """Candidate definitions for ``name`` as it is spelled inside ``module``.
+
+        A same-module definition wins, then an explicit ``from X import name``,
+        then every definition of that name anywhere loaded. That last rung is
+        deliberately conservative: merging same-named helpers from two modules
+        can only add callers, so it can reject a helper that would otherwise
+        pass, never admit one that should fail.
+        """
+        local = self._by_qualified.get((module, name))
+        if local:
+            return local
+        facts = self.facts.get(module)
+        imported = facts.imports.get(name) if facts else None
+        if imported and imported in self._by_qualified:
+            return self._by_qualified[imported]
+        return self._by_name.get(name, [])
+
+    def callers(self) -> dict[FunctionNode, list[FunctionNode | None]]:
+        edges: dict[FunctionNode, list[FunctionNode | None]] = {}
+        for module, facts in self.facts.items():
+            for name, enclosing in facts.calls:
+                for target in self.resolve(module, name):
+                    edges.setdefault(target, []).append(enclosing)
+        return edges
+
+    def accepted(self) -> set[FunctionNode]:
+        """Fixed point over "every path this function builds is temp-rooted"."""
+        accepted = {node for node in self.owner if _is_directly_temp_rooted(node)}
+        edges = self.callers()
+        changed = True
+        while changed:
+            changed = False
+            for node, (module, _name) in self.owner.items():
+                if node in accepted:
+                    continue
+                if self._takes_an_accepted_fixture(node, module, accepted):
+                    accepted.add(node)
+                    changed = True
+                    continue
+                incoming = edges.get(node, [])
+                if incoming and all(c is not None and c in accepted for c in incoming):
+                    accepted.add(node)
+                    changed = True
+        return accepted
+
+    def _takes_an_accepted_fixture(
+        self, node: FunctionNode, module: str, accepted: set[FunctionNode]
+    ) -> bool:
+        """A parameter naming an already-accepted fixture roots the body too.
+
+        ``decoy_repo`` and ``git_sandbox`` are the live cases: both build their
+        sandbox with ``tmp_path_factory`` or ``tempfile``, so a test requesting
+        either receives a temp-rooted path. The ``@pytest.fixture`` check is
+        load-bearing; without it any parameter that happened to share a name
+        with an accepted function anywhere under ``tests/`` would launder the
+        body.
+        """
+        return any(
+            candidate in accepted and _has_fixture_decorator(candidate)
+            for param in _parameter_names(node)
+            for candidate in self.resolve(module, param)
+        )
+
+
+def scan(
+    seed: Mapping[str, str],
+    resolve_more: Callable[[str], Mapping[str, str]] | None = None,
+) -> ScanResult:
+    """Scan ``seed`` modules, pulling more through ``resolve_more`` when needed.
+
+    ``resolve_more(name)`` returns modules that mention ``name``, so the walk
+    reaches the callers of a helper defined in one file and used from another
+    without parsing the whole tree.
+    """
+    graph = _Graph()
+    for module, source in seed.items():
+        graph.add(module, source)
+
+    relevant: set[FunctionNode] = set()
+    for _ in range(_MAX_ROUNDS):
+        accepted = graph.accepted()
+        relevant |= _site_scopes(graph)
+        pending = {graph.owner[node][1] for node in relevant if node not in accepted}
+        if not pending or resolve_more is None:
+            return _report(graph, accepted)
+        extra = {
+            module: source
+            for name in sorted(pending)
+            for module, source in resolve_more(name).items()
+            if module not in graph.facts
+        }
+        if not extra:
+            return _report(graph, accepted)
+        for module, source in extra.items():
+            graph.add(module, source)
+        edges = graph.callers()
+        relevant |= {
+            caller
+            for node in list(relevant)
+            for caller in edges.get(node, [])
+            if caller is not None
+        }
+    raise AssertionError(
+        f"call-graph walk did not settle in {_MAX_ROUNDS} rounds; reporting now "
+        "would claim a clean result for a graph the walk never finished"
+    )
+
+
+def _site_scopes(graph: _Graph) -> set[FunctionNode]:
+    """Functions that must be temp-rooted: site bodies, plus constant readers."""
+    scopes: set[FunctionNode] = set()
+    for facts in graph.facts.values():
+        for _token, _lineno, enclosing, bindings in facts.sites:
+            if enclosing is not None:
+                scopes.add(enclosing)
+                continue
+            for binding in bindings:
+                scopes |= facts.name_reads.get(binding, set())
+    return scopes
+
+
+_NO_TEMP_ROOT = (
+    "no temp root: the function requests no pytest temp fixture, calls no "
+    "tempfile factory, names no .pytest_tmp root, and at least one caller is "
+    "itself not temp-rooted"
+)
+
+
+def _report(graph: _Graph, accepted: set[FunctionNode]) -> ScanResult:
+    result = ScanResult(
+        modules_parsed=len(graph.facts),
+        functions_accepted=len(accepted),
+        functions_seen=len(graph.owner),
+    )
+    for module, facts in sorted(graph.facts.items()):
+        for token, lineno, enclosing, bindings in facts.sites:
+            result.sites_examined += 1
+            if enclosing is None:
+                result.violations.extend(
+                    _constant_violations(facts, module, token, lineno, bindings, accepted)
+                )
+            elif enclosing not in accepted:
+                result.violations.append(
+                    Violation(
+                        module=module,
+                        lineno=lineno,
+                        token=token,
+                        scope=f"{enclosing.name}()",
+                        reason=_NO_TEMP_ROOT,
+                    )
+                )
+    return result
+
+
+def _constant_violations(
+    facts: _ModuleFacts,
+    module: str,
+    token: str,
+    lineno: int,
+    bindings: tuple[str, ...],
+    accepted: set[FunctionNode],
+) -> Iterator[Violation]:
+    readers = {r for b in bindings for r in facts.name_reads.get(b, set())}
+    label = "/".join(bindings) or "<unbound>"
+    for reader in sorted(readers, key=lambda node: node.lineno):
+        if reader in accepted:
+            continue
+        yield Violation(
+            module=module,
+            lineno=lineno,
+            token=token,
+            scope=f"module constant {label} read by {reader.name}()",
+            reason="the function that reads this constant is not temp-rooted",
+        )
+
+
+_SOURCE_CACHE: dict[str, str] | None = None
+
+
+def scannable_sources() -> dict[str, str]:
+    """Every scannable module under ``tests/``, read once and cached.
+
+    Reading the working tree rather than a git ref is required here: a newly
+    added test file is exactly the regression this guards, and
+    ``.claude/rules/ci-scripts.md`` MUST 9 carves out pre-commit-shaped checks
+    for that reason.
+    """
+    global _SOURCE_CACHE
+    if _SOURCE_CACHE is None:
+        cache: dict[str, str] = {}
+        for path in sorted(TESTS_ROOT.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            module = ".".join(path.relative_to(PROJECT_ROOT).with_suffix("").parts)
+            if module in SCANNER_MODULES:
+                continue
+            cache[module] = path.read_text(encoding="utf-8")
+        _SOURCE_CACHE = cache
+    return _SOURCE_CACHE
+
+
+def modules_mentioning(needle: str) -> dict[str, str]:
+    """Scannable modules whose text contains ``needle``.
+
+    A text prefilter rather than a full-tree parse. Parsing all 1000-plus test
+    modules to reach the 48 live literals cost 14.7s of CPU when measured; the
+    prefilter parses only the 23 modules that can matter.
+    """
+    return {module: text for module, text in scannable_sources().items() if needle in text}
+
+
+_SCAN_CACHE: ScanResult | None = None
+
+
+def scan_test_suite() -> ScanResult:
+    """Scan every bare-repository literal under ``tests/``, cached per session."""
+    global _SCAN_CACHE
+    if _SCAN_CACHE is None:
+        seed: dict[str, str] = {}
+        for token in BARE_TOKENS:
+            seed.update(modules_mentioning(token))
+        _SCAN_CACHE = scan(seed, resolve_more=modules_mentioning)
+    return _SCAN_CACHE

--- a/tests/bare_repo_sites.py
+++ b/tests/bare_repo_sites.py
@@ -1,0 +1,447 @@
+"""What one module contributes to the bare-repository scan: its token sites.
+
+Issue #4698 acceptance criterion 3, "Fixture-creating tests are shown to write
+bare repositories only under a temporary path." Split from
+``tests/bare_repo_scan.py``, which owns the call graph and the verdict, so both
+stay under the 500-line taste ceiling. The seam is facts against judgement: this
+module reads one file's syntax tree and answers what is written there, and
+decides nothing about the corpus.
+
+The mechanism the issue names: ``core.bare`` is worktree-specific once
+``extensions.worktreeConfig`` is on, so a ``git init --bare`` or a
+``git config core.bare true`` that resolves against an inherited working
+directory instead of a fixture path writes into the developer's shared
+``.git/config`` and breaks the main worktree and every linked worktree at once.
+
+Two questions are answered per token, and the scan needs both:
+
+* **Is this a command being built, or a value being compared?** Only the first
+  can run. See ``_CONSTRUCTION_PARENTS``.
+* **Which names could carry this command's target?** ``Site.references`` for a
+  direct call, ``Site.carriers`` for the build-then-run shape. Temp-rooting the
+  enclosing function says nothing about the path handed to git, so the verdict
+  module traces one of these back to a root.
+
+Kept out of ``conftest.py`` deliberately: these helpers are specific to one
+assertion, and a package-wide conftest name would be visible to every test
+module. ``tests/gh_base_ref_test_helpers.py`` carries the same reasoning.
+
+Refs #4698, #4717, #4287.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = PROJECT_ROOT / "tests"
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+# The only two spellings by which a git argument vector reaches a bare
+# repository. `git init --bare`, `git clone --bare`, and
+# `git config core.bare <value>` all carry one of them as a literal argument.
+BARE_TOKENS = ("--bare", "core.bare")
+
+# A token counts as a site only where it is being BUILT into something a
+# process could receive: an element of a list or tuple, a value in a dict, an
+# argument to a call, or the right side of an assignment. A token being
+# COMPARED is not a site, which is what keeps assertions and expected-message
+# data out of the corpus: `assert "core.bare" in result.stderr` puts the token
+# under an `ast.Compare`, and no construction node is its parent.
+#
+# The narrower rule of "only inside a subprocess call" was considered and
+# rejected: it under-reports. `tests/gh_base_ref_test_helpers.py:26-30` builds
+# `args = ["git", "init"]`, appends `--bare` conditionally, and passes `args` to
+# `subprocess.run` two statements later, so a lexical test for a subprocess
+# argument list sees no site at a call that really does create a bare
+# repository. Carrier tracking below follows that shape instead.
+_CONSTRUCTION_PARENTS = (
+    ast.Call,
+    ast.keyword,
+    ast.List,
+    ast.Tuple,
+    ast.Set,
+    ast.Dict,
+    ast.Assign,
+    ast.AnnAssign,
+    ast.Starred,
+    ast.Return,
+)
+
+# Methods that append to a command vector already bound to a name. The token
+# reaches a process through the name, not through this call's own arguments.
+_VECTOR_MUTATORS = frozenset({"append", "extend", "insert"})
+
+# Reaching git through the environment rather than through an argument vector.
+# `GIT_CONFIG_KEY_0=core.bare` is the live case in
+# `tests/test_git_isolation_blast_radius.py` and
+# `tests/validation/test_check_repo_health_hostile_inputs.py`: git applies it to
+# whatever repository the child process lands in.
+_ENV_SETTERS = frozenset({"setenv", "putenv"})
+_ENV_KEYWORD = "env"
+
+# pytest's own temp fixtures. Requesting one roots every path the body derives
+# from it under the session temp directory, outside every checkout.
+_PYTEST_TEMP_PARAMS = frozenset(
+    {"tmp_path", "tmp_path_factory", "tmpdir", "tmpdir_factory"}
+)
+
+# stdlib temp factories, matched on the attribute or the bare name so both
+# `tempfile.TemporaryDirectory()` and an imported `TemporaryDirectory()` count.
+_TEMPFILE_FACTORIES = frozenset(
+    {"TemporaryDirectory", "mkdtemp", "mkstemp", "NamedTemporaryFile"}
+)
+
+# This repository's durable fixture root, required by `.claude/rules/testing.md`
+# MUST NOT 4 for fixtures that must outlive one test. `.gitignore` covers it and
+# `validate_plugin_manifests.py` prunes it, so it is a temporary path in the
+# sense the acceptance criterion means even though it sits inside the checkout.
+_REPO_TEMP_ROOT = ".pytest_tmp"
+
+# The scanner's own modules hold the tokens as data rather than as git
+# arguments, so scanning them reports the token table above and the negative
+# controls in the corpus test module. `TestTheScannerRunsNoGitCommand` keeps the
+# exclusion honest by failing if any of them ever spawns a process.
+# `tests/test_bare_repo_scan_targets.py` is deliberately NOT here: its controls
+# carry the tokens inside longer source strings, so it scans clean from inside
+# the corpus, which is a stronger position than an exclusion.
+SCANNER_MODULES = frozenset(
+    {
+        "tests.bare_repo_scan",
+        "tests.bare_repo_sites",
+        "tests.test_bare_repo_fixtures_are_temp_rooted",
+    }
+)
+
+@dataclass(frozen=True)
+class Violation:
+    """One bare-repository literal not traced to a temp-rooted target."""
+
+    module: str
+    lineno: int
+    token: str
+    scope: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.module}:{self.lineno}: {self.token!r} in {self.scope} -- {self.reason}"
+
+
+@dataclass(frozen=True)
+class Site:
+    """One bare-repository token, with the names its command could reach.
+
+    ``references`` are the names the token's own call hands over, which is where
+    the target path or ``cwd=`` sits for a direct
+    ``subprocess.run(["git", "init", "--bare", str(target)])``. ``carriers`` are
+    the names the token flows into instead, for the build-then-run shape where
+    the target reaches a later call.
+    """
+
+    token: str
+    lineno: int
+    enclosing: FunctionNode | None
+    bindings: tuple[str, ...]
+    references: frozenset[str]
+    carriers: frozenset[str]
+    # An environment site carries no path to trace: `GIT_CONFIG_KEY_0=core.bare`
+    # names no repository, and git applies it wherever the child lands. The
+    # question there is the one the call graph already answers, whether every
+    # process the function can spawn runs under a temp root, so target tracing
+    # is skipped rather than failed.
+    environment: bool = False
+
+
+@dataclass
+class ScanResult:
+    """What the scan examined and what it found. Both halves are required.
+
+    A violation count alone cannot distinguish "nothing is wrong" from "nothing
+    was examined" (`.claude/rules/ci-scripts.md` MUST 12), so callers assert on
+    the examined counts too.
+    """
+
+    violations: list[Violation] = field(default_factory=list)
+    modules_parsed: int = 0
+    sites_examined: int = 0
+    functions_accepted: int = 0
+    functions_seen: int = 0
+
+
+class _ModuleFacts:
+    """The AST facts one module contributes to the scan."""
+
+    def __init__(self, module: str, source: str) -> None:
+        self.module = module
+        self.functions: list[FunctionNode] = []
+        self.calls: list[tuple[str, FunctionNode | None]] = []
+        self.sites: list[Site] = []
+        self.imports: dict[str, tuple[str, str]] = {}
+        self.name_reads: dict[str, set[FunctionNode]] = {}
+        # Every call's argument names, per enclosing function. A carrier is
+        # traced by asking which calls in the same scope receive it.
+        self.call_references: dict[FunctionNode | None, list[frozenset[str]]] = {}
+        tree = ast.parse(source, filename=module)
+        parents: dict[ast.AST, ast.AST] = {
+            child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)
+        }
+        self._walk(tree, [], parents)
+
+    def _walk(
+        self,
+        node: ast.AST,
+        stack: list[FunctionNode],
+        parents: Mapping[ast.AST, ast.AST],
+    ) -> None:
+        pushed = self._record(node, stack, parents)
+        for child in ast.iter_child_nodes(node):
+            self._walk(child, stack, parents)
+        if pushed:
+            stack.pop()
+
+    def _record(
+        self,
+        node: ast.AST,
+        stack: list[FunctionNode],
+        parents: Mapping[ast.AST, ast.AST],
+    ) -> bool:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            self.functions.append(node)
+            stack.append(node)
+            return True
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                self.imports[alias.asname or alias.name] = (node.module, alias.name)
+        elif isinstance(node, ast.Call):
+            scope = stack[-1] if stack else None
+            name = _callee_name(node)
+            if name:
+                self.calls.append((name, scope))
+            self.call_references.setdefault(scope, []).append(_argument_names(node))
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and stack:
+            self.name_reads.setdefault(node.id, set()).add(stack[-1])
+        elif (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in BARE_TOKENS
+            and isinstance(parents.get(node), _CONSTRUCTION_PARENTS)
+        ):
+            self._record_site(node, node.value, stack[-1] if stack else None, parents)
+        return False
+
+    def _record_site(
+        self,
+        node: ast.Constant,
+        token: str,
+        enclosing: FunctionNode | None,
+        parents: Mapping[ast.AST, ast.AST],
+    ) -> None:
+        call = _enclosing_call(node, parents)
+        references: frozenset[str] = frozenset()
+        carriers = set(_binding_names(node, parents))
+        if call is not None:
+            receiver = _mutated_vector(call)
+            if receiver is None:
+                references = _argument_names(call)
+            else:
+                carriers.add(receiver)
+        self.sites.append(
+            Site(
+                token=token,
+                lineno=node.lineno,
+                enclosing=enclosing,
+                bindings=_binding_names(node, parents),
+                references=references,
+                carriers=frozenset(carriers),
+                environment=_reaches_git_through_the_environment(node, call, parents),
+            )
+        )
+
+
+def _callee_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _loaded_names(nodes: Iterable[ast.AST]) -> frozenset[str]:
+    """Every name read anywhere inside ``nodes``."""
+    return frozenset(
+        sub.id
+        for node in nodes
+        for sub in ast.walk(node)
+        if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load)
+    )
+
+
+def _argument_names(call: ast.Call) -> frozenset[str]:
+    """Names a call hands over, which is where a target path or ``cwd=`` sits.
+
+    The callee is excluded on purpose: ``_git(repo, ...)`` passes ``repo`` and
+    names ``_git``, and only the first can be a path.
+    """
+    return _loaded_names([*call.args, *(keyword.value for keyword in call.keywords)])
+
+
+def _mutated_vector(call: ast.Call) -> str | None:
+    """Return the name a ``vector.append(...)`` style call mutates, or None."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr in _VECTOR_MUTATORS:
+        if isinstance(func.value, ast.Name):
+            return func.value.id
+    return None
+
+
+def _reaches_git_through_the_environment(
+    node: ast.AST, call: ast.Call | None, parents: Mapping[ast.AST, ast.AST]
+) -> bool:
+    """True when the token is being written into a child process's environment.
+
+    Two spellings: ``monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.bare")``, and
+    a mapping handed to a spawn as ``env=``.
+    """
+    if call is not None and _callee_name(call) in _ENV_SETTERS:
+        return True
+    current: ast.AST | None = parents.get(node)
+    while current is not None and not isinstance(current, ast.stmt):
+        if isinstance(current, ast.keyword) and current.arg == _ENV_KEYWORD:
+            return True
+        current = parents.get(current)
+    return False
+
+
+def _enclosing_call(node: ast.AST, parents: Mapping[ast.AST, ast.AST]) -> ast.Call | None:
+    """Return the innermost call whose arguments contain ``node``, within one statement."""
+    current = parents.get(node)
+    while current is not None and not isinstance(current, ast.stmt):
+        if isinstance(current, ast.Call):
+            return current
+        current = parents.get(current)
+    return None
+
+
+def _binding_names(node: ast.AST, parents: Mapping[ast.AST, ast.AST]) -> tuple[str, ...]:
+    """Names a module-scope literal is assigned to, walking up to the statement.
+
+    A token at module scope runs no git command by itself. ``_HOSTILE_CONFIG``
+    in ``tests/test_git_isolation_blast_radius.py`` is the live example: it
+    holds ``core.bare`` as the payload a negative control injects into a child
+    process. Attributing the site to the functions that read the binding follows
+    the data to where a git command could actually see it.
+    """
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, ast.Assign):
+            return tuple(t.id for t in current.targets if isinstance(t, ast.Name))
+        if isinstance(current, ast.AnnAssign) and isinstance(current.target, ast.Name):
+            return (current.target.id,)
+        current = parents.get(current)
+    return ()
+
+
+def _parameter_names(node: FunctionNode) -> list[str]:
+    args = node.args
+    names = [arg.arg for arg in args.posonlyargs + args.args + args.kwonlyargs]
+    if args.vararg:
+        names.append(args.vararg.arg)
+    if args.kwarg:
+        names.append(args.kwarg.arg)
+    return names
+
+
+def _is_directly_temp_rooted(node: FunctionNode) -> bool:
+    """True when the function establishes a temp root without help from callers."""
+    if _PYTEST_TEMP_PARAMS.intersection(_parameter_names(node)):
+        return True
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            name = _callee_name(sub)
+            if name in _TEMPFILE_FACTORIES:
+                return True
+        if isinstance(sub, ast.Constant) and sub.value == _REPO_TEMP_ROOT:
+            return True
+    return False
+
+
+def _bound_names(target: ast.AST) -> list[str]:
+    """Names one assignment target binds, unpacking tuples and lists.
+
+    ``bare, linked = _make_bare_with_worktree(tmp_path)`` is the live shape;
+    reading only ``ast.Name`` targets loses both names and reports the two paths
+    they hold as untraced.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Tuple | ast.List):
+        return [name for element in target.elts for name in _bound_names(element)]
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return []
+
+
+def _assignment_targets(node: ast.AST) -> tuple[list[str], list[ast.AST]]:
+    """Return ``(names bound, expressions bound from)`` for one statement."""
+    if isinstance(node, ast.Assign):
+        names = [name for target in node.targets for name in _bound_names(target)]
+        return names, [node.value]
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return [node.target.id], [node.value] if node.value else []
+    if isinstance(node, ast.withitem) and node.optional_vars is not None:
+        return _bound_names(node.optional_vars), [node.context_expr]
+    return [], []
+
+
+def _roots_a_path(sources: Iterable[ast.AST], known: frozenset[str]) -> bool:
+    """True when an expression derives from a temp root already established."""
+    for source in sources:
+        for sub in ast.walk(source):
+            if isinstance(sub, ast.Call) and _callee_name(sub) in _TEMPFILE_FACTORIES:
+                return True
+            if isinstance(sub, ast.Constant) and sub.value == _REPO_TEMP_ROOT:
+                return True
+            if isinstance(sub, ast.Name) and sub.id in known:
+                return True
+    return False
+
+
+def _temp_rooted_names(node: FunctionNode, seeds: frozenset[str]) -> frozenset[str]:
+    """Return every name in ``node`` that holds a path under a temp root.
+
+    Starts from ``seeds`` (the parameters a caller or fixture has already
+    vetted) and reaches a fixed point over assignments and ``with`` bindings, so
+    ``bare = tmp_path / name`` carries the root that ``tmp_path`` established.
+
+    This is what makes the scan a claim about the target rather than about the
+    function. Temp-rooting the enclosing function is not evidence that the git
+    command uses that path: ``def test_x(tmp_path): subprocess.run(["git",
+    "init", "--bare", "/home/user/live.git"])`` roots the function and writes
+    the bare repository into a live checkout.
+    """
+    known = set(seeds)
+    known.update(_PYTEST_TEMP_PARAMS.intersection(_parameter_names(node)))
+    changed = True
+    while changed:
+        changed = False
+        for sub in ast.walk(node):
+            names, sources = _assignment_targets(sub)
+            fresh = [name for name in names if name not in known]
+            if fresh and _roots_a_path(sources, frozenset(known)):
+                known.update(fresh)
+                changed = True
+    return frozenset(known)
+
+
+def _has_fixture_decorator(node: FunctionNode) -> bool:
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Attribute) and target.attr == "fixture":
+            return True
+        if isinstance(target, ast.Name) and target.id == "fixture":
+            return True
+    return False

--- a/tests/ci/lefthook_budget_model.py
+++ b/tests/ci/lefthook_budget_model.py
@@ -56,9 +56,10 @@ LEFTHOOK = REPO_ROOT / "lefthook.yml"
 # `test_the_roster_matches_what_the_config_actually_routes` requires the two to
 # agree in both directions, so a job crossing the boundary fails a test that
 # names it instead of changing a number quietly. At the time of writing they
-# agree exactly, 14 clamped and 20 not.
+# agree exactly, 14 clamped and 21 not.
 CONTAINER_UNCLAMPED_JOBS = frozenset(
     {
+        "repo-health",
         "repair-packed-refs",
         "mutation-safety",
         "push-ref-staleness",

--- a/tests/ci/test_lefthook_prepush_fast_fail.py
+++ b/tests/ci/test_lefthook_prepush_fast_fail.py
@@ -32,6 +32,7 @@ _LEFTHOOK = _REPO_ROOT / "lefthook.yml"
 # fast parallel group.
 # The singleton guards that run ahead of both fast-stage groups, in order.
 SINGLETON_GUARDS = (
+    "repo-health",
     "repair-packed-refs",
     "mutation-safety",
     "push-ref-staleness",

--- a/tests/test_bare_repo_fixtures_are_temp_rooted.py
+++ b/tests/test_bare_repo_fixtures_are_temp_rooted.py
@@ -1,0 +1,339 @@
+"""Every bare repository the test suite creates is rooted in a temp directory.
+
+Issue #4698 acceptance criterion 3: "Fixture-creating tests are shown to write
+bare repositories only under a temporary path." ``tests/bare_repo_scan.py``
+carries the scan and the reasoning behind each temp root it recognises; this
+module asserts the corpus result and pins the scan's discrimination.
+
+What the corpus assertion proves, exactly
+-----------------------------------------
+Every ``--bare`` and ``core.bare`` string literal under ``tests/`` sits inside a
+function whose paths are rooted in a temp directory, established one of four
+ways: a pytest temp fixture parameter, a ``tempfile`` factory call, the
+repository's own ``.pytest_tmp`` durable fixture root, or a parameter naming a
+fixture that is itself temp-rooted. A helper taking its target as a parameter,
+such as ``_init_git_repo`` in ``tests/gh_base_ref_test_helpers.py``, is admitted
+only when every caller reached through the call graph is itself temp-rooted.
+
+What it does not prove
+----------------------
+Temp-rooting the enclosing function does not prove the specific argument handed
+to that one git command is the temp path; a temp-rooted test could still pass an
+absolute path elsewhere. This is a shape check over the call graph, not a taint
+analysis.
+
+It also reads argument-vector git calls only. A shell-form invocation, say
+``subprocess.run("git init --bare x", shell=True)``, carries the token inside a
+longer string and is not a site. That shape does not exist in the suite
+(``shell=True`` appears under ``tests/`` only in prose and in assertions
+forbidding it), and matching substrings instead would flag every assertion that
+quotes the repair command, such as the expected-message table in
+``tests/validation/test_check_repo_health_reporting.py``.
+
+The runtime complement is ``tests/test_git_isolation_blast_radius.py``, which
+runs a real child pytest under a hook-shaped hostile environment and asserts a
+decoy repository standing in for the developer's checkout never takes
+``core.bare=true``. The two together cover the static shape and the inherited
+environment; neither alone does.
+
+Refs #4698, #4717, #4287.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from tests.bare_repo_scan import (
+    PROJECT_ROOT,
+    SCANNER_MODULES,
+    ScanResult,
+    scan,
+    scan_test_suite,
+    scannable_sources,
+)
+
+
+def _module(source: str, name: str = "probe") -> dict[str, str]:
+    return {name: source}
+
+
+class TestTheTestSuiteRootsEveryBareRepositoryInTemp:
+    """The corpus assertion. Issue #4698 acceptance criterion 3."""
+
+    @pytest.fixture(scope="class")
+    def result(self) -> ScanResult:
+        return scan_test_suite()
+
+    def test_no_bare_repository_literal_escapes_a_temp_root(
+        self, result: ScanResult
+    ) -> None:
+        assert not result.violations, (
+            "a test creates a bare repository or sets core.bare outside a temp "
+            "root. On a checkout with extensions.worktreeConfig enabled that "
+            "writes core.bare into the shared .git/config and breaks every "
+            "worktree at once (#4698). Root the fixture in tmp_path, a tempfile "
+            "factory, or .pytest_tmp:\n  "
+            + "\n  ".join(str(violation) for violation in result.violations)
+        )
+
+    def test_the_scan_examined_the_corpus_it_claims_to_cover(
+        self, result: ScanResult
+    ) -> None:
+        """A zero-violation result means nothing without the examined count."""
+        assert result.sites_examined >= 40, (
+            f"the scan found only {result.sites_examined} bare-repository "
+            "literals under tests/; the prefilter or the token list has drifted "
+            "and the clean result above covers almost nothing"
+        )
+        assert result.modules_parsed >= 10, result.modules_parsed
+
+    def test_acceptance_is_not_vacuous(self, result: ScanResult) -> None:
+        """If every function were accepted, a clean scan would prove nothing."""
+        assert result.functions_seen > 0
+        rejected = result.functions_seen - result.functions_accepted
+        assert rejected >= result.functions_seen // 10, (
+            f"only {rejected} of {result.functions_seen} functions in the loaded "
+            "modules were rejected as not temp-rooted; acceptance has widened far "
+            "enough that a clean scan is close to unfalsifiable"
+        )
+
+
+class TestTheScannerRunsNoGitCommand:
+    """What justifies excluding the scanner's own two modules from the scan.
+
+    Both files hold ``--bare`` and ``core.bare`` as data: the token table in
+    ``tests/bare_repo_scan.py`` and the negative controls below. The exclusion is
+    safe only while neither shells out, so assert the precondition rather than
+    trusting the comment on ``SCANNER_MODULES``.
+    """
+
+    _PROCESS_SPAWNERS = frozenset(
+        {"run", "Popen", "call", "check_call", "check_output", "system", "spawn"}
+    )
+
+    @pytest.mark.parametrize("module", sorted(SCANNER_MODULES))
+    def test_the_excluded_module_spawns_no_process(self, module: str) -> None:
+        path = PROJECT_ROOT.joinpath(*module.split(".")).with_suffix(".py")
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+        spawns = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in self._PROCESS_SPAWNERS
+        ]
+
+        assert spawns == [], (
+            f"{module} now spawns a process at line(s) {spawns}, so excluding it "
+            "from the corpus scan would hide a real bare-repository call site. "
+            "Either drop the call or stop excluding the module."
+        )
+
+    def test_both_excluded_modules_exist_and_are_excluded(self) -> None:
+        """A stale name in SCANNER_MODULES would silently exclude nothing."""
+        sources = scannable_sources()
+        for module in SCANNER_MODULES:
+            path = PROJECT_ROOT.joinpath(*module.split(".")).with_suffix(".py")
+            assert path.is_file(), f"{module} names no file; the exclusion is stale"
+            assert module not in sources
+
+
+class TestTheScanRejectsUnrootedFixtures:
+    """Negative controls: inputs the corpus does not contain but must fail."""
+
+    def test_a_bare_init_with_no_temp_root_is_rejected(self) -> None:
+        source = (
+            "import subprocess\n"
+            "def test_thing():\n"
+            "    subprocess.run(['git', 'init', '--bare', 'remote.git'])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert len(result.violations) == 1
+        assert result.violations[0].token == "--bare"
+        assert result.violations[0].scope == "test_thing()"
+
+    def test_setting_core_bare_with_no_temp_root_is_rejected(self) -> None:
+        source = (
+            "import subprocess\n"
+            "def test_thing(repo):\n"
+            "    subprocess.run(['git', 'config', 'core.bare', 'true'], cwd=repo)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert [violation.token for violation in result.violations] == ["core.bare"]
+
+    def test_a_helper_with_one_unrooted_caller_is_rejected(self) -> None:
+        """One caller without a temp root is the one handing over an ambient path."""
+        source = (
+            "import subprocess\n"
+            "def _init_bare(path):\n"
+            "    subprocess.run(['git', 'init', '--bare', str(path)])\n"
+            "def test_rooted(tmp_path):\n"
+            "    _init_bare(tmp_path / 'remote.git')\n"
+            "def test_unrooted():\n"
+            "    _init_bare('remote.git')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+        assert result.violations[0].scope == "_init_bare()"
+
+    def test_an_unreferenced_helper_is_rejected(self) -> None:
+        """No caller is not the same as every caller being temp-rooted."""
+        source = (
+            "import subprocess\n"
+            "def _init_bare(path):\n"
+            "    subprocess.run(['git', 'init', '--bare', str(path)])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+
+    def test_a_module_constant_read_by_an_unrooted_function_is_rejected(self) -> None:
+        source = (
+            "import subprocess\n"
+            "HOSTILE = {'GIT_CONFIG_KEY_0': 'core.bare'}\n"
+            "def test_thing():\n"
+            "    subprocess.run(['git', 'status'], env=HOSTILE)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+        assert "module constant HOSTILE" in result.violations[0].scope
+
+    def test_a_plain_parameter_name_does_not_root_the_body(self) -> None:
+        """The fixture rung requires a @pytest.fixture decorator, not a name match."""
+        source = (
+            "def decoy(tmp_path):\n"
+            "    return tmp_path\n"
+            "def test_thing(decoy):\n"
+            "    run(str(decoy), '--bare')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+
+
+class TestTheScanAcceptsTheEstablishedIsolationPatterns:
+    """Positive controls: each temp root the suite actually uses."""
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("tmp_path", "def test_thing(tmp_path):\n    run(str(tmp_path), '--bare')\n"),
+            (
+                "tempfile",
+                "import tempfile\n"
+                "def test_thing():\n"
+                "    with tempfile.TemporaryDirectory() as directory:\n"
+                "        run(directory, '--bare')\n",
+            ),
+            (
+                "pytest_tmp",
+                "def test_thing():\n"
+                "    root = PROJECT_ROOT / '.pytest_tmp' / 'x'\n"
+                "    run(str(root), '--bare')\n",
+            ),
+            (
+                "tmp_path_factory",
+                "def test_thing(tmp_path_factory):\n"
+                "    run(str(tmp_path_factory.mktemp('x')), '--bare')\n",
+            ),
+        ],
+    )
+    def test_an_established_temp_root_is_accepted(self, label: str, body: str) -> None:
+        result = scan(_module(body))
+
+        assert result.sites_examined == 1, label
+        assert result.violations == [], (label, result.violations)
+
+    def test_a_fixture_parameter_roots_the_test_that_requests_it(self) -> None:
+        """The live shape of `decoy_repo` and `git_sandbox`."""
+        source = (
+            "import pytest\n"
+            "@pytest.fixture\n"
+            "def decoy(tmp_path_factory):\n"
+            "    return tmp_path_factory.mktemp('decoy')\n"
+            "def test_thing(decoy):\n"
+            "    run(str(decoy), '--bare')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []
+
+    def test_a_module_constant_read_only_by_a_rooted_function_is_accepted(self) -> None:
+        """The live shape of `_HOSTILE_CONFIG` in test_git_isolation_blast_radius."""
+        source = (
+            "import subprocess\n"
+            "HOSTILE = {'GIT_CONFIG_KEY_0': 'core.bare'}\n"
+            "def test_thing(tmp_path):\n"
+            "    subprocess.run(['git', 'status'], cwd=tmp_path, env=HOSTILE)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+    def test_a_module_constant_nothing_reads_runs_no_git_command(self) -> None:
+        source = "UNUSED = {'GIT_CONFIG_KEY_0': 'core.bare'}\n"
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+
+class TestTheScanReachesAcrossModules:
+    """The `resolve_more` rung: a helper's callers live in another file."""
+
+    _HELPERS = (
+        "import subprocess\n"
+        "def _init_bare(path):\n"
+        "    subprocess.run(['git', 'init', '--bare', str(path)])\n"
+    )
+
+    def _scan_with(self, caller: str) -> ScanResult:
+        return scan(
+            {"tests.helpers": self._HELPERS},
+            resolve_more=lambda name: (
+                {"tests.caller": caller} if name == "_init_bare" else {}
+            ),
+        )
+
+    def test_a_helper_is_admitted_by_callers_in_another_module(self) -> None:
+        result = self._scan_with(
+            "from tests.helpers import _init_bare\n"
+            "def test_thing(tmp_path):\n"
+            "    _init_bare(tmp_path / 'remote.git')\n"
+        )
+
+        assert result.modules_parsed == 2
+        assert result.violations == []
+
+    def test_a_helper_whose_other_module_caller_is_unrooted_is_rejected(self) -> None:
+        """The discriminating control for the test above.
+
+        Same seed, same loader shape, one caller without a temp root. If this
+        passed, the test above would prove only that the loader ran.
+        """
+        result = self._scan_with(
+            "from tests.helpers import _init_bare\n"
+            "def test_thing():\n"
+            "    _init_bare('remote.git')\n"
+        )
+
+        assert result.modules_parsed == 2
+        assert len(result.violations) == 1

--- a/tests/test_bare_repo_fixtures_are_temp_rooted.py
+++ b/tests/test_bare_repo_fixtures_are_temp_rooted.py
@@ -1,34 +1,64 @@
 """Every bare repository the test suite creates is rooted in a temp directory.
 
 Issue #4698 acceptance criterion 3: "Fixture-creating tests are shown to write
-bare repositories only under a temporary path." ``tests/bare_repo_scan.py``
-carries the scan and the reasoning behind each temp root it recognises; this
-module asserts the corpus result and pins the scan's discrimination.
+bare repositories only under a temporary path." ``tests/bare_repo_sites.py``
+reads each module's tokens and ``tests/bare_repo_scan.py`` turns them into a
+verdict; this module asserts the corpus result and pins the temp roots the scan
+recognises. ``tests/test_bare_repo_scan_targets.py`` pins the three narrower
+properties: what counts as a site, that a command's target must reach the root,
+and that a module-level command is a violation on sight.
 
 What the corpus assertion proves, exactly
 -----------------------------------------
-Every ``--bare`` and ``core.bare`` string literal under ``tests/`` sits inside a
-function whose paths are rooted in a temp directory, established one of four
-ways: a pytest temp fixture parameter, a ``tempfile`` factory call, the
-repository's own ``.pytest_tmp`` durable fixture root, or a parameter naming a
-fixture that is itself temp-rooted. A helper taking its target as a parameter,
-such as ``_init_git_repo`` in ``tests/gh_base_ref_test_helpers.py``, is admitted
-only when every caller reached through the call graph is itself temp-rooted.
+Every ``--bare`` and ``core.bare`` token under ``tests/`` that is being built
+into a command sits inside a function whose paths are rooted in a temp
+directory, **and** the command's own target traces back to that root. The root
+is established one of four ways: a pytest temp fixture parameter, a ``tempfile``
+factory call, the repository's own ``.pytest_tmp`` durable fixture root, or a
+parameter naming a fixture that is itself temp-rooted. A helper taking its
+target as a parameter, such as ``_init_git_repo`` in
+``tests/gh_base_ref_test_helpers.py``, is admitted only when every caller
+reached through the call graph is itself temp-rooted, and its parameters then
+count as roots inside its body.
+
+The target trace is what makes the claim about the command rather than about
+the function. ``def test_x(tmp_path): subprocess.run(["git", "init", "--bare",
+"/home/user/live.git"])`` roots the function and writes a bare repository into a
+live checkout; it is a violation here.
+
+What counts as a site
+---------------------
+A token is a site where it is being **built** into something a process could
+receive: an element of a list or tuple, a value in a dict, an argument to a
+call, or the right side of an assignment. A token being **compared** is not,
+which keeps assertions and expected-message data out of the corpus. Measured at
+``26911e9f0``: the old rule, any exact constant anywhere, counted 73 sites; the
+construction rule counts 70. The three dropped are all ``ast.Compare``
+operands, at ``tests/test_lefthook_integration.py:1377``,
+``tests/validation/test_check_repo_health.py:227``, and
+``tests/validation/test_check_repo_health_hostile_inputs.py:191``.
+
+Restricting further, to tokens lexically inside a ``subprocess`` argument list,
+was rejected because it under-reports. ``tests/gh_base_ref_test_helpers.py``
+builds ``args = ["git", "init"]``, appends ``--bare`` conditionally, and passes
+``args`` to ``subprocess.run`` two statements later, so a lexical test sees no
+site at a call that really does create a bare repository. The scanner follows
+the carrier instead.
 
 What it does not prove
 ----------------------
-Temp-rooting the enclosing function does not prove the specific argument handed
-to that one git command is the temp path; a temp-rooted test could still pass an
-absolute path elsewhere. This is a shape check over the call graph, not a taint
-analysis.
-
-It also reads argument-vector git calls only. A shell-form invocation, say
+It reads argument-vector git calls only. A shell-form invocation, say
 ``subprocess.run("git init --bare x", shell=True)``, carries the token inside a
 longer string and is not a site. That shape does not exist in the suite
 (``shell=True`` appears under ``tests/`` only in prose and in assertions
 forbidding it), and matching substrings instead would flag every assertion that
 quotes the repair command, such as the expected-message table in
 ``tests/validation/test_check_repo_health_reporting.py``.
+
+An environment site is graded on the function alone, not on a target. A token
+written with ``monkeypatch.setenv`` or handed over as ``env=`` names no
+repository: git applies ``GIT_CONFIG_KEY_0=core.bare`` wherever the child
+process lands, so the only question is the one the call graph already answers.
 
 The runtime complement is ``tests/test_git_isolation_blast_radius.py``, which
 runs a real child pytest under a hook-shaped hostile environment and asserts a
@@ -101,12 +131,12 @@ class TestTheTestSuiteRootsEveryBareRepositoryInTemp:
 
 
 class TestTheScannerRunsNoGitCommand:
-    """What justifies excluding the scanner's own two modules from the scan.
+    """What justifies excluding the scanner's own modules from the scan.
 
-    Both files hold ``--bare`` and ``core.bare`` as data: the token table in
-    ``tests/bare_repo_scan.py`` and the negative controls below. The exclusion is
-    safe only while neither shells out, so assert the precondition rather than
-    trusting the comment on ``SCANNER_MODULES``.
+    Each holds ``--bare`` and ``core.bare`` as data: the token table in
+    ``tests/bare_repo_sites.py`` and the negative controls below. The exclusion
+    is safe only while none of them shells out, so assert the precondition
+    rather than trusting the comment on ``SCANNER_MODULES``.
     """
 
     _PROCESS_SPAWNERS = frozenset(
@@ -132,7 +162,7 @@ class TestTheScannerRunsNoGitCommand:
             "Either drop the call or stop excluding the module."
         )
 
-    def test_both_excluded_modules_exist_and_are_excluded(self) -> None:
+    def test_every_excluded_module_exists_and_is_excluded(self) -> None:
         """A stale name in SCANNER_MODULES would silently exclude nothing."""
         sources = scannable_sources()
         for module in SCANNER_MODULES:

--- a/tests/test_bare_repo_fixtures_are_temp_rooted.py
+++ b/tests/test_bare_repo_fixtures_are_temp_rooted.py
@@ -33,10 +33,14 @@ receive: an element of a list or tuple, a value in a dict, an argument to a
 call, or the right side of an assignment. A token being **compared** is not,
 which keeps assertions and expected-message data out of the corpus. Measured at
 ``26911e9f0``: the old rule, any exact constant anywhere, counted 73 sites; the
-construction rule counts 70. The three dropped are all ``ast.Compare``
-operands, at ``tests/test_lefthook_integration.py:1377``,
-``tests/validation/test_check_repo_health.py:227``, and
-``tests/validation/test_check_repo_health_hostile_inputs.py:191``.
+construction rule counts 70. All three dropped are ``ast.Compare`` operands,
+each an ``assert "core.bare" in <stream>`` in
+``tests/test_lefthook_integration.py``,
+``tests/validation/test_check_repo_health.py``, and
+``tests/validation/test_check_repo_health_hostile_inputs.py``. Line numbers are
+left off on purpose: the claim is about a shape those files contain, not about
+a contract quoted at one line, which is the only thing
+``check_citation_freshness.py`` can keep true.
 
 Restricting further, to tokens lexically inside a ``subprocess`` argument list,
 was rejected because it under-reports. ``tests/gh_base_ref_test_helpers.py``

--- a/tests/test_bare_repo_scan_targets.py
+++ b/tests/test_bare_repo_scan_targets.py
@@ -1,0 +1,280 @@
+"""The scan is a claim about each git command, not about its enclosing function.
+
+Split from ``tests/test_bare_repo_fixtures_are_temp_rooted.py``, which asserts
+the corpus result, to keep both files under the 500-line taste ceiling. That
+file pins the four temp roots the suite uses and the call-graph walk that
+carries them across modules. This one pins the three narrower properties review
+found missing, each of which let a real bare-repository write pass the gate.
+
+**Only command construction counts as a site.** The scan used to record every
+exact ``--bare`` or ``core.bare`` constant anywhere in a file, which meant
+assertions and expected-message data inflated ``sites_examined`` and could
+raise a violation for a string nobody runs. A token is a site where it is being
+built into something a process could receive; a token being compared is not.
+Measured at ``26911e9f0``, the old rule counted 73 sites against 70, and all
+three dropped are ``ast.Compare`` operands.
+
+**The command's target must reach the temp root.** Temp-rooting the enclosing
+function proves nothing about the path handed to git.
+``def test_x(tmp_path): subprocess.run(["git", "init", "--bare",
+"/home/user/live.git"])`` passed the old gate, and it writes a bare repository
+into a live checkout, which is the exact damage issue #4698 records.
+
+**A module-level command is a violation on sight.** It binds no name, so
+following bindings to their readers found nothing and reported it clean. It
+executes at import, during pytest collection, against whatever directory
+collection happens to be running in.
+
+Every case here is paired with a discriminating control that must come out the
+other way, so an exit-clean result cannot be the scan having stopped looking.
+
+Refs #4698.
+"""
+
+from __future__ import annotations
+
+from tests.bare_repo_scan import scan
+
+
+def _module(source: str, name: str = "probe") -> dict[str, str]:
+    return {name: source}
+
+
+class TestOnlyCommandConstructionCountsAsASite:
+    """A token being compared is not a token being run."""
+
+    def test_an_assertion_quoting_the_token_is_not_a_site(self) -> None:
+        """`assert "core.bare" in stderr` inflated the count and could violate."""
+        source = (
+            "def test_thing(result):\n"
+            "    assert 'core.bare' in result.stderr\n"
+            "    assert result.args == '--bare'\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 0
+        assert result.violations == []
+
+    def test_the_same_token_in_an_argument_vector_is_a_site(self) -> None:
+        """The discriminating control: identical spelling, construction position."""
+        source = (
+            "import subprocess\n"
+            "def test_thing():\n"
+            "    subprocess.run(['git', 'config', 'core.bare', 'true'])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert len(result.violations) == 1
+
+    def test_a_token_appended_to_a_command_vector_is_a_site(self) -> None:
+        """The live `_init_git_repo` shape a subprocess-only rule would miss."""
+        source = (
+            "import subprocess\n"
+            "def test_thing():\n"
+            "    args = ['git', 'init']\n"
+            "    args.append('--bare')\n"
+            "    subprocess.run(args, cwd='/home/user/live')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert len(result.violations) == 1
+
+    def test_a_token_read_back_out_of_a_vector_is_not_a_site(self) -> None:
+        """Branching on what a command said is not building a command."""
+        source = "def test_thing(argv):\n    if argv[2] == '--bare':\n        return 1\n"
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 0
+        assert result.violations == []
+
+
+class TestTheCommandsTargetMustReachTheTempRoot:
+    """A temp-rooted function is not evidence about the path it hands to git."""
+
+    def test_an_absolute_target_inside_a_tmp_path_test_is_rejected(self) -> None:
+        """The exact shape `tests/bare_repo_scan.py` used to admit."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    subprocess.run(['git', 'init', '--bare', '/home/user/live.git'])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert len(result.violations) == 1
+        assert "target is not" in result.violations[0].reason
+
+    def test_the_same_call_using_the_fixture_path_is_accepted(self) -> None:
+        """The discriminating control: one argument differs."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    subprocess.run(['git', 'init', '--bare', str(tmp_path / 'live.git')])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+    def test_a_derived_name_carries_the_root(self) -> None:
+        """`bare = tmp_path / name` is the live `_bare_remote` shape."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    bare = tmp_path / 'remote.git'\n"
+            "    subprocess.run(['git', 'init', '--bare', str(bare)])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []
+
+    def test_tuple_unpacking_carries_the_root(self) -> None:
+        """`bare, linked = _make(tmp_path)` binds two names the walk must follow."""
+        source = (
+            "import subprocess\n"
+            "def _make(root):\n"
+            "    return root / 'a', root / 'b'\n"
+            "def test_x(tmp_path):\n"
+            "    bare, linked = _make(tmp_path)\n"
+            "    subprocess.run(['git', 'config', 'core.bare', 'true'], cwd=linked)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []
+
+    def test_a_cwd_pointing_at_the_root_is_enough(self) -> None:
+        """A relative target is safe when the command runs inside the temp root."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    subprocess.run(['git', 'init', '--bare', 'remote.git'], cwd=tmp_path)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []
+
+    def test_a_command_vector_is_traced_to_the_call_that_runs_it(self) -> None:
+        """The token is appended here and the target travels two statements later."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    args = ['git', 'init']\n"
+            "    args.append('--bare')\n"
+            "    subprocess.run(args, cwd=tmp_path)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+    def test_a_command_vector_run_outside_the_root_is_rejected(self) -> None:
+        """The discriminating control for the case above: only `cwd=` differs."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path):\n"
+            "    args = ['git', 'init']\n"
+            "    args.append('--bare')\n"
+            "    subprocess.run(args, cwd='/home/user/live')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+
+    def test_a_helper_receives_its_root_from_its_callers(self) -> None:
+        """A parameter is a root only where callers vouch for it."""
+        source = (
+            "import subprocess\n"
+            "def _init_bare(path):\n"
+            "    subprocess.run(['git', 'init', '--bare', str(path)])\n"
+            "def test_rooted(tmp_path):\n"
+            "    _init_bare(tmp_path / 'remote.git')\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []
+
+    def test_an_environment_write_is_graded_on_the_function(self) -> None:
+        """`GIT_CONFIG_KEY_0=core.bare` names no repository, so there is no target."""
+        source = (
+            "import subprocess\n"
+            "def test_x(tmp_path, monkeypatch):\n"
+            "    monkeypatch.setenv('GIT_CONFIG_KEY_0', 'core.bare')\n"
+            "    subprocess.run(['git', 'status'], cwd=tmp_path)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+    def test_an_environment_write_in_an_unrooted_function_is_still_rejected(self) -> None:
+        """The discriminating control: skipping the target trace is not a pass."""
+        source = (
+            "import subprocess\n"
+            "def test_x(monkeypatch):\n"
+            "    monkeypatch.setenv('GIT_CONFIG_KEY_0', 'core.bare')\n"
+            "    subprocess.run(['git', 'status'])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert len(result.violations) == 1
+        assert "no temp root" in result.violations[0].reason
+
+
+class TestAModuleLevelCommandIsAViolationOnSight:
+    """It runs at import, during collection, against the ambient directory."""
+
+    def test_an_unbound_module_level_call_is_reported(self) -> None:
+        """It binds no name, so following bindings to readers found nothing."""
+        source = (
+            "import subprocess\n"
+            "subprocess.run(['git', 'init', '--bare', 'remote.git'])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert len(result.violations) == 1
+        assert result.violations[0].scope == "module scope"
+        assert "module scope" in result.violations[0].reason
+
+    def test_the_same_call_inside_a_rooted_function_is_accepted(self) -> None:
+        """The discriminating control: identical call, bound to a rooted scope."""
+        source = (
+            "import subprocess\n"
+            "def test_thing(tmp_path):\n"
+            "    subprocess.run(['git', 'init', '--bare', str(tmp_path / 'remote.git')])\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.sites_examined == 1
+        assert result.violations == []
+
+    def test_a_module_constant_is_still_graded_by_its_readers(self) -> None:
+        """Binding a name is what separates data from a command."""
+        source = (
+            "import subprocess\n"
+            "HOSTILE = {'GIT_CONFIG_KEY_0': 'core.bare'}\n"
+            "def test_thing(tmp_path):\n"
+            "    subprocess.run(['git', 'status'], cwd=tmp_path, env=HOSTILE)\n"
+        )
+
+        result = scan(_module(source))
+
+        assert result.violations == []

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -794,7 +794,11 @@ def test_configuration_uses_named_native_jobs() -> None:
     assert str(pre_commit["push-lock-commit-guard"]["run"]).endswith(
         "check_push_lock_before_commit.py"
     )
-    assert pre_commit["push-lock-commit-guard"]["timeout"] == "30s"
+    # 20s, not the original 30s: repo-health's 10s cap is funded from this job's
+    # slack so the pre-commit declared worst case does not rise against the base
+    # ref (tests/ci/test_lefthook_declared_budget.py). The guard's own bound is a
+    # `timeout=10` subprocess plus a non-blocking flock probe, so 20s is twice it.
+    assert pre_commit["push-lock-commit-guard"]["timeout"] == "20s"
     assert str(pre_push["retrospective-policy"]["run"]).endswith("git_hook_policy.py retrospective")
     assert pre_push["retrospective-policy"]["use_stdin"] is True
     pre_commit_names = [str(job["name"]) for job in _flatten_jobs(config["pre-commit"]["jobs"])]

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -54,6 +54,7 @@ HOOK_PAYLOADS = (
 )
 POLICY_SUPPORT_FILES = (
     "scripts/maintenance/repair_packed_refs.py",
+    "scripts/validation/check_repo_health.py",
     "scripts/validation/git_hook_policy.py",
     "scripts/validation/push_ref_staleness.py",
     "scripts/validation/sha_pinning.py",
@@ -715,6 +716,7 @@ def test_configuration_uses_named_native_jobs() -> None:
     assert "commands" not in config["pre-push"]
     assert set(_job_map(config, "commit-msg")) == {"commit-message-policy"}
     expected_pre_commit = {
+        "repo-health",
         "repair-packed-refs",
         "branch-policy",
         "push-lock-commit-guard",
@@ -756,6 +758,7 @@ def test_configuration_uses_named_native_jobs() -> None:
         "commit-file-count",
     }
     expected_pre_push = {
+        "repo-health",
         "repair-packed-refs",
         "push-ref-policy",
         "retrospective-policy",
@@ -899,8 +902,16 @@ def test_configuration_uses_native_filters_scheduling_and_staging() -> None:
     assert pre_commit["piped"] is True
     assert pre_push["piped"] is True
     assert "files" not in pre_push
-    assert pre_commit["jobs"][0]["name"] == "repair-packed-refs"
-    assert pre_push["jobs"][0]["name"] == "repair-packed-refs"
+    # Issue #4698: repo-health precedes repair-packed-refs because a bare-flagged
+    # checkout makes later jobs fail for reasons that name the wrong component.
+    assert [job["name"] for job in pre_commit["jobs"][:2]] == [
+        "repo-health",
+        "repair-packed-refs",
+    ]
+    assert [job["name"] for job in pre_push["jobs"][:2]] == [
+        "repo-health",
+        "repair-packed-refs",
+    ]
     assert pre_commit_jobs["markdown-autofix"]["stage_fixed"] is True
     markdown_autofix_run = pre_commit_jobs["markdown-autofix"]["run"]
     markdown_check_run = pre_commit_jobs["markdown-check"]["run"]
@@ -1298,7 +1309,73 @@ def test_install_resets_legacy_hooks_path(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("hook_name", ["pre-commit", "pre-push"])
-def test_packed_refs_repair_runs_as_a_native_first_job(
+def test_repo_health_runs_as_a_native_job(hook_name: str, tmp_path: Path) -> None:
+    """The healthy control for the bare-flagged case below (issue #4698)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _copy_runtime_config(repo)
+    head_sha = _commit_file(repo, "tracked.txt", "content\n")
+    push_input = f"refs/heads/feature/test {head_sha} refs/heads/feature/test {head_sha}\n"
+
+    result = _run_lefthook(
+        repo,
+        "run",
+        hook_name,
+        "--job",
+        "repo-health",
+        "--force",
+        stdin=push_input if hook_name == "pre-push" else None,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "repo-health" in result.stdout
+
+
+@pytest.mark.parametrize("hook_name", ["pre-commit", "pre-push"])
+def test_repo_health_blocks_a_hook_when_the_shared_config_is_poisoned(
+    hook_name: str,
+    tmp_path: Path,
+) -> None:
+    """Issue #4698: the gate must stop the hook, not merely print a diagnosis.
+
+    The fixture is the mixed state, not a plainly bare-flagged checkout, and
+    that is not a softer case. Measured on lefthook 2.1.10: from a checkout
+    that resolves bare, lefthook runs ``git rev-parse --path-format=absolute
+    --show-toplevel ...`` before its first job and exits 128 on ``fatal: this
+    operation must be run in a work tree``, so no job of any kind runs there
+    and no hook can report anything. The worktree carrying the worktree-scoped
+    ``false`` that ``.agents/governance/GOTCHAS.md`` prescribes is the one
+    lefthook still runs in, and it is the one that has to raise the alarm for
+    the siblings the shared value has already killed.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _copy_runtime_config(repo)
+    head_sha = _commit_file(repo, "tracked.txt", "content\n")
+    push_input = f"refs/heads/feature/test {head_sha} refs/heads/feature/test {head_sha}\n"
+    _git(repo, "config", "extensions.worktreeConfig", "true")
+    _git(repo, "worktree", "add", "-q", str(tmp_path / "linked"), "-b", "linked")
+    _git(repo, "config", "--worktree", "core.bare", "false")
+    _git(repo, "config", "core.bare", "true")
+
+    result = _run_lefthook(
+        repo,
+        "run",
+        hook_name,
+        "--job",
+        "repo-health",
+        "--force",
+        stdin=push_input if hook_name == "pre-push" else None,
+        check=False,
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "core.bare" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("hook_name", ["pre-commit", "pre-push"])
+def test_packed_refs_repair_runs_as_a_native_job(
     hook_name: str,
     tmp_path: Path,
 ) -> None:

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -52,9 +52,15 @@ HOOK_PAYLOADS = (
     PROJECT_ROOT / "scripts/hooks/pre-push",
     PROJECT_ROOT / "scripts/hooks/commit-msg",
 )
+# Every file a job under test imports, not only the file the job names. The
+# fixture repository holds nothing else, so a script that grows a sibling import
+# fails here with ModuleNotFoundError until that sibling is listed. That is the
+# roster working: it caught `check_repo_health_report.py` on the commit that
+# split it out.
 POLICY_SUPPORT_FILES = (
     "scripts/maintenance/repair_packed_refs.py",
     "scripts/validation/check_repo_health.py",
+    "scripts/validation/check_repo_health_report.py",
     "scripts/validation/git_hook_policy.py",
     "scripts/validation/push_ref_staleness.py",
     "scripts/validation/sha_pinning.py",

--- a/tests/validation/test_check_repo_health.py
+++ b/tests/validation/test_check_repo_health.py
@@ -1,0 +1,568 @@
+"""The repo-health gate refuses a commit or push into a bare-flagged repository.
+
+Issue #4698: something during ``git push`` writes ``core.bare = true`` into the
+shared ``.git/config``, and every git command needing a work tree then fails
+with ``fatal: this operation must be run in a work tree``. It broke the main
+checkout and three of five linked worktrees at once and surfaced as four
+unrelated-looking failures, so the gate's job is to put one accurate message
+ahead of all of them.
+
+Two design decisions are pinned here because both are counterintuitive.
+
+The gate reads config scopes, not the effective ``--is-bare-repository``
+answer. A worktree that carries the worktree-scoped ``false`` GOTCHAS
+prescribes still resolves usable while its siblings are dead, so the effective
+answer reports that checkout healthy and says nothing about the repository.
+``TestAPoisonedSharedConfigIsReportedFromAWorktreeThatStillWorks`` is that case.
+
+Bareness is only a defect where a work tree is meant to exist, and a genuine
+bare repository sets ``core.bare = true`` too, so the discriminator is a
+``.git`` marker naming this repository's git directory.
+
+Every repository under test is a scratch repository under ``tmp_path``. Running
+``git config core.bare true`` against this checkout would write to a
+``.git/config`` shared with every live agent worktree and break all of them,
+which is the incident this gate exists to detect.
+
+Coverage:
+
+- positive: a healthy checkout and a healthy linked worktree exit 0 and name
+  what was read.
+- negative: a bare-flagged checkout, linked worktree, subdirectory, and
+  ``--separate-git-dir`` checkout each exit 1 and name a repair per poisoned
+  scope; a poisoned shared config is reported from an immunized worktree; a
+  value git cannot parse exits 1 and says why no ``git config`` can clear it;
+  the CLI process itself exits nonzero, against a healthy control.
+- edge: a genuine bare repository, a bare repository nested inside a healthy
+  checkout, and a non-repository exit 0; an invalid root exits 2; missing git
+  and timeouts exit 3; every git boolean spelling of true is honored, and
+  ``false`` is not; the immunization line appears only when
+  ``extensions.worktreeConfig`` permits it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+GUARD = _VALIDATION_DIR / "check_repo_health.py"
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path, name: str = "repo") -> Path:
+    """Create a scratch checkout with one commit."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _add_worktree(repo: Path, path: Path, branch: str = "feature") -> Path:
+    _git(repo, "worktree", "add", "-q", str(path), "-b", branch)
+    return path
+
+
+def _run_cli(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Drive the script as lefthook does, so the process exit code is asserted."""
+    return subprocess.run(
+        [sys.executable, str(GUARD), str(repo)],
+        cwd=str(repo),
+        env={**_git_test_env(), "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestHealthyRepositoriesPass:
+    """Positive: nothing flagged bare exits 0 and reports what it read."""
+
+    def test_a_healthy_checkout_exits_zero_and_names_the_repository(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _make_repo(tmp_path)
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert str(repo) in out
+        assert "core.bare read in 1 config scope(s), none set true" in out
+
+    def test_a_healthy_linked_worktree_exits_zero(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+        linked = _add_worktree(repo, tmp_path / "linked")
+
+        assert check_repo_health.main([str(linked)]) == 0
+
+    def test_an_explicit_false_is_not_read_as_bare(self, tmp_path: Path) -> None:
+        """The control for the true-spelling cases below."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "false")
+
+        assert check_repo_health.main([str(repo)]) == 0
+
+
+class TestBareFlaggedWorkTreesFail:
+    """Negative: bareness plus a work tree is the incident, and it blocks."""
+
+    def test_a_bare_flagged_checkout_exits_one_and_names_the_repair(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "true")
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "core.bare is set true (local=true)" in err
+        assert "fatal: this operation must be run in a work tree" in err
+        assert "Fix: git config core.bare false" in err
+        assert "4698" in err
+
+    def test_a_bare_flagged_linked_worktree_exits_one(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "extensions.worktreeConfig", "true")
+        linked = _add_worktree(repo, tmp_path / "linked")
+        _git(repo, "config", "core.bare", "true")
+
+        assert check_repo_health.main([str(linked)]) == 1
+
+    def test_a_subdirectory_of_a_bare_flagged_checkout_exits_one(
+        self, tmp_path: Path
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        nested = repo / "scripts" / "validation"
+        nested.mkdir(parents=True)
+        _git(repo, "config", "core.bare", "true")
+
+        assert check_repo_health.main([str(nested)]) == 1
+
+    def test_a_separate_git_dir_checkout_is_still_detected(self, tmp_path: Path) -> None:
+        """A ``.git`` file outside a linked worktree still marks a work tree."""
+        work = tmp_path / "work"
+        work.mkdir()
+        _git(tmp_path, "init", "-q", "--separate-git-dir", str(tmp_path / "gitdir"), str(work))
+        (work / "tracked.txt").write_text("content\n", encoding="utf-8")
+        _git(work, "add", "tracked.txt")
+        _git(work, "commit", "-q", "-m", "init")
+        _git(work, "config", "core.bare", "true")
+
+        assert check_repo_health.main([str(work)]) == 1
+
+    @pytest.mark.parametrize("spelling", ["true", "yes", "on", "1"])
+    def test_every_git_spelling_of_true_is_honored(
+        self, spelling: str, tmp_path: Path
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", spelling)
+
+        assert check_repo_health.main([str(repo)]) == 1
+
+    def test_a_valueless_core_bare_is_read_as_true(self, tmp_path: Path) -> None:
+        """git reads a variable with no value as true, so the gate must too."""
+        repo = _make_repo(tmp_path)
+        config = repo / ".git" / "config"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace("bare = false", "bare"),
+            encoding="utf-8",
+        )
+
+        assert check_repo_health.main([str(repo)]) == 1
+
+    def test_the_cli_process_exits_nonzero(self, tmp_path: Path) -> None:
+        """A gate that only returns a code to a caller cannot block a hook."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "true")
+
+        result = _run_cli(repo)
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "core.bare" in result.stderr
+
+    def test_the_cli_process_exits_zero_on_a_healthy_checkout(self, tmp_path: Path) -> None:
+        """The negative control for the CLI test above."""
+        repo = _make_repo(tmp_path)
+
+        result = _run_cli(repo)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestAPoisonedSharedConfigIsReportedFromAWorktreeThatStillWorks:
+    """The only state a hook can speak from, and the state the incident left.
+
+    Measured on lefthook 2.1.10: lefthook runs ``git rev-parse
+    --path-format=absolute --show-toplevel ...`` before its first job and exits
+    128 from a bare-flagged worktree, so a job there never runs. A worktree
+    carrying the worktree-scoped ``false`` GOTCHAS prescribes does run, and it
+    is the one that has to raise the alarm for its dead siblings.
+    """
+
+    @staticmethod
+    def _immunized_checkout(tmp_path: Path) -> Path:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "extensions.worktreeConfig", "true")
+        _add_worktree(repo, tmp_path / "linked")
+        _git(repo, "config", "--worktree", "core.bare", "false")
+        _git(repo, "config", "core.bare", "true")
+        return repo
+
+    def test_the_effective_answer_alone_would_call_this_checkout_healthy(
+        self, tmp_path: Path
+    ) -> None:
+        """The control: this is why the gate does not read --is-bare-repository."""
+        repo = self._immunized_checkout(tmp_path)
+
+        effective = subprocess.run(
+            ["git", "rev-parse", "--is-bare-repository"],
+            cwd=str(repo),
+            env=_git_test_env(),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert effective.stdout.strip() == "false"
+
+    def test_the_gate_still_fails_and_names_the_sibling_damage(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = self._immunized_checkout(tmp_path)
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "local=true" in err
+        assert "already broken" in err
+        assert "Fix: git config core.bare false" in err
+
+
+class TestRepairNamesEveryScopeThatCarriesTheValue:
+    """A repair aimed at the wrong config file leaves the checkout broken."""
+
+    def test_a_worktree_scoped_value_gets_a_worktree_scoped_repair(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "extensions.worktreeConfig", "true")
+        _add_worktree(repo, tmp_path / "linked")
+        _git(repo, "config", "--worktree", "core.bare", "true")
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        assert "Fix: git config --worktree core.bare false" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        ("scope", "expected"),
+        [
+            ("local", "git config core.bare false"),
+            ("worktree", "git config --worktree core.bare false"),
+            ("global", "git config --global --unset-all core.bare"),
+            ("system", "git config --system --unset-all core.bare"),
+            ("command", "remove the command-scoped core.bare override"),
+            ("unheard-of", "git config core.bare false"),
+        ],
+    )
+    def test_every_scope_maps_to_a_command_that_can_clear_it(
+        self,
+        scope: str,
+        expected: str,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        health = check_repo_health.RepoHealth(
+            "corrupted", work_tree=tmp_path, bare_scopes=((scope, "true"),)
+        )
+
+        check_repo_health._report_corruption(health)
+
+        assert f"Fix: {expected}" in capsys.readouterr().err
+
+    def test_two_poisoned_scopes_get_two_repairs(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        health = check_repo_health.RepoHealth(
+            "corrupted",
+            work_tree=tmp_path,
+            bare_scopes=(("local", "true"), ("worktree", "true")),
+        )
+
+        check_repo_health._report_corruption(health)
+
+        err = capsys.readouterr().err
+        assert "Fix: git config core.bare false" in err
+        assert "Fix: git config --worktree core.bare false" in err
+
+
+class TestImmunizationHintTracksTheWorktreeConfigExtension:
+    """``git config --worktree`` exits 128 without the extension enabled."""
+
+    @staticmethod
+    def _report(tmp_path: Path, *, worktree_config: bool) -> None:
+        check_repo_health._report_corruption(
+            check_repo_health.RepoHealth(
+                "corrupted",
+                work_tree=tmp_path,
+                bare_scopes=(("local", "true"),),
+                worktree_config=worktree_config,
+            )
+        )
+
+    def test_the_hint_appears_when_the_extension_is_enabled(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._report(tmp_path, worktree_config=True)
+
+        assert "in every worktree" in capsys.readouterr().err
+
+    def test_the_hint_is_withheld_when_the_extension_is_absent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._report(tmp_path, worktree_config=False)
+
+        assert "in every worktree" not in capsys.readouterr().err
+
+    def test_the_hint_is_withheld_when_the_worktree_scope_is_the_offender(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Immunizing with the value that is already wrong is not a repair."""
+        check_repo_health._report_corruption(
+            check_repo_health.RepoHealth(
+                "corrupted",
+                work_tree=tmp_path,
+                bare_scopes=(("worktree", "true"),),
+                worktree_config=True,
+            )
+        )
+
+        assert "in every worktree" not in capsys.readouterr().err
+
+
+class TestRepositoriesWithNoWorkTreeAreOutOfScope:
+    """Edge: bareness is only a defect where a work tree is meant to exist."""
+
+    def test_a_genuine_bare_repository_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bare = tmp_path / "origin.git"
+        _git(tmp_path, "init", "-q", "--bare", str(bare))
+
+        code = check_repo_health.main([str(bare)])
+
+        assert code == 0
+        assert "bare repository with no work tree" in capsys.readouterr().out
+
+    def test_a_bare_repository_inside_a_checkout_is_not_blamed_on_it(
+        self, tmp_path: Path
+    ) -> None:
+        """The ancestor walk must compare git directories, not just find a marker."""
+        repo = _make_repo(tmp_path)
+        nested = repo / "vendor" / "mirror.git"
+        nested.parent.mkdir(parents=True)
+        _git(tmp_path, "init", "-q", "--bare", str(nested))
+
+        assert check_repo_health.main([str(nested)]) == 0
+
+    def test_a_non_repository_reads_no_scopes_and_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        code = check_repo_health.main([str(plain)])
+
+        assert code == 0
+        assert "core.bare read in 0 config scope(s)" in capsys.readouterr().out
+
+    def test_a_global_core_bare_outside_a_repository_exits_zero(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A global value is readable anywhere; only a repository can be broken."""
+        global_config = tmp_path / "gitconfig"
+        global_config.write_text("[core]\n\tbare = true\n", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        code = check_repo_health.main([str(plain)])
+
+        assert code == 0
+        assert "not a git repository" in capsys.readouterr().out
+
+
+class TestUnverifiableStatesFailClosed:
+    """Edge: a state the gate cannot read is not a verified pass."""
+
+    def test_an_invalid_root_exits_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        code = check_repo_health.main([str(tmp_path / "absent")])
+
+        assert code == 2
+        assert "Invalid repository root" in capsys.readouterr().err
+
+    def test_missing_git_exits_three(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        monkeypatch.setattr(check_repo_health.shutil, "which", lambda _name: None)
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 3
+        assert "git executable not found" in capsys.readouterr().err
+
+    def test_a_git_timeout_exits_three(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        repo = _make_repo(tmp_path)
+
+        def _timeout(*_args: object, **_kwargs: object) -> None:
+            raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+        monkeypatch.setattr(check_repo_health.subprocess, "run", _timeout)
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 3
+        assert "could not be verified" in capsys.readouterr().err
+
+    def test_an_unparseable_core_bare_value_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """git refuses every command here, ``git config --unset-all`` included."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "notabool")
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "unusable core.bare value" in err
+        assert "by hand" in err
+
+
+class TestDiagnoseClassifiesWithoutPrinting:
+    """The classifier is separable from the report, so both can be pinned."""
+
+    def test_a_healthy_checkout_is_usable(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+
+        assert check_repo_health.diagnose(repo).status == "usable"
+
+    def test_a_bare_flagged_checkout_is_corrupted(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "true")
+
+        health = check_repo_health.diagnose(repo)
+
+        assert health.status == "corrupted"
+        assert health.work_tree == repo
+        assert health.bare_scopes == (("local", "true"),)
+        assert health.effective_bare is True
+
+    def test_an_immunized_checkout_is_corrupted_but_not_effectively_bare(
+        self, tmp_path: Path
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "extensions.worktreeConfig", "true")
+        _add_worktree(repo, tmp_path / "linked")
+        _git(repo, "config", "--worktree", "core.bare", "false")
+        _git(repo, "config", "core.bare", "true")
+
+        health = check_repo_health.diagnose(repo)
+
+        assert health.status == "corrupted"
+        assert health.effective_bare is False
+        assert ("local", "true") in health.bare_scopes
+
+    def test_a_bare_repository_is_bare_by_design(self, tmp_path: Path) -> None:
+        bare = tmp_path / "origin.git"
+        _git(tmp_path, "init", "-q", "--bare", str(bare))
+
+        assert check_repo_health.diagnose(bare).status == "bare_by_design"
+
+    def test_a_marker_file_with_no_gitdir_line_resolves_to_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        marker = tmp_path / ".git"
+        marker.write_text("not a gitdir pointer\n", encoding="utf-8")
+
+        assert check_repo_health._marker_git_dir(marker) is None
+
+    def test_a_relative_gitdir_pointer_resolves_against_the_marker(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        marker = tmp_path / ".git"
+        marker.write_text("gitdir: elsewhere\n", encoding="utf-8")
+
+        assert check_repo_health._marker_git_dir(marker) == target.resolve()
+
+    def test_an_unreadable_marker_resolves_to_nothing(self, tmp_path: Path) -> None:
+        marker = tmp_path / ".git"
+        marker.mkdir()
+
+        assert check_repo_health._marker_git_dir(marker) is None

--- a/tests/validation/test_check_repo_health.py
+++ b/tests/validation/test_check_repo_health.py
@@ -29,15 +29,19 @@ Coverage:
 - positive: a healthy checkout and a healthy linked worktree exit 0 and name
   what was read.
 - negative: a bare-flagged checkout, linked worktree, subdirectory, and
-  ``--separate-git-dir`` checkout each exit 1 and name a repair per poisoned
-  scope; a poisoned shared config is reported from an immunized worktree; a
-  value git cannot parse exits 1 and says why no ``git config`` can clear it;
-  the CLI process itself exits nonzero, against a healthy control.
+  ``--separate-git-dir`` checkout each exit 1 and name a repair for the scope
+  that carries the value; a poisoned shared config is reported from an
+  immunized worktree; a value git cannot parse exits 1 and says why no ``git
+  config`` can clear it; the CLI process itself exits nonzero, against a
+  healthy control.
 - edge: a genuine bare repository, a bare repository nested inside a healthy
   checkout, and a non-repository exit 0; an invalid root exits 2; missing git
   and timeouts exit 3; every git boolean spelling of true is honored, and
-  ``false`` is not; the immunization line appears only when
-  ``extensions.worktreeConfig`` permits it.
+  ``false`` is not.
+
+``test_check_repo_health_reporting.py`` covers the failure report itself: the
+repair each config scope needs, and when the worktree-scoped immunization line
+is withheld.
 """
 
 from __future__ import annotations
@@ -303,91 +307,6 @@ class TestRepairNamesEveryScopeThatCarriesTheValue:
 
         assert code == 1
         assert "Fix: git config --worktree core.bare false" in capsys.readouterr().err
-
-    @pytest.mark.parametrize(
-        ("scope", "expected"),
-        [
-            ("local", "git config core.bare false"),
-            ("worktree", "git config --worktree core.bare false"),
-            ("global", "git config --global --unset-all core.bare"),
-            ("system", "git config --system --unset-all core.bare"),
-            ("command", "remove the command-scoped core.bare override"),
-            ("unheard-of", "git config core.bare false"),
-        ],
-    )
-    def test_every_scope_maps_to_a_command_that_can_clear_it(
-        self,
-        scope: str,
-        expected: str,
-        tmp_path: Path,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        health = check_repo_health.RepoHealth(
-            "corrupted", work_tree=tmp_path, bare_scopes=((scope, "true"),)
-        )
-
-        check_repo_health._report_corruption(health)
-
-        assert f"Fix: {expected}" in capsys.readouterr().err
-
-    def test_two_poisoned_scopes_get_two_repairs(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        health = check_repo_health.RepoHealth(
-            "corrupted",
-            work_tree=tmp_path,
-            bare_scopes=(("local", "true"), ("worktree", "true")),
-        )
-
-        check_repo_health._report_corruption(health)
-
-        err = capsys.readouterr().err
-        assert "Fix: git config core.bare false" in err
-        assert "Fix: git config --worktree core.bare false" in err
-
-
-class TestImmunizationHintTracksTheWorktreeConfigExtension:
-    """``git config --worktree`` exits 128 without the extension enabled."""
-
-    @staticmethod
-    def _report(tmp_path: Path, *, worktree_config: bool) -> None:
-        check_repo_health._report_corruption(
-            check_repo_health.RepoHealth(
-                "corrupted",
-                work_tree=tmp_path,
-                bare_scopes=(("local", "true"),),
-                worktree_config=worktree_config,
-            )
-        )
-
-    def test_the_hint_appears_when_the_extension_is_enabled(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        self._report(tmp_path, worktree_config=True)
-
-        assert "in every worktree" in capsys.readouterr().err
-
-    def test_the_hint_is_withheld_when_the_extension_is_absent(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        self._report(tmp_path, worktree_config=False)
-
-        assert "in every worktree" not in capsys.readouterr().err
-
-    def test_the_hint_is_withheld_when_the_worktree_scope_is_the_offender(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Immunizing with the value that is already wrong is not a repair."""
-        check_repo_health._report_corruption(
-            check_repo_health.RepoHealth(
-                "corrupted",
-                work_tree=tmp_path,
-                bare_scopes=(("worktree", "true"),),
-                worktree_config=True,
-            )
-        )
-
-        assert "in every worktree" not in capsys.readouterr().err
 
 
 class TestRepositoriesWithNoWorkTreeAreOutOfScope:

--- a/tests/validation/test_check_repo_health.py
+++ b/tests/validation/test_check_repo_health.py
@@ -36,12 +36,14 @@ Coverage:
   healthy control.
 - edge: a genuine bare repository, a bare repository nested inside a healthy
   checkout, and a non-repository exit 0; an invalid root exits 2; missing git
-  and timeouts exit 3; every git boolean spelling of true is honored, and
-  ``false`` is not.
+  and timeouts exit 3; a valueless ``core.bare`` is read as true, and an
+  explicit ``false`` is not read as bare.
 
 ``test_check_repo_health_reporting.py`` covers the failure report itself: the
 repair each config scope needs, and when the worktree-scoped immunization line
-is withheld.
+is withheld. ``test_check_repo_health_boolean_oracle.py`` covers which values
+count as bare at all, deriving every expectation from ``git rev-parse
+--is-bare-repository`` rather than from a list of spellings.
 """
 
 from __future__ import annotations
@@ -202,15 +204,6 @@ class TestBareFlaggedWorkTreesFail:
         _git(work, "config", "core.bare", "true")
 
         assert check_repo_health.main([str(work)]) == 1
-
-    @pytest.mark.parametrize("spelling", ["true", "yes", "on", "1"])
-    def test_every_git_spelling_of_true_is_honored(
-        self, spelling: str, tmp_path: Path
-    ) -> None:
-        repo = _make_repo(tmp_path)
-        _git(repo, "config", "core.bare", spelling)
-
-        assert check_repo_health.main([str(repo)]) == 1
 
     def test_a_valueless_core_bare_is_read_as_true(self, tmp_path: Path) -> None:
         """git reads a variable with no value as true, so the gate must too."""

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -25,20 +25,32 @@ The second layout is a bare repository stored at a path literally named
 ``.git``. git derives a bare repository's main-worktree path by stripping a
 trailing ``.git`` component, so ``git clone --bare seed dirD/.git`` reports
 ``worktree dirD``, which is the same shape a poisoned checkout at
-``corrupt/seed`` reports. Path alone cannot separate them; content can, and
-``TestContentSeparatesAWorkTreeFromAPhantomOne`` pins that.
+``corrupt/seed`` reports. Path alone cannot separate them.
+
+Content alone cannot either, and that was a live false positive: nothing stops
+a bare repository's holding directory carrying a README, a log, or a deploy
+script, and reading the listing alone called such a layout a checkout that had
+lost its files. The separating fact is repository metadata. A checkout has a
+staged index at ``<common>/index``; a bare repository has none, including one
+that has handed out linked worktrees, whose indexes live under
+``<common>/worktrees/<name>/``. ``TestTheStagedIndexSeparatesACheckoutFromABare
+Repository`` pins that measurement, and the content read stays as a second
+condition for the bare repository someone ran ``git read-tree`` inside.
 
 Coverage:
 
 - positive: a linked worktree of a genuinely bare repository, the bare parent
-  read through that worktree, and a bare repository at a ``.git``-named path
-  each exit 0 and print no repair, through ``main`` and through the CLI process.
+  read through that worktree, a bare repository at a ``.git``-named path, and
+  that same repository with an unrelated file beside it each exit 0 and print
+  no repair, through ``main`` and through the CLI process.
 - negative: the discriminating controls. A poisoned main checkout read from its
-  own linked worktree still exits 1, and a ``.git``-named parent that does hold
-  a checkout still exits 1, so the exit-0 cases above are not passing because
-  the gate stopped detecting anything.
-- edge: ``_holds_checked_out_content`` on a directory holding only ``.git``, on
-  a missing directory, and on a real checkout.
+  own linked worktree still exits 1, and a real checkout reported under the
+  same ``worktree holder`` shape still exits 1, so the exit-0 cases above are
+  not passing because the gate stopped detecting anything.
+- edge: ``_has_main_work_tree_index`` on a bare repository, a checkout, a bare
+  repository with a linked worktree, and a missing path;
+  ``_holds_checked_out_content`` on a directory holding only ``.git``, on a
+  missing directory, and on a real checkout.
 """
 
 from __future__ import annotations
@@ -262,18 +274,91 @@ class TestABareRepositoryStoredAtADotGitPath:
         assert "bare repository with no work tree" in captured.out
         assert _REPAIR not in captured.out + captured.err
 
-    def test_a_dot_git_named_repository_holding_a_checkout_still_exits_one(
+    def test_an_unrelated_file_beside_the_bare_repository_still_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Nothing stops a bare repository's holding directory holding a file.
+
+        A README, a log, or a deploy script sitting beside ``holder/.git`` is
+        ordinary. Reading the listing alone called that a checkout that had lost
+        its files and printed the repair that destroys the repository, which is
+        the false positive ``_has_main_work_tree_index`` exists to close.
+        """
+        holder = self._bare_at_dot_git(tmp_path)
+        (holder / "README.md").write_text("unrelated\n", encoding="utf-8")
+
+        code = check_repo_health.main([str(holder / ".git")])
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert _REPAIR not in captured.out + captured.err
+
+    def test_the_listing_alone_would_have_called_that_layout_a_checkout(
         self, tmp_path: Path
     ) -> None:
-        """The discriminating control: same path shape, real files beside it."""
+        """The control for the case above: the old read really did see content."""
         holder = self._bare_at_dot_git(tmp_path)
-        (holder / "checked-out.txt").write_text("content\n", encoding="utf-8")
+        (holder / "README.md").write_text("unrelated\n", encoding="utf-8")
 
+        assert check_repo_health._holds_checked_out_content(holder) is True
+        assert check_repo_health._has_main_work_tree_index(holder / ".git") is False
+
+    def test_a_real_checkout_at_the_same_path_shape_still_exits_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The discriminating control: same reported shape, real staged index.
+
+        ``git worktree list`` names ``holder`` for both layouts, so if this
+        passed, the exit-0 cases above would prove only that the gate had
+        stopped detecting anything.
+        """
+        seed = _make_repo(tmp_path)
+        holder = tmp_path / "holder"
+        _git(tmp_path, "clone", "-q", str(seed), str(holder))
+        _git(holder, "config", "core.bare", "true")
+
+        listing = _try_git(holder / ".git", "worktree", "list", "--porcelain")
+        assert listing.stdout.splitlines()[0] == f"worktree {holder}"
+        assert check_repo_health._has_main_work_tree_index(holder / ".git") is True
         assert check_repo_health.main([str(holder / ".git")]) == 1
 
 
+class TestTheStagedIndexSeparatesACheckoutFromABareRepository:
+    """Edge: the repository metadata that a directory listing cannot supply.
+
+    Measured on git 2.43.0 and pinned here so a git version that starts
+    creating an index for a bare repository fails a test that names the reason
+    rather than silently widening the corrupted verdict.
+    """
+
+    def test_a_bare_repository_has_no_index(self, tmp_path: Path) -> None:
+        seed = _make_repo(tmp_path)
+        bare = tmp_path / "origin.git"
+        _git(tmp_path, "clone", "-q", "--bare", str(seed), str(bare))
+
+        assert check_repo_health._has_main_work_tree_index(bare) is False
+
+    def test_a_checkout_has_an_index(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+
+        assert check_repo_health._has_main_work_tree_index(repo / ".git") is True
+
+    def test_a_bare_repository_that_handed_out_a_worktree_still_has_none(
+        self, tmp_path: Path
+    ) -> None:
+        """The linked worktree's index sits under ``worktrees/<name>/``."""
+        bare, _linked = _make_bare_with_worktree(tmp_path)
+
+        assert check_repo_health._has_main_work_tree_index(bare) is False
+        assert (bare / "worktrees" / "wtA" / "index").is_file()
+
+    def test_a_missing_common_directory_has_no_index(self, tmp_path: Path) -> None:
+        """Ambiguity resolves toward bare by design, so an absent path is False."""
+        assert check_repo_health._has_main_work_tree_index(tmp_path / "absent") is False
+
+
 class TestContentSeparatesAWorkTreeFromAPhantomOne:
-    """Edge: the one filesystem read the path comparison cannot replace."""
+    """Edge: the second condition, for a bare repository that gained an index."""
 
     def test_a_directory_holding_only_a_git_entry_holds_no_content(
         self, tmp_path: Path

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -1,0 +1,303 @@
+"""A legitimately bare repository must not be told to repair itself.
+
+Split from ``test_check_repo_health.py``, which pins detection, to keep both
+files under the 500-line taste ceiling. These cases pin the opposite obligation:
+the layouts where ``core.bare = true`` is correct, and where the repair the gate
+prints for issue #4698 would destroy a healthy repository.
+
+The layout that matters is ordinary git::
+
+    git clone --bare seed bareA.git
+    git -C bareA.git worktree add wtA
+
+``wtA`` is a live checkout. ``git -C wtA status`` works. Its local config scope
+reads ``true``, inherited from the bare parent through the shared config, and
+its ``.git`` marker names a private git directory under
+``bareA.git/worktrees/wtA``. An earlier discriminator anchored on
+``git rev-parse --absolute-git-dir`` found that marker, called the repository
+corrupted, and printed ``Fix: git config core.bare false``. That command writes
+into the bare parent's shared config, so running it breaks ``bareA.git`` and
+every sibling worktree at once.
+``test_the_printed_repair_would_break_the_bare_parent`` measures that damage and
+is the reason the verdict here has to be exit 0.
+
+The second layout is a bare repository stored at a path literally named
+``.git``. git derives a bare repository's main-worktree path by stripping a
+trailing ``.git`` component, so ``git clone --bare seed dirD/.git`` reports
+``worktree dirD``, which is the same shape a poisoned checkout at
+``corrupt/seed`` reports. Path alone cannot separate them; content can, and
+``TestContentSeparatesAWorkTreeFromAPhantomOne`` pins that.
+
+Coverage:
+
+- positive: a linked worktree of a genuinely bare repository, the bare parent
+  read through that worktree, and a bare repository at a ``.git``-named path
+  each exit 0 and print no repair, through ``main`` and through the CLI process.
+- negative: the discriminating controls. A poisoned main checkout read from its
+  own linked worktree still exits 1, and a ``.git``-named parent that does hold
+  a checkout still exits 1, so the exit-0 cases above are not passing because
+  the gate stopped detecting anything.
+- edge: ``_holds_checked_out_content`` on a directory holding only ``.git``, on
+  a missing directory, and on a real checkout.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+GUARD = _VALIDATION_DIR / "check_repo_health.py"
+
+# The command the gate prints for a genuinely corrupted checkout. No stream may
+# carry it for any layout in this file.
+_REPAIR = "core.bare false"
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = _try_git(cwd, *args)
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result
+
+
+def _try_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run git without asserting, for cases where the failure is the evidence."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path, name: str = "seed") -> Path:
+    """Create a scratch checkout with one commit."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _make_bare_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Return ``(bare repository, its linked worktree)`` for a standard layout."""
+    seed = _make_repo(tmp_path)
+    bare = tmp_path / "bareA.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(seed), str(bare))
+    linked = tmp_path / "wtA"
+    _git(bare, "worktree", "add", "-q", "--detach", str(linked))
+    return bare, linked
+
+
+def _run_cli(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Drive the script as lefthook does, so the process exit code is asserted."""
+    return subprocess.run(
+        [sys.executable, str(GUARD), str(repo)],
+        cwd=str(repo),
+        env={**_git_test_env(), "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestALinkedWorktreeOfABareRepositoryIsHealthy:
+    """Positive: the standard bare-plus-worktree layout is not the incident."""
+
+    def test_the_layout_under_test_is_a_working_checkout(self, tmp_path: Path) -> None:
+        """The premise: this is a live work tree reading ``local true``."""
+        _bare, linked = _make_bare_with_worktree(tmp_path)
+
+        assert _try_git(linked, "status", "--short").returncode == 0
+        scopes = _git(linked, "config", "--show-scope", "--get-all", "core.bare")
+        assert scopes.stdout.strip() == "local\ttrue"
+
+    def test_the_printed_repair_would_break_the_bare_parent(self, tmp_path: Path) -> None:
+        """Why exit 0 is required: the repair is destructive on this layout."""
+        bare, linked = _make_bare_with_worktree(tmp_path)
+        assert _try_git(linked, "status", "--short").returncode == 0
+
+        _git(bare, "config", "core.bare", "false")
+
+        broken = _try_git(bare, "status", "--short")
+        assert broken.returncode != 0
+        assert "must be run in a work tree" in broken.stderr
+
+    def test_the_linked_worktree_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _bare, linked = _make_bare_with_worktree(tmp_path)
+
+        code = check_repo_health.main([str(linked)])
+
+        assert code == 0
+        assert "bare repository with no work tree" in capsys.readouterr().out
+
+    def test_the_bare_parent_itself_exits_zero(self, tmp_path: Path) -> None:
+        """A bare repository that has handed out a worktree is still bare."""
+        bare, _linked = _make_bare_with_worktree(tmp_path)
+
+        assert check_repo_health.main([str(bare)]) == 0
+
+    def test_no_repair_reaches_either_stream(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The gate must never hand this reader a command that destroys the repo."""
+        _bare, linked = _make_bare_with_worktree(tmp_path)
+
+        check_repo_health.main([str(linked)])
+
+        captured = capsys.readouterr()
+        assert _REPAIR not in captured.out
+        assert _REPAIR not in captured.err
+        assert "Fix:" not in captured.err
+
+    def test_the_cli_process_exits_zero_and_prints_no_repair(self, tmp_path: Path) -> None:
+        """A return value cannot block a hook; the process status can."""
+        _bare, linked = _make_bare_with_worktree(tmp_path)
+
+        result = _run_cli(linked)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _REPAIR not in result.stdout + result.stderr
+
+    def test_the_classifier_reports_no_work_tree(self, tmp_path: Path) -> None:
+        """``work_tree`` is what ``_report_corruption`` would name in the repair."""
+        _bare, linked = _make_bare_with_worktree(tmp_path)
+
+        health = check_repo_health.diagnose(linked)
+
+        assert health.status == "bare_by_design"
+        assert health.work_tree is None
+
+    def test_a_poisoned_main_checkout_is_still_caught_from_its_linked_worktree(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The discriminating control for every exit-0 case above.
+
+        Same vantage point, same ``local true`` reading, same private ``.git``
+        marker. Only the main worktree differs: here it is a real checkout, so
+        the value is corruption and the repair is correct.
+        """
+        seed = _make_repo(tmp_path)
+        linked = tmp_path / "poisoned-linked"
+        _git(seed, "worktree", "add", "-q", "--detach", str(linked))
+        _git(seed, "config", "core.bare", "true")
+
+        code = check_repo_health.main([str(linked)])
+
+        assert code == 1
+        err = capsys.readouterr().err
+        assert f"Fix: git config {_REPAIR}" in err
+        assert str(seed) in err
+
+
+class TestABareRepositoryStoredAtADotGitPath:
+    """A bare repository named ``.git`` is not a checkout that lost its files."""
+
+    @staticmethod
+    def _bare_at_dot_git(tmp_path: Path) -> Path:
+        seed = _make_repo(tmp_path)
+        holder = tmp_path / "dirD"
+        holder.mkdir()
+        _git(tmp_path, "clone", "-q", "--bare", str(seed), str(holder / ".git"))
+        return holder
+
+    def test_git_names_the_holding_directory_as_the_main_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """The premise: path alone cannot tell this from a poisoned checkout."""
+        holder = self._bare_at_dot_git(tmp_path)
+
+        listing = _git(holder / ".git", "worktree", "list", "--porcelain")
+
+        assert listing.stdout.splitlines()[0] == f"worktree {holder}"
+        assert sorted(entry.name for entry in holder.iterdir()) == [".git"]
+
+    def test_it_exits_zero_and_prints_no_repair(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        holder = self._bare_at_dot_git(tmp_path)
+
+        code = check_repo_health.main([str(holder / ".git")])
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "bare repository with no work tree" in captured.out
+        assert _REPAIR not in captured.out + captured.err
+
+    def test_a_dot_git_named_repository_holding_a_checkout_still_exits_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The discriminating control: same path shape, real files beside it."""
+        holder = self._bare_at_dot_git(tmp_path)
+        (holder / "checked-out.txt").write_text("content\n", encoding="utf-8")
+
+        assert check_repo_health.main([str(holder / ".git")]) == 1
+
+
+class TestContentSeparatesAWorkTreeFromAPhantomOne:
+    """Edge: the one filesystem read the path comparison cannot replace."""
+
+    def test_a_directory_holding_only_a_git_entry_holds_no_content(
+        self, tmp_path: Path
+    ) -> None:
+        holder = tmp_path / "dirD"
+        (holder / ".git").mkdir(parents=True)
+
+        assert check_repo_health._holds_checked_out_content(holder) is False
+
+    def test_a_checkout_holds_content(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+
+        assert check_repo_health._holds_checked_out_content(repo) is True
+
+    def test_a_missing_directory_holds_no_content(self, tmp_path: Path) -> None:
+        """Ambiguity resolves toward bare by design, so an unreadable path is False."""
+        assert check_repo_health._holds_checked_out_content(tmp_path / "absent") is False
+
+    def test_a_dotfile_beside_the_git_entry_counts_as_content(
+        self, tmp_path: Path
+    ) -> None:
+        """``.gitignore`` is tracked content; only ``.git`` itself is excluded."""
+        holder = tmp_path / "dirD"
+        (holder / ".git").mkdir(parents=True)
+        (holder / ".gitignore").write_text("*.log\n", encoding="utf-8")
+
+        assert check_repo_health._holds_checked_out_content(holder) is True

--- a/tests/validation/test_check_repo_health_boolean_oracle.py
+++ b/tests/validation/test_check_repo_health_boolean_oracle.py
@@ -1,0 +1,219 @@
+"""The gate's verdict must be git's boolean reading, not a list of spellings.
+
+Split from ``test_check_repo_health.py`` to keep both files under the 500-line
+taste ceiling. Every expectation in this file is derived from git at run time
+rather than written down, because a written-down list is what the gate got
+wrong.
+
+The gate used to compare ``core.bare`` against ``frozenset({"", "true", "yes",
+"on", "1"})``. That set is wrong at both ends, measured on git 2.43.0:
+
+* ``git_parse_maybe_bool`` falls through to integer parsing, so ``2``, ``42``
+  and ``-1`` are all true to git. The gate read them as false and printed
+  ``core.bare read in 1 config scope(s), none set true`` for a repository whose
+  ``git status`` already fatals.
+* An explicitly empty value (``bare = ``) is false to git, but the empty string
+  was in the set, so the gate exited 1 on a healthy repository. Because
+  repo-health runs first in both the pre-commit and pre-push job lists, that
+  blocked every commit and every push, and the diagnosis it printed was
+  fabricated: it asserted every work-tree command fails when ``git status``
+  works fine.
+
+The test that was supposed to cover this parametrized over ``["true", "yes",
+"on", "1"]``, which is the implementation constant minus the empty string. It
+mirrored the code rather than git, so it passed identically whether or not the
+parser was correct and could not fail for either defect above.
+
+So the oracle here is ``git rev-parse --is-bare-repository``, asked of the same
+repository under test. It is an independent reading of the same question: git's
+own answer to whether this repository is bare. The expected exit code is
+derived from it, so a future edit that reintroduces a hand-rolled parser fails
+these cases without anyone having to remember which spellings git accepts.
+
+The two spellings that need a hand-written config line are the ones
+``--get-all`` cannot distinguish: it prints an identical empty field for a
+valueless variable (``bare``) and an explicitly empty one (``bare = ``), while
+git reads the first as true and the second as false. They are still
+oracle-derived here; only the way they are written into the file differs.
+
+Coverage:
+
+- positive: the healthy spellings (``0``, ``false``, ``no``, ``off``, and an
+  explicitly empty value) exit 0, matching the oracle.
+- negative: the bare spellings (``true``, ``yes``, ``on``, ``1``, the nonzero
+  integers ``2``, ``42`` and ``-1``, and a valueless variable) exit 1, matching
+  the oracle.
+- edge: ``extensions.worktreeConfig`` is read through the same boolean flag, so
+  a nonzero integer enables the worktree-scoped immunization line exactly when
+  git accepts a ``--worktree`` write.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+# Every spelling git accepts as a boolean, including the nonzero integers the
+# retired parser read as false. The expected verdict is never written here; it
+# comes from the oracle.
+_BOOLEAN_SPELLINGS = ["true", "yes", "on", "1", "2", "42", "-1", "0", "false", "no", "off"]
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path, name: str = "repo") -> Path:
+    """Create a scratch checkout with one commit."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _rewrite_bare_line(repo: Path, replacement: str) -> None:
+    """Replace the ``bare = false`` line ``git init`` wrote with ``replacement``.
+
+    ``git config`` cannot write either spelling this reaches: a valueless
+    variable and an explicitly empty one both have to be put in the file by
+    hand.
+    """
+    config = repo / ".git" / "config"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace("bare = false", replacement),
+        encoding="utf-8",
+    )
+
+
+def _oracle(repo: Path) -> str:
+    """Ask git whether this repository is bare. The gate must agree."""
+    return _git(repo, "rev-parse", "--is-bare-repository").stdout.strip()
+
+
+class TestTheVerdictTracksGitsOwnBooleanReading:
+    """The expected exit code is derived from git, never from a spelling list."""
+
+    @pytest.mark.parametrize("spelling", _BOOLEAN_SPELLINGS)
+    def test_a_written_value_exits_as_git_reads_it(
+        self, spelling: str, tmp_path: Path
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", spelling)
+
+        expected = 1 if _oracle(repo) == "true" else 0
+
+        assert check_repo_health.main([str(repo)]) == expected
+
+    def test_a_nonzero_integer_is_bare_to_git_and_to_the_gate(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The all-clear the retired parser printed for a repository git refuses."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "42")
+
+        assert _oracle(repo) == "true"
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "none set true" not in captured.out
+        assert "core.bare is set true" in captured.err
+
+    def test_an_explicitly_empty_value_is_healthy_and_does_not_block(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``bare = `` is false to git, so blocking on it blocks a healthy repo."""
+        repo = _make_repo(tmp_path)
+        _rewrite_bare_line(repo, "bare = ")
+
+        assert _oracle(repo) == "false"
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 0
+        assert "none set true" in capsys.readouterr().out
+
+    def test_a_valueless_variable_is_bare_to_git_and_to_the_gate(
+        self, tmp_path: Path
+    ) -> None:
+        """The control for the case above: same empty field, opposite verdict."""
+        repo = _make_repo(tmp_path)
+        _rewrite_bare_line(repo, "bare")
+
+        assert _oracle(repo) == "true"
+
+        assert check_repo_health.main([str(repo)]) == 1
+
+
+class TestTheWorktreeConfigExtensionIsReadTheSameWay:
+    """The immunization line is offered exactly when ``--worktree`` would work."""
+
+    @staticmethod
+    def _poisoned_with_extension(tmp_path: Path, enabled: str) -> Path:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "extensions.worktreeConfig", enabled)
+        _git(repo, "worktree", "add", "-q", str(tmp_path / "linked"), "-b", "feature")
+        _git(repo, "config", "core.bare", "true")
+        return repo
+
+    def test_a_nonzero_integer_enables_the_immunization_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """git accepts ``2`` as enabling the extension, so the hint is real advice."""
+        repo = self._poisoned_with_extension(tmp_path, "2")
+
+        assert check_repo_health.main([str(repo)]) == 1
+        assert "in every worktree" in capsys.readouterr().err
+
+    def test_a_disabled_extension_withholds_it(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The control: ``0`` is false to git, and ``--worktree`` then exits 128."""
+        repo = self._poisoned_with_extension(tmp_path, "0")
+
+        assert check_repo_health.main([str(repo)]) == 1
+        assert "in every worktree" not in capsys.readouterr().err

--- a/tests/validation/test_check_repo_health_budget.py
+++ b/tests/validation/test_check_repo_health_budget.py
@@ -1,0 +1,293 @@
+"""The gate reports before lefthook's ``timeout:`` can replace its diagnosis.
+
+Issue #4698's whole value is one accurate message arriving ahead of the four
+unrelated-looking failures the corruption would otherwise be blamed for. A
+lefthook cap firing first destroys exactly that: measured on lefthook 2.1.10
+(``.claude/rules/ci-scripts.md`` MUST-19), a ``timeout:`` kill lands on the
+job's shell before any guard in it runs, so the reader gets a generic timeout
+line instead of the repair command.
+
+A per-call watchdog does not prevent it. ``GIT_TIMEOUT_SECONDS`` bounds one
+git call, and the corrupted path runs up to five sequentially: the scoped
+config read, common-dir discovery, the worktree listing, effective-bare, and
+the worktree-config read. Five slow-but-successful calls fit inside every
+per-call watchdog and still exceed the job's 10s cap, which is the shape this
+file exists to refuse.
+
+``GitBudget`` is therefore one deadline for the whole evaluation, clamping each
+call's watchdog to what is left, and failing closed with exit 3 and a named
+command when it runs out.
+
+Coverage:
+
+- positive: a healthy checkout spends a small fraction of the budget, and the
+  budget is threaded rather than re-read per call, so five calls draw down one
+  clock.
+- negative: an exhausted budget exits 3 and names the command it stopped at,
+  through ``main`` and through ``diagnose``; a budget with a little time left
+  clamps the per-call timeout below ``GIT_TIMEOUT_SECONDS``.
+- edge: the arithmetic against ``lefthook.yml``. The budget must sit under
+  every declared ``repo-health`` cap with room for interpreter startup, and the
+  per-call watchdog times the maximum call count must exceed the budget, or the
+  budget would never be the binding constraint and this file would pass
+  vacuously.
+
+The cap is read by parsing ``lefthook.yml`` into its object graph, per
+``.claude/rules/testing.md`` MUST-9: a substring search for ``timeout: 10s``
+matches any job in the file.
+
+Refs #4698.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEFTHOOK = REPO_ROOT / "lefthook.yml"
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+# The corrupted path's git calls, in order. Named rather than counted so a new
+# call added to `diagnose` without revisiting the budget fails a test that says
+# which sequence changed.
+_CORRUPTED_PATH_CALLS = (
+    "config --show-scope --type=bool --get-all core.bare",
+    "rev-parse --path-format=absolute --git-common-dir",
+    "worktree list --porcelain",
+    "rev-parse --is-bare-repository",
+    "config --type=bool --get extensions.worktreeConfig",
+)
+
+# Warm `uv run --frozen python` startup measured on this checkout at 0.077s and
+# 0.130s, and 0.944s on the run that also built the venv. Two seconds of
+# headroom is more than fifteen times the worst of those.
+_STARTUP_HEADROOM_SECONDS = 2
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _seconds(declared: str) -> int:
+    """Parse a lefthook ``timeout:`` scalar such as ``10s`` or ``2m``."""
+    unit, value = declared[-1], declared[:-1]
+    assert unit in {"s", "m"}, f"unhandled lefthook timeout unit in {declared!r}"
+    return int(value) * (60 if unit == "m" else 1)
+
+
+def _repo_health_timeouts() -> dict[str, int]:
+    """Return the declared ``repo-health`` cap per hook, from the object graph."""
+    config: dict[str, Any] = yaml.safe_load(LEFTHOOK.read_text(encoding="utf-8"))
+    found: dict[str, int] = {}
+    for hook, body in config.items():
+        if not isinstance(body, dict):
+            continue
+        for job in body.get("jobs", []):
+            if isinstance(job, dict) and job.get("name") == "repo-health":
+                found[hook] = _seconds(str(job["timeout"]))
+    return found
+
+
+class TestTheDeclaredCapsAndTheBudgetAgree:
+    """Edge: the arithmetic that makes the script, not lefthook, report first."""
+
+    def test_the_job_is_wired_into_both_hook_stages(self) -> None:
+        """The premise: a cap this file does not find cannot be reasoned about."""
+        assert sorted(_repo_health_timeouts()) == ["pre-commit", "pre-push"]
+
+    @pytest.mark.parametrize("hook", ["pre-commit", "pre-push"])
+    def test_the_budget_plus_startup_stays_under_the_declared_cap(self, hook: str) -> None:
+        cap = _repo_health_timeouts()[hook]
+
+        assert check_repo_health.GIT_BUDGET_SECONDS + _STARTUP_HEADROOM_SECONDS <= cap, (
+            f"the {hook} repo-health cap is {cap}s but the script may spend "
+            f"{check_repo_health.GIT_BUDGET_SECONDS}s in git, so lefthook can kill "
+            "the job before it prints the repair. Lower GIT_BUDGET_SECONDS or "
+            "raise the cap, and read ADR-104 rule 7 before raising the cap."
+        )
+
+    def test_the_budget_is_the_binding_constraint(self) -> None:
+        """Without this the test above could pass on a budget nothing enforces."""
+        per_call_ceiling = check_repo_health.GIT_TIMEOUT_SECONDS * len(_CORRUPTED_PATH_CALLS)
+
+        assert per_call_ceiling > check_repo_health.GIT_BUDGET_SECONDS, (
+            f"{len(_CORRUPTED_PATH_CALLS)} calls at "
+            f"{check_repo_health.GIT_TIMEOUT_SECONDS}s each already fit inside the "
+            f"{check_repo_health.GIT_BUDGET_SECONDS}s budget, so the budget bounds "
+            "nothing and the cap arithmetic above proves nothing"
+        )
+
+    def test_the_corrupted_path_issues_the_calls_this_file_counts(
+        self, tmp_path: Path
+    ) -> None:
+        """The count above is a claim about `diagnose`; this is the measurement.
+
+        Read from a linked worktree, which is the longest path: the ancestor
+        walk finds no marker naming the common directory there, so the worktree
+        listing runs as well. A poisoned main checkout short-circuits that call
+        and would measure four.
+        """
+        repo = _make_repo(tmp_path)
+        linked = tmp_path / "linked"
+        _git(repo, "worktree", "add", "-q", "--detach", str(linked))
+        _git(repo, "config", "core.bare", "true")
+        seen: list[str] = []
+        real = check_repo_health.subprocess.run
+
+        def _record(argv: list[str], **kwargs: object) -> object:
+            seen.append(" ".join(argv[1:]))
+            return real(argv, **kwargs)
+
+        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
+        try:
+            health = check_repo_health.diagnose(linked)
+        finally:
+            check_repo_health.subprocess.run = real  # type: ignore[assignment]
+
+        assert health.status == "corrupted"
+        assert seen == list(_CORRUPTED_PATH_CALLS)
+
+
+class TestAnExhaustedBudgetReportsInsteadOfRunningMoreGit:
+    """Negative: the deadline fails closed, and names where it stopped."""
+
+    def test_diagnose_raises_before_spawning_git(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+        spent = check_repo_health.GitBudget(total=0.0)
+        seen: list[list[str]] = []
+        real = check_repo_health.subprocess.run
+
+        def _record(argv: list[str], **kwargs: object) -> object:
+            seen.append(argv)
+            return real(argv, **kwargs)
+
+        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
+        try:
+            with pytest.raises(check_repo_health.GitExecutionError) as caught:
+                check_repo_health.diagnose(repo, budget=spent)
+        finally:
+            check_repo_health.subprocess.run = real  # type: ignore[assignment]
+
+        # The isolating assertion: raising after spawning git would still leave
+        # lefthook free to kill the job mid-call (`testing.md` SHOULD 7).
+        assert seen == []
+        assert "git budget ran out" in str(caught.value)
+        assert "--get-all core.bare" in str(caught.value)
+
+    def test_the_cli_exits_three_when_the_budget_is_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Exit 3 is ADR-035's external failure; a return value cannot block a hook."""
+        repo = _make_repo(tmp_path)
+        monkeypatch.setattr(check_repo_health, "GIT_BUDGET_SECONDS", 0)
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 3
+        err = capsys.readouterr().err
+        assert "could not be verified" in err
+        assert "git budget ran out" in err
+
+    def test_a_healthy_checkout_still_exits_zero_on_the_real_budget(
+        self, tmp_path: Path
+    ) -> None:
+        """The discriminating control for the two cases above."""
+        repo = _make_repo(tmp_path)
+
+        assert check_repo_health.main([str(repo)]) == 0
+
+    def test_the_remaining_budget_clamps_the_per_call_watchdog(
+        self, tmp_path: Path
+    ) -> None:
+        """A late call must not be handed the full per-call watchdog."""
+        repo = _make_repo(tmp_path)
+        nearly_spent = check_repo_health.GitBudget(total=0.25)
+        seen: list[float] = []
+        real = check_repo_health.subprocess.run
+
+        def _record(argv: list[str], **kwargs: Any) -> object:
+            seen.append(kwargs["timeout"])
+            return real(argv, **kwargs)
+
+        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
+        try:
+            check_repo_health.diagnose(repo, budget=nearly_spent)
+        finally:
+            check_repo_health.subprocess.run = real  # type: ignore[assignment]
+
+        assert seen, "no git call was made, so nothing was clamped"
+        assert max(seen) <= 0.25
+        assert max(seen) < check_repo_health.GIT_TIMEOUT_SECONDS
+
+
+class TestTheBudgetIsSharedRatherThanPerCall:
+    """Positive: one clock across the whole evaluation, not one per call."""
+
+    def test_one_budget_object_reaches_every_call(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "core.bare", "true")
+        budget = check_repo_health.GitBudget()
+        before = budget.remaining()
+
+        check_repo_health.diagnose(repo, budget=budget)
+
+        assert budget.remaining() < before
+        assert budget.remaining() > 0
+
+    def test_a_default_budget_starts_fresh_each_evaluation(self, tmp_path: Path) -> None:
+        """Two evaluations in one process must not share a clock."""
+        repo = _make_repo(tmp_path)
+
+        assert check_repo_health.diagnose(repo).status == "usable"
+        assert check_repo_health.diagnose(repo).status == "usable"

--- a/tests/validation/test_check_repo_health_budget.py
+++ b/tests/validation/test_check_repo_health_budget.py
@@ -139,6 +139,24 @@ def _repo_health_timeouts() -> dict[str, int]:
     return found
 
 
+def _record_git_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[list[str], Any]]:
+    """Record every git invocation the gate makes, still running the real one.
+
+    Returns a list of ``(argv, timeout)``. ``monkeypatch.setattr`` rather than a
+    bare assignment: it restores on teardown even when the test raises, and it
+    rebinds a module attribute without a type suppression.
+    """
+    seen: list[tuple[list[str], Any]] = []
+    real = check_repo_health.subprocess.run
+
+    def _record(argv: list[str], **kwargs: Any) -> Any:
+        seen.append((argv, kwargs.get("timeout")))
+        return real(argv, **kwargs)
+
+    monkeypatch.setattr(check_repo_health.subprocess, "run", _record)
+    return seen
+
+
 class TestTheDeclaredCapsAndTheBudgetAgree:
     """Edge: the arithmetic that makes the script, not lefthook, report first."""
 
@@ -169,7 +187,7 @@ class TestTheDeclaredCapsAndTheBudgetAgree:
         )
 
     def test_the_corrupted_path_issues_the_calls_this_file_counts(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The count above is a claim about `diagnose`; this is the measurement.
 
@@ -182,42 +200,26 @@ class TestTheDeclaredCapsAndTheBudgetAgree:
         linked = tmp_path / "linked"
         _git(repo, "worktree", "add", "-q", "--detach", str(linked))
         _git(repo, "config", "core.bare", "true")
-        seen: list[str] = []
-        real = check_repo_health.subprocess.run
+        seen = _record_git_calls(monkeypatch)
 
-        def _record(argv: list[str], **kwargs: object) -> object:
-            seen.append(" ".join(argv[1:]))
-            return real(argv, **kwargs)
-
-        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
-        try:
-            health = check_repo_health.diagnose(linked)
-        finally:
-            check_repo_health.subprocess.run = real  # type: ignore[assignment]
+        health = check_repo_health.diagnose(linked)
 
         assert health.status == "corrupted"
-        assert seen == list(_CORRUPTED_PATH_CALLS)
+        assert [" ".join(argv[1:]) for argv, _timeout in seen] == list(_CORRUPTED_PATH_CALLS)
 
 
 class TestAnExhaustedBudgetReportsInsteadOfRunningMoreGit:
     """Negative: the deadline fails closed, and names where it stopped."""
 
-    def test_diagnose_raises_before_spawning_git(self, tmp_path: Path) -> None:
+    def test_diagnose_raises_before_spawning_git(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         repo = _make_repo(tmp_path)
         spent = check_repo_health.GitBudget(total=0.0)
-        seen: list[list[str]] = []
-        real = check_repo_health.subprocess.run
+        seen = _record_git_calls(monkeypatch)
 
-        def _record(argv: list[str], **kwargs: object) -> object:
-            seen.append(argv)
-            return real(argv, **kwargs)
-
-        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
-        try:
-            with pytest.raises(check_repo_health.GitExecutionError) as caught:
-                check_repo_health.diagnose(repo, budget=spent)
-        finally:
-            check_repo_health.subprocess.run = real  # type: ignore[assignment]
+        with pytest.raises(check_repo_health.GitExecutionError) as caught:
+            check_repo_health.diagnose(repo, budget=spent)
 
         # The isolating assertion: raising after spawning git would still leave
         # lefthook free to kill the job mid-call (`testing.md` SHOULD 7).
@@ -248,27 +250,19 @@ class TestAnExhaustedBudgetReportsInsteadOfRunningMoreGit:
         assert check_repo_health.main([str(repo)]) == 0
 
     def test_the_remaining_budget_clamps_the_per_call_watchdog(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A late call must not be handed the full per-call watchdog."""
         repo = _make_repo(tmp_path)
         nearly_spent = check_repo_health.GitBudget(total=0.25)
-        seen: list[float] = []
-        real = check_repo_health.subprocess.run
+        seen = _record_git_calls(monkeypatch)
 
-        def _record(argv: list[str], **kwargs: Any) -> object:
-            seen.append(kwargs["timeout"])
-            return real(argv, **kwargs)
+        check_repo_health.diagnose(repo, budget=nearly_spent)
 
-        check_repo_health.subprocess.run = _record  # type: ignore[assignment]
-        try:
-            check_repo_health.diagnose(repo, budget=nearly_spent)
-        finally:
-            check_repo_health.subprocess.run = real  # type: ignore[assignment]
-
-        assert seen, "no git call was made, so nothing was clamped"
-        assert max(seen) <= 0.25
-        assert max(seen) < check_repo_health.GIT_TIMEOUT_SECONDS
+        timeouts = [timeout for _argv, timeout in seen]
+        assert timeouts, "no git call was made, so nothing was clamped"
+        assert max(timeouts) <= 0.25
+        assert max(timeouts) < check_repo_health.GIT_TIMEOUT_SECONDS
 
 
 class TestTheBudgetIsSharedRatherThanPerCall:

--- a/tests/validation/test_check_repo_health_hostile_inputs.py
+++ b/tests/validation/test_check_repo_health_hostile_inputs.py
@@ -1,0 +1,261 @@
+"""The gate's answer must come from the repository it was pointed at.
+
+Split from ``test_check_repo_health.py``, which pins detection, to keep both
+files under the 500-line taste ceiling. Two inputs the gate does not control
+reach it before any config does.
+
+The environment. git resolves a repository's location from ``GIT_DIR``,
+``GIT_WORK_TREE``, and ``GIT_COMMON_DIR`` before it reads any config file, so a
+value inherited from whatever invoked the hook redirects every answer the gate
+collects. Measured on git 2.43.0 against a corrupted checkout with ``GIT_DIR``
+naming an unrelated bare repository: ``rev-parse --git-common-dir`` and
+``worktree list --porcelain`` both answered for that other repository, so live
+corruption reported as a verified pass. ``GIT_CONFIG_KEY_n`` and its siblings
+are deliberately left in place, because a command-scoped ``core.bare`` arrives
+that way and the gate exists to report it.
+
+The ``.git`` marker file. ``_marker_git_dir`` reads it while walking ancestors,
+and an ancestor is any directory above the checkout, including directories the
+gate's caller does not own. An unbounded read of a ``.git`` symlinked at a
+character device such as ``/dev/zero`` never returns, which hangs the commit or
+push the gate runs inside.
+
+Coverage:
+
+- positive: a healthy checkout still exits 0 with each override set, so the
+  stripping does not turn every run into a failure.
+- negative: a corrupted checkout still exits 1 with ``GIT_DIR`` or
+  ``GIT_COMMON_DIR`` pointing at a genuine bare repository; ``_git`` passes none
+  of the three location variables to the child while keeping ``GIT_CONFIG_KEY_0``.
+- edge: an oversized marker, a marker that is a character device, and a marker
+  that is a directory each resolve to nothing; a normal marker still resolves.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+# git 2.43.0 answers for the override rather than the working directory for
+# these two, so each is a discriminating input rather than a defensive guess.
+# GIT_WORK_TREE is stripped alongside them and is pinned structurally below.
+_REDIRECTING_OVERRIDES = ["GIT_DIR", "GIT_COMMON_DIR"]
+
+_CHARACTER_DEVICE = Path("/dev/zero")
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path, name: str = "repo") -> Path:
+    """Create a scratch checkout with one commit."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _make_decoy_bare(tmp_path: Path) -> Path:
+    """Create a genuine bare repository for an override to point at."""
+    seed = _make_repo(tmp_path, "seed")
+    decoy = tmp_path / "decoy.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(seed), str(decoy))
+    return decoy
+
+
+class TestAnInheritedLocationOverrideCannotChangeTheVerdict:
+    """Negative: the answer must describe the repository named on the CLI."""
+
+    def test_the_override_really_does_redirect_plain_git(self, tmp_path: Path) -> None:
+        """The control. Without it the cases below prove nothing."""
+        repo = _make_repo(tmp_path)
+        decoy = _make_decoy_bare(tmp_path)
+
+        redirected = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=str(repo),
+            env={**_git_test_env(), "GIT_DIR": str(decoy)},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert Path(redirected.stdout.strip()) == decoy
+
+    @pytest.mark.parametrize("override", _REDIRECTING_OVERRIDES)
+    def test_a_corrupted_checkout_is_still_reported(
+        self,
+        override: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        repo = _make_repo(tmp_path)
+        decoy = _make_decoy_bare(tmp_path)
+        _git(repo, "config", "core.bare", "true")
+        monkeypatch.setenv(override, str(decoy))
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        err = capsys.readouterr().err
+        assert str(repo) in err
+        assert str(decoy) not in err
+
+    @pytest.mark.parametrize("override", _REDIRECTING_OVERRIDES)
+    def test_a_healthy_checkout_still_passes(
+        self, override: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stripping must not convert every run into a failure."""
+        repo = _make_repo(tmp_path)
+        decoy = _make_decoy_bare(tmp_path)
+        monkeypatch.setenv(override, str(decoy))
+
+        assert check_repo_health.main([str(repo)]) == 0
+
+    def test_no_location_variable_reaches_the_child_process(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pins the contract for all three, GIT_WORK_TREE included.
+
+        Read at the boundary rather than through a verdict, because
+        ``GIT_WORK_TREE`` is ignored by a bare-flagged repository and so cannot
+        move any verdict this gate produces.
+        """
+        repo = _make_repo(tmp_path)
+        for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"):
+            monkeypatch.setenv(name, str(tmp_path))
+        monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.bare")
+        seen: dict[str, str] = {}
+        real_run = subprocess.run
+
+        def _capture(*args: Any, **kwargs: Any) -> Any:
+            seen.update(kwargs["env"])
+            return real_run(*args, **kwargs)
+
+        monkeypatch.setattr(check_repo_health.subprocess, "run", _capture)
+
+        check_repo_health.main([str(repo)])
+
+        assert seen, "the gate ran no git command, so nothing was measured"
+        assert "GIT_DIR" not in seen
+        assert "GIT_WORK_TREE" not in seen
+        assert "GIT_COMMON_DIR" not in seen
+        assert seen["GIT_CONFIG_KEY_0"] == "core.bare"
+
+
+class TestAHostileGitMarkerIsRefusedRatherThanRead:
+    """Edge: an ancestor's ``.git`` marker is input the gate does not own."""
+
+    def test_a_normal_marker_still_resolves(self, tmp_path: Path) -> None:
+        """The control for every refusal below."""
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        marker = tmp_path / ".git"
+        marker.write_text("gitdir: elsewhere\n", encoding="utf-8")
+
+        assert check_repo_health._marker_git_dir(marker) == target.resolve()
+
+    def test_an_oversized_marker_resolves_to_nothing(self, tmp_path: Path) -> None:
+        """A real marker holds one short line, so size alone disqualifies this."""
+        marker = tmp_path / ".git"
+        padding = "x" * (check_repo_health._MAX_MARKER_BYTES + 1)
+        marker.write_text(f"gitdir: elsewhere\n{padding}", encoding="utf-8")
+
+        assert marker.stat().st_size > check_repo_health._MAX_MARKER_BYTES
+        assert check_repo_health._marker_git_dir(marker) is None
+
+    def test_a_marker_at_the_size_cap_is_still_read(self, tmp_path: Path) -> None:
+        """The boundary: the cap refuses larger, not equal."""
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        marker = tmp_path / ".git"
+        line = "gitdir: elsewhere\n"
+        marker.write_text(
+            line + "\n" * (check_repo_health._MAX_MARKER_BYTES - len(line)),
+            encoding="utf-8",
+        )
+
+        assert marker.stat().st_size == check_repo_health._MAX_MARKER_BYTES
+        assert check_repo_health._marker_git_dir(marker) == target.resolve()
+
+    @pytest.mark.skipif(
+        not _CHARACTER_DEVICE.exists(), reason="no /dev/zero on this platform"
+    )
+    def test_a_marker_symlinked_at_a_character_device_resolves_to_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """An unbounded read here never returns and hangs the commit."""
+        marker = tmp_path / ".git"
+        marker.symlink_to(_CHARACTER_DEVICE)
+
+        assert check_repo_health._marker_git_dir(marker) is None
+
+    @pytest.mark.skipif(
+        not _CHARACTER_DEVICE.exists(), reason="no /dev/zero on this platform"
+    )
+    def test_the_ancestor_walk_survives_a_character_device_marker(
+        self, tmp_path: Path
+    ) -> None:
+        """The walk is where a real invocation meets an ancestor it does not own."""
+        holder = tmp_path / "holder"
+        holder.mkdir()
+        (holder / ".git").symlink_to(_CHARACTER_DEVICE)
+
+        assert check_repo_health._work_tree_root(holder, tmp_path / "somewhere") is None
+
+    def test_a_marker_that_is_a_directory_resolves_to_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """``_work_tree_root`` resolves a directory itself and never reads it."""
+        marker = tmp_path / ".git"
+        marker.mkdir()
+
+        assert check_repo_health._marker_git_dir(marker) is None

--- a/tests/validation/test_check_repo_health_reporting.py
+++ b/tests/validation/test_check_repo_health_reporting.py
@@ -94,13 +94,18 @@ class TestRepairNamesEveryScopeThatCarriesTheValue:
     def test_the_work_tree_and_every_poisoned_scope_are_named(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """A diagnosis the reader cannot act on is why this incident cost hours."""
-        _report(tmp_path, (("local", "true"), ("global", "yes")))
+        """A diagnosis the reader cannot act on is why this incident cost hours.
+
+        Both scopes read ``true`` because ``_scoped_core_bare`` asks git for
+        ``--type=bool`` and git normalizes every spelling it accepts, so
+        ``yes``, ``on`` and ``42`` never reach the report as themselves.
+        """
+        _report(tmp_path, (("local", "true"), ("global", "true")))
 
         err = capsys.readouterr().err
         assert str(tmp_path) in err
         assert "local=true" in err
-        assert "global=yes" in err
+        assert "global=true" in err
 
 
 class TestImmunizationHintTracksTheWorktreeConfigExtension:

--- a/tests/validation/test_check_repo_health_reporting.py
+++ b/tests/validation/test_check_repo_health_reporting.py
@@ -47,7 +47,7 @@ def _report(
     worktree_config: bool = False,
 ) -> None:
     """Print the failure report for one constructed verdict."""
-    check_repo_health._report_corruption(
+    check_repo_health.report_corruption(
         check_repo_health.RepoHealth(
             "corrupted",
             work_tree=work_tree,

--- a/tests/validation/test_check_repo_health_reporting.py
+++ b/tests/validation/test_check_repo_health_reporting.py
@@ -1,0 +1,129 @@
+"""The repo-health failure report names a repair that can actually clear it.
+
+Split from ``test_check_repo_health.py``, which pins detection, to keep both
+files under the 500-line taste ceiling. These cases drive
+``_report_corruption`` directly against a constructed verdict, so they need no
+scratch repository: the config scopes git can report are enumerable, and
+constructing them is the only way to reach the global, system, and command
+scopes without writing to the host's real configuration.
+
+Issue #4698: the repair GOTCHAS names, ``git config core.bare false``, writes
+to the local config. Pointed at a worktree-scoped, global, or system value it
+reports success and changes nothing, so the reader repairs the wrong file and
+the checkout stays broken.
+
+Coverage:
+
+- positive: each of git's five config scopes, and an unrecognized one, maps to
+  a command that can clear a value held in it; two poisoned scopes get two
+  repairs.
+- negative: the worktree-scoped immunization line is withheld when
+  ``extensions.worktreeConfig`` is absent (``git config --worktree`` exits 128
+  there) and when the worktree scope is itself the offender, where immunizing
+  with the value that is already wrong is not a repair.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+
+def _report(
+    work_tree: Path,
+    bare_scopes: tuple[tuple[str, str], ...],
+    *,
+    worktree_config: bool = False,
+) -> None:
+    """Print the failure report for one constructed verdict."""
+    check_repo_health._report_corruption(
+        check_repo_health.RepoHealth(
+            "corrupted",
+            work_tree=work_tree,
+            bare_scopes=bare_scopes,
+            worktree_config=worktree_config,
+        )
+    )
+
+
+class TestRepairNamesEveryScopeThatCarriesTheValue:
+    """A repair aimed at the wrong config file leaves the checkout broken."""
+
+    @pytest.mark.parametrize(
+        ("scope", "expected"),
+        [
+            ("local", "git config core.bare false"),
+            ("worktree", "git config --worktree core.bare false"),
+            ("global", "git config --global --unset-all core.bare"),
+            ("system", "git config --system --unset-all core.bare"),
+            ("command", "remove the command-scoped core.bare override"),
+            ("unheard-of", "git config core.bare false"),
+        ],
+    )
+    def test_every_scope_maps_to_a_command_that_can_clear_it(
+        self,
+        scope: str,
+        expected: str,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _report(tmp_path, ((scope, "true"),))
+
+        assert f"Fix: {expected}" in capsys.readouterr().err
+
+    def test_two_poisoned_scopes_get_two_repairs(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _report(tmp_path, (("local", "true"), ("worktree", "true")))
+
+        err = capsys.readouterr().err
+        assert "Fix: git config core.bare false" in err
+        assert "Fix: git config --worktree core.bare false" in err
+
+    def test_the_work_tree_and_every_poisoned_scope_are_named(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A diagnosis the reader cannot act on is why this incident cost hours."""
+        _report(tmp_path, (("local", "true"), ("global", "yes")))
+
+        err = capsys.readouterr().err
+        assert str(tmp_path) in err
+        assert "local=true" in err
+        assert "global=yes" in err
+
+
+class TestImmunizationHintTracksTheWorktreeConfigExtension:
+    """``git config --worktree`` exits 128 without the extension enabled."""
+
+    def test_the_hint_appears_when_the_extension_is_enabled(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _report(tmp_path, (("local", "true"),), worktree_config=True)
+
+        assert "in every worktree" in capsys.readouterr().err
+
+    def test_the_hint_is_withheld_when_the_extension_is_absent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _report(tmp_path, (("local", "true"),), worktree_config=False)
+
+        assert "in every worktree" not in capsys.readouterr().err
+
+    def test_the_hint_is_withheld_when_the_worktree_scope_is_the_offender(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Immunizing with the value that is already wrong is not a repair."""
+        _report(tmp_path, (("worktree", "true"),), worktree_config=True)
+
+        assert "in every worktree" not in capsys.readouterr().err

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -159,7 +159,8 @@ class TestAGlobalTrueUnderALocalFalseIsNotTheIncident:
         """The premise: the gate must agree with this, not contradict it."""
         repo, env = self._repo_with(tmp_path, "false")
 
-        scopes = _git(repo, "config", "--show-scope", "--type=bool", "--get-all", "core.bare", env=env)
+        read = ("config", "--show-scope", "--type=bool", "--get-all", "core.bare")
+        scopes = _git(repo, *read, env=env)
 
         assert scopes.splitlines() == ["global\ttrue", "local\tfalse"]
         assert _git(repo, "config", "--get", "core.bare", env=env) == "false"

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -1,0 +1,345 @@
+"""A ``core.bare`` true that git has already overridden is not the incident.
+
+Split from ``test_check_repo_health.py``, which pins detection, to keep both
+files under the 500-line taste ceiling. These cases pin the opposite obligation
+to that file's: the configurations where ``true`` is present in some scope and
+the repository is nevertheless usable, so the gate must not print a repair for
+a condition nobody has.
+
+``core.bare`` is single-valued. Git answers it with one value however many
+scopes carry it, and that value is the last one in precedence order. Reading
+"any scope says true" instead reported corruption for a repository whose
+``git status`` works, and the repair it printed then wrote a value nothing
+needed into a config file that was already correct.
+
+Measured on git 2.43.0, with the ``--get`` column the property under test::
+
+    git config --show-scope --type=bool --get-all core.bare   --get   status
+    global true, local false                                  false   0
+    local true, local false                                   false   0
+    local false, local true                                   true    128
+    local true, worktree false                                false   0
+
+The fourth row is why the effective value alone cannot carry the verdict, and
+it is the one row where the gate still fails: that is the state issue #4698
+left behind, where the shared config poisons every sibling worktree while this
+one carries the worktree-scoped ``false`` GOTCHAS prescribes.
+``test_check_repo_health.py`` owns that case; this file owns the first three
+and their controls.
+
+Coverage:
+
+- positive: a masked ``global true``, a masked earlier ``local true``, and a
+  masked ``true`` under a worktree-scoped ``false`` in a genuinely bare
+  repository each exit 0 and print no repair, through ``main`` and through the
+  CLI process. The usable line names the masked value rather than claiming
+  none was set.
+- negative: the discriminating controls. Reversing the write order in each
+  masked pair makes the same repository exit 1, so the exit-0 cases are not
+  passing because the gate stopped reading config at all.
+- edge: ``_effective_pair`` and ``_active_bare_scopes`` over the scope orders
+  above, including the empty read and the ``ignore_worktree`` projection.
+
+Every configuration here is asserted against git's own answer before the gate
+is run, so a git version that changes precedence fails on the premise rather
+than on the verdict.
+
+Refs #4698.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way production imports (issue #2223): prepend ``scripts/validation``
+# to ``sys.path`` and import by bare name.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_repo_health
+
+GUARD = _VALIDATION_DIR / "check_repo_health.py"
+
+_REPAIR = "core.bare false"
+
+
+def _git_test_env() -> dict[str, str]:
+    """Return a host-independent environment for scratch Git repositories."""
+    return {
+        "PATH": os.environ.get("PATH", ""),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+
+def _git(cwd: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=env or _git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result.stdout.strip()
+
+
+def _git_rc(cwd: Path, *args: str, env: dict[str, str] | None = None) -> int:
+    """Run git without asserting, for cases where the exit code is the evidence."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=env or _git_test_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode
+
+
+@pytest.fixture(autouse=True)
+def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the gate's own git calls off the host's global and system config."""
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+
+def _make_repo(root: Path, name: str = "repo") -> Path:
+    """Create a scratch checkout with one commit."""
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    (repo / "tracked.txt").write_text("content\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _global_config(tmp_path: Path, value: str) -> dict[str, str]:
+    """Return an environment whose global config carries ``core.bare = value``."""
+    path = tmp_path / "gitconfig"
+    path.write_text(f"[core]\n\tbare = {value}\n", encoding="utf-8")
+    return {**_git_test_env(), "GIT_CONFIG_GLOBAL": str(path)}
+
+
+def _run_cli(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Drive the script as lefthook does, so the process exit code is asserted."""
+    return subprocess.run(
+        [sys.executable, str(GUARD), str(repo)],
+        cwd=str(repo),
+        env={**env, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestAGlobalTrueUnderALocalFalseIsNotTheIncident:
+    """The masked pair that spans two config files."""
+
+    @staticmethod
+    def _repo_with(tmp_path: Path, local: str) -> tuple[Path, dict[str, str]]:
+        repo = _make_repo(tmp_path)
+        env = _global_config(tmp_path, "true")
+        _git(repo, "config", "core.bare", local, env=env)
+        return repo, env
+
+    def test_git_itself_resolves_the_repository_usable(self, tmp_path: Path) -> None:
+        """The premise: the gate must agree with this, not contradict it."""
+        repo, env = self._repo_with(tmp_path, "false")
+
+        scopes = _git(repo, "config", "--show-scope", "--type=bool", "--get-all", "core.bare", env=env)
+
+        assert scopes.splitlines() == ["global\ttrue", "local\tfalse"]
+        assert _git(repo, "config", "--get", "core.bare", env=env) == "false"
+        assert _git(repo, "rev-parse", "--is-bare-repository", env=env) == "false"
+        assert _git_rc(repo, "status", "--short", env=env) == 0
+
+    def test_it_exits_zero_and_prints_no_repair(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo, env = self._repo_with(tmp_path, "false")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", env["GIT_CONFIG_GLOBAL"])
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert _REPAIR not in captured.out + captured.err
+        assert "Fix:" not in captured.err
+
+    def test_the_usable_line_names_the_masked_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A flat "none set true" would misdescribe a config that does say true."""
+        repo, env = self._repo_with(tmp_path, "false")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", env["GIT_CONFIG_GLOBAL"])
+
+        check_repo_health.main([str(repo)])
+
+        out = capsys.readouterr().out
+        assert "read in 2 config scope(s)" in out
+        assert "global=true overridden by a later scope" in out
+        assert "none set true" not in out
+
+    def test_the_cli_process_exits_zero(self, tmp_path: Path) -> None:
+        repo, env = self._repo_with(tmp_path, "false")
+
+        result = _run_cli(repo, env)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _REPAIR not in result.stdout + result.stderr
+
+    def test_a_local_true_over_the_same_global_still_exits_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The discriminating control: only the local value differs."""
+        repo, env = self._repo_with(tmp_path, "true")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", env["GIT_CONFIG_GLOBAL"])
+        assert _git_rc(repo, "status", "--short", env=env) == 128
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        assert f"Fix: git config {_REPAIR}" in capsys.readouterr().err
+
+
+class TestARepeatedLocalKeyIsResolvedByOrderNotByPresence:
+    """The masked pair that sits inside one config file."""
+
+    @staticmethod
+    def _repo_with(tmp_path: Path, first: str, second: str) -> Path:
+        repo = _make_repo(tmp_path)
+        _git(repo, "config", "--unset-all", "core.bare")
+        _git(repo, "config", "--add", "core.bare", first)
+        _git(repo, "config", "--add", "core.bare", second)
+        return repo
+
+    def test_git_itself_resolves_a_trailing_false_usable(self, tmp_path: Path) -> None:
+        """The premise: two local values, and only the last one counts."""
+        repo = self._repo_with(tmp_path, "true", "false")
+
+        scopes = _git(repo, "config", "--show-scope", "--type=bool", "--get-all", "core.bare")
+
+        assert scopes.splitlines() == ["local\ttrue", "local\tfalse"]
+        assert _git(repo, "config", "--get", "core.bare") == "false"
+        assert _git_rc(repo, "status", "--short") == 0
+
+    def test_a_trailing_false_exits_zero_and_prints_no_repair(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = self._repo_with(tmp_path, "true", "false")
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert _REPAIR not in captured.out + captured.err
+        assert "local=true overridden by a later scope" in captured.out
+
+    def test_a_trailing_true_still_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The discriminating control: same two values, written the other way."""
+        repo = self._repo_with(tmp_path, "false", "true")
+        assert _git_rc(repo, "status", "--short") == 128
+
+        code = check_repo_health.main([str(repo)])
+
+        assert code == 1
+        assert f"Fix: git config {_REPAIR}" in capsys.readouterr().err
+
+
+class TestAWorktreeScopedFalseOverABareRepositoryIsStillBareByDesign:
+    """The worktree scope wins here too, and the shared value is not a work tree."""
+
+    def test_a_bare_repository_immunizing_itself_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        seed = _make_repo(tmp_path, "seed")
+        bare = tmp_path / "origin.git"
+        _git(tmp_path, "clone", "-q", "--bare", str(seed), str(bare))
+        _git(bare, "config", "extensions.worktreeConfig", "true")
+        _git(bare, "config", "--worktree", "core.bare", "false")
+
+        code = check_repo_health.main([str(bare)])
+
+        assert code == 0
+        assert _REPAIR not in capsys.readouterr().err
+
+
+class TestTheResolverMatchesGitsPrecedenceRule:
+    """Edge: the two pure functions, over the orders measured in the docstring."""
+
+    @pytest.mark.parametrize(
+        ("scoped", "expected", "shared"),
+        [
+            ((), None, None),
+            ((("local", "false"),), ("local", "false"), ("local", "false")),
+            (
+                (("global", "true"), ("local", "false")),
+                ("local", "false"),
+                ("local", "false"),
+            ),
+            (
+                (("local", "false"), ("local", "true")),
+                ("local", "true"),
+                ("local", "true"),
+            ),
+            (
+                (("local", "true"), ("worktree", "false")),
+                ("worktree", "false"),
+                ("local", "true"),
+            ),
+            (
+                (("local", "true"), ("worktree", "false"), ("command", "false")),
+                ("command", "false"),
+                ("command", "false"),
+            ),
+        ],
+    )
+    def test_the_last_pair_wins_and_ignore_worktree_drops_that_scope(
+        self,
+        scoped: tuple[tuple[str, str], ...],
+        expected: tuple[str, str] | None,
+        shared: tuple[str, str] | None,
+    ) -> None:
+        assert check_repo_health._effective_pair(scoped) == expected
+        assert check_repo_health._effective_pair(scoped, ignore_worktree=True) == shared
+
+    @pytest.mark.parametrize(
+        ("scoped", "active"),
+        [
+            ((), ()),
+            ((("local", "false"),), ()),
+            ((("global", "true"), ("local", "false")), ()),
+            ((("local", "true"), ("local", "false")), ()),
+            ((("local", "true"),), (("local", "true"),)),
+            ((("local", "false"), ("local", "true")), (("local", "true"),)),
+            # The sibling check: the worktree-scoped false masks the value here
+            # and nowhere else, so this must stay reported.
+            ((("local", "true"), ("worktree", "false")), (("local", "true"),)),
+            ((("worktree", "true"),), (("worktree", "true"),)),
+            (
+                (("global", "true"), ("local", "true")),
+                (("global", "true"), ("local", "true")),
+            ),
+        ],
+    )
+    def test_only_a_value_in_force_is_reported(
+        self,
+        scoped: tuple[tuple[str, str], ...],
+        active: tuple[tuple[str, str], ...],
+    ) -> None:
+        assert check_repo_health._active_bare_scopes(scoped) == active


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds `scripts/validation/check_repo_health.py` and runs it as the first `pre-commit` and `pre-push` job. It fails the hook when the git config a repository actually resolves sets `core.bare` true while that repository has a work tree, and names a repair for the scope that carries the value.

### Why

Issue #4698. Something during `git push` writes `core.bare = true` into the shared `.git/config`. A bare repository cannot have a work tree, so every git command needing one fails with `fatal: this operation must be run in a work tree`. Measured twice in one session: it broke the main checkout and three of five linked worktrees at once and surfaced as four unrelated-looking failures (two portability checks in the pre-PR gate, a lefthook integration test, and plain `git status`). Three wrong diagnoses were attempted before the shared cause was found, including one issue filed and retracted. `.agents/governance/GOTCHAS.md` records the incident and the repair; nothing detected the condition.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4698 | A session set core.bare=true in shared .git/config, breaking the main worktree and 3 of 5 linked worktrees; no gate detects it |

This PR does not close #4698. It satisfies acceptance criteria 1-3 (detection, hook wiring, tests). Criterion 4, `.git/config` branch-section pruning, is deferred and tracked separately in #5360.

## Review round 2: six threads, six defects

Copilot's second review found six real defects. Each is fixed with a test that fails against the pre-fix code, and each of those negative controls was run rather than assumed.

**1. Directory non-emptiness was not evidence of a checkout.** `_main_work_tree` read "this directory holds something besides `.git`" as proof a work tree exists. Nothing stops a bare repository's holding directory carrying a README, a log, or a deploy script, so `git clone --bare seed holder/.git` plus one unrelated file was classified corrupted and printed `git config core.bare false`, which writes into that bare repository's shared config and breaks it along with every worktree it has handed out. It also contradicted this gate's own stated policy that an ambiguous layout resolves to bare-by-design.

The separating fact is repository metadata. Measured on git 2.43.0:

```
seed/.git/index                  True    ordinary checkout
corrupt/.git/index               True    checkout later flagged bare
dirD/.git/index                  False   git clone --bare seed dirD/.git
holder/.git/index                False   the same, with a README beside it
bareA.git/index                  False   bare repo that handed out a worktree
bareA.git/worktrees/wtA/index    True    that worktree's own index
```

`_holds_checked_out_content` stays as a second, independent condition, because a bare repository someone ran `git read-tree` inside does acquire an index while its phantom work tree still holds nothing but `.git`. Both must hold. The test that pinned the old behavior asserted exit 1 for exactly this false positive; it is inverted, and a real checkout reported under the same `worktree holder` shape replaces it as the discriminating control.

**2. Presence of a `true` is not the same as a `true` in force.** `diagnose` treated any scope carrying `true` as active. `core.bare` is single-valued: git answers it with one value however many scopes carry it, and that value is the last one in precedence order. Measured on git 2.43.0, `--get` and `git status` agreeing in every row:

```
--show-scope --type=bool --get-all       --get   git status
global true, local false                 false   0
local true, local false                  false   0
local false, local true                  true    128
local true, worktree false               false   0
```

Rows 1 and 2 left every worktree usable while the gate returned corrupted and printed a repair for a condition nobody had. `_effective_pair` now reproduces git's rule and `_active_bare_scopes` asks it twice: once for this vantage point, and once ignoring the worktree scope for what a sibling without an override sees. The second read is what keeps row 4 reported, which is the state the incident left behind. Every true-carrying scope is still listed in the repair block, because clearing the governing scope can expose a lower one. The usable line now names a masked value instead of claiming "none set true" for a config that does say true.

**3. The 10s `timeout:` could kill the job before it printed the repair.** `GIT_TIMEOUT_SECONDS = 5` bounds one git call, not the run, and the corrupted path issues five sequentially (scoped read, common-dir discovery, worktree listing, effective-bare, worktree-config), so the per-call watchdog alone allows 25s. Measured on lefthook 2.1.10 (`ci-scripts.md` MUST-19), a `timeout:` kill lands on the job's shell before any guard runs, so the reader would get a generic timeout line in place of the one message this gate exists to deliver.

`GitBudget` is one deadline for the whole evaluation, threaded through every call rather than read from module state so two evaluations do not share a clock. Each call's watchdog is clamped to what is left, and an exhausted budget raises before spawning git, so the gate still blocks but with exit 3 naming the command that ran out. `GIT_BUDGET_SECONDS = 7` plus `uv run` startup (0.077s and 0.130s warm, 0.944s cold) leaves the 10s cap unreached, so the cap is not what stops the job.

The cap itself is unchanged. Raising it would raise the stage's declared worst case, which ADR-104 rule 7 and `tests/ci/test_lefthook_declared_budget.py` both refuse. `tests/validation/test_check_repo_health_budget.py` parses the cap out of `lefthook.yml` (per `testing.md` MUST-9) and fails if either number moves alone; it also measures the five-call sequence rather than asserting the count, and pins that the per-call ceiling exceeds the budget, so the budget cannot bound nothing and pass vacuously.

**4. The corpus scan counted strings nobody runs.** It recorded every exact `--bare` or `core.bare` constant anywhere in a file, not only ones being built into a command, so assertions and expected-message data inflated `sites_examined` and could raise a violation for a token that never reaches a process. A token now counts where it is being built into something a process could receive, and not where it is being compared. Measured at `26911e9f0`: 73 sites under the old rule against 70, and all three dropped are `ast.Compare` operands.

Restricting further, to tokens lexically inside a subprocess argument list, was rejected because it under-reports: `tests/gh_base_ref_test_helpers.py` builds `args = ["git", "init"]`, appends `--bare` conditionally, and runs `args` two statements later. Carrier tracking follows that shape instead.

**5. Temp-rooting the function proved nothing about the path handed to git.** Any `tmp_path` parameter, or any tempfile call anywhere in a body, marked the whole function safe, which is the limitation the old module docstring admitted to. `def test_x(tmp_path): subprocess.run(["git", "init", "--bare", "/home/user/live.git"])` passed the gate.

The scan now traces the command's own argument, its `cwd=`, or the vector carrying it back to a root, reaching a fixed point over assignments and `with` bindings so `bare = tmp_path / name` and `bare, linked = _make(tmp_path)` both carry it. A parameter counts as a root only where callers vouch for it, so rooting a function no longer launders a literal path it also passes. An environment write (`monkeypatch.setenv`, `env=`) names no repository, so it keeps the function-level grade with its reason stated rather than being failed for a target it cannot have.

**6. A module-level command was reported clean.** An unbound module-level site produced empty bindings and therefore an empty reader set, so the generator yielded nothing for it. A module-level `subprocess.run(["git", "init", "--bare", "remote.git"])` executes at import, during pytest collection, against the ambient working directory. It is now a violation on sight.

## Two file splits, and why they are not size dodges

The fixes took two files past the 500-line taste ceiling, and the count ratchet refuses a new error-severity violation.

`scripts/validation/check_repo_health.py` was 63 percent docstring at 101 lines of code, so the prose was tightened first, from 664 lines to 565. The presentation layer then moved to `scripts/validation/check_repo_health_report.py`. The seam is real rather than arithmetic: the new module reads no git and decides nothing, and the gate now spawns no output. Issue #4698 is a diagnosis problem before it is a detection problem, so what the gate prints is the deliverable and is worth being readable on its own.

The scan splits the same way, into `tests/bare_repo_sites.py` (what one module's syntax tree says) and `tests/bare_repo_scan.py` (what the corpus verdict is), with the tests splitting alongside into `tests/test_bare_repo_scan_targets.py`. All files are under the ceiling and the ratchet is back at its 575 baseline.

## Changes

18 files. The gate and its wiring:

- `scripts/validation/check_repo_health.py`: reads `git config --show-scope --type=bool --get-all core.bare`, resolves the effective value by git's precedence, and decides whether a main work tree is meant to exist before failing.
- `scripts/validation/check_repo_health_report.py`: the repair vocabulary and every line the gate prints.
- `lefthook.yml`: `repo-health` is the first job in `pre-commit` and `pre-push`, ahead of `repair-packed-refs`. The comments now carry the budget arithmetic.
- `.agents/governance/GOTCHAS.md`, `tests/ci/lefthook_budget_model.py`, `tests/ci/test_lefthook_prepush_fast_fail.py`, `tests/test_lefthook_integration.py`: the incident entry, the three rosters that pin the hook job sets, and a runtime test driving the real lefthook binary.

Seven gate test files, split because the taste ratchet caps a file at 500 lines:

- `tests/validation/test_check_repo_health.py`: detection, exit codes, and edge cases.
- `tests/validation/test_check_repo_health_reporting.py`: the repair each config scope needs.
- `tests/validation/test_check_repo_health_bare_by_design.py`: the false-positive class, where the repair the gate prints would destroy a healthy repository.
- `tests/validation/test_check_repo_health_scope_precedence.py`: masked `true` values that git has already overridden.
- `tests/validation/test_check_repo_health_budget.py`: the shared deadline, against the cap parsed out of `lefthook.yml`.
- `tests/validation/test_check_repo_health_hostile_inputs.py`: `GIT_DIR` / `GIT_WORK_TREE` / `GIT_COMMON_DIR` stripping, and `.git` marker hardening.
- `tests/validation/test_check_repo_health_boolean_oracle.py`: which values count as bare, derived from `git rev-parse --is-bare-repository` rather than from a list of spellings.

Four files for acceptance criterion 3:

- `tests/bare_repo_sites.py`: what one module's syntax tree says about each `--bare` and `core.bare` token.
- `tests/bare_repo_scan.py`: the call graph, the target trace, and the corpus verdict.
- `tests/test_bare_repo_fixtures_are_temp_rooted.py`: the corpus result and the temp roots the scan recognises.
- `tests/test_bare_repo_scan_targets.py`: what counts as a site, that a command's target must reach the root, and that a module-level command is a violation on sight.

## The work-tree discriminator

Bareness alone is not the defect, since a genuine bare repository answers `local true` too. The question is whether the repository's **main** work tree is meant to exist, not whether the checkout being read has one.

Reading the second is what made an earlier version print destructive advice for a healthy layout. `git clone --bare seed bareA.git` followed by `git -C bareA.git worktree add wtA` is ordinary git. `wtA` is a live checkout, `git -C wtA status` works, and it carries a `gitdir:` marker naming its own private git directory, so anchoring on `git rev-parse --absolute-git-dir` finds a marker and calls the repository corrupted.

The anchor is `git rev-parse --path-format=absolute --git-common-dir`, which answers the same shared path from the main checkout and from every linked worktree. The main work tree is an ancestor whose `.git` marker resolves to that common directory, or otherwise the first `worktree` line of `git worktree list --porcelain`. That path still needs corroboration, because git derives a bare repository's main-worktree path by stripping a trailing `.git` component, so path alone cannot separate a bare repository at `dirD/.git` from a poisoned checkout. Repository metadata can: a checkout has a staged index and a bare repository has none. Content is the second condition, for the bare repository someone ran `git read-tree` inside. Ambiguity resolves toward "bare by design", because a miss returns the reader to the pre-gate status quo while a false alarm hands them a command that destroys a healthy repository.

## The boolean parser

The gate compared `core.bare` against `frozenset({"", "true", "yes", "on", "1"})`. That set is wrong at both ends, measured on git 2.43.0. `git_parse_maybe_bool` falls through to integer parsing, so `core.bare = 2` made `git status` fatal while the gate exited 0 and reported health. An explicitly empty value (`bare = `) is false to git, but the empty string was in the set, so the gate exited 1 on a healthy repository and blocked every commit and push.

The fix is to stop reimplementing the parser. `--type=bool` makes git normalize every spelling it accepts, so the verdict is `value == "true"`. Verified a drop-in: unset still exits 1, an unparseable value still exits 128 with `bad boolean config value`, and scope order and the tab separator are preserved. `extensions.worktreeConfig` gets the same flag.

## Gate output against the full corpus

`.claude/rules/ci-scripts.md` MUST 13. Run on this branch, at `67ff5752e`:

```
$ uv run --frozen python scripts/validation/check_repo_health.py
repo health: core.bare read in 1 config scope(s), none set true, for /home/user/ai-agents/.claude/worktrees/agent-a0b8f3160cc47c131
```

Exit 0. The corpus scan is clean on the same tree: 0 violations across 70 sites in 29 modules. `repo-health` also ran as the first job of every `pre-commit` and of every successful `pre-push` on this branch.

## Acceptance criteria

- [x] A fast check detects `core.bare=true` in a repository that has a work tree and fails loudly
- [x] The check is wired into both the `pre-commit` and `pre-push` stages, ahead of the jobs its failure would otherwise be blamed for
- [x] The failure names a repair command that can clear the value in the scope holding it
- [x] Tests cover the corrupted state (non-zero exit) and the healthy state (zero exit), including the CLI process exit code
- [x] Fixture-creating tests are shown to write bare repositories only under a temporary path, with a standing scan so a new call site cannot regress silently
- [ ] `.git/config` branch-section pruning: deferred, tracked in #5360

## Out of scope

Acceptance criterion 4 of the issue, pruning stale branch sections from `.git/config`, is a separate hygiene concern that does not block corruption detection. Tracked in #5360.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: full review, standard scrutiny, no rush.

**Focus areas**:

- The two conditions in `_main_work_tree`. Metadata and content both have to hold, and the reasoning for each is a measured layout rather than a guess. If either is wrong in the false-positive direction it blocks every commit in some layout nobody thought of.
- `_active_bare_scopes` asking `_effective_pair` twice. The second read is deliberately not git's own answer, and that is the whole reason the gate exists.
- The target trace in `tests/bare_repo_scan.py`. It is a shape analysis, not a taint analysis, and the module docstring says where it stops.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

162 cases: 123 across the seven gate test files, plus 39 for the bare-repo corpus scan. Four runtime lefthook cases sit in the roster files. Coverage is positive, negative, and edge:

- positive: healthy checkout, healthy linked worktree, explicit `false`, an explicitly empty `bare = `, a `global true` masked by a `local false`, a stale `local true` masked by a later `local false`, an unrelated file beside a `.git`-named bare repository, and the healthy boolean spellings
- negative: bare-flagged checkout, linked worktree, subdirectory, `--separate-git-dir` checkout, the bare boolean spellings (including the nonzero integers `2`, `42` and `-1`), a poisoned shared config seen from an immunized worktree, a `core.bare` value git cannot parse at all, and an exhausted git budget
- edge: genuine bare repository, bare repository with a linked worktree, bare repository nested inside a checkout, non-repository, invalid root (exit 2), missing git and git timeout (exit 3), inherited `GIT_DIR` / `GIT_WORK_TREE` / `GIT_COMMON_DIR`, a `.git` marker at a character device, an oversized marker, and the budget arithmetic against the cap parsed out of `lefthook.yml`
- controls: every exit-0 case in the bare-by-design and scope-precedence files is paired with a discriminating control that must still exit 1; the mixed-state class asserts that `--is-bare-repository` alone would have called that checkout healthy; the budget file asserts the per-call ceiling exceeds the budget, so the budget cannot bound nothing

**Every fix in this round has a run negative control.** Restoring each defect fails exactly the cases named for it, while its paired discriminating control passes either way:

| Defect restored | Cases failed |
|---|---|
| directory non-emptiness as work-tree evidence | 7 of 21 |
| presence instead of effective value | 6 of 24 |
| no shared git deadline | 3 of 11 |
| site collection, target tracing, module-level call | 5 of 17 |

The lefthook runtime test earned its keep here: splitting the presentation layer out left `check_repo_health_report.py` absent from `POLICY_SUPPORT_FILES`, and all four `test_repo_health_*` cases failed with `ModuleNotFoundError` from inside the real lefthook binary while every unit test still passed.

Full local runs on this branch: `pre_pr.py` all validations passed; `tests/test_lefthook_integration.py` 856 passed, 1 skipped; the gate and scan suites 162 passed; the complete pre-push suite passed.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `lefthook.yml` (a job added to `pre-commit` and `pre-push`)
- `scripts/validation/check_repo_health.py` (spawns `git` with a fixed argument vector and no shell, only reads config, and strips the three location-override environment variables before each call)

Not yet reviewed by the security agent.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

The taste count ratchet caught this work at the 500-line file-size rule three times, and the type-ignore ratchet once at 50 against a baseline of 44. Every one was tightened or split rather than suppressed; both ratchets are back at their baselines, 575 and 44.

## Related Issues

Refs #4698
Refs #5360 (deferred branch-section pruning criterion)
