### PR TITLE
fix(tests): align stale core.bare and same-repo-ref assertions with source

### DIFF
--- a/tests/ci/test_recovery_manifest_boundaries.py
+++ b/tests/ci/test_recovery_manifest_boundaries.py
@@ -59,7 +59,14 @@ class TestPathFilterScope:
 
     def _plan(self, recovery_event: str):
         return plan(
-            [make_run(1, workflow=REQUIRED_WORKFLOW, context=REQUIRED_CONTEXT)],
+            [
+                make_run(
+                    1,
+                    workflow=REQUIRED_WORKFLOW,
+                    context=REQUIRED_CONTEXT,
+                    head_repo="rjmurillo/ai-agents",
+                )
+            ],
             self._subscriptions(),
             recovery_event,
         )

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -73,9 +73,16 @@ import check_repo_health
 
 GUARD = _VALIDATION_DIR / "check_repo_health.py"
 
-# The command the gate prints for a genuinely corrupted checkout. No stream may
-# carry it for any layout in this file.
+# The exact command the gate prints for a genuinely corrupted checkout.
 _REPAIR = "--replace-all core.bare false"
+
+# A broader marker for "no repair was printed" checks in this file. Without
+# the `--replace-all` flag, so it still catches a regression to the older,
+# unsafe `git config core.bare false` spelling appearing where no repair
+# should print at all -- narrowing this to `_REPAIR` would let that
+# regression through by no longer matching the string it emits. No stream
+# may carry either form for any layout in this file.
+_REPAIR_MARKER = "core.bare false"
 
 
 def _git_test_env() -> dict[str, str]:
@@ -196,8 +203,8 @@ class TestALinkedWorktreeOfABareRepositoryIsHealthy:
         check_repo_health.main([str(linked)])
 
         captured = capsys.readouterr()
-        assert _REPAIR not in captured.out
-        assert _REPAIR not in captured.err
+        assert _REPAIR_MARKER not in captured.out
+        assert _REPAIR_MARKER not in captured.err
         assert "Fix:" not in captured.err
 
     def test_the_cli_process_exits_zero_and_prints_no_repair(self, tmp_path: Path) -> None:
@@ -207,7 +214,7 @@ class TestALinkedWorktreeOfABareRepositoryIsHealthy:
         result = _run_cli(linked)
 
         assert result.returncode == 0, result.stdout + result.stderr
-        assert _REPAIR not in result.stdout + result.stderr
+        assert _REPAIR_MARKER not in result.stdout + result.stderr
 
     def test_the_classifier_reports_no_work_tree(self, tmp_path: Path) -> None:
         """``work_tree`` is what ``_report_corruption`` would name in the repair."""
@@ -272,7 +279,7 @@ class TestABareRepositoryStoredAtADotGitPath:
         assert code == 0
         captured = capsys.readouterr()
         assert "bare repository with no work tree" in captured.out
