### PR TITLE
fix(github): exclude code-span closing keywords from duplicate-PR preflight

### DIFF
--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -77,13 +77,24 @@ _PullRequestPayload = dict[str, object]
 # meant to close the issue and the markup silently defeated it), while this
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
+#
+# The fenced-block alternation `(?:.*?^\1|.*)` is deliberate. CommonMark
+# 0.31.2 section 4.5 says the content of a fenced block runs "until a closing
+# code fence of the same type as the code block began with, or until the end
+# of the containing block", so an opening fence with no closing fence still
+# opens a code block that runs to end of input. The first alternative takes a
+# closing fence when one exists; the second consumes to EOF when none does.
+# Without it a body ending mid-fence matched neither span pattern, so a
+# keyword GitHub never links was read as a real claim (Copilot review on PR
+# #5371). Both alternatives live in `pr_description.py` too, so the "ported
+# verbatim" claim above stays true.
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
 _FENCED_CODE_BLOCK = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n.*?^\1",
+    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
     re.DOTALL | re.MULTILINE,
 )
 
@@ -231,13 +242,24 @@ def filter_prs_for_issue(
 
     Pure matching logic, separated from the ``gh`` fetch so the suppression
     rules are deterministically testable (issue #4965).
+
+    Title and body are matched independently, never as one joined string.
+    GitHub renders them as two separate Markdown documents, so a code span
+    cannot straddle them. Joining them let an unmatched backtick in the title
+    pair with one in the body to form a span that swallowed a real closing
+    keyword between them, hiding a genuine duplicate PR (Copilot review on PR
+    #5371). Each field now gets its own span-exclusion pass.
     """
     matches: list[_PullRequestPayload] = []
     for pr in _iter_pull_requests(prs):
         head_ref = _head_ref(pr)
         author_login = _author_login(pr)
-        text = f"{_as_text(pr.get('title'))}\n{_as_text(pr.get('body'))}"
-        if not references_issue(text, issue, repo_slug=repo_slug):
+        title = _as_text(pr.get("title"))
+        body = _as_text(pr.get("body"))
+        if not (
+            references_issue(title, issue, repo_slug=repo_slug)
+            or references_issue(body, issue, repo_slug=repo_slug)
+        ):
             continue
         if _is_self_branch_pr(
             author_login,
@@ -248,7 +270,7 @@ def filter_prs_for_issue(
             continue
         matches.append({
             "number": pr.get("number"),
-            "title": _as_text(pr.get("title")),
+            "title": title,
             "url": _as_text(pr.get("html_url") or pr.get("url")),
             "head": head_ref,
             "author": author_login,

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -101,13 +101,42 @@ _PullRequestPayload = dict[str, object]
 # match alone matched any line merely *starting* with the same run, closing
 # the block one line too soon and letting a real claim past it that GitHub
 # still renders as code (Copilot review on PR #5371, round 2).
+#
+# CommonMark allows a line ending inside a code span for every delimiter
+# length, not just short runs; confining the 3+ backtick branch to a single
+# line missed a real multiline inline span and read the keyword inside it as
+# a genuine bare claim (Copilot review on PR #5371, round 4). Letting that
+# branch go multiline means it can also match all the way across a real
+# fenced block; `_code_spans_outside_fences` below handles that at the call
+# site by dropping any span match that starts inside a real fence, so a
+# fence still reports as fenced rather than relabeled as an inline span.
+#
+# The two `_FENCE_OPEN_LINE` alternatives are deliberately asymmetric.
+# CommonMark 0.31.2 section 4.5: "If the info string comes after a backtick
+# fence, it may not contain any backtick characters." A tilde fence's info
+# string has no such restriction. `(?![^\n]*`)` on the backtick alternative
+# rejects a line like ` ```lang`x` ` from opening a fence at all, exactly as
+# CommonMark reads it as ordinary text instead (Copilot review on PR #5371,
+# round 4).
+#
+# Known limitation, left deliberately out of scope: this line-anchored
+# search does not reparse list-item or blockquote container prefixes
+# (`- ` / `> `) the way CommonMark does, so a fence nested inside a list
+# item or blockquote is not recognized as a fence at all (Copilot review on
+# PR #5371, round 4, suppressed comments). A closing keyword inside such a
+# nested fence is therefore read as an unfenced bare claim rather than
+# excluded. This preflight targets the common shape of a PR description (a
+# top-level fenced example), not arbitrary nested Markdown containers;
+# closing this gap needs container-prefix-aware line parsing, which is a
+# larger change than this fix round scopes to. Same limitation in
+# `pr_description.py`.
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
-    r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
+    r"(?<!`)(`{3,})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\2(?!`)"
 )
 _FENCE_OPEN_LINE = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    r"^[ ]{0,3}(?:(`{3,})(?![^\n]*`)|(~{3,}))[^\n]*\n",
     re.MULTILINE,
 )
 
@@ -128,7 +157,7 @@ def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
         opener = _FENCE_OPEN_LINE.search(text, pos)
         if opener is None:
             break
-        run = opener.group(1)
+        run = opener.group(1) or opener.group(2)
         closer_pattern = re.compile(
             rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
             re.MULTILINE,
@@ -149,6 +178,22 @@ def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
+def _code_spans_outside_fences(
+    text: str, fenced_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Inline code-span ranges, excluding any that start inside a real fence.
+
+    A real fence always wins (CommonMark parses block structure before
+    inline content, so nothing inside a fenced block's raw text is itself
+    inline-parsed). Ported verbatim from `pr_description.py`.
+    """
+    return [
+        span
+        for span in _span_ranges(text, _INLINE_CODE_SPAN)
+        if not _in_any_range(span[0], fenced_ranges)
+    ]
+
+
 def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     """Return True when ``text`` claims ``issue`` via a closing keyword.
 
@@ -166,7 +211,7 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
     fenced_ranges = _fenced_code_block_ranges(text)
-    code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
+    code_span_ranges = _code_spans_outside_fences(text, fenced_ranges)
     for match in pattern.finditer(text):
         pos = match.start()
         if _in_any_range(pos, fenced_ranges) or _in_any_range(pos, code_span_ranges):

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -78,23 +78,33 @@ _PullRequestPayload = dict[str, object]
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
 #
-# The fenced-block alternation `(?:.*?^\1|.*)` is deliberate. CommonMark
-# 0.31.2 section 4.5 says the content of a fenced block runs "until a closing
-# code fence of the same type as the code block began with, or until the end
-# of the containing block", so an opening fence with no closing fence still
-# opens a code block that runs to end of input. The first alternative takes a
-# closing fence when one exists; the second consumes to EOF when none does.
-# Without it a body ending mid-fence matched neither span pattern, so a
-# keyword GitHub never links was read as a real claim (Copilot review on PR
-# #5371). Both alternatives live in `pr_description.py` too, so the "ported
-# verbatim" claim above stays true.
+# The fenced-block alternation `(?:.*?^[ ]{0,3}\1[ \t]*$|.*)` is deliberate.
+# CommonMark 0.31.2 section 4.5 says the content of a fenced block runs
+# "until a closing code fence of the same type as the code block began with,
+# or until the end of the containing block", so an opening fence with no
+# closing fence still opens a code block that runs to end of input. The first
+# alternative takes a closing fence when one exists; the second consumes to
+# EOF when none does. Without it a body ending mid-fence matched neither span
+# pattern, so a keyword GitHub never links was read as a real claim (Copilot
+# review on PR #5371). Both alternatives live in `pr_description.py` too, so
+# the "ported verbatim" claim above stays true.
+#
+# `[ ]{0,3}` on both the opening and closing fence lines tolerates the
+# indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
+# fourth space starts an indented code block instead, a different construct
+# this module does not classify. `[ \t]*$` on the closer requires the line to
+# hold nothing but the fence run and optional trailing whitespace, so a line
+# like `` ```not-a-closer `` cannot end the block early: `^\1` alone matched
+# any line merely *starting* with the same run, closing the block one line
+# too soon and letting a real claim past it that GitHub still renders as code
+# (Copilot review on PR #5371).
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
 _FENCED_CODE_BLOCK = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -67,8 +67,8 @@ _PullRequestPayload = dict[str, object]
 # the GraphQL `closingIssuesReferences` API), so a match inside either must
 # not count as the PR claiming implementation ownership of the issue. Ported
 # verbatim from `scripts/validation/pr_description.py` (`_INLINE_CODE_SPAN`
-# and `_FENCED_CODE_BLOCK`), which solves the identical problem for the PR
-# description validator's closing-link check (see that module's
+# and `_fenced_code_block_ranges`), which solves the identical problem for
+# the PR description validator's closing-link check (see that module's
 # `validate_closing_links`, issue #3827, PRs #4078 and #4716).
 #
 # Stricter/looser/different than canonical: identical patterns, same
@@ -78,35 +78,66 @@ _PullRequestPayload = dict[str, object]
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
 #
-# The fenced-block alternation `(?:.*?^[ ]{0,3}\1[ \t]*$|.*)` is deliberate.
 # CommonMark 0.31.2 section 4.5 says the content of a fenced block runs
 # "until a closing code fence of the same type as the code block began with,
 # or until the end of the containing block", so an opening fence with no
-# closing fence still opens a code block that runs to end of input. The first
-# alternative takes a closing fence when one exists; the second consumes to
-# EOF when none does. Without it a body ending mid-fence matched neither span
-# pattern, so a keyword GitHub never links was read as a real claim (Copilot
-# review on PR #5371). Both alternatives live in `pr_description.py` too, so
-# the "ported verbatim" claim above stays true.
+# closing fence still opens a code block that runs to end of input, and a
+# closing fence must use the same character as the opener and be AT LEAST as
+# long, not exactly as long. Without the end-of-input fallback a body ending
+# mid-fence matched neither span pattern, so a keyword GitHub never links was
+# read as a real claim (Copilot review on PR #5371). A fixed-length `\1`
+# backreference cannot express "at least as long", so `_fenced_code_block_ranges`
+# below finds each opener's run length first and builds that opener's closer
+# pattern dynamically (Copilot review on PR #5371, round 3). Both mechanisms
+# live in `pr_description.py` too, so the "ported verbatim" claim above stays
+# true.
 #
 # `[ ]{0,3}` on both the opening and closing fence lines tolerates the
 # indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
 # fourth space starts an indented code block instead, a different construct
 # this module does not classify. `[ \t]*$` on the closer requires the line to
 # hold nothing but the fence run and optional trailing whitespace, so a line
-# like `` ```not-a-closer `` cannot end the block early: `^\1` alone matched
-# any line merely *starting* with the same run, closing the block one line
-# too soon and letting a real claim past it that GitHub still renders as code
-# (Copilot review on PR #5371).
+# like `` ```not-a-closer `` cannot end the block early: a bare same-length
+# match alone matched any line merely *starting* with the same run, closing
+# the block one line too soon and letting a real claim past it that GitHub
+# still renders as code (Copilot review on PR #5371, round 2).
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
-_FENCED_CODE_BLOCK = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
-    re.DOTALL | re.MULTILINE,
+_FENCE_OPEN_LINE = re.compile(
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    re.MULTILINE,
 )
+
+
+def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) pairs for every fenced code block in ``text``.
+
+    Walks openers left to right, and for each one builds a closer pattern
+    sized to that opener's own fence-character and run length (CommonMark
+    0.31.2 4.5: same character, length >= opener length). An opener with no
+    matching closer runs to the end of the text. ``pos`` advances to the end
+    of each resolved block so a fence-like line inside one block's content is
+    never re-read as a fresh opener.
+    """
+    ranges: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        opener = _FENCE_OPEN_LINE.search(text, pos)
+        if opener is None:
+            break
+        run = opener.group(1)
+        closer_pattern = re.compile(
+            rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
+            re.MULTILINE,
+        )
+        closer = closer_pattern.search(text, opener.end())
+        end = closer.end() if closer else len(text)
+        ranges.append((opener.start(), end))
+        pos = end
+    return ranges
 
 
 def _span_ranges(text: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
@@ -134,7 +165,7 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
-    fenced_ranges = _span_ranges(text, _FENCED_CODE_BLOCK)
+    fenced_ranges = _fenced_code_block_ranges(text)
     code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
     for match in pattern.finditer(text):
         pos = match.start()

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -62,9 +62,50 @@ _GH_TIMEOUT_SECONDS = 30
 _GIT_TIMEOUT_SECONDS = 10
 _PullRequestPayload = dict[str, object]
 
+# Span-exclusion patterns for issue #3827: GitHub does not parse a closing
+# keyword inside an inline code span or a fenced code block (confirmed via
+# the GraphQL `closingIssuesReferences` API), so a match inside either must
+# not count as the PR claiming implementation ownership of the issue. Ported
+# verbatim from `scripts/validation/pr_description.py` (`_INLINE_CODE_SPAN`
+# and `_FENCED_CODE_BLOCK`), which solves the identical problem for the PR
+# description validator's closing-link check (see that module's
+# `validate_closing_links`, issue #3827, PRs #4078 and #4716).
+#
+# Stricter/looser/different than canonical: identical patterns, same
+# exclusion semantics. The one difference is what a match inside the
+# excluded span means: `pr_description.py` reports a CRITICAL (the author
+# meant to close the issue and the markup silently defeated it), while this
+# module simply treats the match as not claiming ownership at all (a PR
+# quoting or documenting a closing keyword is not implementing the issue).
+_INLINE_CODE_SPAN = re.compile(
+    r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
+    r"|"
+    r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
+)
+_FENCED_CODE_BLOCK = re.compile(
+    r"^(`{3,}|~{3,})[^\n]*\n.*?^\1",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def _span_ranges(text: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
+    """Return (start, end) pairs for all non-overlapping matches of pattern."""
+    return [(m.start(), m.end()) for m in pattern.finditer(text)]
+
+
+def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in ranges)
+
 
 def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
-    """Return True when ``text`` claims ``issue`` via a closing keyword."""
+    """Return True when ``text`` claims ``issue`` via a closing keyword.
+
+    A closing keyword found only inside an inline code span or a fenced code
+    block does not count: GitHub never creates a real closing link there, so
+    treating it as a claim of implementation ownership would let a PR that
+    merely quotes or documents a closing keyword suppress a legitimate new PR
+    as a false duplicate (issue #3827).
+    """
 
     if not text:
         return False
@@ -72,7 +113,14 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
-    return bool(pattern.search(text))
+    fenced_ranges = _span_ranges(text, _FENCED_CODE_BLOCK)
+    code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
+    for match in pattern.finditer(text):
+        pos = match.start()
+        if _in_any_range(pos, fenced_ranges) or _in_any_range(pos, code_span_ranges):
+            continue
+        return True
+    return False
 
 
 def _run(cmd: list[str], *, timeout: int = _GH_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -178,19 +178,29 @@ def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
+def _ranges_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return a[0] < b[1] and b[0] < a[1]
+
+
 def _code_spans_outside_fences(
     text: str, fenced_ranges: list[tuple[int, int]]
 ) -> list[tuple[int, int]]:
-    """Inline code-span ranges, excluding any that start inside a real fence.
+    """Inline code-span ranges, excluding any that overlap a real fence.
 
     A real fence always wins (CommonMark parses block structure before
     inline content, so nothing inside a fenced block's raw text is itself
-    inline-parsed). Ported verbatim from `pr_description.py`.
+    inline-parsed). Rejecting only a span whose START falls inside a fence
+    (round 4) misses a span that STARTS before a fence and ENDS after it --
+    e.g. a 4-backtick run in the paragraph before a fence, paired with a
+    later 4-backtick run after the fence closes -- which still engulfs the
+    fence and any real claim right after it (Copilot review on PR #5371,
+    round 5). Rejecting on any overlap closes both shapes. Ported verbatim
+    from `pr_description.py`.
     """
     return [
         span
         for span in _span_ranges(text, _INLINE_CODE_SPAN)
-        if not _in_any_range(span[0], fenced_ranges)
+        if not any(_ranges_overlap(span, fenced) for fenced in fenced_ranges)
     ]
 
 

--- a/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -108,7 +108,7 @@ _PullRequestPayload = dict[str, object]
 # a genuine bare claim (Copilot review on PR #5371, round 4). Letting that
 # branch go multiline means it can also match all the way across a real
 # fenced block; `_code_spans_outside_fences` below handles that at the call
-# site by dropping any span match that starts inside a real fence, so a
+# site by dropping any span match that overlaps a real fence, so a
 # fence still reports as fenced rather than relabeled as an inline span.
 #
 # The two `_FENCE_OPEN_LINE` alternatives are deliberately asymmetric.
@@ -216,6 +216,10 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
 
     if not text:
         return False
+    # Normalize CRLF to LF: the fence and span regexes use \n anchors, so
+    # CRLF input causes closers to go unrecognized and extends fenced blocks
+    # through EOF (Devin review on PR #5371).
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     issue_ref = rf"#{issue}\b"
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -761,24 +761,36 @@ def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
+def _ranges_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return a[0] < b[1] and b[0] < a[1]
+
+
 def _code_spans_outside_fences(
     body: str, fenced_ranges: list[tuple[int, int]]
 ) -> list[tuple[int, int]]:
-    """Inline code-span ranges, excluding any that start inside a real fence.
+    """Inline code-span ranges, excluding any that overlap a real fence.
 
     CommonMark parses block structure before inline content, so nothing
     inside a fenced code block's raw text is itself inline-parsed; a real
     fence always wins. `_INLINE_CODE_SPAN` allows the 3+ backtick branch to
     span multiple lines (so a real multiline inline span is still caught),
-    which means it can also match all the way across a real fenced block.
-    Dropping any span whose start falls inside `fenced_ranges` keeps that
-    block reported as fenced rather than relabeled as an inline span
-    (Copilot review on PR #5371, round 4).
+    which means it can also match all the way across a real fenced block,
+    or (round 5) START before a fence and END after it -- e.g. a 4-backtick
+    run in the paragraph before a 3-backtick fence, paired with a later
+    4-backtick run after the fence closes. Filtering only on whether the
+    span's START falls inside a fence (round 4) misses that second shape,
+    since the span starts in the preceding paragraph, not inside the fence;
+    it still engulfs the fence and any real claim right after it, hiding a
+    real closing keyword or falsely reporting one that GitHub does link
+    (Copilot review on PR #5371, round 5). Rejecting on ANY overlap, not
+    just start-containment, closes both shapes: nothing can be inline-parsed
+    across a block boundary, so a span overlapping a fence at all is never
+    a real span.
     """
     return [
         span
         for span in _span_ranges(body, _INLINE_CODE_SPAN)
-        if not _in_any_range(span[0], fenced_ranges)
+        if not any(_ranges_overlap(span, fenced) for fenced in fenced_ranges)
     ]
 
 

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -664,7 +664,7 @@ _AUTO_CLOSE_KW: re.Pattern[str] = re.compile(
 # here means this pattern can now also match all the way across a real
 # fenced block. That is handled at the call site, not in this pattern:
 # `validate_closing_links`/`references_issue` compute `fenced_ranges` first
-# and drop any code-span match whose start falls inside one, so a real
+# and drop any code-span match that overlaps one, so a real
 # fence still reports as "fenced code block", never relabeled as an inline
 # span (matching CommonMark's block-before-inline precedence, since nothing
 # inside a fenced block's raw content is inline-parsed in the first place).
@@ -820,6 +820,11 @@ def validate_closing_links(
     """
     if base_branch is not None:
         base_ref = base_branch
+
+    # Normalize CRLF to LF: the fence and span regexes use \n anchors, so
+    # CRLF input causes closers to go unrecognized and extends fenced blocks
+    # through EOF (Devin review on PR #5371).
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
 
     issues: list[Issue] = []
     fenced_ranges = _fenced_code_block_ranges(body)

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -663,8 +663,15 @@ _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
 )
 
 # Fenced code block: backtick or tilde fence with optional language tag.
+# CommonMark 0.31.2 section 4.5: an unclosed fence still opens a code block
+# that runs to the end of the containing block, not to nothing. The first
+# alternative takes a real closing fence when one exists; the second consumes
+# to EOF when none does, so a body ending mid-fence is still recognized as a
+# fenced span instead of matching neither pattern (Copilot review on PR
+# #5371, which found this exact gap in the port at
+# .claude/skills/github/scripts/issue/check_existing_pr_for_issue.py).
 _FENCED_CODE_BLOCK: re.Pattern[str] = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n.*?^\1",
+    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -670,8 +670,18 @@ _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
 # fenced span instead of matching neither pattern (Copilot review on PR
 # #5371, which found this exact gap in the port at
 # .claude/skills/github/scripts/issue/check_existing_pr_for_issue.py).
+#
+# `[ ]{0,3}` on both the opening and closing fence lines tolerates the
+# indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
+# fourth space starts an indented code block instead, a different construct
+# this module does not classify. `[ \t]*$` on the closer requires the line to
+# hold nothing but the fence run and optional trailing whitespace, so a line
+# like a fence marker followed by other text cannot end the block early:
+# `^\1` alone matched any line merely starting with the same run, closing the
+# block one line too soon and letting a real claim past it that GitHub still
+# renders as code (Copilot review on PR #5371, round 2).
 _FENCED_CODE_BLOCK: re.Pattern[str] = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -644,23 +644,34 @@ _AUTO_CLOSE_KW: re.Pattern[str] = re.compile(
 )
 
 # GFM inline code span: one or more backticks as the opening fence, closed by
-# the same-length backtick run. Does not cross newlines. Handles single (`),
-# double (``), triple (```) etc. The previous pattern only matched single
-# backticks, missing ``...`` spans entirely (issue #3827).
+# the same-length backtick run. Handles single (`), double (``), triple
+# (```) etc. The previous pattern only matched single backticks, missing
+# ``...`` spans entirely (issue #3827).
 # CommonMark allows a line ending inside a code span; only a blank line ends
 # it. Restricting the body to [^\n] left a span written across two lines
 # unstripped, so a closing link inside an example was read as a real one and
-# the gate passed on a pull request that closes nothing. Refs #3827.
-# A run of three or more backticks at the start of a line opens a fenced block,
-# which _fenced_code_block_ranges owns. Letting the multiline alternative
-# claim those too would relabel a fence as an inline span and change the
-# reported reason.
-# So newlines are allowed only for runs of one or two backticks, which is where
-# the real gap was; longer runs stay single line and fences handle the rest.
+# the gate passed on a pull request that closes nothing. Refs #3827. This
+# applies to every run length: CommonMark 0.31.2 section 6.1 does not
+# restrict multiline content to short backtick runs. Confining the 3+
+# branch to a single line (an earlier round of this fix) left a real gap:
+# ` ```example\nFixes #N\nend``` ` is one multiline inline span per spec
+# (GitHub renders `Fixes #N` as code, no closing link created), and the
+# single-line branch missed it entirely, reading the keyword as a genuine
+# bare claim (Copilot review on PR #5371, round 4).
+#
+# A run of three or more backticks at the start of a line can ALSO open a
+# fenced block, which `_fenced_code_block_ranges` owns, and going multiline
+# here means this pattern can now also match all the way across a real
+# fenced block. That is handled at the call site, not in this pattern:
+# `validate_closing_links`/`references_issue` compute `fenced_ranges` first
+# and drop any code-span match whose start falls inside one, so a real
+# fence still reports as "fenced code block", never relabeled as an inline
+# span (matching CommonMark's block-before-inline precedence, since nothing
+# inside a fenced block's raw content is inline-parsed in the first place).
 _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
-    r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
+    r"(?<!`)(`{3,})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\2(?!`)"
 )
 
 # Fenced code block: backtick or tilde fence with optional language tag.
@@ -685,8 +696,30 @@ _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
 # same run, closing the block one line too soon and letting a real claim
 # past it that GitHub still renders as code (Copilot review on PR #5371,
 # round 2).
+#
+# The two alternatives are deliberately asymmetric. CommonMark 0.31.2
+# section 4.5: "If the info string comes after a backtick fence, it may not
+# contain any backtick characters." A tilde fence's info string has no such
+# restriction. `(?![^\n]*`)` on the backtick alternative rejects a line like
+# ` ```lang`x` `, whose info string carries a backtick, from opening a fence
+# at all -- exactly as CommonMark reads it as ordinary text instead
+# (Copilot review on PR #5371, round 4). Without this, that line was misread
+# as a valid opener, and everything after it (up to the next actual closer
+# or EOF) was misclassified as fenced, hiding a real closing keyword that
+# follows.
+#
+# Known limitation, left deliberately out of scope: this line-anchored
+# search does not reparse list-item or blockquote container prefixes
+# (`- ` / `> `) the way CommonMark does, so a fence nested inside a list
+# item or blockquote is not recognized as a fence at all (Copilot review on
+# PR #5371, round 4, suppressed comments). A closing keyword inside such a
+# nested fence is therefore read as an unfenced bare claim rather than
+# excluded. This preflight targets the common shape of a PR description (a
+# top-level fenced example), not arbitrary nested Markdown containers;
+# closing this gap needs container-prefix-aware line parsing, which is a
+# larger change than this fix round scopes to.
 _FENCE_OPEN_LINE: re.Pattern[str] = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    r"^[ ]{0,3}(?:(`{3,})(?![^\n]*`)|(~{3,}))[^\n]*\n",
     re.MULTILINE,
 )
 
@@ -707,7 +740,7 @@ def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
         opener = _FENCE_OPEN_LINE.search(text, pos)
         if opener is None:
             break
-        run = opener.group(1)
+        run = opener.group(1) or opener.group(2)
         closer_pattern = re.compile(
             rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
             re.MULTILINE,
@@ -726,6 +759,27 @@ def _span_ranges(body: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
 
 def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
+
+
+def _code_spans_outside_fences(
+    body: str, fenced_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Inline code-span ranges, excluding any that start inside a real fence.
+
+    CommonMark parses block structure before inline content, so nothing
+    inside a fenced code block's raw text is itself inline-parsed; a real
+    fence always wins. `_INLINE_CODE_SPAN` allows the 3+ backtick branch to
+    span multiple lines (so a real multiline inline span is still caught),
+    which means it can also match all the way across a real fenced block.
+    Dropping any span whose start falls inside `fenced_ranges` keeps that
+    block reported as fenced rather than relabeled as an inline span
+    (Copilot review on PR #5371, round 4).
+    """
+    return [
+        span
+        for span in _span_ranges(body, _INLINE_CODE_SPAN)
+        if not _in_any_range(span[0], fenced_ranges)
+    ]
 
 
 def validate_closing_links(
@@ -757,7 +811,7 @@ def validate_closing_links(
 
     issues: list[Issue] = []
     fenced_ranges = _fenced_code_block_ranges(body)
-    code_span_ranges = _span_ranges(body, _INLINE_CODE_SPAN)
+    code_span_ranges = _code_spans_outside_fences(body, fenced_ranges)
     non_default_base = bool(base_ref and default_branch and base_ref != default_branch)
 
     has_closing_keyword = False

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -652,8 +652,9 @@ _AUTO_CLOSE_KW: re.Pattern[str] = re.compile(
 # unstripped, so a closing link inside an example was read as a real one and
 # the gate passed on a pull request that closes nothing. Refs #3827.
 # A run of three or more backticks at the start of a line opens a fenced block,
-# which _FENCED_CODE_BLOCK owns. Letting the multiline alternative claim those
-# too would relabel a fence as an inline span and change the reported reason.
+# which _fenced_code_block_ranges owns. Letting the multiline alternative
+# claim those too would relabel a fence as an inline span and change the
+# reported reason.
 # So newlines are allowed only for runs of one or two backticks, which is where
 # the real gap was; longer runs stay single line and fences handle the rest.
 _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
@@ -664,12 +665,15 @@ _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
 
 # Fenced code block: backtick or tilde fence with optional language tag.
 # CommonMark 0.31.2 section 4.5: an unclosed fence still opens a code block
-# that runs to the end of the containing block, not to nothing. The first
-# alternative takes a real closing fence when one exists; the second consumes
-# to EOF when none does, so a body ending mid-fence is still recognized as a
-# fenced span instead of matching neither pattern (Copilot review on PR
-# #5371, which found this exact gap in the port at
-# .claude/skills/github/scripts/issue/check_existing_pr_for_issue.py).
+# that runs to the end of the containing block, not to nothing. The closing
+# fence must use the same character as the opener and be AT LEAST as long,
+# not exactly as long: a 3-backtick opener closes on a run of 3 or more
+# backticks. A single compiled pattern cannot express "at least as long"
+# with a fixed-length `\1` backreference, so `_fenced_code_block_ranges`
+# below finds each opener's run length first and builds that opener's
+# closer pattern dynamically (Copilot review on PR #5371, round 3, which
+# found this gap in the round-2 `\1`-based pattern at both this module and
+# the port at .claude/skills/github/scripts/issue/check_existing_pr_for_issue.py).
 #
 # `[ ]{0,3}` on both the opening and closing fence lines tolerates the
 # indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
@@ -677,13 +681,42 @@ _INLINE_CODE_SPAN: re.Pattern[str] = re.compile(
 # this module does not classify. `[ \t]*$` on the closer requires the line to
 # hold nothing but the fence run and optional trailing whitespace, so a line
 # like a fence marker followed by other text cannot end the block early:
-# `^\1` alone matched any line merely starting with the same run, closing the
-# block one line too soon and letting a real claim past it that GitHub still
-# renders as code (Copilot review on PR #5371, round 2).
-_FENCED_CODE_BLOCK: re.Pattern[str] = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
-    re.DOTALL | re.MULTILINE,
+# a bare same-length match alone matched any line merely starting with the
+# same run, closing the block one line too soon and letting a real claim
+# past it that GitHub still renders as code (Copilot review on PR #5371,
+# round 2).
+_FENCE_OPEN_LINE: re.Pattern[str] = re.compile(
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    re.MULTILINE,
 )
+
+
+def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) pairs for every fenced code block in ``text``.
+
+    Walks openers left to right, and for each one builds a closer pattern
+    sized to that opener's own fence-character and run length (CommonMark
+    0.31.2 4.5: same character, length >= opener length). An opener with no
+    matching closer runs to the end of the text. ``pos`` advances to the end
+    of each resolved block so a fence-like line inside one block's content is
+    never re-read as a fresh opener.
+    """
+    ranges: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        opener = _FENCE_OPEN_LINE.search(text, pos)
+        if opener is None:
+            break
+        run = opener.group(1)
+        closer_pattern = re.compile(
+            rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
+            re.MULTILINE,
+        )
+        closer = closer_pattern.search(text, opener.end())
+        end = closer.end() if closer else len(text)
+        ranges.append((opener.start(), end))
+        pos = end
+    return ranges
 
 
 def _span_ranges(body: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
@@ -723,7 +756,7 @@ def validate_closing_links(
         base_ref = base_branch
 
     issues: list[Issue] = []
-    fenced_ranges = _span_ranges(body, _FENCED_CODE_BLOCK)
+    fenced_ranges = _fenced_code_block_ranges(body)
     code_span_ranges = _span_ranges(body, _INLINE_CODE_SPAN)
     non_default_base = bool(base_ref and default_branch and base_ref != default_branch)
 

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -77,13 +77,24 @@ _PullRequestPayload = dict[str, object]
 # meant to close the issue and the markup silently defeated it), while this
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
+#
+# The fenced-block alternation `(?:.*?^\1|.*)` is deliberate. CommonMark
+# 0.31.2 section 4.5 says the content of a fenced block runs "until a closing
+# code fence of the same type as the code block began with, or until the end
+# of the containing block", so an opening fence with no closing fence still
+# opens a code block that runs to end of input. The first alternative takes a
+# closing fence when one exists; the second consumes to EOF when none does.
+# Without it a body ending mid-fence matched neither span pattern, so a
+# keyword GitHub never links was read as a real claim (Copilot review on PR
+# #5371). Both alternatives live in `pr_description.py` too, so the "ported
+# verbatim" claim above stays true.
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
 _FENCED_CODE_BLOCK = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n.*?^\1",
+    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
     re.DOTALL | re.MULTILINE,
 )
 
@@ -231,13 +242,24 @@ def filter_prs_for_issue(
 
     Pure matching logic, separated from the ``gh`` fetch so the suppression
     rules are deterministically testable (issue #4965).
+
+    Title and body are matched independently, never as one joined string.
+    GitHub renders them as two separate Markdown documents, so a code span
+    cannot straddle them. Joining them let an unmatched backtick in the title
+    pair with one in the body to form a span that swallowed a real closing
+    keyword between them, hiding a genuine duplicate PR (Copilot review on PR
+    #5371). Each field now gets its own span-exclusion pass.
     """
     matches: list[_PullRequestPayload] = []
     for pr in _iter_pull_requests(prs):
         head_ref = _head_ref(pr)
         author_login = _author_login(pr)
-        text = f"{_as_text(pr.get('title'))}\n{_as_text(pr.get('body'))}"
-        if not references_issue(text, issue, repo_slug=repo_slug):
+        title = _as_text(pr.get("title"))
+        body = _as_text(pr.get("body"))
+        if not (
+            references_issue(title, issue, repo_slug=repo_slug)
+            or references_issue(body, issue, repo_slug=repo_slug)
+        ):
             continue
         if _is_self_branch_pr(
             author_login,
@@ -248,7 +270,7 @@ def filter_prs_for_issue(
             continue
         matches.append({
             "number": pr.get("number"),
-            "title": _as_text(pr.get("title")),
+            "title": title,
             "url": _as_text(pr.get("html_url") or pr.get("url")),
             "head": head_ref,
             "author": author_login,

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -101,13 +101,42 @@ _PullRequestPayload = dict[str, object]
 # match alone matched any line merely *starting* with the same run, closing
 # the block one line too soon and letting a real claim past it that GitHub
 # still renders as code (Copilot review on PR #5371, round 2).
+#
+# CommonMark allows a line ending inside a code span for every delimiter
+# length, not just short runs; confining the 3+ backtick branch to a single
+# line missed a real multiline inline span and read the keyword inside it as
+# a genuine bare claim (Copilot review on PR #5371, round 4). Letting that
+# branch go multiline means it can also match all the way across a real
+# fenced block; `_code_spans_outside_fences` below handles that at the call
+# site by dropping any span match that starts inside a real fence, so a
+# fence still reports as fenced rather than relabeled as an inline span.
+#
+# The two `_FENCE_OPEN_LINE` alternatives are deliberately asymmetric.
+# CommonMark 0.31.2 section 4.5: "If the info string comes after a backtick
+# fence, it may not contain any backtick characters." A tilde fence's info
+# string has no such restriction. `(?![^\n]*`)` on the backtick alternative
+# rejects a line like ` ```lang`x` ` from opening a fence at all, exactly as
+# CommonMark reads it as ordinary text instead (Copilot review on PR #5371,
+# round 4).
+#
+# Known limitation, left deliberately out of scope: this line-anchored
+# search does not reparse list-item or blockquote container prefixes
+# (`- ` / `> `) the way CommonMark does, so a fence nested inside a list
+# item or blockquote is not recognized as a fence at all (Copilot review on
+# PR #5371, round 4, suppressed comments). A closing keyword inside such a
+# nested fence is therefore read as an unfenced bare claim rather than
+# excluded. This preflight targets the common shape of a PR description (a
+# top-level fenced example), not arbitrary nested Markdown containers;
+# closing this gap needs container-prefix-aware line parsing, which is a
+# larger change than this fix round scopes to. Same limitation in
+# `pr_description.py`.
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
-    r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
+    r"(?<!`)(`{3,})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\2(?!`)"
 )
 _FENCE_OPEN_LINE = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    r"^[ ]{0,3}(?:(`{3,})(?![^\n]*`)|(~{3,}))[^\n]*\n",
     re.MULTILINE,
 )
 
@@ -128,7 +157,7 @@ def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
         opener = _FENCE_OPEN_LINE.search(text, pos)
         if opener is None:
             break
-        run = opener.group(1)
+        run = opener.group(1) or opener.group(2)
         closer_pattern = re.compile(
             rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
             re.MULTILINE,
@@ -149,6 +178,22 @@ def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
+def _code_spans_outside_fences(
+    text: str, fenced_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Inline code-span ranges, excluding any that start inside a real fence.
+
+    A real fence always wins (CommonMark parses block structure before
+    inline content, so nothing inside a fenced block's raw text is itself
+    inline-parsed). Ported verbatim from `pr_description.py`.
+    """
+    return [
+        span
+        for span in _span_ranges(text, _INLINE_CODE_SPAN)
+        if not _in_any_range(span[0], fenced_ranges)
+    ]
+
+
 def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     """Return True when ``text`` claims ``issue`` via a closing keyword.
 
@@ -166,7 +211,7 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
     fenced_ranges = _fenced_code_block_ranges(text)
-    code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
+    code_span_ranges = _code_spans_outside_fences(text, fenced_ranges)
     for match in pattern.finditer(text):
         pos = match.start()
         if _in_any_range(pos, fenced_ranges) or _in_any_range(pos, code_span_ranges):

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -78,23 +78,33 @@ _PullRequestPayload = dict[str, object]
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
 #
-# The fenced-block alternation `(?:.*?^\1|.*)` is deliberate. CommonMark
-# 0.31.2 section 4.5 says the content of a fenced block runs "until a closing
-# code fence of the same type as the code block began with, or until the end
-# of the containing block", so an opening fence with no closing fence still
-# opens a code block that runs to end of input. The first alternative takes a
-# closing fence when one exists; the second consumes to EOF when none does.
-# Without it a body ending mid-fence matched neither span pattern, so a
-# keyword GitHub never links was read as a real claim (Copilot review on PR
-# #5371). Both alternatives live in `pr_description.py` too, so the "ported
-# verbatim" claim above stays true.
+# The fenced-block alternation `(?:.*?^[ ]{0,3}\1[ \t]*$|.*)` is deliberate.
+# CommonMark 0.31.2 section 4.5 says the content of a fenced block runs
+# "until a closing code fence of the same type as the code block began with,
+# or until the end of the containing block", so an opening fence with no
+# closing fence still opens a code block that runs to end of input. The first
+# alternative takes a closing fence when one exists; the second consumes to
+# EOF when none does. Without it a body ending mid-fence matched neither span
+# pattern, so a keyword GitHub never links was read as a real claim (Copilot
+# review on PR #5371). Both alternatives live in `pr_description.py` too, so
+# the "ported verbatim" claim above stays true.
+#
+# `[ ]{0,3}` on both the opening and closing fence lines tolerates the
+# indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
+# fourth space starts an indented code block instead, a different construct
+# this module does not classify. `[ \t]*$` on the closer requires the line to
+# hold nothing but the fence run and optional trailing whitespace, so a line
+# like `` ```not-a-closer `` cannot end the block early: `^\1` alone matched
+# any line merely *starting* with the same run, closing the block one line
+# too soon and letting a real claim past it that GitHub still renders as code
+# (Copilot review on PR #5371).
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
 _FENCED_CODE_BLOCK = re.compile(
-    r"^(`{3,}|~{3,})[^\n]*\n(?:.*?^\1|.*)",
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -67,8 +67,8 @@ _PullRequestPayload = dict[str, object]
 # the GraphQL `closingIssuesReferences` API), so a match inside either must
 # not count as the PR claiming implementation ownership of the issue. Ported
 # verbatim from `scripts/validation/pr_description.py` (`_INLINE_CODE_SPAN`
-# and `_FENCED_CODE_BLOCK`), which solves the identical problem for the PR
-# description validator's closing-link check (see that module's
+# and `_fenced_code_block_ranges`), which solves the identical problem for
+# the PR description validator's closing-link check (see that module's
 # `validate_closing_links`, issue #3827, PRs #4078 and #4716).
 #
 # Stricter/looser/different than canonical: identical patterns, same
@@ -78,35 +78,66 @@ _PullRequestPayload = dict[str, object]
 # module simply treats the match as not claiming ownership at all (a PR
 # quoting or documenting a closing keyword is not implementing the issue).
 #
-# The fenced-block alternation `(?:.*?^[ ]{0,3}\1[ \t]*$|.*)` is deliberate.
 # CommonMark 0.31.2 section 4.5 says the content of a fenced block runs
 # "until a closing code fence of the same type as the code block began with,
 # or until the end of the containing block", so an opening fence with no
-# closing fence still opens a code block that runs to end of input. The first
-# alternative takes a closing fence when one exists; the second consumes to
-# EOF when none does. Without it a body ending mid-fence matched neither span
-# pattern, so a keyword GitHub never links was read as a real claim (Copilot
-# review on PR #5371). Both alternatives live in `pr_description.py` too, so
-# the "ported verbatim" claim above stays true.
+# closing fence still opens a code block that runs to end of input, and a
+# closing fence must use the same character as the opener and be AT LEAST as
+# long, not exactly as long. Without the end-of-input fallback a body ending
+# mid-fence matched neither span pattern, so a keyword GitHub never links was
+# read as a real claim (Copilot review on PR #5371). A fixed-length `\1`
+# backreference cannot express "at least as long", so `_fenced_code_block_ranges`
+# below finds each opener's run length first and builds that opener's closer
+# pattern dynamically (Copilot review on PR #5371, round 3). Both mechanisms
+# live in `pr_description.py` too, so the "ported verbatim" claim above stays
+# true.
 #
 # `[ ]{0,3}` on both the opening and closing fence lines tolerates the
 # indentation CommonMark 0.31.2 section 4.5 allows (up to three spaces); a
 # fourth space starts an indented code block instead, a different construct
 # this module does not classify. `[ \t]*$` on the closer requires the line to
 # hold nothing but the fence run and optional trailing whitespace, so a line
-# like `` ```not-a-closer `` cannot end the block early: `^\1` alone matched
-# any line merely *starting* with the same run, closing the block one line
-# too soon and letting a real claim past it that GitHub still renders as code
-# (Copilot review on PR #5371).
+# like `` ```not-a-closer `` cannot end the block early: a bare same-length
+# match alone matched any line merely *starting* with the same run, closing
+# the block one line too soon and letting a real claim past it that GitHub
+# still renders as code (Copilot review on PR #5371, round 2).
 _INLINE_CODE_SPAN = re.compile(
     r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
     r"|"
     r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
 )
-_FENCED_CODE_BLOCK = re.compile(
-    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n(?:.*?^[ ]{0,3}\1[ \t]*$|.*)",
-    re.DOTALL | re.MULTILINE,
+_FENCE_OPEN_LINE = re.compile(
+    r"^[ ]{0,3}(`{3,}|~{3,})[^\n]*\n",
+    re.MULTILINE,
 )
+
+
+def _fenced_code_block_ranges(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) pairs for every fenced code block in ``text``.
+
+    Walks openers left to right, and for each one builds a closer pattern
+    sized to that opener's own fence-character and run length (CommonMark
+    0.31.2 4.5: same character, length >= opener length). An opener with no
+    matching closer runs to the end of the text. ``pos`` advances to the end
+    of each resolved block so a fence-like line inside one block's content is
+    never re-read as a fresh opener.
+    """
+    ranges: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        opener = _FENCE_OPEN_LINE.search(text, pos)
+        if opener is None:
+            break
+        run = opener.group(1)
+        closer_pattern = re.compile(
+            rf"^[ ]{{0,3}}{re.escape(run[0])}{{{len(run)},}}[ \t]*$",
+            re.MULTILINE,
+        )
+        closer = closer_pattern.search(text, opener.end())
+        end = closer.end() if closer else len(text)
+        ranges.append((opener.start(), end))
+        pos = end
+    return ranges
 
 
 def _span_ranges(text: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
@@ -134,7 +165,7 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
-    fenced_ranges = _span_ranges(text, _FENCED_CODE_BLOCK)
+    fenced_ranges = _fenced_code_block_ranges(text)
     code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
     for match in pattern.finditer(text):
         pos = match.start()

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -62,9 +62,50 @@ _GH_TIMEOUT_SECONDS = 30
 _GIT_TIMEOUT_SECONDS = 10
 _PullRequestPayload = dict[str, object]
 
+# Span-exclusion patterns for issue #3827: GitHub does not parse a closing
+# keyword inside an inline code span or a fenced code block (confirmed via
+# the GraphQL `closingIssuesReferences` API), so a match inside either must
+# not count as the PR claiming implementation ownership of the issue. Ported
+# verbatim from `scripts/validation/pr_description.py` (`_INLINE_CODE_SPAN`
+# and `_FENCED_CODE_BLOCK`), which solves the identical problem for the PR
+# description validator's closing-link check (see that module's
+# `validate_closing_links`, issue #3827, PRs #4078 and #4716).
+#
+# Stricter/looser/different than canonical: identical patterns, same
+# exclusion semantics. The one difference is what a match inside the
+# excluded span means: `pr_description.py` reports a CRITICAL (the author
+# meant to close the issue and the markup silently defeated it), while this
+# module simply treats the match as not claiming ownership at all (a PR
+# quoting or documenting a closing keyword is not implementing the issue).
+_INLINE_CODE_SPAN = re.compile(
+    r"(?<!`)(`{1,2})(?!`)(?:[^\n]|\n(?!\s*\n))+?(?<!`)\1(?!`)"
+    r"|"
+    r"(?<!`)(`{3,})(?!`)[^\n]+?(?<!`)\2(?!`)"
+)
+_FENCED_CODE_BLOCK = re.compile(
+    r"^(`{3,}|~{3,})[^\n]*\n.*?^\1",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def _span_ranges(text: str, pattern: re.Pattern[str]) -> list[tuple[int, int]]:
+    """Return (start, end) pairs for all non-overlapping matches of pattern."""
+    return [(m.start(), m.end()) for m in pattern.finditer(text)]
+
+
+def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in ranges)
+
 
 def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
-    """Return True when ``text`` claims ``issue`` via a closing keyword."""
+    """Return True when ``text`` claims ``issue`` via a closing keyword.
+
+    A closing keyword found only inside an inline code span or a fenced code
+    block does not count: GitHub never creates a real closing link there, so
+    treating it as a claim of implementation ownership would let a PR that
+    merely quotes or documents a closing keyword suppress a legitimate new PR
+    as a false duplicate (issue #3827).
+    """
 
     if not text:
         return False
@@ -72,7 +113,14 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"
     pattern = re.compile(rf"(?i)\b(?:{_KEYWORDS})\b[\s:]*{issue_ref}")
-    return bool(pattern.search(text))
+    fenced_ranges = _span_ranges(text, _FENCED_CODE_BLOCK)
+    code_span_ranges = _span_ranges(text, _INLINE_CODE_SPAN)
+    for match in pattern.finditer(text):
+        pos = match.start()
+        if _in_any_range(pos, fenced_ranges) or _in_any_range(pos, code_span_ranges):
+            continue
+        return True
+    return False
 
 
 def _run(cmd: list[str], *, timeout: int = _GH_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -178,19 +178,29 @@ def _in_any_range(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
+def _ranges_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return a[0] < b[1] and b[0] < a[1]
+
+
 def _code_spans_outside_fences(
     text: str, fenced_ranges: list[tuple[int, int]]
 ) -> list[tuple[int, int]]:
-    """Inline code-span ranges, excluding any that start inside a real fence.
+    """Inline code-span ranges, excluding any that overlap a real fence.
 
     A real fence always wins (CommonMark parses block structure before
     inline content, so nothing inside a fenced block's raw text is itself
-    inline-parsed). Ported verbatim from `pr_description.py`.
+    inline-parsed). Rejecting only a span whose START falls inside a fence
+    (round 4) misses a span that STARTS before a fence and ENDS after it --
+    e.g. a 4-backtick run in the paragraph before a fence, paired with a
+    later 4-backtick run after the fence closes -- which still engulfs the
+    fence and any real claim right after it (Copilot review on PR #5371,
+    round 5). Rejecting on any overlap closes both shapes. Ported verbatim
+    from `pr_description.py`.
     """
     return [
         span
         for span in _span_ranges(text, _INLINE_CODE_SPAN)
-        if not _in_any_range(span[0], fenced_ranges)
+        if not any(_ranges_overlap(span, fenced) for fenced in fenced_ranges)
     ]
 
 

--- a/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py
@@ -108,7 +108,7 @@ _PullRequestPayload = dict[str, object]
 # a genuine bare claim (Copilot review on PR #5371, round 4). Letting that
 # branch go multiline means it can also match all the way across a real
 # fenced block; `_code_spans_outside_fences` below handles that at the call
-# site by dropping any span match that starts inside a real fence, so a
+# site by dropping any span match that overlaps a real fence, so a
 # fence still reports as fenced rather than relabeled as an inline span.
 #
 # The two `_FENCE_OPEN_LINE` alternatives are deliberately asymmetric.
@@ -216,6 +216,10 @@ def references_issue(text: str, issue: int, repo_slug: str = "") -> bool:
 
     if not text:
         return False
+    # Normalize CRLF to LF: the fence and span regexes use \n anchors, so
+    # CRLF input causes closers to go unrecognized and extends fenced blocks
+    # through EOF (Devin review on PR #5371).
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     issue_ref = rf"#{issue}\b"
     if repo_slug:
         issue_ref = rf"(?:{re.escape(repo_slug)}#|#){issue}\b"

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -108,6 +108,41 @@ class TestReferencesIssue:
     def test_empty(self):
         assert _check.references_issue("", 5) is False
 
+    # -- issue #3827: closing keyword inside a code span must not count --
+
+    def test_inline_code_span_not_matched(self):
+        # Repro from issue #3827 comment (against issue 4965): a backtick-
+        # wrapped closing keyword never creates a real GitHub closing link,
+        # so it must not count as a claim of implementation ownership.
+        assert _check.references_issue("Example: `Fixes #4965`", 4965) is False
+
+    def test_double_backtick_inline_code_span_not_matched(self):
+        assert _check.references_issue("See `` Fixes #42 `` for context", 42) is False
+
+    def test_fenced_code_block_not_matched(self):
+        body = "Prior attempt:\n```\nFixes #4965\n```\n"
+        assert _check.references_issue(body, 4965) is False
+
+    def test_tilde_fenced_code_block_not_matched(self):
+        body = "~~~\nFixes #4965\n~~~\n"
+        assert _check.references_issue(body, 4965) is False
+
+    def test_bare_keyword_outside_code_span_still_matches(self):
+        # Positive control: the same keyword as a real claim, no markup.
+        assert _check.references_issue("Fixes #4965 on its own line", 4965) is True
+
+    def test_keyword_in_code_span_plus_real_claim_outside_still_matches(self):
+        # Edge: one match is excluded (code span) and a second, real match
+        # for the SAME issue exists outside any span. The function must not
+        # let the excluded match short-circuit the real one.
+        body = "Example: `Fixes #4965`. Fixes #4965"
+        assert _check.references_issue(body, 4965) is True
+
+    def test_diagnostic_reference_in_code_span_still_not_matched(self):
+        # Refs is already excluded by _KEYWORDS; confirm code-span exclusion
+        # does not accidentally flip a non-keyword into a match.
+        assert _check.references_issue("`Refs #4965`", 4965) is False
+
 
 class TestFindOpenPrsForIssue:
     def test_match_in_body(self):
@@ -132,6 +167,30 @@ class TestFindOpenPrsForIssue:
         with patch.object(_check.subprocess, "run", return_value=_proc(0, json.dumps([prs]))):
             out = _check.find_open_prs_for_issue("o", "r", 2477)
         assert [m["number"] for m in out] == [10]
+
+    def test_code_span_closing_keyword_does_not_suppress_new_pr(self):
+        # End-to-end regression for issue #3827: a PR that only quotes a
+        # closing keyword inside backticks (e.g. documenting the bug, as
+        # this repro does) must not be surfaced as an existing claim on the
+        # issue, or a legitimate new PR gets falsely blocked as a duplicate.
+        prs = [
+            {
+                "number": 5296,
+                "title": "docs(github): note the code-span closing-keyword defect",
+                "body": "The matcher incorrectly treats `Fixes #4965` as a real claim.",
+                "html_url": "https://github.com/rjmurillo/ai-agents/pull/5296",
+                "head": {"ref": "docs/note-3827-code-span-defect"},
+                "user": {"login": "rjmurillo"},
+            }
+        ]
+        with patch.object(
+            _check.subprocess,
+            "run",
+            return_value=_proc(0, json.dumps([prs])),
+        ):
+            out = _check.find_open_prs_for_issue("rjmurillo", "ai-agents", 4965)
+
+        assert out == []
 
     def test_diagnostic_reference_does_not_claim_implementation(self):
         prs = [

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import scripts.validation.pr_description as _prdesc
+
 _SCRIPTS_DIR = (
     Path(__file__).resolve().parents[1]
     / ".claude" / "skills" / "github" / "scripts" / "issue"
@@ -154,6 +156,41 @@ class TestReferencesIssue:
     def test_unclosed_tilde_fence_still_excludes_the_keyword_inside_it(self):
         body = "~~~\nFixes #4965"
         assert _check.references_issue(body, 4965) is False
+
+    def test_fence_indented_up_to_three_spaces_still_excludes_the_keyword(self):
+        # CommonMark 0.31.2 4.5 permits up to 3 spaces of indent on both the
+        # opening and closing fence (Copilot, PR #5371 round 2). A fence
+        # requiring column-0 anchoring would misread this as ordinary text
+        # and count the keyword as a real claim.
+        body = "  ```\n  Fixes #4965\n  ```\n"
+        assert _check.references_issue(body, 4965) is False
+
+    def test_a_line_starting_with_the_fence_chars_does_not_close_it_early(self):
+        # A closing fence line must hold nothing but the fence run and
+        # trailing whitespace. `` ```not-a-closer `` merely starts with the
+        # same run; ending the block there would let the following keyword
+        # (still code to GitHub) count as a real claim (Copilot, PR #5371
+        # round 2).
+        body = "```\n```not-a-closer\nFixes #4965\n```\n"
+        assert _check.references_issue(body, 4965) is False
+
+
+class TestSpanPatternsMatchCanonical:
+    """Drift guard for the two duplicated regex pairs (PR #5371 review).
+
+    `references_issue()`'s span-exclusion patterns are ported verbatim from
+    `scripts/validation/pr_description.py`. Nothing else keeps the two in
+    sync, so a fix applied to one copy and not the other silently reopens
+    whichever gap the fix closed. Asserting the compiled `.pattern` strings
+    are equal converts the PR's own "confirm no drift" reviewer note into a
+    gate.
+    """
+
+    def test_inline_code_span_pattern_matches_canonical(self):
+        assert _check._INLINE_CODE_SPAN.pattern == _prdesc._INLINE_CODE_SPAN.pattern
+
+    def test_fenced_code_block_pattern_matches_canonical(self):
+        assert _check._FENCED_CODE_BLOCK.pattern == _prdesc._FENCED_CODE_BLOCK.pattern
 
 
 class TestFindOpenPrsForIssue:

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -143,6 +143,18 @@ class TestReferencesIssue:
         # does not accidentally flip a non-keyword into a match.
         assert _check.references_issue("`Refs #4965`", 4965) is False
 
+    def test_unclosed_fence_still_excludes_the_keyword_inside_it(self):
+        # Copilot review on PR #5371: CommonMark treats an unclosed fence as
+        # running to end of input, not as no fence at all. A body ending
+        # mid-fence must still be excluded, or the keyword inside it counts
+        # as a real claim GitHub never linked.
+        body = "Prior attempt:\n```\nFixes #4965"
+        assert _check.references_issue(body, 4965) is False
+
+    def test_unclosed_tilde_fence_still_excludes_the_keyword_inside_it(self):
+        body = "~~~\nFixes #4965"
+        assert _check.references_issue(body, 4965) is False
+
 
 class TestFindOpenPrsForIssue:
     def test_match_in_body(self):
@@ -167,6 +179,26 @@ class TestFindOpenPrsForIssue:
         with patch.object(_check.subprocess, "run", return_value=_proc(0, json.dumps([prs]))):
             out = _check.find_open_prs_for_issue("o", "r", 2477)
         assert [m["number"] for m in out] == [10]
+
+    def test_a_backtick_split_across_title_and_body_does_not_hide_a_real_claim(self):
+        # Copilot review on PR #5371: title and body are two separate
+        # Markdown documents, so a code span cannot straddle them. An
+        # unmatched backtick in the title paired with one in the body used
+        # to form an artificial cross-field span that swallowed a real
+        # closing keyword sitting in the body.
+        prs = [
+            {
+                "number": 42,
+                "title": "fix: handle the `weird case",
+                "body": "Fixes #4965`, see the linked discussion.",
+                "html_url": "u",
+                "head": {"ref": "b"},
+                "user": {"login": "alice"},
+            }
+        ]
+        with patch.object(_check.subprocess, "run", return_value=_proc(0, json.dumps([prs]))):
+            out = _check.find_open_prs_for_issue("o", "r", 4965)
+        assert [m["number"] for m in out] == [42]
 
     def test_code_span_closing_keyword_does_not_suppress_new_pr(self):
         # End-to-end regression for issue #3827: a PR that only quotes a

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -174,23 +174,51 @@ class TestReferencesIssue:
         body = "```\n```not-a-closer\nFixes #4965\n```\n"
         assert _check.references_issue(body, 4965) is False
 
+    def test_closer_longer_than_opener_still_closes_the_fence(self):
+        # CommonMark 0.31.2 4.5: the closer must be the same character and
+        # AT LEAST as long as the opener, not exactly as long. A 3-backtick
+        # opener closes on a 4-backtick line, so the claim after it is real,
+        # unfenced text (Copilot, PR #5371 round 3).
+        body = "```\nignore this\n````\nFixes #4965\n"
+        assert _check.references_issue(body, 4965) is True
+
 
 class TestSpanPatternsMatchCanonical:
-    """Drift guard for the two duplicated regex pairs (PR #5371 review).
+    """Drift guard for the two duplicated span-exclusion mechanisms (PR #5371 review).
 
     `references_issue()`'s span-exclusion patterns are ported verbatim from
     `scripts/validation/pr_description.py`. Nothing else keeps the two in
     sync, so a fix applied to one copy and not the other silently reopens
-    whichever gap the fix closed. Asserting the compiled `.pattern` strings
-    are equal converts the PR's own "confirm no drift" reviewer note into a
-    gate.
+    whichever gap the fix closed. `_INLINE_CODE_SPAN` stays one static
+    pattern, so a `.pattern`/`.flags` comparison still fits it. The fenced
+    block is no longer one static pattern (round 3: CommonMark's "at least
+    as long" closer rule needs a per-opener dynamic closer, not a fixed `\1`
+    backreference), so its drift guard compares `_fenced_code_block_ranges`
+    output on shared tricky inputs instead of comparing source text.
     """
 
     def test_inline_code_span_pattern_matches_canonical(self):
         assert _check._INLINE_CODE_SPAN.pattern == _prdesc._INLINE_CODE_SPAN.pattern
+        assert _check._INLINE_CODE_SPAN.flags == _prdesc._INLINE_CODE_SPAN.flags
 
-    def test_fenced_code_block_pattern_matches_canonical(self):
-        assert _check._FENCED_CODE_BLOCK.pattern == _prdesc._FENCED_CODE_BLOCK.pattern
+    def test_fence_open_line_pattern_matches_canonical(self):
+        assert _check._FENCE_OPEN_LINE.pattern == _prdesc._FENCE_OPEN_LINE.pattern
+        assert _check._FENCE_OPEN_LINE.flags == _prdesc._FENCE_OPEN_LINE.flags
+
+    def test_fenced_code_block_ranges_behavior_matches_canonical(self):
+        bodies = [
+            "```\nFixes #1\n```\n",
+            "~~~\nFixes #1",
+            "  ```\n  Fixes #1\n  ```\n",
+            "```\n```not-a-closer\nFixes #1\n```\n",
+            "```\nignore this\n````\nFixes #1\n",
+            "no fence here at all",
+            "```\nfirst\n```\ntext\n~~~\nsecond\n~~~\n",
+        ]
+        for body in bodies:
+            assert _check._fenced_code_block_ranges(
+                body
+            ) == _prdesc._fenced_code_block_ranges(body), body
 
 
 class TestFindOpenPrsForIssue:

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -182,6 +182,22 @@ class TestReferencesIssue:
         body = "```\nignore this\n````\nFixes #4965\n"
         assert _check.references_issue(body, 4965) is True
 
+    def test_multiline_triple_backtick_inline_span_still_excludes_the_keyword(self):
+        # CommonMark 0.31.2 6.1 allows a code span to cross lines for any
+        # delimiter length; confining the 3+ backtick branch to a single
+        # line missed this and read the keyword as a genuine bare claim
+        # (Copilot, PR #5371 round 4).
+        body = "See ```example\nFixes #4965\nend``` for details."
+        assert _check.references_issue(body, 4965) is False
+
+    def test_backtick_fence_opener_with_backtick_in_info_string_is_not_a_fence(self):
+        # CommonMark 0.31.2 4.5: a backtick fence's info string must not
+        # itself contain a backtick; an opener that does isn't a fence at
+        # all, so a real keyword after it is a genuine unfenced claim
+        # (Copilot, PR #5371 round 4).
+        body = "```lang`x`\nFixes #4965\n"
+        assert _check.references_issue(body, 4965) is True
+
 
 class TestSpanPatternsMatchCanonical:
     """Drift guard for the two duplicated span-exclusion mechanisms (PR #5371 review).
@@ -214,11 +230,28 @@ class TestSpanPatternsMatchCanonical:
             "```\nignore this\n````\nFixes #1\n",
             "no fence here at all",
             "```\nfirst\n```\ntext\n~~~\nsecond\n~~~\n",
+            "```lang`x`\nFixes #1\n",
+            "~~~lang`x`\nFixes #1\n~~~\n",
+            "See ```example\nFixes #1\nend``` for details.",
         ]
         for body in bodies:
             assert _check._fenced_code_block_ranges(
                 body
             ) == _prdesc._fenced_code_block_ranges(body), body
+
+    def test_code_spans_outside_fences_behavior_matches_canonical(self):
+        bodies = [
+            "`Fixes #1`",
+            "``Fixes #1``",
+            "See ```example\nFixes #1\nend``` for details.",
+            "```\nFixes #1\n```\n",
+            "```\nignore this\n````\nFixes #1\n",
+        ]
+        for body in bodies:
+            fenced = _check._fenced_code_block_ranges(body)
+            assert _check._code_spans_outside_fences(
+                body, fenced
+            ) == _prdesc._code_spans_outside_fences(body, fenced), body
 
 
 class TestFindOpenPrsForIssue:

--- a/tests/test_issue_coordination.py
+++ b/tests/test_issue_coordination.py
@@ -198,6 +198,17 @@ class TestReferencesIssue:
         body = "```lang`x`\nFixes #4965\n"
         assert _check.references_issue(body, 4965) is True
 
+    def test_span_crossing_a_real_fence_does_not_hide_a_claim_after_it(self):
+        # A 4-backtick run in the paragraph before a real 3-backtick fence
+        # can pair with a later 4-backtick run after the fence closes,
+        # producing a candidate span that starts before the fence and ends
+        # after it, engulfing both the fence and a real claim right after
+        # it. Rejecting a span only when its start falls inside the fence
+        # (round 4) missed this shape and could let a duplicate PR through
+        # undetected (Copilot, PR #5371 round 5).
+        body = "See ````\n```\nhidden\n```\nFixes #4965 end````\n"
+        assert _check.references_issue(body, 4965) is True
+
 
 class TestSpanPatternsMatchCanonical:
     """Drift guard for the two duplicated span-exclusion mechanisms (PR #5371 review).
@@ -233,6 +244,7 @@ class TestSpanPatternsMatchCanonical:
             "```lang`x`\nFixes #1\n",
             "~~~lang`x`\nFixes #1\n~~~\n",
             "See ```example\nFixes #1\nend``` for details.",
+            "See ````\n```\nhidden\n```\nFixes #1 end````\n",
         ]
         for body in bodies:
             assert _check._fenced_code_block_ranges(
@@ -246,6 +258,7 @@ class TestSpanPatternsMatchCanonical:
             "See ```example\nFixes #1\nend``` for details.",
             "```\nFixes #1\n```\n",
             "```\nignore this\n````\nFixes #1\n",
+            "See ````\n```\nhidden\n```\nFixes #1 end````\n",
         ]
         for body in bodies:
             fenced = _check._fenced_code_block_ranges(body)

--- a/tests/test_pr_description_closing_links.py
+++ b/tests/test_pr_description_closing_links.py
@@ -189,6 +189,15 @@ class TestFencedCodeBlock:
         assert len(issues) == 1
         assert issues[0].severity == "CRITICAL"
 
+    def test_closer_longer_than_opener_still_closes_the_fence(self):
+        """CommonMark 0.31.2 4.5: the closer must be the same character and
+        AT LEAST as long as the opener, not exactly as long. A 3-backtick
+        opener closes on a 4-backtick line, so a keyword after it is real,
+        unfenced text and must be reported as a genuine closing keyword, not
+        excused as still-fenced (Copilot, PR #5371 round 3)."""
+        body = "```\nignore this\n````\nFixes #42\n"
+        assert validate_closing_links(body, "main", "main") == []
+
 
 class TestStackedPR:
     """Non-default base branch should produce WARNING when body has closing keywords."""

--- a/tests/test_pr_description_closing_links.py
+++ b/tests/test_pr_description_closing_links.py
@@ -127,6 +127,25 @@ class TestInlineCodeSpan:
         assert len(issues) == 1
         assert issues[0].severity == "CRITICAL"
 
+    def test_multiline_triple_backtick_inline_span_is_caught(self):
+        """CommonMark 0.31.2 6.1 allows a code span to cross lines for any
+        delimiter length, not just short runs; confining the 3+ backtick
+        branch to a single line missed this and read the keyword as a
+        genuine bare claim (Copilot, PR #5371 round 4)."""
+        body = "See ```example\nFixes #4965\nend``` for details."
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+        assert "inline code span" in issues[0].issue_type
+
+    def test_backtick_fence_opener_with_backtick_in_info_string_is_not_a_fence(self):
+        """CommonMark 0.31.2 4.5: a backtick fence's info string must not
+        itself contain a backtick; an opener that does isn't a fence at
+        all, so text after it is ordinary prose, not fenced content
+        (Copilot, PR #5371 round 4)."""
+        body = "```lang`x`\nFixes #4965\n"
+        assert validate_closing_links(body, "main", "main") == []
+
 
 class TestFencedCodeBlock:
     """Closing keyword inside a fenced block should be CRITICAL."""
@@ -153,6 +172,16 @@ class TestFencedCodeBlock:
         issues = validate_closing_links(body, "main", "main")
         assert len(issues) == 1
         assert issues[0].severity == "CRITICAL"
+
+    def test_tilde_fence_info_string_may_contain_a_backtick(self):
+        """CommonMark 0.31.2 4.5 restricts backticks in the info string to
+        backtick fences only; a tilde fence's info string is unrestricted,
+        so this must still open a real fence (Copilot, PR #5371 round 4)."""
+        body = "~~~lang`x`\nFixes #42\n~~~\n"
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+        assert issues[0].issue_type == "Closing keyword in fenced code block"
 
     def test_unclosed_backtick_fence_still_reports_the_keyword_as_fenced(self):
         """CommonMark 0.31.2 4.5: an unclosed fence still runs to EOF (Copilot, PR #5371)."""

--- a/tests/test_pr_description_closing_links.py
+++ b/tests/test_pr_description_closing_links.py
@@ -154,6 +154,41 @@ class TestFencedCodeBlock:
         assert len(issues) == 1
         assert issues[0].severity == "CRITICAL"
 
+    def test_unclosed_backtick_fence_still_reports_the_keyword_as_fenced(self):
+        """CommonMark 0.31.2 4.5: an unclosed fence still runs to EOF (Copilot, PR #5371)."""
+        body = "```\nFixes #42"
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+        assert issues[0].issue_type == "Closing keyword in fenced code block"
+
+    def test_unclosed_tilde_fence_still_reports_the_keyword_as_fenced(self):
+        body = "~~~\nCloses #10"
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+
+    def test_fence_indented_up_to_three_spaces_is_still_a_fence(self):
+        """CommonMark 0.31.2 4.5 permits up to 3 spaces of indent on both
+        fences; the keyword inside must still be reported as fenced, not
+        read as ordinary un-indented text outside any span."""
+        body = "  ```\n  Fixes #42\n  ```\n"
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+        assert issues[0].issue_type == "Closing keyword in fenced code block"
+
+    def test_a_line_that_only_starts_with_the_fence_chars_does_not_close_it(self):
+        """A closing fence line must hold nothing but the fence run and
+        trailing whitespace. A line that merely starts with the same run
+        (e.g. a fence marker immediately followed by other text) is still
+        code to GitHub and must not end the block early (Copilot, PR #5371
+        round 2)."""
+        body = "```\n```not-a-closer\nFixes #42\n```\n"
+        issues = validate_closing_links(body, "main", "main")
+        assert len(issues) == 1
+        assert issues[0].severity == "CRITICAL"
+
 
 class TestStackedPR:
     """Non-default base branch should produce WARNING when body has closing keywords."""

--- a/tests/test_pr_description_closing_links.py
+++ b/tests/test_pr_description_closing_links.py
@@ -146,6 +146,19 @@ class TestInlineCodeSpan:
         body = "```lang`x`\nFixes #4965\n"
         assert validate_closing_links(body, "main", "main") == []
 
+    def test_span_crossing_a_real_fence_does_not_hide_a_claim_after_it(self):
+        """A 4-backtick run in the paragraph before a real 3-backtick fence
+        can pair with a later 4-backtick run after the fence closes,
+        producing a candidate inline-span match that STARTS before the
+        fence and ENDS after it. CommonMark ends the paragraph where the
+        fence starts, so nothing can be inline-parsed across that boundary;
+        rejecting a span only when its START falls inside the fence (round
+        4) missed this shape and let the span engulf both the real fence
+        and a real claim right after it. Rejecting on any overlap, not just
+        start-containment, is required (Copilot, PR #5371 round 5)."""
+        body = "See ````\n```\nhidden\n```\nFixes #4965 end````\n"
+        assert validate_closing_links(body, "main", "main") == []
+
 
 class TestFencedCodeBlock:
     """Closing keyword inside a fenced block should be CRITICAL."""


### PR DESCRIPTION
## Summary

### What

Ports the code-span/fenced-block exclusion from `scripts/validation/pr_description.py`'s `validate_closing_links()` into `references_issue()` in `.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py`, so a backtick-wrapped or fenced closing keyword no longer counts as a real claim of implementation ownership during the duplicate-PR preflight.

### Why

GitHub never creates a closing link for a keyword inside inline code or a fenced code block (confirmed via the `closingIssuesReferences` GraphQL API in issue #3827's original report). `references_issue()` used a plain regex with no such exclusion, so a PR body that only quotes or documents a closing keyword was read as a genuine claim. That false claim can make the preflight suppress a legitimate new PR as a duplicate. The exact repro, a closing keyword for issue 4965 wrapped in backticks inside a bug writeup, was posted to issue #3827's thread on 2026-08-14.

The fix reuses the code-span and fenced-block exclusion logic already proven correct in `pr_description.py` for the identical problem (same issue #3827, PRs #4078 and #4716), rather than re-deriving new regexes.

## Specification References

| Type | Reference | Description |
|------|-----------|--------------|
| **Issue** | Refs #3827 | closing keyword in a code span/fenced block false-positives in the duplicate-PR preflight matcher |

## Changes

- `.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py`: add `_INLINE_CODE_SPAN`, `_FENCE_OPEN_LINE`, `_fenced_code_block_ranges()`, `_code_spans_outside_fences()`, `_span_ranges`, `_in_any_range` (ported verbatim from `pr_description.py`); `references_issue()` now excludes a keyword match that falls inside either span. Four review rounds fixed successive gaps: (1) an unclosed fence now still excludes its contents (falls back to end-of-input per CommonMark 4.5), and title/body are matched independently so an unmatched backtick in one field cannot pair with one in the other to hide a real claim; (2) fence lines now tolerate CommonMark's 0-3 space indentation, and a closing line must hold nothing but the fence run plus trailing whitespace, not arbitrary following text; (3) the fenced-block matcher was rewritten from a single regex with a `\1` backreference (exactly-equal-length closer only) to `_fenced_code_block_ranges()`, which builds each opener's own closer pattern requiring the same character and a run **at least** as long, per CommonMark 0.31.2 4.5; (4) the inline code-span pattern's 3+ backtick branch now allows multiline content (CommonMark 6.1 does not restrict multiline spans to short runs), a backtick-fence opener whose info string itself contains a backtick is now correctly rejected as not-a-fence (CommonMark 4.5 forbids backticks in a backtick fence's info string; tilde fences have no such restriction), and `_code_spans_outside_fences()` drops any code-span match that starts inside a real fence so letting the span pattern go multiline can't relabel a real fence as an inline span.
- `src/copilot-cli/skills/github/scripts/issue/check_existing_pr_for_issue.py`: regenerated mirror, byte-identical to the canonical source.
- `scripts/validation/pr_description.py`: the same four rounds of fixes applied to the canonical matchers (`_fenced_code_block_ranges()`, `_code_spans_outside_fences()`), so the "ported verbatim" parity claim stays true.
- `tests/test_issue_coordination.py`: 64 tests total (up from a 44-test baseline). Additions across the four rounds cover inline single/double-backtick spans, a multiline 3+ backtick span, fenced backtick/tilde blocks, unclosed fences, 0-3 space indentation, a closer-line-with-trailing-text edge case, a closer strictly longer than its opener, a backtick-in-info-string non-fence, and an end-to-end `TestFindOpenPrsForIssue` regression proving a PR that only quotes a closing keyword no longer suppresses a new PR for the same issue. `TestSpanPatternsMatchCanonical` is the drift guard between this file's span-exclusion logic and the canonical copy in `pr_description.py`: it compares `.pattern` **and** `.flags` for the two static patterns, and compares `_fenced_code_block_ranges()`/`_code_spans_outside_fences()` output on a shared set of tricky inputs across both modules.
- `tests/test_pr_description_closing_links.py`: 40 tests total, including the same unclosed-fence, indentation, closer-with-trailing-text, closer-longer-than-opener, multiline-span, and info-string cases against `validate_closing_links()`.

Known, documented limitation left out of scope: neither matcher reparses list-item or blockquote container prefixes, so a fence nested inside a list item or blockquote (e.g. `- \`\`\`\n  Fixes #N\n  \`\`\``) is not recognized as a fence and its content is read as unfenced. This preflight targets the common shape of a PR description (a top-level fenced example), not arbitrary nested Markdown containers; the code comments above `_FENCE_OPEN_LINE` in both files name this explicitly.

## Acceptance criteria

- [x] A closing keyword inside a single- or double-backtick inline code span does not count as a claim
- [x] A closing keyword inside a multiline 3+ backtick inline code span does not count as a claim
- [x] A closing keyword inside a fenced code block (backtick or tilde) does not count as a claim, including an unclosed fence, an indented fence, and a closer strictly longer than its opener
- [x] A genuine closing keyword outside any span still counts (no regression)
- [x] `find_open_prs_for_issue()` no longer reports a PR that only quotes a closing keyword

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, no rush

**Focus areas**: the fenced-block closer-length rule (same character, length >= opener length, not exactly equal) and the backtick-fence-info-string rejection in `_FENCE_OPEN_LINE`; confirm both copies (`check_existing_pr_for_issue.py` and canonical `pr_description.py`) stay behaviorally identical if either changes again. The container-nesting limitation noted above is a deliberate scope boundary, not an oversight.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

`uv run --frozen python -m pytest tests/test_issue_coordination.py tests/test_pr_description_closing_links.py -q` reports **104 passed** (64 in `test_issue_coordination.py`, 40 in `test_pr_description_closing_links.py`) on the pushed branch tip.

Negative control, repeated for each review round: reverted the source fix (`git stash push` on the three source files only, keeping the new tests) and reran; the new/updated tests failed against the pre-fix code with the expected assertion errors (round 4: two `AssertionError`s on the multiline-span and info-string cases, plus an `AttributeError` on the retired `_code_spans_outside_fences` reference in the drift-guard parity test). Restored the fix and reran: 104/104 pass.

`uv run --frozen python scripts/validation/pre_pr.py`: all validations pass on the pushed branch tip.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable): N/A, no doc surface for this internal preflight
- [x] No new warnings introduced
- [x] Closing-keyword claim verified against the diff: downgraded to `Refs #3827` because this PR fixes only the duplicate-PR-preflight consumer of the code-span bug, not issue #3827's own proposed fix (a PR-validation-job check comparing body claims against `closingIssuesReferences`), which already shipped separately in `pr_description.py` (PRs #4078, #4716). See PR review discussion.

## Related Issues

Refs #3827


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcZBovWi3YsZokqmjR763D)_