### PR TITLE
fix(ci): guard codeql check-blocking-issues against cancelled runs

### DIFF
--- a/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
+++ b/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
@@ -1,0 +1,133 @@
+# Retrospective: Issue #5104 (CodeQL check-blocking-issues cancellation guard)
+
+## Session Info
+
+- **Date**: 2026-09-01
+- **Agent**: Claude Code (fleet worker, isolated external worktree)
+- **Task Type**: Bug fix (CI reliability), single issue
+- **Outcome**: Success, one commit plus this retrospective
+
+## What shipped
+
+`.github/workflows/codeql-analysis.yml::check-blocking-issues` ran under
+`always()`. The workflow sets `cancel-in-progress`, so a push that supersedes
+a run cancels the `analyze` matrix legs before they reach their
+`Upload SARIF artifact` step. The `always()` gate then ran
+`check-blocking-issues` anyway, its `actions/download-artifact` step errored
+on artifacts that were never uploaded, and GitHub recorded a red check run
+against a head nobody was waiting on.
+
+One commit on `claude/fix-5104-codeql-cancelled-guard`:
+
+- `fix(ci): guard codeql check-blocking-issues against cancelled runs`.
+  Swapped `always()` for `!cancelled()` (the substitution PR #5103 applied to
+  the five result-reading aggregators), and widened the classifier in
+  `tests/workflows/test_aggregator_cancellation_guard.py` so the
+  repository-wide sweep covers this job's shape.
+
+## The interesting part: why the #5097 sweep missed this
+
+PR #5103 swept every `needs` + `always()` job and fixed five. Its audit table
+flagged this job but did not fix it, and issue #5104 exists because of that
+gap. The sweep's classifier, `_consumes_dependency_results`, defined an
+aggregator as a job whose payload matches
+`needs\.[A-Za-z0-9_-]+\.result|toJSON\(\s*needs\s*\)`.
+
+`check-blocking-issues` matches neither. It never reads a dependency result.
+It depends on upstream work through downloaded artifacts instead, and its
+only `needs.` reference is `needs.check-paths.outputs.should-run-analysis`,
+which lives in `if:` and is deliberately excluded from the payload scan.
+
+So there are two distinct ways a job can depend on upstream work, and both go
+red identically under `always()`:
+
+1. Read `needs.<job>.result`, score the `cancelled` value, exit non-zero.
+   That is #5097.
+2. Download an artifact the upstream job never uploaded because cancellation
+   reached it first, and let `actions/download-artifact` error. That is
+   #5104.
+
+The fix that actually closes the class, rather than this one instance, is
+`depends_on_upstream_output = _consumes_dependency_results or
+_consumes_dependency_artifacts`. The sweep now sees both shapes.
+
+## What went right
+
+**Measured the blast radius before widening the classifier.** Broadening a
+repository-wide sweep is the kind of change that quietly turns one issue into
+a twelve-job refactor. Before editing anything I ran a throwaway probe that
+applied the proposed classifier across `.github/workflows/*.yml` and printed
+every job it would newly examine. Result: exactly two, this job and
+`pytest.yml::coverage`, and the latter was already guarded with
+`!cancelled()`. That single measurement turned "is this scope creep?" from a
+judgment call into a number, and justified raising
+`MINIMUM_AGGREGATORS_EXAMINED` from 5 to 7 with evidence rather than by
+adjusting it until tests passed.
+
+**Two negative controls, not one.** The obvious control is reverting the
+workflow. I also ran the less obvious one: revert the classifier widening
+while keeping the workflow fixed. Both were needed and both found something.
+
+- Workflow reverted, tests kept: 3 failures, and the sweep named
+  `codeql-analysis.yml::check-blocking-issues` by id.
+- Classifier reverted, workflow kept: 3 failures, on the examined floor and
+  the two new sweep cases.
+
+The second control is what proves the sweep widening is load-bearing rather
+than decorative. Without it, a reviewer could not distinguish "the sweep now
+covers artifact consumers" from "a new fixture entry was added and the sweep
+is unchanged." Adding the job to `FIXED_AGGREGATORS` alone would have passed
+the first control and taught nobody anything.
+
+**Named the inverse before writing the fix.** Widening a detector has a
+standing obligation: prove it does not over-fire. The mirror case here is
+`actions/upload-artifact`, the step the analyze legs themselves run. A
+classifier matching `artifact` loosely would tag every producer job as an
+aggregator and demand cancellation guards from jobs that depend on nothing.
+`test_uploading_an_artifact_does_not_count` pins that, and matching the
+literal action reference rather than a step name is what makes it hold.
+
+## What to watch
+
+**The premise test had to be generalized, and that is a real trade.**
+`test_aggregator_still_reads_dependency_results` existed to fail loudly if a
+job stopped being the thing the module describes. Renaming it to
+`test_aggregator_still_depends_on_upstream_output` and accepting either shape
+weakens it slightly: a job that swapped a result read for an artifact
+download would now pass silently. That seemed right, because both shapes need
+the same guard and the guard is what the module protects, but it is a
+loosening and worth knowing about.
+
+**`MINIMUM_AGGREGATORS_EXAMINED` is now a number two changes have moved.**
+The comment above it already carries the #5142 warning about raising it to
+paper over a regression. I extended that comment with how 7 was measured and
+which job the artifact classifier added. If a future change makes this number
+move again, the honest move is still to re-measure and explain, not to adjust
+until green.
+
+**Two stale counts fixed on the way past.** The module docstring said
+`MINIMUM_AGGREGATORS_EXAMINED` "reflects the five aggregators this module now
+covers" and a comment read "The five jobs this change converted." Both became
+wrong the moment a sixth was added. Fixed in the same commit rather than left
+as a broken window, since I was editing the lines directly above them.
+
+## Process notes
+
+- Verified no competing PR and no `PR-AUTOFIX-LEASE` marker on the issue
+  before starting, per fleet protocol. Both clean.
+- Worked in an external worktree at `/root/src/scratch/worktrees/fix-5104`
+  per `.claude/rules/universal.md` ("Git worktrees MUST be external").
+- `uv run --frozen python -m pytest tests/workflows/ -q`: 421 passed.
+- `uv run --frozen python scripts/validation/pre_pr.py`:
+  `RESULT: All validations passed`.
+- No hook bypass used. The retrospective gate blocked the first push, which
+  is what produced this file.
+
+## Follow-up
+
+None required for #5104. One observation for whoever next touches this
+module: the sweep classifies by pattern-matching workflow YAML, so any third
+way a job can depend on upstream work (a `gh run download` in a `run:` block,
+for instance, or a cache restore keyed on an upstream artifact) would be
+invisible to it the same way the artifact shape was. That is not a defect to
+fix speculatively, but it is the shape of the next miss if there is one.

