### PR TITLE
fix(ci): count a conflicted path once, not once per merge stage

### DIFF
--- a/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
+++ b/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
@@ -12,10 +12,17 @@
 
 `git ls-files` prints one line per index entry, and an unmerged path holds one
 entry per merge stage. `count_ratchet.tracked_files` returned that raw list, so
-every ratchet under `scripts/ci` handed its linter the same conflicted path two
-or three times and counted its violations that many times. The reporter saw
+all six ratchets under `scripts/ci` were handed the same conflicted path two or
+three times. Five of them counted its violations that many times. The
+memory-index ratchet did not, because its `_tracked_relative_paths` builds a set
+and the repeats collapsed before anything counted them. The reporter saw
 `585 violations > baseline 583 (+2)` on a branch whose only conflicted file was
 byte-identical to `origin/main`, and `git add` of unchanged content cleared it.
+
+Fixing the shared enumeration still covers the immune consumer, because it reads
+the index like the rest and so carries the mid-merge note. That note is a
+reporting concern rather than a counting one, which is the distinction the
+first draft of this record blurred.
 
 `deduplicate_index_entries` keeps the first occurrence and the original order.
 Repeats are reported on stderr rather than through a second git call, because a
@@ -96,6 +103,8 @@ is deferred, so no follow-up issue is open against this record.
 | 2 | Emit a stderr note naming the unmerged paths, capped at five | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 | 3 | Pin git's per-stage enumeration so a future git that stops repeating cannot leave the fix guarding nothing | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 | 4 | Drive each of the six consumers' real `current_count` through a spy, so one leaving the shared enumeration fails | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 5 | Suppress the note on the run's second index read, so one run prints one caveat | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 6 | Narrow the impact claim to the five ratchets that actually double-counted | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 
 On action 2: the count is right after the fix, and the note still earns its
 place, because the linter reads content off disk, so conflict markers left in
@@ -149,3 +158,43 @@ place of the remediation table. Both are now supplied above.
 The through-line across all three: each was a claim stated in the right shape
 without the thing that makes the shape load-bearing. That is the same defect
 class as the bug this PR fixes, one level up.
+
+## Correction, 2026-09-01, review round 2
+
+Three more findings, all real, all confirmed by reading the cited source before
+acting.
+
+**A duplicate note, which is the fix reproducing the defect it fixes.** On a
+regression `run` reads the index twice: once through the counter, then again
+through the lister that renders the violations. Both reads saw the same unmerged
+index, so both emitted the identical caveat and a contributor mid-merge read it
+twice for one run. The note exists to make a mid-merge count legible, and
+printing it twice makes the output harder to read, not easier. Fixed by giving
+the enumeration an `announce_unmerged` keyword that the counting read leaves
+true and both listers pass false: the counting read runs on every invocation, so
+it owns the announcement, and the diagnostic re-read stays silent because the
+count already said it. `memory_index_count_ratchet` needed the keyword threaded
+two frames down, through `_collect` and `_tracked_relative_paths`.
+
+Negative control: restoring both call sites to the announcing form failed three
+cases, the end-to-end once-only assertion and one lister case per module, with
+28 passing. Both restores were confirmed byte-identical and returned all 31 to
+green. The end-to-end case drives `main` rather than the helpers, because the
+double emission only exists in the sequence `run` performs, and it asserts the
+violations header so a future change that skips the lister entirely cannot make
+it pass vacuously. A paired control asserts the counting read still announces,
+because silencing both reads would leave a mid-merge run with no caveat at all,
+which is this defect one step further on.
+
+**An overstated impact claim, twice.** The first draft of this record and the
+test module both said every ratchet counted the conflicted path two or three
+times. Five did. `memory_index_count_ratchet._tracked_relative_paths` builds a
+set, so the repeats collapsed there before anything counted them, and that
+consumer was already immune to the counting symptom while still sharing the
+enumeration. The PR description's scope analysis had this right from the start,
+so the defect was an inconsistency between two documents in the same change,
+where the narrower and correct claim was already written down.
+
+The pattern worth keeping from this round: the strongest claim reachable is not
+always the true one, and a claim already stated correctly somewhere else in the
+same change is the cheapest place to catch that.

--- a/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
+++ b/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
@@ -105,6 +105,8 @@ is deferred, so no follow-up issue is open against this record.
 | 4 | Drive each of the six consumers' real `current_count` through a spy, so one leaving the shared enumeration fails | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 | 5 | Suppress the note on the run's second index read, so one run prints one caveat | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 | 6 | Narrow the impact claim to the five ratchets that actually double-counted | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 7 | Announce once for the two-scope consumer, whose reads are both counting reads | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 8 | Assert exact per-consumer read counts, so dropping one of several scopes fails | `@rjmurillo` | PR #5454, issue #4746 | DONE |
 
 On action 2: the count is right after the fix, and the note still earns its
 place, because the linter reads content off disk, so conflict markers left in
@@ -198,3 +200,53 @@ where the narrower and correct claim was already written down.
 The pattern worth keeping from this round: the strongest claim reachable is not
 always the true one, and a claim already stated correctly somewhere else in the
 same change is the cheapest place to catch that.