-        assert _REPAIR not in captured.out + captured.err
+        assert _REPAIR_MARKER not in captured.out + captured.err
 
     def test_an_unrelated_file_beside_the_bare_repository_still_exits_zero(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -291,7 +298,7 @@ class TestABareRepositoryStoredAtADotGitPath:
 
         assert code == 0
         captured = capsys.readouterr()
-        assert _REPAIR not in captured.out + captured.err
+        assert _REPAIR_MARKER not in captured.out + captured.err
 
     def test_the_listing_alone_would_have_called_that_layout_a_checkout(
         self, tmp_path: Path

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -75,7 +75,7 @@ GUARD = _VALIDATION_DIR / "check_repo_health.py"
 
 # The command the gate prints for a genuinely corrupted checkout. No stream may
 # carry it for any layout in this file.
-_REPAIR = "core.bare false"
+_REPAIR = "--replace-all core.bare false"
 
 
 def _git_test_env() -> dict[str, str]:

--- a/tests/validation/test_check_repo_health_reporting.py
+++ b/tests/validation/test_check_repo_health_reporting.py
@@ -63,12 +63,12 @@ class TestRepairNamesEveryScopeThatCarriesTheValue:
     @pytest.mark.parametrize(
         ("scope", "expected"),
         [
-            ("local", "git config core.bare false"),
-            ("worktree", "git config --worktree core.bare false"),
+            ("local", "git config --replace-all core.bare false"),
+            ("worktree", "git config --worktree --replace-all core.bare false"),
             ("global", "git config --global --unset-all core.bare"),
             ("system", "git config --system --unset-all core.bare"),
             ("command", "remove the command-scoped core.bare override"),
-            ("unheard-of", "git config core.bare false"),
+            ("unheard-of", "git config --replace-all core.bare false"),
         ],
     )
     def test_every_scope_maps_to_a_command_that_can_clear_it(
@@ -88,8 +88,8 @@ class TestRepairNamesEveryScopeThatCarriesTheValue:
         _report(tmp_path, (("local", "true"), ("worktree", "true")))
 
         err = capsys.readouterr().err
-        assert "Fix: git config core.bare false" in err
-        assert "Fix: git config --worktree core.bare false" in err
+        assert "Fix: git config --replace-all core.bare false" in err
+        assert "Fix: git config --worktree --replace-all core.bare false" in err
 
     def test_the_work_tree_and_every_poisoned_scope_are_named(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -67,7 +67,7 @@ import check_repo_health
 
 GUARD = _VALIDATION_DIR / "check_repo_health.py"
 
-_REPAIR = "core.bare false"
+_REPAIR = "--replace-all core.bare false"
 
 
 def _git_test_env() -> dict[str, str]:

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -67,7 +67,15 @@ import check_repo_health
 
 GUARD = _VALIDATION_DIR / "check_repo_health.py"
 
+# The exact command the gate prints for a genuine local-scope repair.
 _REPAIR = "--replace-all core.bare false"
+
+# A broader marker for "no repair was printed" checks. Deliberately without
+# the `--replace-all` flag, so it still catches a regression to the older,
+# unsafe `git config core.bare false` spelling appearing where no repair
+# should print at all -- narrowing this to `_REPAIR` would let that
+# regression through by no longer matching the string it emits.
+_REPAIR_MARKER = "core.bare false"
 
 
 def _git_test_env() -> dict[str, str]:
@@ -177,7 +185,7 @@ class TestAGlobalTrueUnderALocalFalseIsNotTheIncident:
 
         assert code == 0
         captured = capsys.readouterr()
-        assert _REPAIR not in captured.out + captured.err
+        assert _REPAIR_MARKER not in captured.out + captured.err
         assert "Fix:" not in captured.err
 
     def test_the_usable_line_names_the_masked_value(
@@ -200,7 +208,7 @@ class TestAGlobalTrueUnderALocalFalseIsNotTheIncident:
         result = _run_cli(repo, env)
 
         assert result.returncode == 0, result.stdout + result.stderr
-        assert _REPAIR not in result.stdout + result.stderr
+        assert _REPAIR_MARKER not in result.stdout + result.stderr
 
     def test_a_local_true_over_the_same_global_still_exits_one(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -246,7 +254,7 @@ class TestARepeatedLocalKeyIsResolvedByOrderNotByPresence:
 
         assert code == 0
         captured = capsys.readouterr()
-        assert _REPAIR not in captured.out + captured.err
+        assert _REPAIR_MARKER not in captured.out + captured.err
         assert "local=true overridden by a later scope" in captured.out
 
     def test_a_trailing_true_still_exits_one(
@@ -277,7 +285,7 @@ class TestAWorktreeScopedFalseOverABareRepositoryIsStillBareByDesign:
         code = check_repo_health.main([str(bare)])
 
         assert code == 0
-        assert _REPAIR not in capsys.readouterr().err
+        assert _REPAIR_MARKER not in capsys.readouterr().err
 
 
 class TestTheResolverMatchesGitsPrecedenceRule:


### PR DESCRIPTION
## Summary

Two of main's required checks (`Run Python Tests`, `pytest (bulk-nested)`) are failing independent of any pending PR. This fixes both; no production code changed.

### What / why

- PR #5345 changed `_SCOPE_REPAIRS` in check_repo_health_report.py (unchanged; only its tests are) to print `git config --replace-all core.bare false` (a plain `git config core.bare false` errors with "cannot overwrite multiple values with a single value" on the repeated-local-key layout the PR itself added coverage for), but three of its own test files still asserted the pre-change text. Updates `test_check_repo_health_scope_precedence.py`, `test_check_repo_health_bare_by_design.py`, and `test_check_repo_health_reporting.py` to assert the text the source actually prints.
- PR #5357 added a same-repository-ref guard to `plan_recovery` that fails closed when `head_repo` is empty, but its own `test_a_non_pull_request_event_is_not_blocked_by_a_path_filter` fixture never set `head_repo`, so the `workflow_dispatch` case failed closed against its own test premise. Passes `head_repo="rjmurillo/ai-agents"` in `TestPathFilterScope._plan` to match the same-repo scenario the test documents.

Discovered while triaging rjmurillo/ai-agents#5361: `triage_red_check.py` classified both checks `RED_ON_MAIN` for #5361, confirmed by reproducing all 8 failures against a clean `origin/main` checkout unrelated to that PR's diff.

## Testing

- Ran the 8 originally-failing node IDs individually against the fix: all pass (one is flaky under this sandbox's Windows subprocess/handle limits, confirmed by isolated rerun -- unrelated to the fix and irrelevant on the Linux CI runner).
- Confirmed via `git show <main-sha>:<path>` that the pre-fix assertion text is what is actually committed on `main`, not a local artifact.
- scripts/validation/check_repo_health_report.py (`_SCOPE_REPAIRS`) is unchanged; only test expectations moved to match already-shipped, intentional source behavior.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Documentation update
- [ ] Infrastructure/CI change

No issue filed for this; opened directly as the minimal fix once root-caused. Ref: `.serena/memories/ci-infrastructure-observations.md` (PR #5358 / issue #4789 session) independently recorded the same main regression.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rjmurillo/ai-agents/pull/5444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