--- a/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
+++ b/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
@@ -9,25 +9,20 @@
 
 ## Failure Mode Classification
 
-**Primary**: FM-9 (Confident-Incorrectness Recurrence,
-`.agents/governance/FAILURE-MODES.md` lines 284-311).
+**Primary**: No existing `FAILURE-MODES.md` class cleanly matches.
+Issue #5145 tracks the proposed class `State Conflation in a Boolean Guard`.
 
-PR #5103's sweep reported the repository's `always()`-gated aggregators as
-fixed after modeling "depends on upstream work" as one shape (a job that
-reads `needs.<job>.result`). `check-blocking-issues` depends on upstream work
-through a second shape (a downloaded artifact the upstream job never
-produced when cancelled) that the classifier's regex could not see. The
-sweep's audit table even flagged the job by name and still reported it
-unfixed without anyone treating that flag as a live defect, which is FM-9's
-shape exactly: a validator shipped confidence ("the five result-reading
-aggregators are now guarded") from a partial signal (one dependency shape),
-and the gap surfaced only when issue #5104 reproduced it live, one round of
-correction after the flag was already on record. The fix in this PR does not
-just patch the instance; per FM-9's Enforcement Pattern, it widens the
-classifier itself (`depends_on_upstream_output`) so the artifact-consuming
-shape is part of the checked contract going forward, and the PR's
-measured-blast-radius table stands in for the "quote the canonical source"
-step, since the source here is the workflow YAML shape rather than a schema.
+PR #5103 did not miss this job. Its audit table flagged
+`codeql-analysis.yml::check-blocking-issues` as outside the result-reading
+shape and left it as a follow-up. Issue #5104 cites that audit, not a live
+reproduction. The defect here is the job's `always()` guard on a PR head: it
+collapses cancellation and failure into the same visible red path on a
+superseded head. That shape is not FM-9, and it is not FM-10 because nothing
+is hidden.
+
+The fix in this PR does not just patch the instance; it widens the classifier
+itself (`depends_on_upstream_output`) so the artifact-consuming shape is part
+of the checked contract going forward.
 
 ## What shipped
 
@@ -48,12 +43,13 @@ Implementation on `claude/fix-5104-codeql-cancelled-guard`:
   `tests/workflows/test_aggregator_cancellation_guard.py` so the sweep
   covers this job's shape.
 
-## The interesting part: why the #5097 sweep missed this
+## The interesting part: why the #5097 sweep left this open
 
-PR #5103 swept every `needs` + `always()` job and fixed five. Its audit table
-flagged this job but did not fix it, and issue #5104 exists because of that
-gap. The sweep's classifier, `_consumes_dependency_results`, defined an
-aggregator as a job whose payload matches
+PR #5103 audited every `needs` + `always()` job and fixed five. Its audit
+table flagged this job but deliberately left it open because it never reads a
+dependency result. Issue #5104 reports that follow-up. The sweep's
+classifier, `_consumes_dependency_results`, defined an aggregator as a job
+whose payload matches
 `needs\.[A-Za-z0-9_-]+\.result|toJSON\(\s*needs\s*\)`.
 
 `check-blocking-issues` matches neither. It never reads a dependency result.

--- a/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
+++ b/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
@@ -7,6 +7,28 @@
 - **Task Type**: Bug fix (CI reliability), single issue
 - **Outcome**: Success, one commit plus this retrospective
 
+## Failure Mode Classification
+
+**Primary**: FM-9 (Confident-Incorrectness Recurrence,
+`.agents/governance/FAILURE-MODES.md` lines 284-311).
+
+PR #5103's sweep reported the repository's `always()`-gated aggregators as
+fixed after modeling "depends on upstream work" as one shape (a job that
+reads `needs.<job>.result`). `check-blocking-issues` depends on upstream work
+through a second shape (a downloaded artifact the upstream job never
+produced when cancelled) that the classifier's regex could not see. The
+sweep's audit table even flagged the job by name and still reported it
+unfixed without anyone treating that flag as a live defect, which is FM-9's
+shape exactly: a validator shipped confidence ("the five result-reading
+aggregators are now guarded") from a partial signal (one dependency shape),
+and the gap surfaced only when issue #5104 reproduced it live, one round of
+correction after the flag was already on record. The fix in this PR does not
+just patch the instance; per FM-9's Enforcement Pattern, it widens the
+classifier itself (`depends_on_upstream_output`) so the artifact-consuming
+shape is part of the checked contract going forward, and the PR's
+measured-blast-radius table stands in for the "quote the canonical source"
+step, since the source here is the workflow YAML shape rather than a schema.
+
 ## What shipped
 
 `.github/workflows/codeql-analysis.yml::check-blocking-issues` ran under

--- a/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
+++ b/.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md
@@ -5,7 +5,7 @@
 - **Date**: 2026-09-01
 - **Agent**: Claude Code (fleet worker, isolated external worktree)
 - **Task Type**: Bug fix (CI reliability), single issue
-- **Outcome**: Success, one commit plus this retrospective
+- **Outcome**: Success. The PR shipped the cancellation guard, the classifier widening, and the retrospective record for Issue #5104.
 
 ## Failure Mode Classification
 
@@ -39,13 +39,14 @@ a run cancels the `analyze` matrix legs before they reach their
 on artifacts that were never uploaded, and GitHub recorded a red check run
 against a head nobody was waiting on.
 
-One commit on `claude/fix-5104-codeql-cancelled-guard`:
+Implementation on `claude/fix-5104-codeql-cancelled-guard`:
 
 - `fix(ci): guard codeql check-blocking-issues against cancelled runs`.
   Swapped `always()` for `!cancelled()` (the substitution PR #5103 applied to
-  the five result-reading aggregators), and widened the classifier in
-  `tests/workflows/test_aggregator_cancellation_guard.py` so the
-  repository-wide sweep covers this job's shape.
+  the five result-reading aggregators), and widened the classifier that
+  powers the repository-wide sweep in
+  `tests/workflows/test_aggregator_cancellation_guard.py` so the sweep
+  covers this job's shape.
 
 ## The interesting part: why the #5097 sweep missed this
 
@@ -69,7 +70,8 @@ red identically under `always()`:
    reached it first, and let `actions/download-artifact` error. That is
    #5104.
 
-The fix that actually closes the class, rather than this one instance, is
+The fix that actually closes the class, rather than this one instance, lives
+in the repository-wide sweep module itself:
 `depends_on_upstream_output = _consumes_dependency_results or
 _consumes_dependency_artifacts`. The sweep now sees both shapes.
 
@@ -130,8 +132,10 @@ until green.
 **Two stale counts fixed on the way past.** The module docstring said
 `MINIMUM_AGGREGATORS_EXAMINED` "reflects the five aggregators this module now
 covers" and a comment read "The five jobs this change converted." Both became
-wrong the moment a sixth was added. Fixed in the same commit rather than left
-as a broken window, since I was editing the lines directly above them.
+wrong once this PR added a sixth guarded aggregator and a seventh examined
+job (`pytest.yml::coverage`, already guarded). Fixed in the same commit rather
+than left as a broken window, since I was editing the lines directly above
+them.
 
 ## Process notes
 
@@ -145,11 +149,22 @@ as a broken window, since I was editing the lines directly above them.
 - No hook bypass used. The retrospective gate blocked the first push, which
   is what produced this file.
 
-## Follow-up
+## Remediation
 
-None required for #5104. One observation for whoever next touches this
-module: the sweep classifies by pattern-matching workflow YAML, so any third
-way a job can depend on upstream work (a `gh run download` in a `run:` block,
-for instance, or a cache restore keyed on an upstream artifact) would be
-invisible to it the same way the artifact shape was. That is not a defect to
-fix speculatively, but it is the shape of the next miss if there is one.
+- [Complete] Issue #5104: workflow guard. Changed
+  `.github/workflows/codeql-analysis.yml::check-blocking-issues` from
+  `always()` to `!cancelled()` so a superseded run stops before the missing
+  SARIF download path can fail red.
+- [Complete] Issue #5104: classifier widening. Updated
+  `tests/workflows/test_aggregator_cancellation_guard.py::depends_on_upstream_output`
+  and `_consumes_dependency_artifacts` in the repository-wide sweep module so
+  the sweep classifies both result-reading aggregators and
+  artifact-consuming aggregators.
+
+## Future observation
+
+The sweep still classifies by pattern-matching workflow YAML, so any third way
+a job can depend on upstream work, such as `gh run download` in a `run:` block
+or a cache restore keyed on an upstream artifact, would be invisible to it the
+same way the artifact shape was. That is not a defect to fix speculatively, but
+it is the shape of the next miss if there is one.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -223,7 +223,14 @@ jobs:
   check-blocking-issues:
     name: Check for Blocking Issues
     needs: [check-paths, analyze]
-    if: always() && needs.check-paths.outputs.should-run-analysis == 'true'
+    # `!cancelled()` rather than `always()` (issue #5104). This job consumes the
+    # SARIF artifacts the analyze legs upload. When a push supersedes the run,
+    # concurrency cancels those legs before they upload, and an `always()` gate
+    # runs this job anyway; the download step then errors on the missing
+    # artifacts and publishes a red check against a head nobody is waiting on.
+    # `!cancelled()` still runs the job when analyze FAILED or was SKIPPED, so a
+    # live run with real findings fails exactly as before.
+    if: ${{ !cancelled() && needs.check-paths.outputs.should-run-analysis == 'true' }}
     # ADR-055: ARM runner for cost optimization
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/tests/workflows/test_aggregator_cancellation_guard.py
+++ b/tests/workflows/test_aggregator_cancellation_guard.py
@@ -1,4 +1,4 @@
-"""Regression guard for #5097: superseded runs must not publish red aggregates.
+"""Regression guard for #5097 and #5104: superseded runs must not publish red.
 
 Every workflow here uses `cancel-in-progress`, so pushing to a branch while a
 run is live cancels that run and leaves its jobs reporting `cancelled`. A
@@ -32,11 +32,21 @@ produced, and `cancelled` is (like `skipped`) neither `success` nor
 `failure`, so branch protection keeps waiting on a superseded run instead
 of reading a false green.
 
+A job can depend on an upstream job's work in two ways, and both go red the
+same way under `always()`. #5097 covered the first: the job reads
+`needs.<job>.result`, scores the `cancelled` value, and exits non-zero. #5104
+is the second: the job downloads an artifact the upstream job never uploaded
+because cancellation reached it first, and `actions/download-artifact` errors
+on the missing artifact. `codeql-analysis.yml::check-blocking-issues` is that
+second shape, which is why the #5097 sweep walked past it: it mentions no
+`needs.<job>.result` anywhere. `depends_on_upstream_output` now recognizes
+both, so the sweep covers both.
+
 Two workflows fixed for #2347 with the equivalent `always() && !cancelled()`
 spelling (`ai-pr-quality-gate.yml`, `ai-session-protocol.yml`) were later
-deleted (#5132, #5135); `MINIMUM_AGGREGATORS_EXAMINED` below reflects the
-five aggregators this module now covers, not the seven that existed when it
-was fixed.
+deleted (#5132, #5135); `MINIMUM_AGGREGATORS_EXAMINED` below reflects what
+the sweep examines today, not the seven jobs that existed when #5097 was
+fixed.
 
 Assertions run against `yaml.safe_load` output, never against workflow text
 (`.claude/rules/testing.md` MUST 9).
@@ -61,17 +71,32 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 # `pytest.yml::main-failure-alert` and `installed-plugin-hook-guard.yml`.
 CONSUMES_NEEDS_RESULT = re.compile(r"needs\.[A-Za-z0-9_-]+\.result|toJSON\(\s*needs\s*\)")
 
+# The second way a job depends on upstream work: it downloads an artifact an
+# upstream job uploaded. Issue #5104. `codeql-analysis.yml::check-blocking-issues`
+# reads no `needs.<job>.result` at all, so the result-only classifier above
+# never examined it, and the #5097 sweep reported clean while that job still
+# carried `always()`. A cancelled run leaves the analyze legs with nothing
+# uploaded, and `actions/download-artifact` errors on the missing artifacts
+# instead of the job skipping. Matching the action reference (rather than a
+# step name) keeps this literal: `actions/upload-artifact` does not match, so
+# a producer is never mistaken for a consumer.
+CONSUMES_DEPENDENCY_ARTIFACTS = re.compile(r"actions/download-artifact")
+
 # Events that put a check run on a pull request head. A schedule-only or
 # dispatch-only aggregate cannot produce the #5097 noise, so it is out of scope.
 PR_HEAD_EVENTS = frozenset({"pull_request", "push"})
 
-# The five jobs this change converted. Keyed workflow file to job id.
+# Every job converted to the guard, across #5097 and #5104. Workflow file to
+# job id.
 FIXED_AGGREGATORS: tuple[tuple[str, str], ...] = (
     ("pytest.yml", "test-result"),
     ("pytest.yml", "main-failure-alert"),
     ("cli-smoke.yml", "smoke-result"),
     ("installed-plugin-hook-guard.yml", "guard-result"),
     ("test-codeql-integration.yml", "aggregate-results"),
+    # Added for #5104. Depends on upstream output through downloaded SARIF
+    # artifacts, not through `needs.<job>.result`.
+    ("codeql-analysis.yml", "check-blocking-issues"),
 )
 
 # The `if` each fixed job carried before this change, read verbatim from
@@ -91,19 +116,27 @@ PRE_FIX_CONDITIONS: dict[tuple[str, str], str] = {
     ("cli-smoke.yml", "smoke-result"): "always()",
     ("installed-plugin-hook-guard.yml", "guard-result"): "always()",
     ("test-codeql-integration.yml", "aggregate-results"): "always()",
+    ("codeql-analysis.yml", "check-blocking-issues"): (
+        "always() && needs.check-paths.outputs.should-run-analysis == 'true'"
+    ),
 }
 
 # Lower bound on what the repository-wide sweep must examine. Without it a
 # broken classifier that matches nothing reports a clean sweep
 # (`.claude/rules/testing.md` MUST 10: report the scope size, not only the
-# finding count). Measured at 5: the five aggregators in FIXED_AGGREGATORS.
+# finding count). Measured at 7 by running the sweep against
+# `.github/workflows/*.yml` at this commit: the six jobs in FIXED_AGGREGATORS
+# plus `pytest.yml::coverage`, which the artifact classifier added for #5104
+# and which was already guarded (`needs.check-paths.outputs.python-changed ==
+# 'true' && !cancelled() && needs.test.result == 'success'`), so widening the
+# classifier flagged nothing beyond the job #5104 reports.
 # Two more (`ai-pr-quality-gate.yml::aggregate`, `ai-session-protocol.yml::aggregate`,
 # guarded for #2347) counted toward this bound until #5132 and #5135 deleted
 # those workflows in full, a legitimate cleanup and not a classifier
 # regression (issue #5142). Drop this count again if a future PR removes one
-# of the five that remain, rather than raising MINIMUM_AGGREGATORS_EXAMINED
+# of the jobs that remain, rather than raising MINIMUM_AGGREGATORS_EXAMINED
 # to paper over a real regression.
-MINIMUM_AGGREGATORS_EXAMINED = 5
+MINIMUM_AGGREGATORS_EXAMINED = 7
 
 
 def _load_workflow(name: str) -> Mapping[Any, Any]:
@@ -163,6 +196,30 @@ def _consumes_dependency_results(job: Mapping[str, Any]) -> bool:
     """
     payload = {key: value for key, value in job.items() if key not in _CONTROL_ONLY_KEYS}
     return any(CONSUMES_NEEDS_RESULT.search(text) for text in _strings(payload))
+
+
+def _consumes_dependency_artifacts(job: Mapping[str, Any]) -> bool:
+    """True if the job's own execution payload downloads an artifact.
+
+    Same payload scan as `_consumes_dependency_results`, for the same reason:
+    the reference lives in a step's `uses`, and a reusable-workflow call job
+    carries no `steps` at all. `if` and `needs` stay excluded so this answers
+    "does this job operationally consume upstream output" rather than "does
+    its guard mention one".
+    """
+    payload = {key: value for key, value in job.items() if key not in _CONTROL_ONLY_KEYS}
+    return any(CONSUMES_DEPENDENCY_ARTIFACTS.search(text) for text in _strings(payload))
+
+
+def depends_on_upstream_output(job: Mapping[str, Any]) -> bool:
+    """True if the job reads a dependency result or downloads its artifacts.
+
+    Either shape turns a cancelled upstream into a red check when the job is
+    gated on `always()`: the result reader scores a `cancelled` value, and the
+    artifact consumer errors on a download that was never uploaded. #5097
+    fixed the first shape; #5104 is the second.
+    """
+    return _consumes_dependency_results(job) or _consumes_dependency_artifacts(job)
 
 
 def _strip_expression_wrapper(condition: str) -> str:
@@ -298,7 +355,7 @@ def unguarded_pr_head_aggregators(workflow: Mapping[Any, Any]) -> tuple[list[str
     for job_id, job in (workflow.get("jobs") or {}).items():
         if not isinstance(job, dict) or not job.get("needs"):
             continue
-        if not _consumes_dependency_results(job):
+        if not depends_on_upstream_output(job):
             continue
         examined += 1
         if cancellation_guard_violations(job):
@@ -325,18 +382,20 @@ class TestFixedAggregators:
         key, job = fixed_aggregator
         assert bare_always_violations(job) == [], f"{key[0]}::{key[1]} kept always()"
 
-    def test_aggregator_still_reads_dependency_results(
+    def test_aggregator_still_depends_on_upstream_output(
         self, fixed_aggregator: tuple[tuple[str, str], dict[str, Any]]
     ) -> None:
         """Guards the premise, not the fix.
 
-        If a job stops reading `needs.<job>.result` it is no longer the
-        aggregator these assertions describe, and the sweep below would stop
-        examining it. Failing here is a signal to re-derive the list, not to
-        delete the case.
+        If a job stops reading `needs.<job>.result` AND stops downloading a
+        dependency's artifacts, it is no longer the aggregator these
+        assertions describe, and the sweep below would stop examining it.
+        Failing here is a signal to re-derive the list, not to delete the case.
         """
         key, job = fixed_aggregator
-        assert _consumes_dependency_results(job), f"{key[0]}::{key[1]} reads no dependency result"
+        assert depends_on_upstream_output(job), (
+            f"{key[0]}::{key[1]} neither reads a dependency result nor downloads its artifacts"
+        )
 
     def test_pre_fix_condition_is_rejected(
         self, fixed_aggregator: tuple[tuple[str, str], dict[str, Any]]
@@ -531,6 +590,96 @@ class TestRepositoryWideSweep:
         }
 
         assert unguarded_pr_head_aggregators(document) == (["result"], 1)
+
+
+class TestArtifactConsumerClassifier:
+    """The #5104 shape: depends on upstream output without reading a result.
+
+    `codeql-analysis.yml::check-blocking-issues` scores downloaded SARIF and
+    never mentions `needs.<job>.result`, so the result-only classifier walked
+    past it and the #5097 sweep reported clean while the job still carried
+    `always()`. These cases pin the widened classifier in both directions: it
+    must see a consumer, and it must not invent one.
+    """
+
+    def test_downloading_an_artifact_counts_as_depending_on_upstream(self) -> None:
+        job = {
+            "needs": ["analyze"],
+            "if": "always()",
+            "steps": [{"uses": "actions/download-artifact@v8", "with": {"pattern": "results-*"}}],
+        }
+
+        assert _consumes_dependency_results(job) is False
+        assert depends_on_upstream_output(job) is True
+
+    def test_uploading_an_artifact_does_not_count(self) -> None:
+        """Negative control: a producer is not a consumer.
+
+        `actions/upload-artifact` is the step the analyze legs run. Matching
+        it here would classify every producer job as an aggregator and demand
+        a cancellation guard from jobs that depend on nothing.
+        """
+        job = {
+            "needs": ["build"],
+            "if": "always()",
+            "steps": [{"uses": "actions/upload-artifact@v7", "with": {"name": "results"}}],
+        }
+
+        assert _consumes_dependency_artifacts(job) is False
+        assert depends_on_upstream_output(job) is False
+
+    def test_sweep_flags_an_unguarded_artifact_consumer(self) -> None:
+        document = {
+            "on": {"pull_request": None},
+            "jobs": {
+                "analyze": {"runs-on": "ubuntu-latest", "steps": []},
+                "check": {
+                    "needs": ["analyze"],
+                    "if": "always()",
+                    "steps": [{"uses": "actions/download-artifact@v8"}],
+                },
+            },
+        }
+
+        violations, examined = unguarded_pr_head_aggregators(document)
+
+        assert examined == 1
+        assert violations == ["check"]
+
+    def test_sweep_examines_but_clears_a_guarded_artifact_consumer(self) -> None:
+        """Shape of `pytest.yml::coverage`: examined, and already safe.
+
+        Distinguishes "the classifier now sees artifact consumers" from "the
+        classifier now fails them", which a flag-everything regression would
+        conflate.
+        """
+        document = {
+            "on": {"pull_request": None},
+            "jobs": {
+                "test": {"runs-on": "ubuntu-latest", "steps": []},
+                "coverage": {
+                    "needs": ["test"],
+                    "if": "!cancelled() && needs.test.result == 'success'",
+                    "steps": [{"uses": "actions/download-artifact@v8"}],
+                },
+            },
+        }
+
+        assert unguarded_pr_head_aggregators(document) == ([], 1)
+
+    def test_sweep_ignores_an_artifact_consumer_with_no_needs(self) -> None:
+        """A job with no dependencies cannot be orphaned by a cancelled one."""
+        document = {
+            "on": {"pull_request": None},
+            "jobs": {
+                "check": {
+                    "if": "always()",
+                    "steps": [{"uses": "actions/download-artifact@v8"}],
+                },
+            },
+        }
+
+        assert unguarded_pr_head_aggregators(document) == ([], 0)
 
 
 class TestConcurrencyStaysOn:


### PR DESCRIPTION
## Summary

### What

`.github/workflows/codeql-analysis.yml::check-blocking-issues` now runs under `!cancelled()` instead of `always()`. The regression module that swept for this class of bug is widened so it can see the job's shape, which is why the original sweep walked past it.

### Why

The workflow sets `cancel-in-progress`. When a push supersedes a run, concurrency cancels the `analyze` matrix legs before they reach their `Upload SARIF artifact` step. The `always()` gate ran `check-blocking-issues` anyway, its `actions/download-artifact` step errored on artifacts that were never uploaded, and GitHub recorded a red check run against a head nobody was waiting on. The next push repeated it.

`!cancelled()` is the substitution the vendor documents for exactly this (docs.github.com, expressions reference) and the one PR #5103 applied to the five result-reading aggregators. The job still runs when `analyze` FAILED or was SKIPPED, so a live run with real SARIF findings fails exactly as before. Only cancellation now excludes it.

**Why the #5097 sweep missed this one.** PR #5103's audit table flagged this job but did not fix it. Its classifier defined an aggregator as a job whose payload matches `needs\.[A-Za-z0-9_-]+\.result|toJSON\(\s*needs\s*\)`. `check-blocking-issues` matches neither: it never reads a dependency result, and its only `needs.` reference is `needs.check-paths.outputs.should-run-analysis`, which lives in `if:` and is deliberately excluded from the payload scan.

There are two ways a job can depend on upstream work, and both go red identically under `always()`:

1. Read `needs.NAME.result`, score the `cancelled` value, exit non-zero. That is #5097.
2. Download an artifact the upstream job never uploaded because cancellation reached it first, and let `actions/download-artifact` error. That is #5104.

`depends_on_upstream_output` now recognizes both, so the repository-wide sweep covers the artifact-consuming shape rather than only this one instance.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5104 | ci(codeql): check-blocking-issues keeps always() and can go red on a cancelled run via missing SARIF artifacts |
| **Related** | Refs #5097, PR #5103 | The sweep that fixed the result-reading shape and flagged this job without fixing it |

## Changes

- `.github/workflows/codeql-analysis.yml`: `check-blocking-issues` gate goes from `always() && needs.check-paths.outputs.should-run-analysis == 'true'` to `!cancelled() && needs.check-paths.outputs.should-run-analysis == 'true'`, with a comment recording why.
- `tests/workflows/test_aggregator_cancellation_guard.py`:
  - New `CONSUMES_DEPENDENCY_ARTIFACTS` matcher and `_consumes_dependency_artifacts`, combined with the existing result matcher into `depends_on_upstream_output`, which the repository-wide sweep now uses.
  - `codeql-analysis.yml::check-blocking-issues` added to `FIXED_AGGREGATORS` and `PRE_FIX_CONDITIONS` (pre-fix condition read verbatim from `git show origin/main:.github/workflows/codeql-analysis.yml` and parsed with the same loader the tests use).
  - `MINIMUM_AGGREGATORS_EXAMINED` raised 5 to 7, with the measurement recorded in the comment.
  - New `TestArtifactConsumerClassifier` (5 cases).
  - Premise test generalized to `test_aggregator_still_depends_on_upstream_output`.
  - Two stale counts in the module's own prose corrected ("the five aggregators this module now covers", "The five jobs this change converted"), since a sixth was added directly above them.

### Measured blast radius of widening the classifier

Widening a repository-wide sweep can quietly turn one issue into a large refactor, so I measured it before editing. Running the proposed classifier across `.github/workflows/*.yml` adds exactly two examined jobs:

| Job | Newly examined because | Guarded already? |
|---|---|---|
| `codeql-analysis.yml::check-blocking-issues` | downloads SARIF artifacts | No. This is the bug. |
| `pytest.yml::coverage` | downloads coverage artifacts | Yes: `... && !cancelled() && needs.test.result == 'success'` |

Nothing else in the repository is affected, which is what justifies the examined floor moving 5 to 7 rather than the number being tuned until green.

## Acceptance criteria

- [x] A superseded (cancelled) CodeQL run produces no failure-conclusion `check-blocking-issues` check run. `!cancelled()` evaluates false during cancellation, so the job concludes `cancelled`, which is neither `success` nor `failure`; branch protection keeps waiting on a superseded run rather than reading a red or a false green. Pinned by `test_aggregator_skips_a_cancelled_run[codeql-analysis.yml::check-blocking-issues]` and the repository-wide sweep.
- [x] A live run with real SARIF findings still fails the job. `!cancelled()` is true on any non-cancelled run, including one where `analyze` FAILED or was SKIPPED, so the download and the SARIF-scoring script run unchanged. No step, gate, or threshold in the scoring path is touched by this PR.

### Negative controls (both run, both failed as required)

The repo has been caught shipping tests that do not prove the fix, so both directions were verified rather than one.

1. **Revert the workflow to `always()`, keep the tests.** 3 failed, 44 passed. The sweep named the job by id: `AssertionError: unguarded PR-head aggregators: ['codeql-analysis.yml::check-blocking-issues']`
2. **Revert the classifier widening, keep the workflow fixed.** 3 failed, 44 passed, on `MINIMUM_AGGREGATORS_EXAMINED` and the two new sweep cases.

Control 2 is the one that matters for review: it proves the sweep widening is load-bearing rather than decorative. Adding the job to `FIXED_AGGREGATORS` alone would have passed control 1 while leaving the class of bug undetected. Restored after both, 47 passed.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**:

1. The classifier widening in `test_aggregator_cancellation_guard.py`. It is the part with reach beyond this issue. The blast-radius table above is the evidence that it flags nothing else; re-run it if you want independent confirmation.
2. Whether generalizing the premise test is the right trade. See "Trade accepted" below.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Commands run in the worktree:

- `uv run --frozen python -m pytest tests/workflows/test_aggregator_cancellation_guard.py -q`: 47 passed
- `uv run --frozen python -m pytest tests/workflows/ -q`: 421 passed
- `uv run --frozen ruff check` and `ruff format --check` on the changed test file: clean
- `uv run --frozen python scripts/validation/pre_pr.py`: `RESULT: All validations passed`

No hook bypass was used at any point. All pre-commit and pre-push jobs ran and passed; the retrospective gate blocked the first push, which produced `.agents/retrospective/2026-09-01-issue-5104-codeql-cancellation-guard.md`.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security patterns applied (see `.agents/security/`)

**This PR changes when a security gate runs, so it deserves an explicit argument rather than a checked box.** `check-blocking-issues` is the job that fails the build on a critical CodeQL finding. Loosening its gate could in principle let a real finding through, so:

- The only execution the change removes is on a **cancelled** run. On every other outcome (`success`, `failure`, `skipped`) `!cancelled()` is true and the job runs exactly as it did under `always()`.
- A cancelled run cannot produce a false green. A `cancelled` conclusion is neither `success` nor `failure`, so a required-check gate keeps waiting rather than passing. The head that matters is the superseding push, whose own run scores its own SARIF.
- Under `always()` the job could not have blocked on a real finding in the cancelled case anyway: the SARIF it needed was never uploaded. It failed on a missing download, not on a finding. So no detection capability is lost.
- The script that scores SARIF findings, its severity threshold, and the `analyze` legs are untouched by this PR (no file under `scripts/ci/` is part of this diff).

**Files requiring security review:**

- `.github/workflows/codeql-analysis.yml`

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Trade accepted, and one thing to watch

**The premise test was generalized, which loosens it slightly.** `test_aggregator_still_reads_dependency_results` existed to fail loudly if a job stopped being the thing the module describes. It is now `test_aggregator_still_depends_on_upstream_output` and accepts either shape, so a job that swapped a result read for an artifact download would pass silently. That seemed correct, because both shapes need the same guard and the guard is what the module protects, but it is a real loosening and a reviewer may disagree.

**Not fixed here, flagged instead.** The sweep classifies by pattern-matching workflow YAML, so a third way of depending on upstream work (a `gh run download` inside a `run:` block, say, or a cache restore keyed on an upstream artifact) would be invisible to it the same way the artifact shape was. No such job exists in the repository today, so fixing it now would be speculative scope. It is the shape of the next miss if there is one.

## Related Issues

Fixes #5104
Refs #5097


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcZBovWi3YsZokqmjR763D)_


---

<a href="https://app.devin.ai/review/rjmurillo/ai-agents/pull/5450" rel="nofollow noreferrer noopener" target="_blank">
  
    
    ``&lt;img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review"&gt;``
  
</a>