+
+## Correction, 2026-09-01, review round 3
+
+Two findings, both real, both consequences of the round 2 fix rather than of the
+original defect.
+
+**The round 2 fix left one consumer behind.** It assigned the announcement to
+"the counting read", on the assumption that each ratchet has exactly one.
+`cli_exit_contract_ratchet` has two: it counts from `scripts/ci/*.py` and
+`.github/scripts/*.py` in one read and `tests/**/*.py` in another, disjoint
+scopes that can each legitimately hold an unmerged path. Both defaulted to
+announcing, so a merge conflicting a file in each scope printed one note per
+scope for a single run. That is the duplicate output round 2 removed,
+reintroduced at a shape the round 2 rule did not describe.
+
+Silencing the second read would have been wrong in the other direction: a
+conflict confined to `tests/` would then announce nothing at all, which is worse
+than announcing twice. The fix reads the union of both pathspecs first, gives
+that read the announcement, and silences both scoped reads. One run, one caveat,
+naming every unmerged path either scope would have counted. The union read also
+serves as the git-health probe for the pair, so its None short-circuits before
+either scoped read runs.
+
+Negative control: reverting to two independent announcing reads, against a
+fixture carrying a conflict in both scopes, failed on `one run printed the
+mid-merge note 2 times`. Restore confirmed byte-identical.
+
+**The wiring test's lower bound could not see a half-broken consumer.** It
+asserted `spy.calls >= 1`, which any one surviving read satisfies, so a consumer
+that dropped one of several scopes for a raw filesystem walk would still have
+passed. The counts are now exact per consumer and per condition: one read when
+the first enumeration is unusable, and for the two-scope consumer three when
+every enumeration is readable.
+
+Negative control, run in two halves against the same mutation. With the tests
+scope switched to `rglob`, the exact assertion failed with
+`made 2 enumeration read(s), expected 3`. Loosening that one assertion back to
+`>= 1`, with the mutation still in place, passed 16 of 16. The lower bound
+demonstrably could not see the defect.
+
+Deviation from the review's suggested shape, recorded because it is visible in
+the diff: the review asked for exactly two reads for this consumer, one per
+glob. It makes three, because the union read that owns the announcement is a
+third. The intent, catching a consumer that silently drops a read, is served
+identically by an exact three.
+
+The pattern across rounds 2 and 3: a rule that assigns a responsibility ("the
+counting read announces") is only as good as its enumeration of the cases. This
+one was written from five consumers that share a shape and applied to a sixth
+that does not. Worth checking the odd one out before generalising, not after.

--- a/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
+++ b/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
@@ -57,22 +57,54 @@ duplicate index entry is what an unmerged path is.
 
 ## Failure mode classification
 
-A measurement gate reported a number that described no tree that existed, with
-no signal distinguishing it from a real regression. The count and the printed
-violation list were internally consistent, so the output actively led the reader
-away from the index. It fires exactly when someone is mid-merge and least able
-to tell an artifact from a regression, which is what turned a two-line defect
-into a substantial diagnostic detour for the reporter.
+**Failure mode 10, silent defaults and guard-clause suppression**
+(`.agents/governance/FAILURE-MODES.md`). That entry's unifying property, quoted
+verbatim: "the call site has no way to know the operation didn't actually do
+what its name claims." The enumeration claims paths and returned index entries,
+all six call sites consumed the difference as though it were paths, and the
+verdict that came out was internally consistent with the file list printed
+beneath it. The reporter could not tell from the output that the index was the
+cause, which is the whole of that mode. It fires exactly when someone is
+mid-merge and least able to tell an artifact from a regression.
+
+The shape is inverted from that entry's canonical examples, and worth naming so
+the next reader is not misled: those describe a check falling through to a
+positive signal, while this one falls through to a false RED. The suppression is
+the same either way, because a verdict nobody can place is what both produce.
+The remedy the entry asks for is the one taken here, which is to surface the
+suppression rather than only correct the number.
+
+**Not failure mode 9** (confident-incorrectness recurrence), which the symptom
+superficially resembles. That entry describes "an agent reaches a conclusion
+from partial signal, delivers it with full confidence." No agent asserted this
+count. The gate computed it from a mis-measured input, so the defect is in the
+measurement, not in a claim anyone made about it.
+
+**Not failure mode 4** (false completion markers), whose direction is opposite:
+success reported against an artifact that does not satisfy the criteria. This
+gate reported failure against a tree that did.
 
 ## Remediation
 
-- Deduplication at the shared seam, so all six ratchets are covered at once.
-- A stderr note naming the unmerged paths. The count is right after the fix, and
-  the note still earns its place: the linter reads content off disk, so conflict
-  markers left in the working copy add lines and can push a file over a size
-  threshold on their own. A count taken mid-merge deserves the caveat.
-- The note is capped at five named paths, because a two-hundred-file conflict
-  printed above a 40-line violation cap buries the payload.
+Every action below is a code change, and all of them landed in PR #5454 against
+issue #4746. Owner: the PR author (`@rjmurillo`, agent-assisted). Nothing here
+is deferred, so no follow-up issue is open against this record.
+
+| # | Action | Owner | Tracking | Status |
+|---|--------|-------|----------|--------|
+| 1 | Deduplicate at the shared seam, covering all six ratchets at once | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 2 | Emit a stderr note naming the unmerged paths, capped at five | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 3 | Pin git's per-stage enumeration so a future git that stops repeating cannot leave the fix guarding nothing | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+| 4 | Drive each of the six consumers' real `current_count` through a spy, so one leaving the shared enumeration fails | `@rjmurillo` | PR #5454, issue #4746 | DONE |
+
+On action 2: the count is right after the fix, and the note still earns its
+place, because the linter reads content off disk, so conflict markers left in
+the working copy add lines and can push a file over a size threshold on their
+own. A count taken mid-merge deserves the caveat. The five-path cap exists
+because a two-hundred-file conflict printed above a 40-line violation cap buries
+the payload.
+
+On action 4: this replaced a weaker first attempt. See the correction below.
 
 ## Learnings
 
@@ -82,6 +114,38 @@ into a substantial diagnostic detour for the reporter.
 - When a gate reports a number, the honest failure is one that says which tree
   it measured. Correcting the count and dropping the mid-merge note would have
   left a second, smaller version of the same defect: a number nobody can place.
-- A shared helper makes the mirror obligation cheap to discharge but easy to
-  under-claim. Asserting each consumer still holds the fixed reference costs six
-  lines and converts "they share it today" into a standing check.
+- A shared helper makes the mirror obligation cheap to discharge and easy to
+  over-claim. The first wiring test asserted each consumer still held the
+  imported reference, which proves an import survived and not that anything
+  calls it. See the correction below.
+
+## Correction, 2026-09-01, review round 1
+
+Appended rather than rewritten, per this repository's rule that a landed retro
+is corrected by addition.
+
+Review found the wiring claim above unsupported by the test that was supposed to
+carry it. The original test asserted `module.tracked_files is
+count_ratchet.tracked_files` for each of the six consumers. That is an
+identity check on an imported name: a consumer can stop calling the enumeration,
+keep the now-unused import, and pass.
+
+Measured rather than argued. One consumer was rewritten to walk the filesystem
+with `rglob` instead of calling the shared enumeration, with the import left in
+place. Under that mutation the identity assertion evaluated `True`, so the
+original test would have shipped green against exactly the regression it was
+written to catch. The replacement, which drives each consumer's real
+`current_count` with the enumeration monkeypatched to a spy, failed both of that
+consumer's cases on the same mutation. Restoring the consumer was confirmed
+byte-identical and returned all 26 cases to green.
+
+Second and third findings, both real and both against
+`.claude/rules/retros.md`: MUST 2 requires a retro to classify its failure
+against a numbered entry in `.agents/governance/FAILURE-MODES.md`, and MUST 4
+requires remediation actions to carry owners or issues. The original record had
+a prose description in place of the classification and a bare bullet list in
+place of the remediation table. Both are now supplied above.
+
+The through-line across all three: each was a claim stated in the right shape
+without the thing that makes the shape load-bearing. That is the same defect
+class as the bug this PR fixes, one level up.

--- a/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
+++ b/.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md
@@ -1,0 +1,87 @@
+# Retrospective: Issue #4746 (a conflicted path counted once per merge stage)
+
+## Session Info
+
+- **Date**: 2026-09-01
+- **Agent**: Claude Code (remote session, implementer)
+- **Task Type**: Bug fix (CI gate correctness), P2 backlog
+- **Outcome**: Fix, tests, and negative control shipped on the PR that closes
+  issue #4746
+
+## What shipped
+
+`git ls-files` prints one line per index entry, and an unmerged path holds one
+entry per merge stage. `count_ratchet.tracked_files` returned that raw list, so
+every ratchet under `scripts/ci` handed its linter the same conflicted path two
+or three times and counted its violations that many times. The reporter saw
+`585 violations > baseline 583 (+2)` on a branch whose only conflicted file was
+byte-identical to `origin/main`, and `git add` of unchanged content cleared it.
+
+`deduplicate_index_entries` keeps the first occurrence and the original order.
+Repeats are reported on stderr rather than through a second git call, because a
+duplicate index entry is what an unmerged path is.
+
+## What worked
+
+- **Reproducing before designing.** A scratch repository with a 601-line file
+  conflicted content-versus-content measured 4 violations mid-merge against 2
+  after staging byte-identical content. The `+2` matched the issue exactly, and
+  the decomposition (1 for the linter's own copy, 3 for the conflicted file)
+  confirmed the mechanism rather than inferring it from the symptom.
+- **Pinning the git behavior, not only the fix.** A separate case asserts
+  `git ls-files -z` really does repeat an unmerged path three times. Without it
+  a future git that stopped repeating would leave the deduplication passing its
+  own tests while guarding nothing.
+- **Answering the issue's open question by measurement.** It asked whether the
+  sibling ratchets share the enumeration. All six do, so one seam fix covers
+  all six, and a per-consumer test now fails if one stops sharing it.
+- **The negative control found the real blast radius.** Restoring the defect
+  failed exactly three cases (`assert 3 == 1`, `assert 2 == 1`, `assert 4 == 2`)
+  and left the seventeen order, cap, and wiring cases green, which is the
+  evidence that those seventeen are not the ones doing the work.
+
+## What failed, and the correction
+
+- **The main checkout was behind `origin/main` by a wide margin.** The first
+  read of `count_ratchet.py` returned a 541-line file; the worktree cut from a
+  freshly fetched `origin/main` holds 1019 lines, with an exit-code contract and
+  a `--base-ref` policy the older copy never mentions. The edit landed correctly
+  only because `tracked_files` happened not to have moved. Correction: read the
+  file from the worktree you are about to change, not from whichever checkout is
+  open. This is the same staleness trap `.claude/rules/ci-scripts.md` MUST 14
+  records for ratchet counts, arriving through a different door.
+- **The mid-merge inflation is not a fixed multiple.** The reported case had
+  three stages, but add/add and delete/modify carry two, so dividing by three
+  would have been wrong on half the conflict shapes. Deduplication is
+  shape-independent; a two-stage case pins it.
+
+## Failure mode classification
+
+A measurement gate reported a number that described no tree that existed, with
+no signal distinguishing it from a real regression. The count and the printed
+violation list were internally consistent, so the output actively led the reader
+away from the index. It fires exactly when someone is mid-merge and least able
+to tell an artifact from a regression, which is what turned a two-line defect
+into a substantial diagnostic detour for the reporter.
+
+## Remediation
+
+- Deduplication at the shared seam, so all six ratchets are covered at once.
+- A stderr note naming the unmerged paths. The count is right after the fix, and
+  the note still earns its place: the linter reads content off disk, so conflict
+  markers left in the working copy add lines and can push a file over a size
+  threshold on their own. A count taken mid-merge deserves the caveat.
+- The note is capped at five named paths, because a two-hundred-file conflict
+  printed above a 40-line violation cap buries the payload.
+
+## Learnings
+
+- A git plumbing command's unit of output is worth checking before it is
+  consumed as a set. `ls-files` enumerates index entries, not paths, and the two
+  differ only in a state most sessions never reach.
+- When a gate reports a number, the honest failure is one that says which tree
+  it measured. Correcting the count and dropping the mid-merge note would have
+  left a second, smaller version of the same defect: a number nobody can place.
+- A shared helper makes the mirror obligation cheap to discharge but easy to
+  under-claim. Asserting each consumer still holds the fixed reference costs six
+  lines and converts "they share it today" into a standing check.

--- a/scripts/ci/cli_exit_contract_ratchet.py
+++ b/scripts/ci/cli_exit_contract_ratchet.py
@@ -98,11 +98,33 @@ def _read(repo_root: Path, relative: str) -> str | None:
 
 
 def uncovered_scripts(repo_root: Path) -> list[str] | None:
-    """Script paths that define ``main`` with no test proving a nonzero exit."""
-    scripts = tracked_files(repo_root, _SCRIPT_GLOBS)
+    """Script paths that define ``main`` with no test proving a nonzero exit.
+
+    Three index reads, and only the first announces. This ratchet is the one
+    consumer that counts from two disjoint scopes rather than one, so the
+    "counting read announces, diagnostic re-read stays silent" split the other
+    five use does not describe it: both scoped reads below are counting reads,
+    and leaving both announcing printed one note per scope for a single run.
+    That is the duplicate output issue #4746 exists to remove, reintroduced at
+    a different shape.
+
+    Passing ``announce_unmerged=False`` to just the second read would be wrong
+    in the other direction: a merge conflicted only under ``tests/`` would then
+    announce nothing at all. So the union of both pathspecs is read first and
+    owns the announcement, and both scoped reads stay silent. One run, one
+    caveat, naming every unmerged path either scope would have counted.
+
+    The union read is also the git-health probe for the pair: git either
+    answers for both scopes or the whole enumeration is unusable, so its None
+    short-circuits before either scoped read runs.
+    """
+    merge_state = tracked_files(repo_root, (*_SCRIPT_GLOBS, *_TEST_GLOBS))
+    if merge_state is None:
+        return None
+    scripts = tracked_files(repo_root, _SCRIPT_GLOBS, announce_unmerged=False)
     if scripts is None:
         return None
-    tests = tracked_files(repo_root, _TEST_GLOBS)
+    tests = tracked_files(repo_root, _TEST_GLOBS, announce_unmerged=False)
     if tests is None:
         return None
 

--- a/scripts/ci/count_ratchet.py
+++ b/scripts/ci/count_ratchet.py
@@ -20,7 +20,9 @@ untracked scratch, nested worktrees, and vendored caches that a contributor
 happens to have on disk, which inflated a local ruff run to 767 against a real
 tracked count of 361 and made that gate report a phantom regression outside CI.
 Tracked files are the only thing a PR can change, so they are the only thing a
-baseline should freeze.
+baseline should freeze. That enumeration lists INDEX ENTRIES, so an unmerged
+path arrives once per merge stage and must be deduplicated before it reaches a
+linter (issue #4746); see ``deduplicate_index_entries``.
 
 The baseline is a committed absolute number, so two branches can each remove one
 violation and write the same lowered value. Git merges the identical one-line
@@ -165,15 +167,106 @@ def _git_rc(repo_root: Path, argv: Sequence[str]) -> int | None:
     return None if proc is None else proc.returncode
 
 
+MAX_NAMED_UNMERGED = 5
+"""How many unmerged paths the mid-merge note lists before summarising.
+
+A merge that conflicts on one file needs the name. A merge that conflicts on
+two hundred needs the count and nothing else, and printing two hundred paths
+above a capped violation list buries the thing the reader came for.
+"""
+
+
+def deduplicate_index_entries(entries: Sequence[str]) -> tuple[list[str], list[str]]:
+    """Split ``git ls-files`` output into unique paths and repeated ones.
+
+    ``git ls-files`` prints one line per INDEX ENTRY, and an unmerged path
+    holds one entry per merge stage. Measured on git 2.43.0 against a scratch
+    repository whose only conflict is ``a.txt``::
+
+        $ git status --porcelain
+        UU a.txt
+        $ git ls-files -z | tr '\\0' '\\n'
+        a.txt
+        a.txt
+        a.txt
+        keep.txt
+        $ git ls-files -u
+        100644 df967b96... 1   a.txt
+        100644 ba2906d0... 2   a.txt
+        100644 c7747099... 3   a.txt
+
+    Handing that list to a linter scans the same file on disk once per stage
+    and counts its violations that many times, so a single conflicted path
+    reports a regression that exists in no tree (issue #4746). Reproduced end
+    to end: a 601-line file conflicted content-versus-content measured 4
+    violations mid-merge against 2 after ``git add`` of byte-identical content,
+    the exact ``+2`` in that issue. Not every conflict has three stages, so the
+    inflation is not a fixed multiple: add/add and the delete/modify pair carry
+    two, which is why this deduplicates rather than dividing by three.
+
+    First occurrence wins and the rest of the order is preserved, so a run over
+    a clean index returns exactly what git printed. That matters because the
+    fix must be a no-op outside a merge: every ratchet in ``scripts/ci`` reads
+    its file list through ``tracked_files``, and a reordering here would move
+    which violations survive the 40-line cap in ``run``.
+
+    The repeated list is what the caller reports, not a separate git call. A
+    duplicate index entry is what an unmerged path IS, so the enumeration
+    already carries the answer.
+    """
+    unique: list[str] = []
+    repeated: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if entry in seen:
+            if entry not in repeated:
+                repeated.append(entry)
+            continue
+        seen.add(entry)
+        unique.append(entry)
+    return unique, repeated
+
+
+def _unmerged_note(paths: Sequence[str]) -> str:
+    """The stderr note naming paths that are unmerged in the index.
+
+    The count is now right, and the reader still needs to know the tree is
+    mid-merge: the linter reads content off disk, so conflict markers left in
+    the working copy add lines and can push a file over a size threshold on
+    their own. Issue #4746 records the cost of a number with no such hint. Its
+    author diffed violation sets against a clean tree, diffed per-file counts,
+    and checked whether test files had crossed 500 lines, because the count and
+    the file list were internally consistent and nothing pointed at the index.
+    """
+    named = ", ".join(paths[:MAX_NAMED_UNMERGED])
+    if len(paths) > MAX_NAMED_UNMERGED:
+        named += f", and {len(paths) - MAX_NAMED_UNMERGED} more"
+    return (
+        f"note: {len(paths)} path(s) unmerged in the index, counted once each "
+        f"rather than once per merge stage: {named}. The count measures the "
+        f"working tree, so any conflict markers still on disk count with it. "
+        f"Finish the merge before trusting this verdict.\n"
+    )
+
+
 def tracked_files(repo_root: Path, globs: Sequence[str]) -> list[str] | None:
-    """Git-tracked paths matching ``globs``, or None when git could not run."""
+    """Git-tracked paths matching ``globs``, or None when git could not run.
+
+    Each path appears once even mid-merge. See ``deduplicate_index_entries``
+    for why git repeats an unmerged one and what that cost (issue #4746).
+    """
     proc = _git_run(repo_root, ["ls-files", "-z", "--", *globs])
     if proc is None:
         return None
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)
         return None
-    return [path for path in proc.stdout.split("\0") if path]
+    unique, unmerged = deduplicate_index_entries(
+        [path for path in proc.stdout.split("\0") if path]
+    )
+    if unmerged:
+        sys.stderr.write(_unmerged_note(unmerged))
+    return unique
 
 
 def _diff_paths(repo_root: Path, spec: str, scope: str) -> frozenset[str]:

--- a/scripts/ci/count_ratchet.py
+++ b/scripts/ci/count_ratchet.py
@@ -249,11 +249,23 @@ def _unmerged_note(paths: Sequence[str]) -> str:
     )
 
 
-def tracked_files(repo_root: Path, globs: Sequence[str]) -> list[str] | None:
+def tracked_files(
+    repo_root: Path, globs: Sequence[str], *, announce_unmerged: bool = True
+) -> list[str] | None:
     """Git-tracked paths matching ``globs``, or None when git could not run.
 
     Each path appears once even mid-merge. See ``deduplicate_index_entries``
     for why git repeats an unmerged one and what that cost (issue #4746).
+
+    ``announce_unmerged=False`` returns the same paths without the mid-merge
+    note. One ratchet run reads the index twice: ``run`` calls the counter,
+    and then on a regression calls the lister, which enumerates again to
+    render the violations. Both reads see the same unmerged index, so both
+    emitted the identical note and a contributor mid-merge read the same
+    caveat twice for one run. The counting read owns the announcement because
+    it happens on every run; the diagnostic re-read passes False because the
+    count already said it. The returned paths are identical either way, so
+    this suppresses an emission and never changes a count.
     """
     proc = _git_run(repo_root, ["ls-files", "-z", "--", *globs])
     if proc is None:
@@ -264,7 +276,7 @@ def tracked_files(repo_root: Path, globs: Sequence[str]) -> list[str] | None:
     unique, unmerged = deduplicate_index_entries(
         [path for path in proc.stdout.split("\0") if path]
     )
-    if unmerged:
+    if unmerged and announce_unmerged:
         sys.stderr.write(_unmerged_note(unmerged))
     return unique
 

--- a/scripts/ci/memory_index_count_ratchet.py
+++ b/scripts/ci/memory_index_count_ratchet.py
@@ -179,9 +179,21 @@ def _warning_lines(repo_root: Path) -> list[str] | None:
     return warnings
 
 
-def _tracked_relative_paths(repo_root: Path) -> set[str] | None:
-    """Tracked memory files as paths relative to the memories directory."""
-    files = tracked_files(repo_root, (f"{_MEMORIES_DIR}/**",))
+def _tracked_relative_paths(
+    repo_root: Path, *, announce_unmerged: bool = True
+) -> set[str] | None:
+    """Tracked memory files as paths relative to the memories directory.
+
+    The set comprehension below already collapsed a path git listed once per
+    merge stage, so this ratchet never double-counted one the way its siblings
+    did (issue #4746). It still reads the shared enumeration, so it still
+    carries the mid-merge note, and ``announce_unmerged`` is threaded through
+    for the reason the other ratchets need it: ``run`` reads the index twice on
+    a regression and the note belongs to the counting read alone.
+    """
+    files = tracked_files(
+        repo_root, (f"{_MEMORIES_DIR}/**",), announce_unmerged=announce_unmerged
+    )
     if files is None:
         return None
     prefix = f"{_MEMORIES_DIR}/"
@@ -213,12 +225,12 @@ def _is_tracked(warning: str, tracked: set[str]) -> bool:
     return _subject(warning) in tracked
 
 
-def _collect(repo_root: Path) -> list[str] | None:
+def _collect(repo_root: Path, *, announce_unmerged: bool = True) -> list[str] | None:
     """Tracked-file warnings from one healthy scan, or None when unusable."""
     warnings = _warning_lines(repo_root)
     if warnings is None:
         return None
-    tracked = _tracked_relative_paths(repo_root)
+    tracked = _tracked_relative_paths(repo_root, announce_unmerged=announce_unmerged)
     if tracked is None:
         return None
     return [w for w in warnings if _is_tracked(w, tracked)]
@@ -242,8 +254,13 @@ def list_violations(
     ``priority_paths`` holds repository-relative paths while a warning names a
     path relative to the memories directory, so the subject is re-prefixed
     before the comparison.
+
+    ``announce_unmerged=False`` because this is the run's second index read.
+    ``run`` calls ``current_count`` before it calls this, and that read already
+    emitted the mid-merge note. Without the suppression a contributor mid-merge
+    saw the identical caveat twice for one regression (issue #4746).
     """
-    warnings = _collect(repo_root)
+    warnings = _collect(repo_root, announce_unmerged=False)
     if warnings is None:
         return None
     hot: list[str] = []

--- a/scripts/ci/taste_count_ratchet.py
+++ b/scripts/ci/taste_count_ratchet.py
@@ -259,8 +259,13 @@ def list_violations(
 
     None means the scan could not be read, which is not the same as a clean
     tree and never renders as one. Every leg that returns it says why.
+
+    ``announce_unmerged=False`` because this is the run's second index read.
+    ``run`` calls ``current_count`` before it calls this, and that read
+    already emitted the mid-merge note. Without the suppression a contributor
+    mid-merge saw the identical caveat twice for one regression (issue #4746).
     """
-    files = tracked_files(repo_root, ("*",))
+    files = tracked_files(repo_root, ("*",), announce_unmerged=False)
     if files is None:
         return None
     if not files:

--- a/tests/ci/test_count_ratchet_unmerged_consumers.py
+++ b/tests/ci/test_count_ratchet_unmerged_consumers.py
@@ -1,0 +1,192 @@
+"""Each ratchet must reach the deduplicating enumeration, and announce once.
+
+Companion to ``test_count_ratchet_unmerged_index.py``, which pins the
+deduplication itself against real git. This module pins the two claims that
+depend on the CONSUMERS rather than on git: that all six ratchets still count
+through ``count_ratchet.tracked_files``, and that one run prints the mid-merge
+note once rather than once per index read (issue #4746).
+
+Split from that module at this seam because the two halves need opposite
+fixtures. Those cases build real repositories and run the real linter; these
+replace the enumeration with a spy and never touch git at all, which is what
+lets them drive all six consumers in under a second.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import (
+    cli_exit_contract_ratchet,
+    memory_index_count_ratchet,
+    ruff_count_ratchet,
+    subprocess_encoding_count_ratchet,
+    taste_count_ratchet,
+    type_ignore_count_ratchet,
+)
+
+
+class _EnumerationSpy:
+    """Stands in for ``tracked_files`` and records that it was reached.
+
+    Asserting that a module still holds the imported name proves only that the
+    import survived: a consumer can stop calling it, keep the unused import,
+    and pass. Driving the real counting entry point with this in place is what
+    the repository's consumer-wiring rule asks for.
+    """
+
+    def __init__(self, result: list[str] | None) -> None:
+        self.result = result
+        self.calls = 0
+        self.announced: list[bool] = []
+
+    def __call__(
+        self, repo_root: Path, globs: Sequence[str], *, announce_unmerged: bool = True
+    ) -> list[str] | None:
+        """Mirrors ``tracked_files``, keyword included, so a caller that passes
+        ``announce_unmerged`` is exercised rather than rejected by the spy."""
+        self.calls += 1
+        self.announced.append(announce_unmerged)
+        return self.result
+
+
+def _stub_memory_tier_validator(monkeypatch) -> None:
+    """Stub the external validator ``memory_index_count_ratchet`` shells out to.
+
+    That module runs the memory-tier validator before it enumerates, and the
+    validator is absent from a scratch root, so the module would bail before
+    reaching the enumeration and the spy would prove nothing. This mocks at the
+    process boundary only, leaving the enumeration on the path under test. The
+    stub warning names a file that the empty enumeration will report untracked,
+    which is what makes the control below land on zero.
+    """
+    monkeypatch.setattr(
+        memory_index_count_ratchet,
+        "_warning_lines",
+        lambda _root: ["a.md: no index references this file"],
+    )
+
+
+_RATCHET_CONSUMERS = [
+    (cli_exit_contract_ratchet, None),
+    (memory_index_count_ratchet, _stub_memory_tier_validator),
+    (ruff_count_ratchet, None),
+    (subprocess_encoding_count_ratchet, None),
+    (taste_count_ratchet, None),
+    (type_ignore_count_ratchet, None),
+]
+
+_CONSUMER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, _ in _RATCHET_CONSUMERS]
+
+
+@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+def test_every_ratchet_counts_through_the_shared_enumeration(
+    module, prepare, monkeypatch, tmp_path
+):
+    """A ratchet that rolls its own ``ls-files`` reopens #4746 for itself.
+
+    The issue asked whether the siblings share the enumeration. They do, which
+    is why one fix covers all six. This drives each consumer's real
+    ``current_count`` and fails the moment one stops routing through the
+    deduplicating helper.
+
+    The unreadable-enumeration verdict is asserted alongside the call, because
+    a consumer that reached the helper and then ignored its ``None`` would be
+    wired and still wrong: each of these modules documents returning None
+    rather than 0 as load-bearing, since a zero from a broken scan reads as a
+    clean tree and ``--update`` would write it into the baseline.
+    """
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy(None)
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    result = module.current_count(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert result is None, f"{module.__name__} reported a count from an unreadable scan"
+
+
+@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+def test_a_readable_enumeration_is_not_reported_as_a_failed_scan(
+    module, prepare, monkeypatch, tmp_path
+):
+    """Control for the case above: the None must come from the enumeration.
+
+    Same consumer, same input, differing only in the condition under test. A
+    module that returned None for an unrelated reason fails here too, so the
+    case above cannot pass for the wrong reason.
+    """
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy([])
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    result = module.current_count(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert result == 0, f"{module.__name__} did not count an empty tree as zero"
+
+
+# ---------------------------------------------------------------------------
+# The note belongs to the counting read, not to the diagnostic re-read (#4746)
+# ---------------------------------------------------------------------------
+
+_LISTER_CONSUMERS = [
+    (memory_index_count_ratchet, _stub_memory_tier_validator),
+    (taste_count_ratchet, None),
+]
+
+_LISTER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, _ in _LISTER_CONSUMERS]
+
+
+@pytest.mark.parametrize(("module", "prepare"), _LISTER_CONSUMERS, ids=_LISTER_IDS)
+def test_the_diagnostic_re_read_does_not_repeat_the_note(
+    module, prepare, monkeypatch, tmp_path
+):
+    """Both listers must enumerate silently, whatever their path to the helper.
+
+    ``taste_count_ratchet`` calls the enumeration straight from its lister;
+    ``memory_index_count_ratchet`` reaches it two frames down, through
+    ``_collect`` and ``_tracked_relative_paths``. The end-to-end case covers
+    the first shape only, because the second needs the external memory-tier
+    validator. This pins both, so a future edit that drops the keyword
+    somewhere along the second path is caught here.
+    """
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy([])
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    module.list_violations(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} lister did not reach the enumeration"
+    assert not any(spy.announced), (
+        f"{module.__name__} lister re-announced the mid-merge note on the "
+        f"run's second index read"
+    )
+
+
+@pytest.mark.parametrize(("module", "prepare"), _LISTER_CONSUMERS, ids=_LISTER_IDS)
+def test_the_counting_read_still_announces(module, prepare, monkeypatch, tmp_path):
+    """Control for the case above: suppression must not have reached the count.
+
+    Same consumer, same input, differing only in which entry point is driven.
+    Silencing both reads would leave a contributor mid-merge with no caveat at
+    all, which is the defect the note exists to prevent, one step further on.
+    """
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy([])
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    module.current_count(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} counter did not reach the enumeration"
+    assert all(spy.announced), (
+        f"{module.__name__} counting read went silent, so a mid-merge run "
+        f"would print no caveat at all"
+    )

--- a/tests/ci/test_count_ratchet_unmerged_consumers.py
+++ b/tests/ci/test_count_ratchet_unmerged_consumers.py
@@ -70,21 +70,31 @@ def _stub_memory_tier_validator(monkeypatch) -> None:
     )
 
 
+# (module, prepare, reads when the first enumeration is unusable, reads when
+# every enumeration is readable). The counts are exact, not lower bounds: a
+# lower bound is satisfied by any one surviving read, so a consumer that
+# dropped one of its scopes for a raw filesystem walk would still have passed.
+# ``cli_exit_contract_ratchet`` is the only two-scope consumer. It reads three
+# times when everything is readable, once over the union of both pathspecs to
+# own the mid-merge announcement and once per scope to partition, and stops
+# after the first when that union read is unusable.
 _RATCHET_CONSUMERS = [
-    (cli_exit_contract_ratchet, None),
-    (memory_index_count_ratchet, _stub_memory_tier_validator),
-    (ruff_count_ratchet, None),
-    (subprocess_encoding_count_ratchet, None),
-    (taste_count_ratchet, None),
-    (type_ignore_count_ratchet, None),
+    (cli_exit_contract_ratchet, None, 1, 3),
+    (memory_index_count_ratchet, _stub_memory_tier_validator, 1, 1),
+    (ruff_count_ratchet, None, 1, 1),
+    (subprocess_encoding_count_ratchet, None, 1, 1),
+    (taste_count_ratchet, None, 1, 1),
+    (type_ignore_count_ratchet, None, 1, 1),
 ]
 
-_CONSUMER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, _ in _RATCHET_CONSUMERS]
+_CONSUMER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, *_ in _RATCHET_CONSUMERS]
+
+_CONSUMER_ARGS = "module, prepare, unusable_reads, readable_reads"
 
 
-@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+@pytest.mark.parametrize(_CONSUMER_ARGS, _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
 def test_every_ratchet_counts_through_the_shared_enumeration(
-    module, prepare, monkeypatch, tmp_path
+    module, prepare, unusable_reads, readable_reads, monkeypatch, tmp_path
 ):
     """A ratchet that rolls its own ``ls-files`` reopens #4746 for itself.
 
@@ -93,12 +103,20 @@ def test_every_ratchet_counts_through_the_shared_enumeration(
     ``current_count`` and fails the moment one stops routing through the
     deduplicating helper.
 
-    The unreadable-enumeration verdict is asserted alongside the call, because
+    The read count is exact so that a consumer dropping ONE of several scopes
+    is caught. ``>= 1`` passed as long as any single read survived, which is
+    the same shape of insufficiency as the identity assertion this test
+    replaced: true of a consumer that is half broken.
+
+    The unreadable-enumeration verdict is asserted alongside the count, because
     a consumer that reached the helper and then ignored its ``None`` would be
     wired and still wrong: each of these modules documents returning None
     rather than 0 as load-bearing, since a zero from a broken scan reads as a
-    clean tree and ``--update`` would write it into the baseline.
+    clean tree and ``--update`` would write it into the baseline. The exact
+    count doubles as the short-circuit proof: a consumer that kept reading
+    after an unusable enumeration exceeds it.
     """
+    del readable_reads  # asserted by the control below
     if prepare is not None:
         prepare(monkeypatch)
     spy = _EnumerationSpy(None)
@@ -106,20 +124,28 @@ def test_every_ratchet_counts_through_the_shared_enumeration(
 
     result = module.current_count(tmp_path)
 
-    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert spy.calls == unusable_reads, (
+        f"{module.__name__} made {spy.calls} enumeration read(s) on an unusable "
+        f"scan, expected {unusable_reads}"
+    )
     assert result is None, f"{module.__name__} reported a count from an unreadable scan"
 
 
-@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+@pytest.mark.parametrize(_CONSUMER_ARGS, _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
 def test_a_readable_enumeration_is_not_reported_as_a_failed_scan(
-    module, prepare, monkeypatch, tmp_path
+    module, prepare, unusable_reads, readable_reads, monkeypatch, tmp_path
 ):
     """Control for the case above: the None must come from the enumeration.
 
     Same consumer, same input, differing only in the condition under test. A
     module that returned None for an unrelated reason fails here too, so the
     case above cannot pass for the wrong reason.
+
+    This is also where every scope a consumer reads is counted, since nothing
+    short-circuits when the enumeration is readable. Dropping one of
+    ``cli_exit_contract_ratchet``'s three reads fails here.
     """
+    del unusable_reads  # asserted by the case above
     if prepare is not None:
         prepare(monkeypatch)
     spy = _EnumerationSpy([])
@@ -127,7 +153,10 @@ def test_a_readable_enumeration_is_not_reported_as_a_failed_scan(
 
     result = module.current_count(tmp_path)
 
-    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert spy.calls == readable_reads, (
+        f"{module.__name__} made {spy.calls} enumeration read(s), expected "
+        f"{readable_reads}: a scope was added or dropped"
+    )
     assert result == 0, f"{module.__name__} did not count an empty tree as zero"
 
 

--- a/tests/ci/test_count_ratchet_unmerged_index.py
+++ b/tests/ci/test_count_ratchet_unmerged_index.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci import count_ratchet, taste_count_ratchet
+from scripts.ci import cli_exit_contract_ratchet, count_ratchet, taste_count_ratchet
 from tests.ci.count_ratchet_git_harness import commit_all as _commit_all
 from tests.ci.count_ratchet_git_harness import git as _git
 from tests.ci.count_ratchet_git_harness import init_repo as _init_repo
@@ -344,3 +344,58 @@ def test_one_run_prints_the_mid_merge_note_once(tmp_path, capsys):
     assert err.count("unmerged in the index") == 1, (
         f"the mid-merge note was printed {err.count('unmerged in the index')} times"
     )
+
+
+def _conflict(repo: Path, relative: str, body: str) -> None:
+    """Leave ``relative`` unmerged in the index, resolved on disk."""
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# base\n{body}", encoding="utf-8")
+
+
+@needs_git
+def test_two_counting_scopes_still_print_one_note(tmp_path, capsys):
+    """The two-scope consumer announces once, naming paths from both scopes.
+
+    ``cli_exit_contract_ratchet`` counts from two disjoint pathspecs,
+    ``scripts/ci/*.py`` and ``tests/**/*.py``, so it has two counting reads
+    rather than one. Leaving both announcing printed a separate note per scope
+    for a single run, which is the duplicate output #4746 exists to remove at
+    a different shape. Silencing only the second would be wrong the other way:
+    a conflict confined to ``tests/`` would then announce nothing.
+
+    Both scopes carry a conflict here, so a fix that suppresses the wrong read
+    fails this on the path list rather than only on the count.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _conflict(repo, "scripts/ci/a.py", "x = 1\n")
+    _conflict(repo, "tests/test_b.py", "y = 1\n")
+    _commit_all(repo, "base")
+
+    _git(repo, "checkout", "-q", "-b", "feat")
+    _conflict(repo, "scripts/ci/a.py", "x = 2\n")
+    _conflict(repo, "tests/test_b.py", "y = 2\n")
+    _commit_all(repo, "feat")
+
+    _git(repo, "checkout", "-q", "main")
+    _conflict(repo, "scripts/ci/a.py", "x = 3\n")
+    _conflict(repo, "tests/test_b.py", "y = 3\n")
+    _commit_all(repo, "main")
+
+    assert _git(repo, "merge", "feat").returncode != 0, "the fixture must stop conflicted"
+    unmerged = _git(repo, "ls-files", "-u").stdout
+    assert "scripts/ci/a.py" in unmerged and "tests/test_b.py" in unmerged, (
+        "the fixture must leave a conflict in BOTH counting scopes"
+    )
+
+    result = cli_exit_contract_ratchet.uncovered_scripts(repo)
+
+    err = capsys.readouterr().err
+    assert result is not None, "the enumeration must still succeed mid-merge"
+    assert err.count("unmerged in the index") == 1, (
+        f"one run printed the mid-merge note {err.count('unmerged in the index')} times"
+    )
+    assert "scripts/ci/a.py" in err, "the note dropped the script scope"
+    assert "tests/test_b.py" in err, "the note dropped the test scope"

--- a/tests/ci/test_count_ratchet_unmerged_index.py
+++ b/tests/ci/test_count_ratchet_unmerged_index.py
@@ -1,0 +1,336 @@
+"""A conflicted path must be counted once, not once per merge stage (#4746).
+
+``git ls-files`` prints one line per index entry, and an unmerged path holds
+one entry per merge stage. Every ratchet under ``scripts/ci`` enumerates
+through ``count_ratchet.tracked_files``, so mid-merge each of them handed its
+linter the same path two or three times and counted its violations that many
+times. The reported symptom was ``585 violations > baseline 583 (+2)`` on a
+tree whose only conflicted file was byte-identical to ``origin/main``.
+
+Git is the boundary under test here, so it is not mocked. The end-to-end case
+also drives the real taste linter, because the defect lives in the seam between
+the enumeration and the scan and a fake counter cannot show it.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import (
+    cli_exit_contract_ratchet,
+    count_ratchet,
+    memory_index_count_ratchet,
+    ruff_count_ratchet,
+    subprocess_encoding_count_ratchet,
+    taste_count_ratchet,
+    type_ignore_count_ratchet,
+)
+from tests.ci.count_ratchet_git_harness import commit_all as _commit_all
+from tests.ci.count_ratchet_git_harness import git as _git
+from tests.ci.count_ratchet_git_harness import init_repo as _init_repo
+
+needs_git = pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
+
+_LINTER_RELATIVE = Path(".claude/skills/taste-lints/scripts/taste_lints.py")
+
+
+# ---------------------------------------------------------------------------
+# deduplicate_index_entries: the pure half, no git required
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_enumeration_is_returned_unchanged():
+    """The no-op case. Outside a merge this fix must change nothing at all."""
+    entries = ["b.py", "a.py", "nested/c.py"]
+
+    unique, unmerged = count_ratchet.deduplicate_index_entries(entries)
+
+    assert unique == entries
+    assert unmerged == []
+
+
+def test_a_three_stage_conflict_collapses_to_one_path():
+    """The reported shape: content-versus-content, stages 1, 2 and 3."""
+    entries = ["a.py", "big.py", "big.py", "big.py", "z.py"]
+
+    unique, unmerged = count_ratchet.deduplicate_index_entries(entries)
+
+    assert unique == ["a.py", "big.py", "z.py"]
+    assert unmerged == ["big.py"]
+
+
+def test_a_two_stage_conflict_collapses_too():
+    """Add/add and delete/modify carry two stages, not three.
+
+    The inflation is therefore not a fixed multiple, which is why the fix
+    deduplicates instead of dividing the count by three.
+    """
+    unique, unmerged = count_ratchet.deduplicate_index_entries(["a.py", "a.py", "b.py"])
+
+    assert unique == ["a.py", "b.py"]
+    assert unmerged == ["a.py"]
+
+
+def test_an_empty_enumeration_reports_nothing():
+    """An empty index is not a conflict and must not read as one."""
+    assert count_ratchet.deduplicate_index_entries([]) == ([], [])
+
+
+def test_first_occurrence_wins_and_the_rest_of_the_order_survives():
+    """Order is load-bearing: ``run`` caps the printed violation list at 40.
+
+    A reordering here would silently change which violations a contributor
+    sees on a regression, so the surviving order must be the order git printed.
+    """
+    entries = ["z.py", "m.py", "z.py", "a.py", "m.py", "z.py"]
+
+    unique, unmerged = count_ratchet.deduplicate_index_entries(entries)
+
+    assert unique == ["z.py", "m.py", "a.py"]
+    assert unmerged == ["z.py", "m.py"]
+
+
+def test_each_conflicted_path_is_reported_once_however_many_stages_it_has():
+    """Three stages must not report the same path three times in the note."""
+    _, unmerged = count_ratchet.deduplicate_index_entries(["a.py"] * 3 + ["b.py"] * 3)
+
+    assert unmerged == ["a.py", "b.py"]
+
+
+# ---------------------------------------------------------------------------
+# The mid-merge note
+# ---------------------------------------------------------------------------
+
+
+def test_the_note_names_the_conflicted_path_and_the_working_tree_caveat():
+    """The count is right now; the reader still has to know the tree is mid-merge.
+
+    Conflict markers left on disk add lines, so a file can cross a size
+    threshold on their own, and the issue records the detour a bare number cost.
+    """
+    note = count_ratchet._unmerged_note(["tests/build_scripts/test_x.py"])
+
+    assert "1 path(s) unmerged in the index" in note
+    assert "tests/build_scripts/test_x.py" in note
+    assert "measures the working tree" in note
+    assert note.endswith("\n")
+
+
+def test_a_large_conflict_is_summarised_rather_than_listed():
+    """Two hundred paths above a 40-line violation cap buries the payload."""
+    paths = [f"f{index}.py" for index in range(9)]
+
+    note = count_ratchet._unmerged_note(paths)
+
+    assert "9 path(s) unmerged" in note
+    assert "f0.py" in note
+    assert "f4.py" in note
+    assert "f5.py" not in note
+    assert f"and {9 - count_ratchet.MAX_NAMED_UNMERGED} more" in note
+
+
+# ---------------------------------------------------------------------------
+# tracked_files, against real git
+# ---------------------------------------------------------------------------
+
+
+def _conflicted_repo(repo: Path, *, same_base: bool = True) -> None:
+    """A repository stopped mid-merge with ``a.txt`` unmerged.
+
+    ``same_base=False`` builds an add/add conflict, which git records with two
+    stages instead of three.
+    """
+    _init_repo(repo)
+    (repo / "keep.txt").write_text("keep\n", encoding="utf-8")
+    if same_base:
+        (repo / "a.txt").write_text("base\n", encoding="utf-8")
+    _commit_all(repo, "base")
+
+    _git(repo, "checkout", "-q", "-b", "feat")
+    (repo / "a.txt").write_text("feat\n", encoding="utf-8")
+    _commit_all(repo, "feat")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "a.txt").write_text("main\n", encoding="utf-8")
+    _commit_all(repo, "main")
+
+    merged = _git(repo, "merge", "feat")
+    assert merged.returncode != 0, "the fixture must stop in a conflicted state"
+
+
+@needs_git
+def test_git_repeats_an_unmerged_path_once_per_stage(tmp_path):
+    """Pin the git behavior itself, so the fix is not aimed at a guess.
+
+    Without this, a git release that stopped repeating unmerged entries would
+    leave the deduplication passing its own tests while guarding nothing.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _conflicted_repo(repo)
+
+    listed = _git(repo, "ls-files", "-z").stdout.split("\0")
+
+    assert [path for path in listed if path].count("a.txt") == 3
+
+
+@needs_git
+def test_tracked_files_lists_a_conflicted_path_once(tmp_path, capsys):
+    """The fix at the seam every ratchet reads through."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _conflicted_repo(repo)
+
+    files = count_ratchet.tracked_files(repo, ("*",))
+
+    assert files is not None
+    assert files.count("a.txt") == 1
+    assert "keep.txt" in files
+    assert "unmerged in the index" in capsys.readouterr().err
+
+
+@needs_git
+def test_tracked_files_lists_a_two_stage_conflict_once(tmp_path, capsys):
+    """An add/add conflict has no stage 1 and must collapse the same way."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _conflicted_repo(repo, same_base=False)
+
+    files = count_ratchet.tracked_files(repo, ("*",))
+
+    assert files is not None
+    assert files.count("a.txt") == 1
+    assert "unmerged in the index" in capsys.readouterr().err
+
+
+@needs_git
+def test_a_clean_tree_lists_every_path_once_and_says_nothing(tmp_path, capsys):
+    """Negative control for the note: no merge, no message.
+
+    Without this the note could fire on every run and the assertions above
+    would still pass.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "a.txt").write_text("a\n", encoding="utf-8")
+    (repo / "b.txt").write_text("b\n", encoding="utf-8")
+    _commit_all(repo, "clean")
+
+    files = count_ratchet.tracked_files(repo, ("*",))
+
+    assert sorted(files or []) == ["a.txt", "b.txt"]
+    assert capsys.readouterr().err == ""
+
+
+@needs_git
+def test_a_resolved_merge_lists_every_path_once_and_says_nothing(tmp_path, capsys):
+    """Staging the resolution is what cleared the symptom in the report.
+
+    The count must already match before that ``git add``, and the note must
+    stop once the index is merged.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _conflicted_repo(repo)
+    (repo / "a.txt").write_text("resolved\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+
+    files = count_ratchet.tracked_files(repo, ("*",))
+
+    assert sorted(files or []) == ["a.txt", "keep.txt"]
+    assert capsys.readouterr().err == ""
+
+
+# ---------------------------------------------------------------------------
+# End to end: the reported ratchet, the real linter (#4746)
+# ---------------------------------------------------------------------------
+
+
+def _install_linter(repo: Path) -> None:
+    """Copy the taste linter into ``repo`` at the path the ratchet expects.
+
+    ``taste_count_ratchet`` runs the linter as ``cwd=repo_root`` plus a
+    repo-relative path, so a scratch repository needs its own copy. The linter
+    is a single stdlib-only file, so copying it introduces no import graph.
+    """
+    source = Path(__file__).resolve().parents[2] / _LINTER_RELATIVE
+    assert source.is_file(), f"the taste linter moved: {source}"
+    destination = repo / _LINTER_RELATIVE
+    destination.parent.mkdir(parents=True)
+    shutil.copy(source, destination)
+
+
+def _oversized(marker: str) -> str:
+    """A file over the 500-line ``file-size`` ceiling, differing by one line."""
+    return f"# {marker}\n" + "".join(f"x{index} = {index}\n" for index in range(600))
+
+
+@needs_git
+def test_a_conflicted_file_counts_the_same_as_the_tree_it_resolves_to(tmp_path):
+    """The issue's reproduction, asserted end to end.
+
+    Content is identical either side of the ``git add``, so any difference in
+    the count comes from the index alone. Before the fix this measured 4
+    against 2: one violation for the linter's own copy plus three for the
+    conflicted file, the ``+2`` the issue reports.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _install_linter(repo)
+    big = repo / "big.py"
+    big.write_text(_oversized("base"), encoding="utf-8")
+    _commit_all(repo, "base")
+
+    _git(repo, "checkout", "-q", "-b", "feat")
+    big.write_text(_oversized("feat"), encoding="utf-8")
+    _commit_all(repo, "feat")
+
+    _git(repo, "checkout", "-q", "main")
+    big.write_text(_oversized("main"), encoding="utf-8")
+    _commit_all(repo, "main")
+
+    assert _git(repo, "merge", "feat").returncode != 0
+    # Resolve on disk only, leaving the index unmerged. The bytes below are the
+    # bytes that get staged, so the two measurements see identical content.
+    resolution = _oversized("main")
+    big.write_text(resolution, encoding="utf-8")
+
+    mid_merge = taste_count_ratchet.current_count(repo)
+
+    _git(repo, "add", "big.py")
+    assert big.read_text(encoding="utf-8") == resolution
+    resolved = taste_count_ratchet.current_count(repo)
+
+    assert mid_merge == resolved
+    assert resolved is not None and resolved > 0, "the fixture must carry a violation"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the fix only helps a ratchet that reads through the fixed seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        cli_exit_contract_ratchet,
+        memory_index_count_ratchet,
+        ruff_count_ratchet,
+        subprocess_encoding_count_ratchet,
+        taste_count_ratchet,
+        type_ignore_count_ratchet,
+    ],
+    ids=lambda module: module.__name__.rsplit(".", 1)[-1],
+)
+def test_every_ratchet_enumerates_through_the_shared_helper(module):
+    """A ratchet that rolls its own ``ls-files`` reopens #4746 for itself.
+
+    The issue asked whether the siblings share the enumeration. They do, which
+    is why one fix covers all six. This fails the moment one stops sharing it.
+    """
+    assert module.tracked_files is count_ratchet.tracked_files

--- a/tests/ci/test_count_ratchet_unmerged_index.py
+++ b/tests/ci/test_count_ratchet_unmerged_index.py
@@ -15,6 +15,7 @@ the enumeration and the scan and a fake counter cannot show it.
 from __future__ import annotations
 
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -315,22 +316,97 @@ def test_a_conflicted_file_counts_the_same_as_the_tree_it_resolves_to(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "module",
-    [
-        cli_exit_contract_ratchet,
+class _EnumerationSpy:
+    """Stands in for ``tracked_files`` and records that it was reached.
+
+    Asserting that a module still holds the imported name proves only that the
+    import survived: a consumer can stop calling it, keep the unused import,
+    and pass. Driving the real counting entry point with this in place is what
+    the repository's consumer-wiring rule asks for.
+    """
+
+    def __init__(self, result: list[str] | None) -> None:
+        self.result = result
+        self.calls = 0
+
+    def __call__(self, repo_root: Path, globs: Sequence[str]) -> list[str] | None:
+        self.calls += 1
+        return self.result
+
+
+def _stub_memory_tier_validator(monkeypatch) -> None:
+    """Stub the external validator ``memory_index_count_ratchet`` shells out to.
+
+    That module runs the memory-tier validator before it enumerates, and the
+    validator is absent from a scratch root, so the module would bail before
+    reaching the enumeration and the spy would prove nothing. This mocks at the
+    process boundary only, leaving the enumeration on the path under test. The
+    stub warning names a file that the empty enumeration will report untracked,
+    which is what makes the control below land on zero.
+    """
+    monkeypatch.setattr(
         memory_index_count_ratchet,
-        ruff_count_ratchet,
-        subprocess_encoding_count_ratchet,
-        taste_count_ratchet,
-        type_ignore_count_ratchet,
-    ],
-    ids=lambda module: module.__name__.rsplit(".", 1)[-1],
-)
-def test_every_ratchet_enumerates_through_the_shared_helper(module):
+        "_warning_lines",
+        lambda _root: ["a.md: no index references this file"],
+    )
+
+
+_RATCHET_CONSUMERS = [
+    (cli_exit_contract_ratchet, None),
+    (memory_index_count_ratchet, _stub_memory_tier_validator),
+    (ruff_count_ratchet, None),
+    (subprocess_encoding_count_ratchet, None),
+    (taste_count_ratchet, None),
+    (type_ignore_count_ratchet, None),
+]
+
+_CONSUMER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, _ in _RATCHET_CONSUMERS]
+
+
+@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+def test_every_ratchet_counts_through_the_shared_enumeration(
+    module, prepare, monkeypatch, tmp_path
+):
     """A ratchet that rolls its own ``ls-files`` reopens #4746 for itself.
 
     The issue asked whether the siblings share the enumeration. They do, which
-    is why one fix covers all six. This fails the moment one stops sharing it.
+    is why one fix covers all six. This drives each consumer's real
+    ``current_count`` and fails the moment one stops routing through the
+    deduplicating helper.
+
+    The unreadable-enumeration verdict is asserted alongside the call, because
+    a consumer that reached the helper and then ignored its ``None`` would be
+    wired and still wrong: each of these modules documents returning None
+    rather than 0 as load-bearing, since a zero from a broken scan reads as a
+    clean tree and ``--update`` would write it into the baseline.
     """
-    assert module.tracked_files is count_ratchet.tracked_files
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy(None)
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    result = module.current_count(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert result is None, f"{module.__name__} reported a count from an unreadable scan"
+
+
+@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
+def test_a_readable_enumeration_is_not_reported_as_a_failed_scan(
+    module, prepare, monkeypatch, tmp_path
+):
+    """Control for the case above: the None must come from the enumeration.
+
+    Same consumer, same input, differing only in the condition under test. A
+    module that returned None for an unrelated reason fails here too, so the
+    case above cannot pass for the wrong reason.
+    """
+    if prepare is not None:
+        prepare(monkeypatch)
+    spy = _EnumerationSpy([])
+    monkeypatch.setattr(module, "tracked_files", spy)
+
+    result = module.current_count(tmp_path)
+
+    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
+    assert result == 0, f"{module.__name__} did not count an empty tree as zero"

--- a/tests/ci/test_count_ratchet_unmerged_index.py
+++ b/tests/ci/test_count_ratchet_unmerged_index.py
@@ -1,11 +1,17 @@
 """A conflicted path must be counted once, not once per merge stage (#4746).
 
 ``git ls-files`` prints one line per index entry, and an unmerged path holds
-one entry per merge stage. Every ratchet under ``scripts/ci`` enumerates
-through ``count_ratchet.tracked_files``, so mid-merge each of them handed its
-linter the same path two or three times and counted its violations that many
-times. The reported symptom was ``585 violations > baseline 583 (+2)`` on a
-tree whose only conflicted file was byte-identical to ``origin/main``.
+one entry per merge stage. All six ratchets under ``scripts/ci`` enumerate
+through ``count_ratchet.tracked_files``, so mid-merge each was handed the same
+path two or three times. Five of them then counted its violations that many
+times. The memory-index ratchet did not: its ``_tracked_relative_paths``
+builds a set, so the repeats collapsed before anything counted them. The
+reported symptom was ``585 violations > baseline 583 (+2)`` on a tree whose
+only conflicted file was byte-identical to ``origin/main``.
+
+Fixing the shared enumeration still covers the immune consumer, because it
+reads the index like the rest and so carries the mid-merge note. That note is
+a reporting concern, not a counting one.
 
 Git is the boundary under test here, so it is not mocked. The end-to-end case
 also drives the real taste linter, because the defect lives in the seam between
@@ -15,20 +21,11 @@ the enumeration and the scan and a fake counter cannot show it.
 from __future__ import annotations
 
 import shutil
-from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
-from scripts.ci import (
-    cli_exit_contract_ratchet,
-    count_ratchet,
-    memory_index_count_ratchet,
-    ruff_count_ratchet,
-    subprocess_encoding_count_ratchet,
-    taste_count_ratchet,
-    type_ignore_count_ratchet,
-)
+from scripts.ci import count_ratchet, taste_count_ratchet
 from tests.ci.count_ratchet_git_harness import commit_all as _commit_all
 from tests.ci.count_ratchet_git_harness import git as _git
 from tests.ci.count_ratchet_git_harness import init_repo as _init_repo
@@ -270,14 +267,11 @@ def _oversized(marker: str) -> str:
     return f"# {marker}\n" + "".join(f"x{index} = {index}\n" for index in range(600))
 
 
-@needs_git
-def test_a_conflicted_file_counts_the_same_as_the_tree_it_resolves_to(tmp_path):
-    """The issue's reproduction, asserted end to end.
+def _taste_repo_stopped_mid_merge(tmp_path: Path) -> tuple[Path, str]:
+    """A repo mid-merge on an oversized file, resolved on disk but not staged.
 
-    Content is identical either side of the ``git add``, so any difference in
-    the count comes from the index alone. Before the fix this measured 4
-    against 2: one violation for the linter's own copy plus three for the
-    conflicted file, the ``+2`` the issue reports.
+    Returns the repo and the exact bytes on disk, so a caller that stages the
+    resolution can prove the two measurements saw identical content.
     """
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -295,118 +289,58 @@ def test_a_conflicted_file_counts_the_same_as_the_tree_it_resolves_to(tmp_path):
     big.write_text(_oversized("main"), encoding="utf-8")
     _commit_all(repo, "main")
 
-    assert _git(repo, "merge", "feat").returncode != 0
-    # Resolve on disk only, leaving the index unmerged. The bytes below are the
-    # bytes that get staged, so the two measurements see identical content.
+    assert _git(repo, "merge", "feat").returncode != 0, "the fixture must stop conflicted"
     resolution = _oversized("main")
     big.write_text(resolution, encoding="utf-8")
+    return repo, resolution
+
+
+@needs_git
+def test_a_conflicted_file_counts_the_same_as_the_tree_it_resolves_to(tmp_path):
+    """The issue's reproduction, asserted end to end.
+
+    Content is identical either side of the ``git add``, so any difference in
+    the count comes from the index alone. Before the fix this measured 4
+    against 2: one violation for the linter's own copy plus three for the
+    conflicted file, the ``+2`` the issue reports.
+    """
+    repo, resolution = _taste_repo_stopped_mid_merge(tmp_path)
 
     mid_merge = taste_count_ratchet.current_count(repo)
 
     _git(repo, "add", "big.py")
-    assert big.read_text(encoding="utf-8") == resolution
+    assert (repo / "big.py").read_text(encoding="utf-8") == resolution
     resolved = taste_count_ratchet.current_count(repo)
 
     assert mid_merge == resolved
     assert resolved is not None and resolved > 0, "the fixture must carry a violation"
 
 
-# ---------------------------------------------------------------------------
-# Wiring: the fix only helps a ratchet that reads through the fixed seam
-# ---------------------------------------------------------------------------
+@needs_git
+def test_one_run_prints_the_mid_merge_note_once(tmp_path, capsys):
+    """A regression reads the index twice; the caveat is still printed once.
 
+    ``run`` calls the counter, then on a regression calls the lister to render
+    the violations, and the lister enumerates again. Both reads see the same
+    unmerged index, so both emitted the identical note and a contributor
+    mid-merge read the same caveat twice for one run.
 
-class _EnumerationSpy:
-    """Stands in for ``tracked_files`` and records that it was reached.
-
-    Asserting that a module still holds the imported name proves only that the
-    import survived: a consumer can stop calling it, keep the unused import,
-    and pass. Driving the real counting entry point with this in place is what
-    the repository's consumer-wiring rule asks for.
+    Driven through ``main`` rather than the helpers, because the double
+    emission only exists in the sequence ``run`` performs. The violations
+    header is asserted so the lister is known to have run: without that this
+    would pass just as well if the second read never happened at all.
     """
+    repo, _ = _taste_repo_stopped_mid_merge(tmp_path)
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("0\n", encoding="utf-8")
 
-    def __init__(self, result: list[str] | None) -> None:
-        self.result = result
-        self.calls = 0
-
-    def __call__(self, repo_root: Path, globs: Sequence[str]) -> list[str] | None:
-        self.calls += 1
-        return self.result
-
-
-def _stub_memory_tier_validator(monkeypatch) -> None:
-    """Stub the external validator ``memory_index_count_ratchet`` shells out to.
-
-    That module runs the memory-tier validator before it enumerates, and the
-    validator is absent from a scratch root, so the module would bail before
-    reaching the enumeration and the spy would prove nothing. This mocks at the
-    process boundary only, leaving the enumeration on the path under test. The
-    stub warning names a file that the empty enumeration will report untracked,
-    which is what makes the control below land on zero.
-    """
-    monkeypatch.setattr(
-        memory_index_count_ratchet,
-        "_warning_lines",
-        lambda _root: ["a.md: no index references this file"],
+    rc = taste_count_ratchet.main(
+        ["--repo-root", str(repo), "--baseline", str(baseline)]
     )
 
-
-_RATCHET_CONSUMERS = [
-    (cli_exit_contract_ratchet, None),
-    (memory_index_count_ratchet, _stub_memory_tier_validator),
-    (ruff_count_ratchet, None),
-    (subprocess_encoding_count_ratchet, None),
-    (taste_count_ratchet, None),
-    (type_ignore_count_ratchet, None),
-]
-
-_CONSUMER_IDS = [module.__name__.rsplit(".", 1)[-1] for module, _ in _RATCHET_CONSUMERS]
-
-
-@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
-def test_every_ratchet_counts_through_the_shared_enumeration(
-    module, prepare, monkeypatch, tmp_path
-):
-    """A ratchet that rolls its own ``ls-files`` reopens #4746 for itself.
-
-    The issue asked whether the siblings share the enumeration. They do, which
-    is why one fix covers all six. This drives each consumer's real
-    ``current_count`` and fails the moment one stops routing through the
-    deduplicating helper.
-
-    The unreadable-enumeration verdict is asserted alongside the call, because
-    a consumer that reached the helper and then ignored its ``None`` would be
-    wired and still wrong: each of these modules documents returning None
-    rather than 0 as load-bearing, since a zero from a broken scan reads as a
-    clean tree and ``--update`` would write it into the baseline.
-    """
-    if prepare is not None:
-        prepare(monkeypatch)
-    spy = _EnumerationSpy(None)
-    monkeypatch.setattr(module, "tracked_files", spy)
-
-    result = module.current_count(tmp_path)
-
-    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
-    assert result is None, f"{module.__name__} reported a count from an unreadable scan"
-
-
-@pytest.mark.parametrize(("module", "prepare"), _RATCHET_CONSUMERS, ids=_CONSUMER_IDS)
-def test_a_readable_enumeration_is_not_reported_as_a_failed_scan(
-    module, prepare, monkeypatch, tmp_path
-):
-    """Control for the case above: the None must come from the enumeration.
-
-    Same consumer, same input, differing only in the condition under test. A
-    module that returned None for an unrelated reason fails here too, so the
-    case above cannot pass for the wrong reason.
-    """
-    if prepare is not None:
-        prepare(monkeypatch)
-    spy = _EnumerationSpy([])
-    monkeypatch.setattr(module, "tracked_files", spy)
-
-    result = module.current_count(tmp_path)
-
-    assert spy.calls >= 1, f"{module.__name__} did not reach the shared enumeration"
-    assert result == 0, f"{module.__name__} did not count an empty tree as zero"
+    err = capsys.readouterr().err
+    assert rc == count_ratchet.EXIT_REGRESSION, "the fixture must trip the ratchet"
+    assert "Current violations:" in err, "the lister did not run, so nothing re-read"
+    assert err.count("unmerged in the index") == 1, (
+        f"the mid-merge note was printed {err.count('unmerged in the index')} times"
+    )


### PR DESCRIPTION
# Pull Request

## Summary

### What

Deduplicate the git enumeration every count ratchet reads through, so a path that is unmerged in the index is counted once instead of once per merge stage. The mid-merge caveat is announced exactly once per run.

### Why

git ls-files prints one line per index entry, and an unmerged path holds one entry per merge stage. The shared helper returned that raw list, so during a merge each ratchet was handed the same conflicted path two or three times.

The reporter saw `585 violations > baseline 583 (+2)` on a branch whose only conflicted file was byte-identical to `origin/main`, and `git add` of unchanged content cleared it. The number was real-looking and pointed at the wrong thing: the count and the printed violation list were internally consistent, so nothing in the output suggested the index. It fires exactly when someone is mid-merge and least able to tell an artifact from a regression, which is what turned a two-line defect into a substantial diagnostic detour.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #4746 | taste ratchet counts a conflicted file once per merge stage, reporting a regression that exists in no tree |

## Changes

- `scripts/ci/count_ratchet.py`: add `deduplicate_index_entries`, splitting a git enumeration into unique paths and repeated ones, first occurrence and original order preserved. `tracked_files` returns the unique list, writes a note naming the unmerged paths (capped at five), and takes an `announce_unmerged` keyword.
- `scripts/ci/taste_count_ratchet.py`: the lister enumerates silently.
- `scripts/ci/memory_index_count_ratchet.py`: same, threaded through `_collect` and `_tracked_relative_paths`.
- `scripts/ci/cli_exit_contract_ratchet.py`: the two-scope consumer reads the union of both pathspecs first to own the announcement, then both scopes silently.
- `tests/ci/test_count_ratchet_unmerged_index.py`: the pure split, the note, real-git enumeration, the end-to-end reproduction against the real linter, and the two-scope once-only case.
- `tests/ci/test_count_ratchet_unmerged_consumers.py`: spy-driven consumer wiring with exact per-consumer read counts, and note ownership.
- `.agents/retrospective/2026-09-01-issue-4746-unmerged-index-entries.md`: session record, with failure-mode classification, an owned remediation table, and three dated correction sections.

### Design notes

**Deduplicate rather than divide.** The reported case had three stages, but add/add and delete/modify carry two, so the inflation is not a fixed multiple.

**Order is preserved.** The 40-line violation cap in `run` means a reordering would silently change which violations a contributor sees on a regression, so the surviving order is the order git printed. Outside a merge the helper returns exactly what it returned before.

**The note stays after the count is fixed.** The linter reads content off disk, so conflict markers left in the working copy add lines and can push a file over a size threshold on their own. A count taken mid-merge deserves the caveat.

**One run announces once, and the owner depends on the consumer's shape.** Five ratchets have a single counting read plus, on a regression, a diagnostic re-read; there the counting read announces and the re-read stays silent. `cli_exit_contract_ratchet` has two counting reads over disjoint scopes, so neither is "the" one: it reads the union of both pathspecs first, gives that read the announcement, and silences both scoped reads. Silencing only the second would be wrong the other way, since a conflict confined to `tests/` would announce nothing at all.

### Scope: which ratchets were affected

All six enumerate through the shared seam, so the fix covers all six. Five double-counted: the taste, ruff, type-ignore and subprocess-encoding counters pass the list straight through, and the CLI exit-contract counter appends per occurrence. The memory-index ratchet did not, because `_tracked_relative_paths` builds a set and the repeats collapsed before anything counted them. It still reads the index, so it still carries the mid-merge note, which is a reporting concern rather than a counting one.

## Acceptance criteria

- [x] A path unmerged in the index is enumerated once, for both three-stage and two-stage conflicts
- [x] The count taken mid-merge equals the count taken after staging byte-identical content
- [x] A clean tree and a resolved merge are unchanged and emit no note
- [x] The mid-merge note names the unmerged paths and states that the count measures the working tree
- [x] One run prints the note exactly once, for a single-scope consumer reading the index twice and for a two-scope consumer with a conflict in each scope
- [x] All six ratchets are covered, with exact per-consumer read counts so dropping one of several scopes fails
- [x] Reverting each fix turns its paired tests red (negative controls below)

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the two-scope announcement. I read the union of both pathspecs as a third enumeration rather than carrying run-scoped announcement state, because that state would be module-level mutable data shared by six consumers and the whole test suite, buying test-order coupling to save one `ls-files`. Push back if you would rather pay the state.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

### Reproduction, before the fix

A scratch repository with a 601-line file conflicted content-versus-content, resolved on disk but not staged:

```
merge: CONFLICT (content): Merge conflict in big.py
status: UU big.py
count with unmerged index: 4
count after git add     : 2
MISMATCH
```

4 against 2 with byte-identical content on both measurements. The decomposition is 1 for the linter's own copy plus 3 for the conflicted file, which is the `+2` the issue reports. After the fix: 2 and 2.

### Negative control 1, the count

| Run | Result |
|---|---|
| Fix present | 20 passed |
| Fix reverted | 3 failed, 17 passed |
| Fix restored | 20 passed |

Failures: `assert 3 == 1` and `assert 2 == 1` on the three-stage and two-stage enumerations, `assert 4 == 2` end-to-end.

### Negative control 2, the consumer-wiring test

Round 1 found the first wiring test asserted identity on an imported name. One consumer was rewritten to `rglob`, its import left in place:

```
old identity assertion under the mutation: True
```

The replacement failed both of that consumer's cases. Restore byte-identical, 26 green.

### Negative control 3, the duplicate note

| Run | Result |
|---|---|
| Fix present | 31 passed |
| Fix reverted | 3 failed, 28 passed |
| Fix restored | 31 passed |

Failures: the end-to-end once-only assertion plus one lister case per module.

### Negative control 4, the two-scope note

Fixture carries a conflict in both scopes, asserted via `git ls-files -u` so it cannot silently degrade to one. Reverting to two independent announcing reads:

```
E   AssertionError: one run printed the mid-merge note 2 times
```

The test also asserts both scopes' paths appear in the note, so a fix that silences the wrong read fails on the path list, not only on the count.

### Negative control 5, the exact read counts

Run in two halves against the same mutation, with the tests scope switched to a raw `rglob` walk:

```
# exact assertion
E   AssertionError: scripts.ci.cli_exit_contract_ratchet made 2 enumeration read(s), expected 3
1 failed, 15 passed

# same mutation, assertion loosened back to >= 1
16 passed
```

The lower bound demonstrably could not see the defect.

### Gates

- pytest over the whole ci test directory: 2682 passed, 12 skipped
- the canonical pre-PR runner: RESULT: All validations passed
- ruff over the changed trees: All checks passed
- mypy over the changed modules: Success, no issues found
- Pre-push suite green on all four pushes, including count-ratchets, python-tests, and pre-pr-validation. No hook bypass.
- Baselines unchanged. All six ratchets: ruff `OK (count == baseline 0)`, type-ignore `OK (count == baseline 44)`, memory index `OK. 377 <= baseline 378`, subprocess encoding `OK (count == baseline 238)`, cli exit contract `OK (count == baseline 18)`, taste `OK (count == baseline 575)`.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The change is confined to how a git enumeration is deduplicated and reported before it reaches a linter. No new subprocess arguments, no path construction from untrusted input, no auth or secret handling. The paths it deduplicates come from git itself, exactly as before.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

### Review rounds

Every finding across three rounds was real, verified against the cited source before acting, fixed, and replied to on its thread with the measurement.

**Round 1, three findings.** A test insufficiency (identity assertion) and two `.claude/rules/retros.md` violations, MUST 2 and MUST 4. Fixed in `f69503181`.

**Round 2, three findings.** The duplicate mid-merge note on a single-scope consumer's two reads, and an overstated impact claim in two places. Fixed in `3b280c414` and `0714d4b46`. The test module crossed the 500-line taste ceiling while fixing this, caught locally by the ratchet at 576 against baseline 575, and was split at the seam the two halves already had.

**Round 3, two findings.** Both were consequences of the round 2 fix rather than the original defect: the "counting read announces" rule was written from five consumers that share a shape and applied to a sixth that does not, and the wiring test's `>= 1` could not see a consumer that dropped one of several reads. Fixed in `2b23d558a` and `491bfce87`.

Devin Review round 1: no issues found; later rounds skipped, trial expired. CodeRabbit: skipped by label config. Codex and Cursor Bugbot did not run, both reporting account usage limits, which is outside this PR.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #4746
