### PR TITLE
fix(tests): make recovery fixtures platform-safe

### DIFF
--- a/tests/ci/bulk_cancel_fixtures.py
+++ b/tests/ci/bulk_cancel_fixtures.py
@@ -37,6 +37,7 @@ SECOND_REQUIRED_WORKFLOW = "Python Tests"
 SECOND_REQUIRED_CONTEXT = "Run Python Tests"
 OPTIONAL_WORKFLOW = "Label PR"
 OPTIONAL_CONTEXT = "Sync Labels"
+BASE_REPOSITORY = "rjmurillo/ai-agents"
 
 _WORKFLOW_CONTEXTS = (
     (REQUIRED_WORKFLOW, REQUIRED_CONTEXT),
@@ -56,7 +57,7 @@ def make_run(
     branch: str | None = None,
     event: str = "synchronize",
     status: str = "queued",
-    head_repo: str = "",
+    head_repo: str = BASE_REPOSITORY,
 ) -> WorkflowRun:
     """Build one run record with sensible incident-shaped defaults.
 
@@ -144,7 +145,7 @@ def plan_with_pinned_contract(runs, subscriptions, recovery_event):
         required=REQUIRED_CONTEXTS,
         subscriptions=subscriptions,
         recovery_event=recovery_event,
-        repository="rjmurillo/ai-agents",
+        repository=BASE_REPOSITORY,
         now=PINNED_CLOCK,
     )
 

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -103,6 +103,7 @@ def _try_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
         ["git", *args],
         cwd=str(cwd),
         env=_git_test_env(),
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
@@ -114,6 +115,14 @@ def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the gate's own git calls off the host's global and system config."""
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+    real_run = subprocess.run
+
+    def run_with_devnull(*args, **kwargs):
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", run_with_devnull)
 
 
 def _make_repo(root: Path, name: str = "seed") -> Path:
@@ -143,6 +152,7 @@ def _run_cli(repo: Path) -> subprocess.CompletedProcess[str]:
         [sys.executable, str(GUARD), str(repo)],
         cwd=str(repo),
         env={**_git_test_env(), "PYTHONPATH": str(REPO_ROOT)},
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
@@ -259,7 +269,7 @@ class TestABareRepositoryStoredAtADotGitPath:
 
         listing = _git(holder / ".git", "worktree", "list", "--porcelain")
 
-        assert listing.stdout.splitlines()[0] == f"worktree {holder}"
+        assert listing.stdout.splitlines()[0] == f"worktree {holder.as_posix()}"
         assert sorted(entry.name for entry in holder.iterdir()) == [".git"]
 
     def test_it_exits_zero_and_prints_no_repair(
@@ -318,7 +328,7 @@ class TestABareRepositoryStoredAtADotGitPath:
         _git(holder, "config", "core.bare", "true")
 
         listing = _try_git(holder / ".git", "worktree", "list", "--porcelain")
-        assert listing.stdout.splitlines()[0] == f"worktree {holder}"
+        assert listing.stdout.splitlines()[0] == f"worktree {holder.as_posix()}"
         assert check_repo_health._has_main_work_tree_index(holder / ".git") is True
         assert check_repo_health.main([str(holder / ".git")]) == 1
 

--- a/tests/validation/test_check_repo_health_bare_by_design.py
+++ b/tests/validation/test_check_repo_health_bare_by_design.py
@@ -55,6 +55,7 @@ Coverage:
 
 from __future__ import annotations
 
+import functools
 import os
 import subprocess
 import sys
@@ -116,13 +117,11 @@ def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
 
-    real_run = subprocess.run
-
-    def run_with_devnull(*args, **kwargs):
-        kwargs.setdefault("stdin", subprocess.DEVNULL)
-        return real_run(*args, **kwargs)
-
-    monkeypatch.setattr(subprocess, "run", run_with_devnull)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        functools.partial(subprocess.run, stdin=subprocess.DEVNULL),
+    )
 
 
 def _make_repo(root: Path, name: str = "seed") -> Path:

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -88,6 +88,7 @@ def _git(cwd: Path, *args: str, env: dict[str, str] | None = None) -> str:
         ["git", *args],
         cwd=str(cwd),
         env=env or _git_test_env(),
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
@@ -102,6 +103,7 @@ def _git_rc(cwd: Path, *args: str, env: dict[str, str] | None = None) -> int:
         ["git", *args],
         cwd=str(cwd),
         env=env or _git_test_env(),
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
@@ -113,6 +115,14 @@ def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the gate's own git calls off the host's global and system config."""
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+
+    real_run = subprocess.run
+
+    def run_with_devnull(*args, **kwargs):
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", run_with_devnull)
 
 
 def _make_repo(root: Path, name: str = "repo") -> Path:
@@ -139,6 +149,7 @@ def _run_cli(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str
         [sys.executable, str(GUARD), str(repo)],
         cwd=str(repo),
         env={**env, "PYTHONPATH": str(REPO_ROOT)},
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,

--- a/tests/validation/test_check_repo_health_scope_precedence.py
+++ b/tests/validation/test_check_repo_health_scope_precedence.py
@@ -49,6 +49,7 @@ Refs #4698.
 
 from __future__ import annotations
 
+import functools
 import os
 import subprocess
 import sys
@@ -116,13 +117,11 @@ def _use_scratch_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
 
-    real_run = subprocess.run
-
-    def run_with_devnull(*args, **kwargs):
-        kwargs.setdefault("stdin", subprocess.DEVNULL)
-        return real_run(*args, **kwargs)
-
-    monkeypatch.setattr(subprocess, "run", run_with_devnull)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        functools.partial(subprocess.run, stdin=subprocess.DEVNULL),
+    )
 
 
 def _make_repo(root: Path, name: str = "repo") -> Path:


### PR DESCRIPTION
# Pull Request

## Summary

### What

Make repo-health subprocess tests noninteractive and path-portable on Windows, and give recovery-manifest fixture runs a same-repository identity by default.

### Why

Tests added with #5345 inherited pytest capture stdin and compared Git porcelain paths to Windows-native Path strings, causing 19 failures on current main. Fixtures from #5357 could also hit the unrelated same-repository guard before the behavior under test.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #5446 | Platform-safe repo-health subprocess and recovery fixtures |

## Changes

- Pass subprocess.DEVNULL through repo-health Git/CLI test subprocesses and exercised guard calls.
- Compare git worktree porcelain paths using slash-normalized Path values.
- Default bulk-cancellation test runs to the pinned base repository while preserving explicit fork and missing-identity cases.

## Acceptance criteria

- [x] Repo-health subprocess tests run noninteractively on Windows.
- [x] Git porcelain path assertions are platform-correct.
- [x] Recovery fixtures default to same-repository identity without weakening fork coverage.
- [x] Positive, negative, and edge suites pass.
- [x] No production behavior changes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted / standard / unblocks required tests

**Focus areas**: subprocess stdin isolation, Git path normalization, and preservation of explicit fork or missing-head-repository coverage.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

- Current-main Windows baseline: 19 failed, 60 passed.
- Fixed focused suite on Windows: 79 passed.
- Fixed focused suite on Linux: 79 passed.
- All bulk-cancel and recovery-manifest tests: 138 passed on Windows and Linux.
- Scoped Ruff: passed on Windows and Linux.
- Pre-commit, commit-msg, and pre-push Lefthook hooks: passed.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see .agents/security/)

**Files requiring security review:** None. Test-only change.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

The original dirty reporting assertions were independently absorbed by main in 5886cccc9. This PR retains only the additional Windows subprocess/path fixes and the shared recovery fixture correction.

## Related Issues

Closes #5446
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rjmurillo/ai-agents/pull/5448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->