### PR TITLE
fix(eval): route Copilot skills and instructions by artifact type

### DIFF
--- a/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
+++ b/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
@@ -128,6 +128,69 @@ reference rows and asserts the misroute returns, and a per-row test asserts ever
 row still wins for its own representative path. Without those two, the suite
 would have been pinning a property it was not actually testing.
 
+## Second failure, same session: the imagined child contract
+
+Round one of review caught a defect in the fix that is a textbook FM-9,
+Confident-Incorrectness Recurrence. The section above rules FM-9 out for the
+original defect and notes it was "a live risk in the fix". It landed anyway, in
+a place I did not check.
+
+`run_rule_activation` parsed the child evaluator's stdout as JSON, because the
+three sibling runners in the same file do exactly that. I never ran the child.
+The real contract, at `scripts/eval/eval-rule-activation.py:2450-2452`, is:
+
+```python
+    if args.output:
+        Path(args.output).write_text(json.dumps(all_results, indent=2), encoding="utf-8")
+        print(f"\nWrote results: {args.output}")
+```
+
+JSON goes to `--output` only. stdout gets a human table. Every real rule
+evaluation would have failed to parse and returned `EXIT_EXTERNAL`, which is the
+same failure shape as the bug this PR set out to fix, reintroduced one layer
+down.
+
+The mock hid it. `_stub_child` returned `{"verdict": "PASS"}` on stdout, so nine
+tests agreed with the imagination instead of the CLI. This is the
+"self-referential test" anti-pattern in `.claude/rules/canonical-source-mirror.md`:
+the test asserted the shape I assumed rather than the shape the artifact
+produces.
+
+Measured after the fix, by running the real CLI:
+
+```text
+$ eval-rule-activation.py --scenarios tests/evals/rule-scenarios/code-quality.json \
+    --dry-run --output /tmp/rr.json
+exit=0
+stdout: [DRY-RUN] code-quality: 4 scenarios x 3 mechanisms x 4 ... = 48 calls
+/tmp/rr.json: No such file or directory
+```
+
+Two facts that only running it produces: stdout is not JSON, and `--dry-run`
+returns before the `--output` write, so a dry run yields no results file at all.
+Both are now pinned by tests that invoke the real child rather than a mock.
+
+The generalizable lesson is narrower than "read the source". It is: **when you
+copy a call pattern from a sibling, you have inherited that sibling's contract
+assumption, not verified your own.** Three runners parsing stdout is evidence
+about those three children, not about a fourth.
+
+## Remediation actions
+
+| # | Action | Status | Owner or issue |
+|---|---|---|---|
+| 1 | Replace broad prefix matching with the ordered `ROUTING_RULES` table | Done, this PR | PR #5460 |
+| 2 | Give every category a runner or an explicit `not_evaluated` reason, pinned by a test that fails if a category has neither | Done, this PR | PR #5460 |
+| 3 | Make `--dry-run` invoke no evaluator and parse no model output | Done, this PR | PR #5460 |
+| 4 | Read the rule evaluator's results from `--output`, not stdout, and pin the contract with tests that run the real child CLI | Done, this PR | PR #5460 |
+| 5 | Filter the routing plan by `--scope` so the dry-run plan matches `_run_evals` | Done, this PR | PR #5460 |
+| 6 | Reconcile the published plan against actual results so a scored rule is not reported unscored | Done, this PR | PR #5460 |
+| 7 | Fail loudly on a malformed scenario file instead of reporting `not_evaluated`, matching the canonical coverage checker | Done, this PR | PR #5460 |
+| 8 | Replace the always-skipping end-to-end test with one that builds an isolated fixture repository | Done, this PR | PR #5460 |
+| 9 | Three-state evidence in the activation coverage checker's own output, so baseline exemption is never read as efficacy | Not done, deliberately out of scope | Issue #4882, acceptance criterion 7 |
+| 10 | Shape `routing_plan` for the always-on reduction work to consume | Not done, needs that work's requirements first | Issue #4871 |
+| 11 | The three `nosemgrep` comments in this file sit two lines above their `subprocess.run`, so they attach to nothing; decide whether to repair or delete them repo-wide | Not done, collides with the staged-suppression gate | Flagged to a maintainer on PR #5460 |
+
 ## What I would tell the next person
 
 Two things.

--- a/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
+++ b/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
@@ -185,11 +185,43 @@ about those three children, not about a fourth.
 | 4 | Read the rule evaluator's results from `--output`, not stdout, and pin the contract with tests that run the real child CLI | Done, this PR | PR #5460 |
 | 5 | Filter the routing plan by `--scope` so the dry-run plan matches `_run_evals` | Done, this PR | PR #5460 |
 | 6 | Reconcile the published plan against actual results so a scored rule is not reported unscored | Done, this PR | PR #5460 |
-| 7 | Fail loudly on a malformed scenario file instead of reporting `not_evaluated`, matching the canonical coverage checker | Done, this PR | PR #5460 |
+| 7 | Fail loudly on a malformed scenario file instead of reporting `not_evaluated`, matching the canonical coverage checker | Done in two passes. Round two caught only `OSError` and `JSONDecodeError`; round three found `UnicodeDecodeError` subclasses `ValueError`, so a binary scenario file still crashed with a traceback instead of the documented config exit. Both paths are now covered and pinned | PR #5460 |
 | 8 | Replace the always-skipping end-to-end test with one that builds an isolated fixture repository | Done, this PR | PR #5460 |
 | 9 | Three-state evidence in the activation coverage checker's own output, so baseline exemption is never read as efficacy | Not done, deliberately out of scope | Issue #4882, acceptance criterion 7 |
 | 10 | Shape `routing_plan` for the always-on reduction work to consume | Not done, needs that work's requirements first | Issue #4871 |
-| 11 | The three `nosemgrep` comments in this file sit two lines above their `subprocess.run`, so they attach to nothing; decide whether to repair or delete them repo-wide | Not done, collides with the staged-suppression gate | Flagged to a maintainer on PR #5460 |
+| 11 | The three `nosemgrep` comments in this file sit two lines above their `subprocess.run`, so they attach to nothing; decide whether to repair or delete them repo-wide | Not done. Measured with a probe, patch written, commit refused by `security-suppressions-staged`, reverted | Flagged to a maintainer on PR #5460 |
+| 12 | Reject a parseable child payload that names no verdict for the requested rule, instead of reading it as scored | Done, round three | PR #5460 |
+| 13 | Preserve the child's own exit code (2 config, 4 auth) instead of flattening a missing results file to 3 | Done, round three | PR #5460 |
+| 14 | Promote a routing-plan entry to `scored` only on the runner's evidence label, never inferred from `passed` | Done, round three | PR #5460 |
+
+## Third failure, same shape as the second
+
+Round two fixed the child contract but left four adjacent paths wrong, and the
+common thread is the same one the section above names: I fixed the case I was
+shown rather than the class it belongs to.
+
+- Round two made the runner read `--output`. It did not ask what a *parseable
+  but empty* payload should mean, so `{"schema_version": 1, "rules": {}}` was
+  accepted as a pass and published as scored efficacy evidence for a run that
+  produced no verdict.
+- Round two mapped a missing results file to `EXIT_EXTERNAL`. The child exits 2
+  on an invalid scenario and 4 on a missing key, writing no file in either
+  case, so that mapping reported an API failure for a config or auth fault.
+- Round two caught `OSError` and `JSONDecodeError` on scenario reads.
+  `UnicodeDecodeError` subclasses `ValueError`, so it escaped both.
+- Round two reconciled the plan by checking `"passed" in outcome`. `passed` is
+  False for a failing verdict, a timeout, and an unreadable result alike, so a
+  timeout was promoted to `scored`.
+
+Each is a different exception type or a different branch, and each was
+reachable from the code round two shipped. The generalizable lesson: **after
+fixing a contract, enumerate the states the contract can be in, not just the
+state that failed.** Parse success is not verdict presence; a nonzero exit is
+not one kind of failure; a decode error is not an I/O error; and a boolean that
+means "did not pass" cannot distinguish "failed" from "never ran".
+
+The negative control for round three: reverting all four fixes at once fails 16
+tests, spread across all four findings.
 
 ## What I would tell the next person
 

--- a/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
+++ b/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
@@ -1,0 +1,154 @@
+# Issue #4882: the eval router's `other` bucket was a silent default
+
+**Date**: 2026-09-01
+**Issue**: #4882
+**Scope**: `scripts/eval/eval-suite.py` routing table plus its tests
+**Failure mode**: FM-10, Silent Defaults and Guard-Clause Suppression
+(`.agents/governance/FAILURE-MODES.md`, section 10)
+
+## What happened
+
+`classify_changes` in `scripts/eval/eval-suite.py` routed changed files by broad
+directory prefix. `AGENT_PATTERNS` carried `src/copilot-cli/`, and the agent
+branch ran before the skill branch, so every Markdown file anywhere under the
+Copilot plugin tree was classified as an agent. `.claude/rules/` and
+`.github/instructions/` matched no pattern at all and fell into `other`.
+
+Reproduced at the commit the issue names,
+`2628d8c1282277ad39bc605eb6a31131eff2d77e`, with the issue's own command:
+
+```text
+PYTHONPATH=scripts/eval uv run --frozen python \
+  scripts/eval/eval-suite.py --base-ref HEAD~1 --dry-run --scope all
+
+Changed files: 17
+agents: 4 files
+skills: 2 files
+other: 11 files
+Overall: FAIL
+exit 3
+```
+
+That output matches the issue body line for line, so the report was not stale.
+
+## Why FM-10
+
+FM-10's unifying property is stated as: "the call site has no way to know the
+operation didn't actually do what its name claims."
+
+`eval-suite.py --scope all` claims to evaluate everything that changed. On this
+diff it evaluated no rule and no instruction mirror, and said nothing about it.
+Six context-bearing files landed in a bucket named `other` that has no runner,
+no message, and no exit-code consequence. The categories were even printed
+(`other: 11 files`), which reads as accounting rather than as a gap. That is
+FM-10's `dict.get(key, default)` shape at the routing layer: the missing key was
+itself the bug, and the default absorbed it.
+
+The second half is the same mode with the polarity flipped. The misrouted files
+did reach a runner, `eval-agents.py`, which cannot evaluate them:
+
+```text
+$ eval-agents.py --agent canonical-source-mirror.instructions --dry-run
+exit=1
+stderr: ERROR: Agent definition not found: .../.claude/agents/canonical-source-mirror.instructions.md
+```
+
+Empty stdout, so `_parse_child_json` raised, so `exit_code` became
+`EXIT_EXTERNAL`, so the suite exited 3. The suite reported an external API
+failure for what was actually a routing bug. The verdict was wrong about its own
+cause, which is the "verdict laundering" bullet in FM-10's trigger list read in
+reverse: absence of signal became a confident, and misattributed, negative one.
+
+## Near-miss modes ruled out
+
+**FM-9, Confident-Incorrectness Recurrence.** The closest call, because this fix
+touches a component that mirrors another source. FM-9 requires an author who
+"models the contract from memory instead of reading it." The original defect has
+no such claim: `AGENT_PATTERNS` asserts nothing about a canonical source, it is
+just a prefix list that grew too broad. FM-9 was a live risk in the *fix*, not
+the defect, because the new `rule_id_for_path` claims to mirror
+`scripts/validation/check_rule_activation_coverage.py`. That claim is quoted
+verbatim in the docstring per `.claude/rules/canonical-source-mirror.md`, and the
+scenario lookup reads each scenario's `rule_path` rather than assuming the
+filename stem, which is what would have been the imagined contract:
+`tests/evals/rule-scenarios/` also holds ADR-088 scenarios carrying `skill_path`
+and no `rule_path`, so a stem convention would have invented rule ids for
+`clean-architecture`, `data-intensive-applications`, and four others.
+Not FM-9, but only because the check was run.
+
+**FM-4, False Completion Markers.** FM-4 is an agent reporting success against an
+unmet acceptance criterion. Here the suite reported FAIL, loudly, with a nonzero
+exit. Nothing claimed completion. FM-10 is named upstream of FM-4 in the catalog;
+this incident stopped at the mechanism and never produced the symptom.
+
+**FM-11, Customer-facing generated artifact shipped without runtime
+verification.** `eval-suite.py` is a contributor-facing script under `scripts/`.
+It is not inside `.claude/`, `src/claude/`, or `src/copilot-cli/`, so it ships in
+no plugin and reaches no consumer. FM-11 does not apply.
+
+**FM-3, Ambiguous Instruction Inversion.** No instruction was inverted. The
+routing table did exactly what it said; what it said was too broad.
+
+## What changed
+
+An ordered `ROUTING_RULES` table replaces the prefix loops, per
+`.claude/rules/code-quality.md` section "Table-Driven Logic". Narrowest row
+first, first match wins. Reference rows precede the trees that contain them;
+instruction rows precede agent rows.
+
+Every category now names a runner or carries an explicit `not_evaluated` reason,
+and a test asserts that each category appears in exactly one of
+`RUNNER_BY_CATEGORY` and `NOT_EVALUATED_REASONS`. That is the direct FM-10
+countermeasure: a new category cannot be added without deciding, in code, whether
+it is evaluated.
+
+`--dry-run` no longer invokes any child evaluator. The same reproduction now
+exits 0 in 0.3 seconds and prints a deterministic routing plan.
+
+## Negative controls
+
+The ordering claim is the load-bearing one, so it is tested rather than asserted.
+
+Reintroducing the bare `src/copilot-cli/` prefix into `AGENT_PATTERNS` fails four
+tests, verified by doing it:
+
+```text
+FAILED test_classify_path_routes_to_expected_category[src/copilot-cli/docs/copilot-instructions.md-other]
+FAILED test_classify_changes_agrees_with_classify_path[src/copilot-cli/docs/copilot-instructions.md-other]
+FAILED test_non_agent_paths_never_route_to_the_agent_evaluator[src/copilot-cli/docs/copilot-instructions.md]
+FAILED test_agent_rows_no_longer_carry_the_broad_copilot_prefix
+4 failed, 120 passed
+```
+
+Worth recording what that run also showed: with the broad prefix restored, skill
+references and instruction mirrors still routed correctly, because the ordering
+protects them independently of the prefix width. Narrowing the prefix is not what
+fixes those; row order is. So a second control moves the agent rows ahead of the
+reference rows and asserts the misroute returns, and a per-row test asserts every
+row still wins for its own representative path. Without those two, the suite
+would have been pinning a property it was not actually testing.
+
+## What I would tell the next person
+
+Two things.
+
+A fall-through bucket with no runner is a silent default even when it is printed.
+`other: 11 files` looks like accounting and reads like coverage. If a category
+can hold something that should have been evaluated, it needs a reason string, not
+a count.
+
+And when a fix has two plausible mechanisms, find out which one is load bearing
+before writing the test. I assumed narrowing the prefix was the fix and would
+have shipped tests that passed for the wrong reason. The negative control is what
+surfaced that ordering, not prefix width, is what actually protects the narrow
+categories.
+
+## References
+
+- Issue #4882.
+- `.agents/governance/FAILURE-MODES.md`, section 10.
+- `.claude/rules/code-quality.md`, section "Table-Driven Logic".
+- `.claude/rules/canonical-source-mirror.md`.
+- `scripts/validation/check_rule_activation_coverage.py`, the canonical
+  scenario-to-rule-id contract.
+- `tests/eval/test_eval_suite_routing.py`.

--- a/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
+++ b/.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md
@@ -193,6 +193,47 @@ about those three children, not about a fourth.
 | 12 | Reject a parseable child payload that names no verdict for the requested rule, instead of reading it as scored | Done, round three | PR #5460 |
 | 13 | Preserve the child's own exit code (2 config, 4 auth) instead of flattening a missing results file to 3 | Done, round three | PR #5460 |
 | 14 | Promote a routing-plan entry to `scored` only on the runner's evidence label, never inferred from `passed` | Done, round three | PR #5460 |
+| 15 | Route command-mirror Copilot skills away from the skill evaluator, which cannot resolve them | Done, round four | PR #5460 |
+| 16 | Move the entrypoint row ahead of the prefix rows and test it through the assembled table | Done, round four | PR #5460 |
+| 17 | Accept only the real ADR-088 shape as a reference-scenario skip; everything else is malformed | Done, round four | PR #5460 |
+| 18 | Give every timeout an explicit `EXIT_EXTERNAL` code, at all five runner sites | Done, round four | PR #5460 |
+
+## Fourth round: the original bug, twice more, inside my own fix
+
+Round four found `src/copilot-cli/skills/` conflates two artifact kinds. Most
+entries mirror `.claude/skills/<name>/`. Fourteen mirror
+`.claude/commands/<name>.md` and have no Claude skill at all. The skill
+evaluator resolves only `.claude/skills/`:
+
+```text
+$ eval-knowledge-integration.py --skill spec --dry-run
+exit=1
+ERROR: Skill directory not found for 'spec' in .../.claude/skills
+```
+
+That is issue #4882's exact failure shape, at a site my own fix created by
+adding `src/copilot-cli/skills/` to the skill prefixes without asking what was
+actually in that directory. I widened a prefix to fix a widening bug.
+
+The same round found the `entrypoints` row was dead. It sat after the prefix
+rows in a first-match table, and every real path-local entrypoint lives inside
+a prefix that precedes it, so `.claude/commands/CLAUDE.md`,
+`.claude/skills/CLAUDE.md`, `.claude/skills/github/CLAUDE.md` and twenty more
+were classified as prompts or skills. My round-one test exercised the matcher
+in isolation, where it passed. The shadowing exists only in the assembled
+table, and no test drove that.
+
+Both are one mistake in different clothes: **I checked that each rule matches
+what it should, never that it wins.** The reachability test from round one used
+synthetic representative paths, so it proved each row could win for a path
+invented to suit it, not for the paths that actually exist in the tree. A
+routing table's contract is resolution order against real inputs, and synthetic
+inputs cannot test order because they were built to match exactly one row.
+
+Round four's tests are anchored to real tree contents, with negative controls
+asserting the premise (these entrypoint files exist; these fourteen skills have
+a command and no Claude skill) so the assertions cannot pass vacuously.
+Reverting the four fixes together fails 37 tests.
 
 ## Third failure, same shape as the second
 

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -85,7 +85,7 @@ override the executable and the default 900s timeout.
 
 | Script | Purpose | ADR |
 |--------|---------|-----|
-| `eval-suite.py` | Orchestrator. Detects changes, routes to correct evaluator. | ADR-023 + ADR-057 |
+| `eval-suite.py` | Orchestrator. Detects changes, routes to correct evaluator via the ordered `ROUTING_RULES` table. `--dry-run` prints the routing plan and invokes no evaluator. | ADR-023 + ADR-057 |
 | `eval-prompt-change.py` | Before/after behavioral comparison for prompt changes. | ADR-057 |
 | `eval-agents.py` | Agent definition quality assessment (standalone). | Complementary |
 | `eval-knowledge-integration.py` | Skill context value measurement (baseline vs enhanced). | Complementary |
@@ -1355,7 +1355,7 @@ All scripts that call the API support `--dry-run` (validate inputs, no API calls
 | `--runs N` | eval-agents, eval-knowledge-integration | Multi-run flakiness detection |
 | `--security-critical` | eval-prompt-change | 5 runs, 100% pass required |
 | `--base-ref REF` | eval-prompt-change, eval-suite | Git ref for comparison (default: main) |
-| `--scope` | eval-suite | Limit to prompts, agents, or skills |
+| `--scope` | eval-suite | Limit to prompts, agents, skills, or rules |
 | `--pairs FILE` | eval-skill-overlap | cluster.json with explicit `[skillA, skillB]` pairs and prompts |
 | `--run-id ID` | eval-skill-overlap | Override the report directory name (`overlap-<ID>`) |
 

--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -62,6 +62,7 @@ EXIT_OK = 0
 EXIT_LOGIC = 1
 EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
+EXIT_AUTH = 4
 
 # Security-critical path patterns (ADR-057: 5 runs, 100% pass)
 SECURITY_PATTERNS = [
@@ -133,6 +134,46 @@ def _contains_external_failure(value: object) -> bool:
     if isinstance(value, list):
         return any(_contains_external_failure(item) for item in value)
     return False
+
+
+def _recorded_exit_codes(value: object) -> list[int]:
+    """Every `exit_code` a child runner recorded, at any depth."""
+    codes: list[int] = []
+    if isinstance(value, dict):
+        code = value.get("exit_code")
+        if isinstance(code, int):
+            codes.append(code)
+        for nested in value.values():
+            codes.extend(_recorded_exit_codes(nested))
+    elif isinstance(value, list):
+        for item in value:
+            codes.extend(_recorded_exit_codes(item))
+    return codes
+
+
+def worst_exit_code(results: dict[str, Any], any_failure: bool) -> int:
+    """Reduce child exit codes to one, keeping the most specific.
+
+    Reduced with `max`, mirroring the accumulator in
+    `scripts/eval/eval-rule-activation.py:_process_scenario_file`:
+
+        state.worst_exit = max(state.worst_exit, _classify_verdict(result["summary"]["verdict"]))
+
+    and the reason its main loop gives for that choice:
+
+        # max, not the bare code: a hard refusal stops the run, but an
+        # earlier target may already have recorded something worse. A
+        # config refusal on file 8 must not lower an API failure seen on
+        # file 1, or adding a target could improve the exit.
+
+    Keeping `max` preserves a child's config (2) or auth (4) refusal instead
+    of flattening every failure to logic (1) or external (3). A failure with
+    no recorded code floors at EXIT_LOGIC.
+    """
+    if not any_failure:
+        return EXIT_OK
+    codes = [code for code in _recorded_exit_codes(results) if code != EXIT_OK]
+    return max(codes) if codes else EXIT_LOGIC
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +491,11 @@ def find_rule_scenarios() -> dict[str, str]:
     for candidate in sorted(scenario_dir.glob("*.json")):
         try:
             raw = candidate.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
+            # UnicodeDecodeError subclasses ValueError, not OSError, so a
+            # binary or mis-encoded scenario file escapes an OSError-only
+            # guard and crashes with a traceback instead of the config exit
+            # this function documents.
             raise ScenarioConfigError(
                 f"cannot read scenario file {candidate}: {exc}"
             ) from exc
@@ -604,9 +649,15 @@ def reconcile_routing_plan(
 ) -> list[dict[str, Any]]:
     """Promote plan entries to `scored` once an evaluation actually ran.
 
-    `scored` means an evaluation ran and produced a verdict. A failing run is
-    still scored: the evidence exists, it is just negative. Only a run that
-    never happened stays at `scenario_defined_not_scored`.
+    `scored` means an evaluation ran and produced a verdict. A failing verdict
+    is still scored: the evidence exists, it is just negative. A timeout or an
+    unreadable result produced no verdict and stays at
+    `scenario_defined_not_scored`.
+
+    Promotion keys on the runner's own `evidence` label, never on `passed`.
+    `passed` is False for a failing verdict, a timeout, and a missing verdict
+    alike, so inferring from it would publish scored efficacy evidence for
+    runs that produced none.
     """
     rule_results = results.get("rules", {}).get("rules", {})
     if not rule_results:
@@ -626,7 +677,10 @@ def reconcile_routing_plan(
         for path in entry["files"]:
             rule_id = rule_id_for_path(path)
             outcome = rule_results.get(rule_id) if rule_id else None
-            if isinstance(outcome, dict) and "passed" in outcome:
+            if (
+                isinstance(outcome, dict)
+                and outcome.get("evidence") == EVIDENCE_SCORED
+            ):
                 scored.append(path)
             else:
                 unscored.append(path)
@@ -669,9 +723,42 @@ def _read_child_json_file(path: Path, context: str) -> tuple[dict[str, Any] | No
     """Read a child evaluator's `--output` JSON file."""
     try:
         raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         return None, f"no results file for {context}: {exc}"
     return _parse_child_json(raw, context)
+
+
+def _verdict_error(parsed: dict[str, Any] | None, rule_id: str) -> str | None:
+    """Return why `parsed` carries no usable verdict for `rule_id`, or None.
+
+    Parseable is not the same as scored. `{"schema_version": 1, "rules": {}}`
+    is valid JSON and names no verdict, so accepting it would publish scored
+    efficacy evidence for a run that produced none.
+
+    The shape is set by `scripts/eval/eval-rule-activation.py:_process_scenario_file`:
+
+        all_results["rules"][rule_id] = result
+        state.worst_exit = max(state.worst_exit, _classify_verdict(result["summary"]["verdict"]))
+
+    so a scored rule always has a string at `rules.<rule_id>.summary.verdict`.
+    """
+    if not isinstance(parsed, dict):
+        return f"results are not an object for rule {rule_id}"
+    rules = parsed.get("rules")
+    if not isinstance(rules, dict):
+        return f"results carry no rules map for rule {rule_id}"
+    entry = rules.get(rule_id)
+    if entry is None:
+        return f"results carry no entry for rule {rule_id}"
+    if not isinstance(entry, dict):
+        return f"results entry is not an object for rule {rule_id}"
+    summary = entry.get("summary")
+    if not isinstance(summary, dict):
+        return f"results carry no summary for rule {rule_id}"
+    verdict = summary.get("verdict")
+    if not isinstance(verdict, str) or not verdict.strip():
+        return f"results carry no verdict for rule {rule_id}"
+    return None
 
 
 def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
@@ -739,17 +826,27 @@ def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
                 results["rules"][rule_id] = {"passed": False, "reason": "timeout (600s)"}
                 continue
 
-            parsed, parse_error = _read_child_json_file(output_path, f"rule {rule_id}")
-            passed = result.returncode == 0 and parse_error is None
-            exit_code = EXIT_EXTERNAL if parse_error is not None else result.returncode
-            if parse_error is not None:
-                print(f"WARNING: {parse_error}", file=sys.stderr)
-                parsed = {"stderr_preview": result.stderr[:500], "error": parse_error}
+            parsed, signal_error = _read_child_json_file(output_path, f"rule {rule_id}")
+            if signal_error is None:
+                signal_error = _verdict_error(parsed, rule_id)
+
+            passed = result.returncode == 0 and signal_error is None
+            if signal_error is None:
+                exit_code = result.returncode
+            else:
+                # Keep the child's own refusal code. It exits 2 on an invalid
+                # scenario and 4 on a missing key, in both cases without
+                # writing the output file, so mapping every missing signal to
+                # EXIT_EXTERNAL would report an API failure for a config or
+                # auth fault. Only a child that claimed success and produced
+                # nothing is an external failure.
+                exit_code = result.returncode if result.returncode != EXIT_OK else EXIT_EXTERNAL
+                print(f"WARNING: {signal_error}", file=sys.stderr)
+                parsed = {"stderr_preview": result.stderr[:500], "error": signal_error}
 
             # `scored` records that an evaluation ran and produced a verdict.
-            # A failing run is scored; only a run that produced no verdict is
-            # not.
-            evidence = EVIDENCE_SCENARIO if parse_error is not None else EVIDENCE_SCORED
+            # A failing verdict is scored; a missing one never is.
+            evidence = EVIDENCE_SCENARIO if signal_error is not None else EVIDENCE_SCORED
             results["rules"][rule_id] = {
                 "passed": passed,
                 "exit_code": exit_code,
@@ -1143,9 +1240,7 @@ def main() -> None:
         print(json_output)
 
     _print_summary(output)
-    if not any_failure:
-        sys.exit(EXIT_OK)
-    sys.exit(EXIT_EXTERNAL if _contains_external_failure(results) else EXIT_LOGIC)
+    sys.exit(worst_exit_code(results, any_failure))
 
 
 if __name__ == "__main__":

--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -49,6 +49,7 @@ import argparse
 import json
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -407,6 +408,14 @@ def rule_id_for_path(path: str) -> str | None:
     return None
 
 
+class ScenarioConfigError(RuntimeError):
+    """A scenario file exists but cannot be read as a scenario.
+
+    Separate from "no scenario exists". A broken scenario file is an authoring
+    mistake that must surface, not be silently downgraded to `not_evaluated`.
+    """
+
+
 def find_rule_scenarios() -> dict[str, str]:
     """Map rule id -> scenario file, read from each scenario's `rule_path`.
 
@@ -414,6 +423,24 @@ def find_rule_scenarios() -> dict[str, str]:
     also holds skill-targeted scenarios (ADR-088 reference scenarios carry
     `skill_path` and no `rule_path`), so a stem convention would claim rule ids
     that do not exist.
+
+    Fails loudly on an unreadable or malformed scenario file, mirroring
+    `scripts/validation/check_rule_activation_coverage.py:_read_scenario_json`:
+
+        try:
+            ...
+        except OSError as exc:
+            raise CoverageConfigError(f"cannot read scenario file {path}: {exc}") from exc
+        ...
+            raise CoverageConfigError(f"invalid JSON in scenario file {path}: {exc}") from exc
+
+    Stricter/looser/different than canonical: the canonical reader also
+    validates scenario entries, target kinds, and traversal, and raises when a
+    file sets neither or both of `rule_path`/`skill_path`. This one validates
+    only readability and JSON object shape, because it is a lookup, not the
+    ratchet; a file carrying `skill_path` and no `rule_path` is a valid
+    ADR-088 scenario here and is skipped rather than refused. The canonical
+    checker owns the rest and runs in pre-PR validation.
     """
     scenarios: dict[str, str] = {}
     scenario_dir = REPO_ROOT / RULE_SCENARIO_DIR
@@ -422,14 +449,29 @@ def find_rule_scenarios() -> dict[str, str]:
 
     for candidate in sorted(scenario_dir.glob("*.json")):
         try:
-            data = json.loads(candidate.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
+            raw = candidate.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ScenarioConfigError(
+                f"cannot read scenario file {candidate}: {exc}"
+            ) from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ScenarioConfigError(
+                f"invalid JSON in scenario file {candidate}: {exc}"
+            ) from exc
         if not isinstance(data, dict):
-            continue
+            raise ScenarioConfigError(
+                f"scenario file must contain an object: {candidate}"
+            )
         rule_path = data.get("rule_path")
-        if not isinstance(rule_path, str) or not rule_path.strip():
+        if rule_path is None:
+            # A skill-targeted ADR-088 scenario. Not a rule; not an error.
             continue
+        if not isinstance(rule_path, str) or not rule_path.strip():
+            raise ScenarioConfigError(
+                f"rule_path must be a non-empty string in {candidate}"
+            )
         scenarios[Path(rule_path).stem] = str(candidate.relative_to(REPO_ROOT))
 
     return scenarios
@@ -464,12 +506,39 @@ def _rule_plan_entries(files: list[str]) -> tuple[list[str], list[str]]:
     return with_scenario, without_scenario
 
 
-def build_routing_plan(classified: dict[str, list[str]]) -> list[dict[str, Any]]:
+# Which --scope value enables each runner-backed category. Mirrors the gates in
+# `_run_evals`, so the dry-run plan cannot promise work the real path skips.
+SCOPE_BY_CATEGORY: dict[str, str] = {
+    "prompts": "prompts",
+    "structural_test_targets": "prompts",
+    "agents": "agents",
+    "skills": "skills",
+    "skill_references": "skills",
+    "rules": "rules",
+    "instructions": "rules",
+}
+
+
+def category_in_scope(category: str, scope: str) -> bool:
+    """Whether `--scope <scope>` runs this category, matching `_run_evals`."""
+    required = SCOPE_BY_CATEGORY.get(category)
+    if required is None:
+        return False
+    return scope in (required, "all")
+
+
+def build_routing_plan(
+    classified: dict[str, list[str]], scope: str = "all"
+) -> list[dict[str, Any]]:
     """Describe what each classified category routes to, and its evidence state.
 
     Deterministic: entries follow CATEGORIES order and files are sorted. This
     is what `--dry-run` prints, and it is produced without invoking any
     evaluator or parsing any model output.
+
+    Scope-aware: a category the current `--scope` excludes is reported
+    `not_evaluated` with that reason, so the plan describes what this
+    invocation will actually do rather than what some invocation could do.
     """
     plan: list[dict[str, Any]] = []
 
@@ -486,6 +555,16 @@ def build_routing_plan(classified: dict[str, list[str]]) -> list[dict[str, Any]]
                 "runner": None,
                 "evidence": EVIDENCE_NONE,
                 "reason": NOT_EVALUATED_REASONS[category],
+            })
+            continue
+
+        if not category_in_scope(category, scope):
+            plan.append({
+                "category": category,
+                "files": files,
+                "runner": None,
+                "evidence": EVIDENCE_NONE,
+                "reason": f"excluded by --scope {scope}",
             })
             continue
 
@@ -520,6 +599,51 @@ def build_routing_plan(classified: dict[str, list[str]]) -> list[dict[str, Any]]
     return plan
 
 
+def reconcile_routing_plan(
+    plan: list[dict[str, Any]], results: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Promote plan entries to `scored` once an evaluation actually ran.
+
+    `scored` means an evaluation ran and produced a verdict. A failing run is
+    still scored: the evidence exists, it is just negative. Only a run that
+    never happened stays at `scenario_defined_not_scored`.
+    """
+    rule_results = results.get("rules", {}).get("rules", {})
+    if not rule_results:
+        return plan
+
+    reconciled: list[dict[str, Any]] = []
+    for entry in plan:
+        if entry["category"] not in ("rules", "instructions"):
+            reconciled.append(entry)
+            continue
+        if entry["evidence"] != EVIDENCE_SCENARIO:
+            reconciled.append(entry)
+            continue
+
+        scored = []
+        unscored = []
+        for path in entry["files"]:
+            rule_id = rule_id_for_path(path)
+            outcome = rule_results.get(rule_id) if rule_id else None
+            if isinstance(outcome, dict) and "passed" in outcome:
+                scored.append(path)
+            else:
+                unscored.append(path)
+
+        if scored:
+            reconciled.append({
+                **entry,
+                "files": scored,
+                "evidence": EVIDENCE_SCORED,
+                "reason": "activation evaluated; verdict recorded in results",
+            })
+        if unscored:
+            reconciled.append({**entry, "files": unscored})
+
+    return reconciled
+
+
 def _print_routing_plan(plan: list[dict[str, Any]]) -> None:
     print("\n--- Routing Plan ---", file=sys.stderr)
     if not plan:
@@ -541,12 +665,36 @@ def _print_routing_plan(plan: list[dict[str, Any]]) -> None:
 # Individual eval runners
 # ---------------------------------------------------------------------------
 
+def _read_child_json_file(path: Path, context: str) -> tuple[dict[str, Any] | None, str | None]:
+    """Read a child evaluator's `--output` JSON file."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"no results file for {context}: {exc}"
+    return _parse_child_json(raw, context)
+
+
 def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
     """Score rule and instruction changes via eval-rule-activation.py.
 
     Reuses the existing activation evaluator rather than adding a parallel
     harness (issue #4882, required work item 6). A rule with no scenario file
     is reported `not_evaluated`, never silently passed.
+
+    Results come from `--output`, not stdout. Unlike the other three child
+    evaluators this suite calls, `eval-rule-activation.py` prints a
+    human-readable table to stdout and serializes JSON only to the output
+    path. Verified against the real CLI at
+    `scripts/eval/eval-rule-activation.py:2450-2452`:
+
+        if args.output:
+            Path(args.output).write_text(json.dumps(all_results, indent=2), encoding="utf-8")
+            print(f"\\nWrote results: {args.output}")
+
+    Parsing stdout here would fail on every real run. `--dry-run` is never
+    passed: the child returns at line 2442, before that write, so a dry run
+    produces no results file at all. This suite's own `--dry-run` short
+    circuits before reaching any runner instead.
     """
     scenarios = find_rule_scenarios()
     results: dict[str, Any] = {"rules": {}}
@@ -570,36 +718,45 @@ def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
             targets[rule_id] = scenarios[rule_id]
 
     for rule_id, scenario_path in sorted(targets.items()):
-        cmd = [
-            sys.executable, str(SCRIPT_DIR / "eval-rule-activation.py"),
-            "--scenarios", scenario_path, "--model", model,
-        ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=600,
-                cwd=str(REPO_ROOT),
-            )
-            parsed, parse_error = _parse_child_json(result.stdout, f"rule {rule_id}")
+        with tempfile.TemporaryDirectory(prefix="eval-suite-rules-") as tmp_dir:
+            output_path = Path(tmp_dir) / f"{rule_id}-activation.json"
+            cmd = [
+                sys.executable, str(SCRIPT_DIR / "eval-rule-activation.py"),
+                "--scenarios", scenario_path, "--model", model,
+                "--output", str(output_path),
+            ]
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=600,
+                    cwd=str(REPO_ROOT),
+                )
+            except subprocess.TimeoutExpired:
+                results["rules"][rule_id] = {"passed": False, "reason": "timeout (600s)"}
+                continue
+
+            parsed, parse_error = _read_child_json_file(output_path, f"rule {rule_id}")
             passed = result.returncode == 0 and parse_error is None
             exit_code = EXIT_EXTERNAL if parse_error is not None else result.returncode
             if parse_error is not None:
                 print(f"WARNING: {parse_error}", file=sys.stderr)
-                parsed = {"raw_output": result.stdout[:500], "error": parse_error}
+                parsed = {"stderr_preview": result.stderr[:500], "error": parse_error}
 
+            # `scored` records that an evaluation ran and produced a verdict.
+            # A failing run is scored; only a run that produced no verdict is
+            # not.
+            evidence = EVIDENCE_SCENARIO if parse_error is not None else EVIDENCE_SCORED
             results["rules"][rule_id] = {
                 "passed": passed,
                 "exit_code": exit_code,
-                "evidence": EVIDENCE_SCORED if passed else EVIDENCE_SCENARIO,
+                "evidence": evidence,
                 "scenarios": scenario_path,
                 "results": parsed,
             }
-        except subprocess.TimeoutExpired:
-            results["rules"][rule_id] = {"passed": False, "reason": "timeout (600s)"}
 
     scored = [r for r in results["rules"].values() if not r.get("skipped")]
     results["passed"] = all(r.get("passed", False) for r in scored)
@@ -863,10 +1020,17 @@ def _run_evals(
         if not result.get("passed"):
             any_failure = True
 
-    skill_files = classified["skills"] + classified["skill_references"]
-    if skill_files and args.scope in ("skills", "all"):
+    # A skill reference is part of its parent skill, so fold the two lists
+    # together once and leave the dispatch below unchanged. Rebound rather than
+    # mutated: `main` holds the original mapping for the routing plan.
+    classified = {
+        **classified,
+        "skills": classified["skills"] + classified["skill_references"],
+    }
+
+    if classified["skills"] and args.scope in ("skills", "all"):
         print("\n--- Skill Knowledge Assessment ---", file=sys.stderr)
-        result = run_skill_knowledge(skill_files, args.model, args.dry_run)
+        result = run_skill_knowledge(classified["skills"], args.model, args.dry_run)
         results["skills"] = result
         if not result.get("passed"):
             any_failure = True
@@ -936,7 +1100,11 @@ def main() -> None:
     except ChangeDetectionError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(EXIT_CONFIG)
-    plan = build_routing_plan(classified)
+    try:
+        plan = build_routing_plan(classified, args.scope)
+    except ScenarioConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
 
     # A dry run validates routing and planned work only. It invokes no
     # evaluator and parses no model output (issue #4882, required work item 3).
@@ -945,7 +1113,12 @@ def main() -> None:
         results: dict[str, Any] = {}
         any_failure = False
     else:
-        results, any_failure = _run_evals(classified, args)
+        try:
+            results, any_failure = _run_evals(classified, args)
+        except ScenarioConfigError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(EXIT_CONFIG)
+        plan = reconcile_routing_plan(plan, results)
 
     elapsed = round(time.time() - start_time, 1)
     output: dict[str, Any] = {

--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -1,14 +1,27 @@
 #!/usr/bin/env python3
+# taste-lint: ignore file-size, orchestrator keeps routing and its runners together.
+# taste-lint: ignore naming, hyphenated CLI name is the shipped entrypoint.
 """Eval Suite: Unified test orchestrator for prompt, skill, and command changes.
 
 Detects what changed via git diff, classifies changes, and routes to the
 appropriate evaluator. Single entry point for all eval types.
+
+Routing is table-driven (`ROUTING_RULES`), ordered narrowest first, first match
+wins. See `.claude/rules/code-quality.md`, section "Table-Driven Logic": "When
+branching grows past three or four cases, replace conditional code with a table."
 
 Evaluator routing:
     - Prompt structural changes  -> Pester tests (ADR-023)
     - Prompt behavioral changes  -> eval-prompt-change.py (ADR-057)
     - Agent definition changes   -> eval-agents.py (quality assessment)
     - Skill definition changes   -> eval-knowledge-integration.py (knowledge eval)
+    - Skill reference changes    -> eval-knowledge-integration.py (parent skill)
+    - Canonical rule changes     -> eval-rule-activation.py (scenario-gated)
+    - Instruction mirror changes -> eval-rule-activation.py (via canonical rule)
+
+Every classified category either names a runner or carries an explicit
+`not_evaluated` reason in the routing plan. No context-bearing category falls
+silently into `other` (issue #4882, required work item 2).
 
 Usage:
     # Auto-detect from git diff against main:
@@ -21,8 +34,9 @@ Usage:
     python3 scripts/eval/eval-suite.py --scope prompts
     python3 scripts/eval/eval-suite.py --scope agents
     python3 scripts/eval/eval-suite.py --scope skills
+    python3 scripts/eval/eval-suite.py --scope rules
 
-    # Dry run (detect and classify only):
+    # Dry run (classify and print the routing plan; no subprocess, no model):
     python3 scripts/eval/eval-suite.py --dry-run
 
     # Output results to file:
@@ -37,7 +51,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from _anthropic_api import DEFAULT_MODEL
 
@@ -130,73 +144,207 @@ PROMPT_PATTERNS = [
     ".agents/security/prompts/",
 ]
 
+# Agent definition trees. Narrowed from a bare `src/copilot-cli/` prefix, which
+# captured every Markdown file in that tree (issue #4882). `src/copilot-cli/`
+# also holds `instructions/`, `skills/`, `docs/`, and `lib/`, none of which are
+# agents.
 AGENT_PATTERNS = [
     ".claude/agents/",
     "src/claude/",
-    "src/copilot-cli/",
+    "src/copilot-cli/agents/",
     "src/vs-code-agents/",
 ]
 
 SKILL_PATTERNS = [
     ".claude/skills/",
+    "src/copilot-cli/skills/",
 ]
+
+# Canonical rules. `build/scripts/generate_rules.py` mirrors these into the two
+# instruction trees below.
+RULE_PATTERNS = [
+    ".claude/rules/",
+]
+
+INSTRUCTION_PATTERNS = [
+    ".github/instructions/",
+    "src/copilot-cli/instructions/",
+]
+
+INSTRUCTION_SUFFIX = ".instructions.md"
 
 SCENARIO_DIRS = [
     "tests/evals/",
     ".agents/security/benchmarks/",
 ]
 
+# Preserved verbatim from the pre-#4882 agent branch, which read:
+#     skip = ("CLAUDE.md", "README.md", "INDEX.md", "AGENTS.md")
+#     if name not in skip and ".template." not in name:
+AGENT_EXCLUDED_BASENAMES = frozenset({"CLAUDE.md", "README.md", "INDEX.md", "AGENTS.md"})
+AGENT_EXCLUDED_SUBSTRINGS = (".template.",)
+
+# Path-local and root harness entrypoints. Two of the four basenames the agent
+# branch excluded are context-bearing, so they get a category instead of
+# dropping into `other`.
+ENTRYPOINT_BASENAMES = frozenset({"AGENTS.md", "CLAUDE.md"})
+
+REFERENCE_SEGMENT = "references"
+
+
+class RoutingRule(NamedTuple):
+    """One row of the routing table: a path shape mapped to a category.
+
+    A path matches when every constraint set on the row holds. Unset
+    constraints do not filter.
+
+    prefix              path must start with this string
+    suffix              path must end with this string ("" disables)
+    segment             this directory component must appear in the path,
+                        excluding the basename
+    basenames           basename must be one of these
+    exclude_basenames   basename must not be one of these
+    exclude_substrings  basename must contain none of these
+    """
+
+    category: str
+    prefix: str = ""
+    suffix: str = ".md"
+    segment: str | None = None
+    basenames: frozenset[str] = frozenset()
+    exclude_basenames: frozenset[str] = frozenset()
+    exclude_substrings: tuple[str, ...] = ()
+
+    def matches(self, path: str) -> bool:
+        if self.prefix and not path.startswith(self.prefix):
+            return False
+        if self.suffix and not path.endswith(self.suffix):
+            return False
+        parts = path.split("/")
+        name = parts[-1]
+        if self.basenames and name not in self.basenames:
+            return False
+        if name in self.exclude_basenames:
+            return False
+        if any(token in name for token in self.exclude_substrings):
+            return False
+        if self.segment is not None and self.segment not in parts[:-1]:
+            return False
+        return True
+
+
+def _rules_for(
+    category: str,
+    prefixes: list[str],
+    suffix: str = ".md",
+    segment: str | None = None,
+    exclude_basenames: frozenset[str] = frozenset(),
+    exclude_substrings: tuple[str, ...] = (),
+) -> tuple[RoutingRule, ...]:
+    """Expand one category across several path prefixes, one row per prefix."""
+    return tuple(
+        RoutingRule(
+            category,
+            prefix=prefix,
+            suffix=suffix,
+            segment=segment,
+            exclude_basenames=exclude_basenames,
+            exclude_substrings=exclude_substrings,
+        )
+        for prefix in prefixes
+    )
+
+
+# Ordered narrowest first; the first matching row wins. Ordering is the whole
+# contract here: issue #4882 was a broad `src/copilot-cli/` agent prefix placed
+# ahead of the skill rows, so Copilot skills, skill references, and instruction
+# mirrors were all sent to `eval-agents.py`, which then exited 1 with empty
+# stdout and turned the suite's dry run into a JSON parse failure.
+#
+# `tests/eval/test_eval_suite_routing.py` pins this order two ways: every row
+# must win for its own representative path (no row may be shadowed), and a
+# negative control replays the broad prefix to prove the tests catch a
+# reintroduction.
+ROUTING_RULES: tuple[RoutingRule, ...] = (
+    *_rules_for("prompts", PROMPT_PATTERNS),
+    # References must precede the trees that contain them.
+    *_rules_for("skill_references", SKILL_PATTERNS, segment=REFERENCE_SEGMENT),
+    *_rules_for("skills", SKILL_PATTERNS, suffix=""),
+    *_rules_for("references", AGENT_PATTERNS, segment=REFERENCE_SEGMENT),
+    *_rules_for("rules", RULE_PATTERNS),
+    *_rules_for("instructions", INSTRUCTION_PATTERNS, suffix=INSTRUCTION_SUFFIX),
+    *_rules_for(
+        "agents",
+        AGENT_PATTERNS,
+        exclude_basenames=AGENT_EXCLUDED_BASENAMES,
+        exclude_substrings=AGENT_EXCLUDED_SUBSTRINGS,
+    ),
+    RoutingRule("entrypoints", basenames=ENTRYPOINT_BASENAMES),
+    *_rules_for("scenarios", SCENARIO_DIRS, suffix=""),
+)
+
+CATEGORIES: tuple[str, ...] = (
+    "prompts",
+    "agents",
+    "skills",
+    "skill_references",
+    "references",
+    "rules",
+    "instructions",
+    "entrypoints",
+    "scenarios",
+    "structural_test_targets",
+    "other",
+)
+
+# Category -> the evaluator that consumes it. A category absent from this map
+# carries a reason in NOT_EVALUATED_REASONS instead. Every entry in CATEGORIES
+# must appear in exactly one of the two (pinned by the routing tests).
+RUNNER_BY_CATEGORY: dict[str, str] = {
+    "prompts": "eval-prompt-change.py",
+    "agents": "eval-agents.py",
+    "skills": "eval-knowledge-integration.py",
+    "skill_references": "eval-knowledge-integration.py",
+    "rules": "eval-rule-activation.py",
+    "instructions": "eval-rule-activation.py",
+    "structural_test_targets": "Invoke-Pester",
+}
+
+NOT_EVALUATED_REASONS: dict[str, str] = {
+    "references": (
+        "reference material for a non-skill artifact; no evaluator consumes it"
+    ),
+    "entrypoints": (
+        "no behavioral evaluator exists for AGENTS.md/CLAUDE.md entrypoints"
+    ),
+    "scenarios": "scenario corpora are eval inputs, not evaluated artifacts",
+    "other": "no routing rule claims this path",
+}
+
+
+def classify_path(path: str) -> str:
+    """Return the routing category for one path via first match in ROUTING_RULES."""
+    for rule in ROUTING_RULES:
+        if rule.matches(path):
+            return rule.category
+    return "other"
+
 
 def classify_changes(files: list[str]) -> dict[str, list[str]]:
-    """Classify changed files into categories for eval routing."""
-    classified: dict[str, list[str]] = {
-        "prompts": [],
-        "agents": [],
-        "skills": [],
-        "scenarios": [],
-        "structural_test_targets": [],
-        "other": [],
-    }
+    """Classify changed files into categories for eval routing.
+
+    Categories are exclusive except `structural_test_targets`, which is an
+    additional tag applied to quality-gate prompts per ADR-023 and which the
+    pre-#4882 code also applied alongside the exclusive category.
+    """
+    classified: dict[str, list[str]] = {category: [] for category in CATEGORIES}
 
     for f in files:
-        matched = False
-
-        for pattern in PROMPT_PATTERNS:
-            if f.startswith(pattern) and f.endswith(".md"):
-                classified["prompts"].append(f)
-                matched = True
-                break
-
-        if not matched:
-            for pattern in AGENT_PATTERNS:
-                if f.startswith(pattern) and f.endswith(".md"):
-                    name = Path(f).name
-                    skip = ("CLAUDE.md", "README.md", "INDEX.md", "AGENTS.md")
-                    if name not in skip and ".template." not in name:
-                        classified["agents"].append(f)
-                        matched = True
-                    break
-
-        if not matched:
-            for pattern in SKILL_PATTERNS:
-                if f.startswith(pattern):
-                    classified["skills"].append(f)
-                    matched = True
-                    break
-
-        if not matched:
-            for pattern in SCENARIO_DIRS:
-                if f.startswith(pattern):
-                    classified["scenarios"].append(f)
-                    matched = True
-                    break
+        classified[classify_path(f)].append(f)
 
         # Structural test targets (quality gate prompts per ADR-023)
         if f.startswith(".github/prompts/pr-quality-gate-"):
             classified["structural_test_targets"].append(f)
-
-        if not matched:
-            classified["other"].append(f)
 
     return classified
 
@@ -223,9 +371,240 @@ def find_scenarios_for_prompt(prompt_path: str) -> str | None:
     return None
 
 
+RULE_SCENARIO_DIR = "tests/evals/rule-scenarios"
+
+
+def rule_id_for_path(path: str) -> str | None:
+    """Map a canonical rule or generated instruction mirror to its rule id.
+
+    The rule id is the canonical rule's file stem. This mirrors
+    `scripts/validation/check_rule_activation_coverage.py`, whose
+    `discover_rules` reads:
+
+        ids = {p.stem for p in rules_dir.glob("*.md") if p.is_file()}
+
+    and whose `_resolve_target` derives the same id from a scenario target:
+
+        if kind == "rule":
+            if resolved.suffix != ".md":
+                raise CoverageConfigError(
+                    f"rule_path must be a .md file: {target_str}"
+                )
+            artifact_id = resolved.stem
+
+    Stricter/looser/different than canonical: the canonical functions read only
+    `.claude/rules/`. This one additionally accepts a generated instruction
+    mirror and strips the `.instructions.md` suffix that
+    `build/scripts/generate_rules.py` appends, because a mirror change is a
+    change to the same rule. It performs no filesystem or traversal
+    validation; the canonical checker owns that.
+    """
+    name = Path(path).name
+    if classify_path(path) == "rules":
+        return name[: -len(".md")] if name.endswith(".md") else None
+    if classify_path(path) == "instructions" and name.endswith(INSTRUCTION_SUFFIX):
+        return name[: -len(INSTRUCTION_SUFFIX)]
+    return None
+
+
+def find_rule_scenarios() -> dict[str, str]:
+    """Map rule id -> scenario file, read from each scenario's `rule_path`.
+
+    Read rather than inferred from the filename: `tests/evals/rule-scenarios/`
+    also holds skill-targeted scenarios (ADR-088 reference scenarios carry
+    `skill_path` and no `rule_path`), so a stem convention would claim rule ids
+    that do not exist.
+    """
+    scenarios: dict[str, str] = {}
+    scenario_dir = REPO_ROOT / RULE_SCENARIO_DIR
+    if not scenario_dir.is_dir():
+        return scenarios
+
+    for candidate in sorted(scenario_dir.glob("*.json")):
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        rule_path = data.get("rule_path")
+        if not isinstance(rule_path, str) or not rule_path.strip():
+            continue
+        scenarios[Path(rule_path).stem] = str(candidate.relative_to(REPO_ROOT))
+
+    return scenarios
+
+
+# ---------------------------------------------------------------------------
+# Routing plan (issue #4882, required work items 2 and 4)
+# ---------------------------------------------------------------------------
+
+# Three evidence states, kept distinct so a consumer cannot read structural
+# coverage as efficacy. Baseline membership in
+# `scripts/validation/check_rule_activation_coverage.py` is not one of these:
+# that ratchet records whether an artifact has a scenario at all, which is
+# state STRUCTURAL here, never SCORED.
+EVIDENCE_STRUCTURAL = "structurally_covered"
+EVIDENCE_SCENARIO = "scenario_defined_not_scored"
+EVIDENCE_SCORED = "scored"
+EVIDENCE_NONE = "not_evaluated"
+
+
+def _rule_plan_entries(files: list[str]) -> tuple[list[str], list[str]]:
+    """Split rule and instruction paths into (with scenario, without scenario)."""
+    scenarios = find_rule_scenarios()
+    with_scenario: list[str] = []
+    without_scenario: list[str] = []
+    for path in files:
+        rule_id = rule_id_for_path(path)
+        if rule_id is not None and rule_id in scenarios:
+            with_scenario.append(path)
+        else:
+            without_scenario.append(path)
+    return with_scenario, without_scenario
+
+
+def build_routing_plan(classified: dict[str, list[str]]) -> list[dict[str, Any]]:
+    """Describe what each classified category routes to, and its evidence state.
+
+    Deterministic: entries follow CATEGORIES order and files are sorted. This
+    is what `--dry-run` prints, and it is produced without invoking any
+    evaluator or parsing any model output.
+    """
+    plan: list[dict[str, Any]] = []
+
+    for category in CATEGORIES:
+        files = sorted(classified.get(category, []))
+        if not files:
+            continue
+
+        runner = RUNNER_BY_CATEGORY.get(category)
+        if runner is None:
+            plan.append({
+                "category": category,
+                "files": files,
+                "runner": None,
+                "evidence": EVIDENCE_NONE,
+                "reason": NOT_EVALUATED_REASONS[category],
+            })
+            continue
+
+        if category in ("rules", "instructions"):
+            with_scenario, without_scenario = _rule_plan_entries(files)
+            if with_scenario:
+                plan.append({
+                    "category": category,
+                    "files": with_scenario,
+                    "runner": runner,
+                    "evidence": EVIDENCE_SCENARIO,
+                    "reason": "activation scenario defined; run without --dry-run to score",
+                })
+            if without_scenario:
+                plan.append({
+                    "category": category,
+                    "files": without_scenario,
+                    "runner": None,
+                    "evidence": EVIDENCE_NONE,
+                    "reason": f"no activation scenario under {RULE_SCENARIO_DIR}/",
+                })
+            continue
+
+        plan.append({
+            "category": category,
+            "files": files,
+            "runner": runner,
+            "evidence": EVIDENCE_STRUCTURAL,
+            "reason": "routed to a runner; scoring requires a non-dry run",
+        })
+
+    return plan
+
+
+def _print_routing_plan(plan: list[dict[str, Any]]) -> None:
+    print("\n--- Routing Plan ---", file=sys.stderr)
+    if not plan:
+        print("  (nothing to route)", file=sys.stderr)
+        return
+    for entry in plan:
+        runner = entry["runner"] or "(none)"
+        print(
+            f"  {entry['category']:<24} {len(entry['files']):>3} file(s)"
+            f"  -> {runner}  [{entry['evidence']}]",
+            file=sys.stderr,
+        )
+        print(f"      reason: {entry['reason']}", file=sys.stderr)
+        for path in entry["files"]:
+            print(f"      - {path}", file=sys.stderr)
+
+
 # ---------------------------------------------------------------------------
 # Individual eval runners
 # ---------------------------------------------------------------------------
+
+def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
+    """Score rule and instruction changes via eval-rule-activation.py.
+
+    Reuses the existing activation evaluator rather than adding a parallel
+    harness (issue #4882, required work item 6). A rule with no scenario file
+    is reported `not_evaluated`, never silently passed.
+    """
+    scenarios = find_rule_scenarios()
+    results: dict[str, Any] = {"rules": {}}
+
+    targets: dict[str, str] = {}
+    for path in files:
+        rule_id = rule_id_for_path(path)
+        if rule_id is None:
+            results["rules"][path] = {
+                "skipped": True,
+                "evidence": EVIDENCE_NONE,
+                "reason": "path carries no resolvable rule id",
+            }
+        elif rule_id not in scenarios:
+            results["rules"][rule_id] = {
+                "skipped": True,
+                "evidence": EVIDENCE_NONE,
+                "reason": f"no activation scenario under {RULE_SCENARIO_DIR}/",
+            }
+        else:
+            targets[rule_id] = scenarios[rule_id]
+
+    for rule_id, scenario_path in sorted(targets.items()):
+        cmd = [
+            sys.executable, str(SCRIPT_DIR / "eval-rule-activation.py"),
+            "--scenarios", scenario_path, "--model", model,
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=600,
+                cwd=str(REPO_ROOT),
+            )
+            parsed, parse_error = _parse_child_json(result.stdout, f"rule {rule_id}")
+            passed = result.returncode == 0 and parse_error is None
+            exit_code = EXIT_EXTERNAL if parse_error is not None else result.returncode
+            if parse_error is not None:
+                print(f"WARNING: {parse_error}", file=sys.stderr)
+                parsed = {"raw_output": result.stdout[:500], "error": parse_error}
+
+            results["rules"][rule_id] = {
+                "passed": passed,
+                "exit_code": exit_code,
+                "evidence": EVIDENCE_SCORED if passed else EVIDENCE_SCENARIO,
+                "scenarios": scenario_path,
+                "results": parsed,
+            }
+        except subprocess.TimeoutExpired:
+            results["rules"][rule_id] = {"passed": False, "reason": "timeout (600s)"}
+
+    scored = [r for r in results["rules"].values() if not r.get("skipped")]
+    results["passed"] = all(r.get("passed", False) for r in scored)
+    return results
+
 
 def run_structural_tests(targets: list[str], dry_run: bool) -> dict[str, Any]:
     """Run Pester structural tests (ADR-023)."""
@@ -484,10 +863,19 @@ def _run_evals(
         if not result.get("passed"):
             any_failure = True
 
-    if classified["skills"] and args.scope in ("skills", "all"):
+    skill_files = classified["skills"] + classified["skill_references"]
+    if skill_files and args.scope in ("skills", "all"):
         print("\n--- Skill Knowledge Assessment ---", file=sys.stderr)
-        result = run_skill_knowledge(classified["skills"], args.model, args.dry_run)
+        result = run_skill_knowledge(skill_files, args.model, args.dry_run)
         results["skills"] = result
+        if not result.get("passed"):
+            any_failure = True
+
+    rule_files = classified["rules"] + classified["instructions"]
+    if rule_files and args.scope in ("rules", "all"):
+        print("\n--- Rule Activation Assessment ---", file=sys.stderr)
+        result = run_rule_activation(rule_files, args.model)
+        results["rules"] = result
         if not result.get("passed"):
             any_failure = True
 
@@ -533,7 +921,7 @@ def main() -> None:
     parser.add_argument("--base-ref", type=str, default="main",
                         help="Git ref to compare against (default: main)")
     parser.add_argument("--scope", type=str,
-                        choices=["prompts", "agents", "skills", "all"],
+                        choices=["prompts", "agents", "skills", "rules", "all"],
                         default="all", help="Limit to specific scope")
     parser.add_argument("--model", type=str, default=DEFAULT_MODEL,
                         help="Model for LLM-based assessments")
@@ -548,16 +936,27 @@ def main() -> None:
     except ChangeDetectionError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(EXIT_CONFIG)
-    results, any_failure = _run_evals(classified, args)
+    plan = build_routing_plan(classified)
+
+    # A dry run validates routing and planned work only. It invokes no
+    # evaluator and parses no model output (issue #4882, required work item 3).
+    if args.dry_run:
+        _print_routing_plan(plan)
+        results: dict[str, Any] = {}
+        any_failure = False
+    else:
+        results, any_failure = _run_evals(classified, args)
 
     elapsed = round(time.time() - start_time, 1)
     output: dict[str, Any] = {
-        "suite_version": "1.0.0",
+        "suite_version": "1.1.0",
         "base_ref": args.base_ref,
         "model": args.model,
         "scope": args.scope,
+        "dry_run": args.dry_run,
         "changed_files": sum(len(v) for v in classified.values()),
         "classification": {k: v for k, v in classified.items() if v},
+        "routing_plan": plan,
         "results": results,
         "elapsed_seconds": elapsed,
         "passed": not any_failure,

--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -18,10 +18,17 @@ Evaluator routing:
     - Skill reference changes    -> eval-knowledge-integration.py (parent skill)
     - Canonical rule changes     -> eval-rule-activation.py (scenario-gated)
     - Instruction mirror changes -> eval-rule-activation.py (via canonical rule)
+    - Command mirror changes     -> not evaluated (evaluate the command instead)
+    - Entrypoint changes         -> not evaluated (no evaluator exists)
 
 Every classified category either names a runner or carries an explicit
 `not_evaluated` reason in the routing plan. No context-bearing category falls
 silently into `other` (issue #4882, required work item 2).
+
+Two rows are identified by something other than a directory prefix, so they run
+before every prefix row: entrypoints, which are named by filename and live
+inside the prompt and skill trees, and command mirrors, which sit in the
+Copilot skills tree but are generated from `.claude/commands/`.
 
 Usage:
     # Auto-detect from git diff against main:
@@ -51,6 +58,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -256,6 +264,7 @@ class RoutingRule(NamedTuple):
     basenames: frozenset[str] = frozenset()
     exclude_basenames: frozenset[str] = frozenset()
     exclude_substrings: tuple[str, ...] = ()
+    predicate: Callable[[str], bool] | None = None
 
     def matches(self, path: str) -> bool:
         if self.prefix and not path.startswith(self.prefix):
@@ -272,7 +281,40 @@ class RoutingRule(NamedTuple):
             return False
         if self.segment is not None and self.segment not in parts[:-1]:
             return False
+        if self.predicate is not None and not self.predicate(path):
+            return False
         return True
+
+
+def is_command_mirror_skill(path: str) -> bool:
+    """Whether a generated Copilot skill mirrors a command, not a Claude skill.
+
+    `src/copilot-cli/skills/` holds two different kinds of artifact. Most
+    entries mirror `.claude/skills/<name>/`. Fourteen instead mirror
+    `.claude/commands/<name>.md` and have no `.claude/skills/<name>/` at all:
+    build, checkpoint, context-hub-setup, plan, pr-autofix, pr-review,
+    push-pr, research, retro, ship, sync, spec, test, validate-pr-description.
+
+    The distinction is load bearing because `eval-knowledge-integration.py`
+    resolves a skill only under `.claude/skills/`. Measured:
+
+        $ eval-knowledge-integration.py --skill spec --dry-run
+        exit=1
+        ERROR: Skill directory not found for 'spec' in .../.claude/skills
+
+    Routing a command mirror there reproduces issue #4882's own failure shape
+    at a new site, so these are reported `not_evaluated` instead.
+
+    Reads the filesystem because the distinction exists only there: nothing in
+    the path spells out which kind a Copilot skill is.
+    """
+    parts = path.split("/")
+    if not path.startswith("src/copilot-cli/skills/") or len(parts) < 4:
+        return False
+    name = parts[3]
+    if (REPO_ROOT / ".claude" / "skills" / name).is_dir():
+        return False
+    return (REPO_ROOT / ".claude" / "commands" / f"{name}.md").is_file()
 
 
 def _rules_for(
@@ -308,6 +350,21 @@ def _rules_for(
 # negative control replays the broad prefix to prove the tests catch a
 # reintroduction.
 ROUTING_RULES: tuple[RoutingRule, ...] = (
+    # Basename rows first. An entrypoint is identified by its filename, not by
+    # where it sits, and real ones live inside the prompt and skill trees
+    # (`.claude/commands/CLAUDE.md`, `.claude/skills/CLAUDE.md`,
+    # `.claude/skills/adr-review/CLAUDE.md`, `src/copilot-cli/skills/github/
+    # CLAUDE.md`, and 14 more). Behind the prefix rows they were all captured
+    # as prompts or skills.
+    RoutingRule("entrypoints", basenames=ENTRYPOINT_BASENAMES),
+    # Command mirrors before the skill rows: they live under the Copilot skills
+    # tree but the skill evaluator cannot resolve them.
+    RoutingRule(
+        "command_mirrors",
+        prefix="src/copilot-cli/skills/",
+        suffix="",
+        predicate=is_command_mirror_skill,
+    ),
     *_rules_for("prompts", PROMPT_PATTERNS),
     # References must precede the trees that contain them.
     *_rules_for("skill_references", SKILL_PATTERNS, segment=REFERENCE_SEGMENT),
@@ -321,7 +378,6 @@ ROUTING_RULES: tuple[RoutingRule, ...] = (
         exclude_basenames=AGENT_EXCLUDED_BASENAMES,
         exclude_substrings=AGENT_EXCLUDED_SUBSTRINGS,
     ),
-    RoutingRule("entrypoints", basenames=ENTRYPOINT_BASENAMES),
     *_rules_for("scenarios", SCENARIO_DIRS, suffix=""),
 )
 
@@ -330,6 +386,7 @@ CATEGORIES: tuple[str, ...] = (
     "agents",
     "skills",
     "skill_references",
+    "command_mirrors",
     "references",
     "rules",
     "instructions",
@@ -353,6 +410,10 @@ RUNNER_BY_CATEGORY: dict[str, str] = {
 }
 
 NOT_EVALUATED_REASONS: dict[str, str] = {
+    "command_mirrors": (
+        "generated from a .claude/commands/ file; the skill evaluator resolves "
+        "only .claude/skills/, so evaluate the generating command instead"
+    ),
     "references": (
         "reference material for a non-skill artifact; no evaluator consumes it"
     ),
@@ -510,13 +571,33 @@ def find_rule_scenarios() -> dict[str, str]:
                 f"scenario file must contain an object: {candidate}"
             )
         rule_path = data.get("rule_path")
-        if rule_path is None:
-            # A skill-targeted ADR-088 scenario. Not a rule; not an error.
-            continue
-        if not isinstance(rule_path, str) or not rule_path.strip():
+        has_rule = isinstance(rule_path, str) and bool(rule_path.strip())
+        if not has_rule:
+            # Only the real ADR-088 reference-scenario shape is a legitimate
+            # skip. The canonical test is
+            # `check_rule_activation_coverage.py:_is_reference_scenario`:
+            #
+            #     has_reference = isinstance(reference, str) and bool(reference.strip())
+            #     has_skill = isinstance(skill, str) and bool(skill.strip())
+            #     has_rule = isinstance(rule, str) and bool(rule.strip())
+            #     if not (has_reference and has_skill and not has_rule):
+            #         return False
+            #
+            # An empty object, or a lone skill_path with no reference_path, is
+            # not a reference scenario. Treating it as one turns a malformed
+            # file into a silent absence, which is the failure this function
+            # exists to prevent.
+            reference = data.get("reference_path")
+            skill = data.get("skill_path")
+            has_reference = isinstance(reference, str) and bool(reference.strip())
+            has_skill = isinstance(skill, str) and bool(skill.strip())
+            if has_reference and has_skill:
+                continue
             raise ScenarioConfigError(
-                f"rule_path must be a non-empty string in {candidate}"
+                f"scenario names no rule_path and is not an ADR-088 reference "
+                f"scenario (needs both skill_path and reference_path): {candidate}"
             )
+        assert isinstance(rule_path, str)
         scenarios[Path(rule_path).stem] = str(candidate.relative_to(REPO_ROOT))
 
     return scenarios
@@ -823,7 +904,11 @@ def run_rule_activation(files: list[str], model: str) -> dict[str, Any]:
                     cwd=str(REPO_ROOT),
                 )
             except subprocess.TimeoutExpired:
-                results["rules"][rule_id] = {"passed": False, "reason": "timeout (600s)"}
+                results["rules"][rule_id] = {
+                    "passed": False,
+                    "exit_code": EXIT_EXTERNAL,
+                    "reason": "timeout (600s)",
+                }
                 continue
 
             parsed, signal_error = _read_child_json_file(output_path, f"rule {rule_id}")
@@ -891,7 +976,12 @@ def run_structural_tests(targets: list[str], dry_run: bool) -> dict[str, Any]:
     except FileNotFoundError:
         return {"skipped": True, "reason": "pwsh not found", "targets": targets}
     except subprocess.TimeoutExpired:
-        return {"passed": False, "reason": "timeout (60s)", "targets": targets}
+        return {
+            "passed": False,
+            "exit_code": EXIT_EXTERNAL,
+            "reason": "timeout (60s)",
+            "targets": targets,
+        }
 
 
 def run_behavioral_for_prompt(
@@ -943,7 +1033,12 @@ def run_behavioral_for_prompt(
             "results": parsed,
         }
     except subprocess.TimeoutExpired:
-        return {"passed": False, "reason": "timeout (600s)", "prompt": prompt_path}
+        return {
+            "passed": False,
+            "exit_code": EXIT_EXTERNAL,
+            "reason": "timeout (600s)",
+            "prompt": prompt_path,
+        }
 
 
 def run_agent_quality(
@@ -986,7 +1081,11 @@ def run_agent_quality(
                 "results": parsed,
             }
         except subprocess.TimeoutExpired:
-            results["agents"][name] = {"passed": False, "reason": "timeout (300s)"}
+            results["agents"][name] = {
+                "passed": False,
+                "exit_code": EXIT_EXTERNAL,
+                "reason": "timeout (300s)",
+            }
 
     results["passed"] = all(a.get("passed", False) for a in results["agents"].values())
     return results
@@ -1040,7 +1139,11 @@ def run_skill_knowledge(
                 "results": parsed,
             }
         except subprocess.TimeoutExpired:
-            results["skills"][name] = {"passed": False, "reason": "timeout (300s)"}
+            results["skills"][name] = {
+                "passed": False,
+                "exit_code": EXIT_EXTERNAL,
+                "reason": "timeout (300s)",
+            }
 
     results["passed"] = all(s.get("passed", False) for s in results["skills"].values())
     return results

--- a/tests/eval/test_eval_suite_routing.py
+++ b/tests/eval/test_eval_suite_routing.py
@@ -468,37 +468,73 @@ def test_find_rule_scenarios_returns_empty_when_the_directory_is_absent(
     assert suite.find_rule_scenarios() == {}
 
 
-def test_find_rule_scenarios_skips_malformed_json(
+def test_find_rule_scenarios_raises_on_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken scenario file is an authoring bug, not an absent scenario.
+
+    Mirrors `check_rule_activation_coverage.py:_read_scenario_json`, which
+    raises CoverageConfigError rather than skipping the file.
+    """
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "broken.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(suite.ScenarioConfigError, match="invalid JSON"):
+        suite.find_rule_scenarios()
+
+
+def test_find_rule_scenarios_raises_on_unreadable_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     scenario_dir = _scenario_root(tmp_path, monkeypatch)
-    (scenario_dir / "broken.json").write_text("{not json", encoding="utf-8")
+    # A directory named *.json satisfies the glob but cannot be read as text.
+    (scenario_dir / "adirectory.json").mkdir()
+    with pytest.raises(suite.ScenarioConfigError, match="cannot read scenario file"):
+        suite.find_rule_scenarios()
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ('["not", "an", "object"]', "must contain an object"),
+        ('{"rule_path": ""}', "non-empty string"),
+        ('{"rule_path": "   "}', "non-empty string"),
+        ('{"rule_path": 42}', "non-empty string"),
+    ],
+    ids=["list", "empty", "blank", "wrong_type"],
+)
+def test_find_rule_scenarios_raises_on_broken_rule_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str, match: str
+) -> None:
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
+    with pytest.raises(suite.ScenarioConfigError, match=match):
+        suite.find_rule_scenarios()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ['{"skill_path": ".claude/skills/analyze/SKILL.md"}', "{}"],
+    ids=["skill_target", "no_keys"],
+)
+def test_find_rule_scenarios_skips_scenarios_with_no_rule_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str
+) -> None:
+    """ADR-088 skill scenarios live in the same directory and are not errors."""
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
+    assert suite.find_rule_scenarios() == {}
+
+
+def test_find_rule_scenarios_reads_a_valid_rule_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
     (scenario_dir / "good.json").write_text(
         '{"rule_path": ".claude/rules/good.md"}', encoding="utf-8"
     )
     assert suite.find_rule_scenarios() == {
         "good": f"{suite.RULE_SCENARIO_DIR}/good.json"
     }
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
-        '["not", "an", "object"]',
-        '{"skill_path": ".claude/skills/analyze/SKILL.md"}',
-        '{"rule_path": ""}',
-        '{"rule_path": "   "}',
-        '{"rule_path": 42}',
-        "{}",
-    ],
-    ids=["list", "skill_target", "empty", "blank", "wrong_type", "no_keys"],
-)
-def test_find_rule_scenarios_ignores_non_rule_targets(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str
-) -> None:
-    scenario_dir = _scenario_root(tmp_path, monkeypatch)
-    (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
-    assert suite.find_rule_scenarios() == {}
 
 
 # ---------------------------------------------------------------------------
@@ -544,17 +580,36 @@ class _FakeCompleted:
         self.stderr = ""
 
 
+# The real child prints a human table to stdout. Any mock that returns JSON on
+# stdout encodes the imagined contract that shipped the first version of this
+# runner; keep the stub faithful to
+# `scripts/eval/eval-rule-activation.py:2450-2452`.
+_CHILD_STDOUT = "code-quality  activation 4.2  citation 3.9\n\nWrote results: /tmp/x.json\n"
+
+
+def _output_path_from(cmd: list[str]) -> Path | None:
+    if "--output" not in cmd:
+        return None
+    return Path(cmd[cmd.index("--output") + 1])
+
+
 def _stub_child(
     monkeypatch: pytest.MonkeyPatch,
-    stdout: str = '{"verdict": "PASS"}',
+    file_payload: str | None = '{"schema_version": 1, "rules": {}}',
     returncode: int = 0,
 ) -> list[list[str]]:
-    """Replace subprocess.run and record the argv of every invocation."""
+    """Replace subprocess.run with a stub that honors the --output contract.
+
+    `file_payload=None` simulates a child that writes no results file.
+    """
     calls: list[list[str]] = []
 
     def fake_run(cmd, **_kwargs):
         calls.append(list(cmd))
-        return _FakeCompleted(stdout, returncode)
+        target = _output_path_from(list(cmd))
+        if target is not None and file_payload is not None:
+            target.write_text(file_payload, encoding="utf-8")
+        return _FakeCompleted(_CHILD_STDOUT, returncode)
 
     monkeypatch.setattr(suite.subprocess, "run", fake_run)
     return calls
@@ -574,6 +629,48 @@ def test_run_rule_activation_scores_a_scenario_backed_rule(
     assert "eval-rule-activation.py" in calls[0][1]
     assert "--scenarios" in calls[0]
     assert "tests/evals/rule-scenarios/code-quality.json" in calls[0]
+    # The results contract: JSON comes from --output, never stdout.
+    assert "--output" in calls[0]
+    assert "--dry-run" not in calls[0]
+
+
+def test_run_rule_activation_reads_results_from_the_output_file_not_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the imagined-contract bug this runner shipped with.
+
+    The child prints a table to stdout and serializes JSON only to --output.
+    A runner that parsed stdout would fail on every real run.
+    """
+    _stub_child(monkeypatch, file_payload='{"schema_version": 1, "rules": {"x": 1}}')
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    entry = result["rules"]["code-quality"]
+    assert entry["results"] == {"schema_version": 1, "rules": {"x": 1}}
+    assert entry["passed"] is True
+
+
+def test_run_rule_activation_fails_when_no_results_file_is_written(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exit 0 with no results file must not read as a pass."""
+    _stub_child(monkeypatch, file_payload=None, returncode=0)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    entry = result["rules"]["code-quality"]
+    assert entry["passed"] is False
+    assert entry["exit_code"] == suite.EXIT_EXTERNAL
+    assert entry["evidence"] == suite.EVIDENCE_SCENARIO
+    assert "no results file" in entry["results"]["error"]
+
+
+def test_run_rule_activation_marks_a_failing_run_as_scored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A verdict that ran and failed is still scored evidence."""
+    _stub_child(monkeypatch, returncode=1)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    entry = result["rules"]["code-quality"]
+    assert entry["passed"] is False
+    assert entry["evidence"] == suite.EVIDENCE_SCORED
 
 
 def test_run_rule_activation_dedupes_a_rule_and_its_two_mirrors(
@@ -625,22 +722,29 @@ def test_run_rule_activation_fails_when_the_child_exits_nonzero(
     _stub_child(monkeypatch, returncode=1)
     result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
     assert result["passed"] is False
-    entry = result["rules"]["code-quality"]
-    assert entry["exit_code"] == 1
-    assert entry["evidence"] == suite.EVIDENCE_SCENARIO
+    assert result["rules"]["code-quality"]["exit_code"] == 1
 
 
-def test_run_rule_activation_maps_unparseable_child_output_to_external(
+def test_run_rule_activation_maps_unparseable_results_to_external(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The failure shape issue #4882 produced: empty stdout from the child."""
-    _stub_child(monkeypatch, stdout="", returncode=1)
+    _stub_child(monkeypatch, file_payload="not json at all", returncode=0)
     result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
     entry = result["rules"]["code-quality"]
     assert entry["exit_code"] == suite.EXIT_EXTERNAL
     assert entry["evidence"] == suite.EVIDENCE_SCENARIO
     assert "error" in entry["results"]
     assert suite._contains_external_failure(result) is True
+
+
+def test_run_rule_activation_rejects_non_object_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_child(monkeypatch, file_payload='["a", "list"]', returncode=0)
+    entry = suite.run_rule_activation(
+        [".claude/rules/code-quality.md"], "test-model"
+    )["rules"]["code-quality"]
+    assert entry["exit_code"] == suite.EXIT_EXTERNAL
 
 
 def test_run_rule_activation_handles_a_child_timeout(
@@ -679,6 +783,75 @@ def test_run_rule_activation_pins_utf8_decoding(
     assert seen["encoding"] == "utf-8"
     assert seen["errors"] == "replace"
     assert seen["capture_output"] is True
+
+
+# ---------------------------------------------------------------------------
+# Real child CLI contract (no mock)
+# ---------------------------------------------------------------------------
+
+def _run_child(args: list[str], tmp_path: Path):
+    import os
+    import subprocess as _subprocess
+
+    return _subprocess.run(
+        [sys.executable, str(EVAL_DIR / "eval-rule-activation.py"), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=300,
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(EVAL_DIR)},
+    )
+
+
+def test_child_cli_does_not_emit_json_on_stdout() -> None:
+    """The contract the first version of this runner got wrong.
+
+    `eval-rule-activation.py` prints a human table to stdout and serializes
+    JSON only to `--output`. This runs the real CLI to prove it, so the mock
+    above cannot drift back to the imagined stdout-JSON contract.
+    """
+    import json as _json
+
+    proc = _run_child(
+        ["--scenarios", "tests/evals/rule-scenarios/code-quality.json", "--dry-run"],
+        REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert proc.stdout.strip(), "child produced no stdout at all"
+    with pytest.raises(_json.JSONDecodeError):
+        _json.loads(proc.stdout)
+
+
+def test_child_cli_writes_no_results_file_during_dry_run(tmp_path: Path) -> None:
+    """Why the suite never passes --dry-run to this child.
+
+    The child returns before the --output write, so a dry run yields no
+    results file. The suite short circuits its own dry run instead.
+    """
+    out = tmp_path / "results.json"
+    proc = _run_child(
+        [
+            "--scenarios", "tests/evals/rule-scenarios/code-quality.json",
+            "--dry-run", "--output", str(out),
+        ],
+        tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert not out.exists()
+
+
+def test_suite_invokes_the_child_with_output_and_without_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ties the runner's argv to the contract the two tests above measured."""
+    calls = _stub_child(monkeypatch)
+    suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    argv = calls[0]
+    assert "--output" in argv
+    assert "--dry-run" not in argv
+    assert argv[argv.index("--output") + 1].endswith(".json")
 
 
 # ---------------------------------------------------------------------------
@@ -767,44 +940,340 @@ def test_agents_scope_does_not_run_rules(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "rules" not in seen
 
 
+def test_run_evals_propagates_a_rule_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(suite, "run_rule_activation", lambda *_: {"passed": False})
+    classified = suite.classify_changes([".claude/rules/code-quality.md"])
+    _results, any_failure = suite._run_evals(classified, _Args("all"))
+    assert any_failure is True
+
+
+def test_run_evals_propagates_a_skill_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(suite, "run_skill_knowledge", lambda *_: {"passed": False})
+    classified = suite.classify_changes([".claude/skills/analyze/SKILL.md"])
+    _results, any_failure = suite._run_evals(classified, _Args("all"))
+    assert any_failure is True
+
+
+def test_run_evals_reports_no_failure_when_every_runner_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _record_runners(monkeypatch)
+    classified = suite.classify_changes([
+        ".claude/rules/code-quality.md",
+        ".claude/skills/analyze/SKILL.md",
+        ".claude/agents/implementer.md",
+    ])
+    _results, any_failure = suite._run_evals(classified, _Args("all"))
+    assert any_failure is False
+
+
 def test_rules_is_an_accepted_scope_value() -> None:
     source = (EVAL_DIR / "eval-suite.py").read_text(encoding="utf-8")
     assert '"prompts", "agents", "skills", "rules", "all"' in source
 
 
 # ---------------------------------------------------------------------------
+# Scope: the dry-run plan must describe what THIS invocation will do
+# ---------------------------------------------------------------------------
+
+SCOPED_PATHS = [
+    ".claude/commands/spec.md",
+    ".claude/agents/implementer.md",
+    ".claude/skills/analyze/SKILL.md",
+    ".claude/rules/code-quality.md",
+]
+
+
+@pytest.mark.parametrize(
+    "scope,expected_runner_categories",
+    [
+        ("all", {"prompts", "agents", "skills", "rules"}),
+        ("prompts", {"prompts"}),
+        ("agents", {"agents"}),
+        ("skills", {"skills"}),
+        ("rules", {"rules"}),
+    ],
+)
+def test_plan_reports_only_in_scope_categories_as_routed(
+    scope: str, expected_runner_categories: set[str]
+) -> None:
+    plan = suite.build_routing_plan(suite.classify_changes(SCOPED_PATHS), scope)
+    routed = {e["category"] for e in plan if e["runner"] is not None}
+    assert routed == expected_runner_categories
+
+
+@pytest.mark.parametrize("scope", ["prompts", "agents", "skills", "rules"])
+def test_out_of_scope_categories_say_why(scope: str) -> None:
+    plan = suite.build_routing_plan(suite.classify_changes(SCOPED_PATHS), scope)
+    for entry in plan:
+        if entry["runner"] is None and entry["category"] in suite.SCOPE_BY_CATEGORY:
+            assert entry["evidence"] == suite.EVIDENCE_NONE
+            assert entry["reason"] == f"excluded by --scope {scope}"
+
+
+def test_plan_scope_gate_matches_run_evals_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plan must not promise work the real path skips.
+
+    Runs both sides for every scope and asserts they agree on which
+    runner-backed categories are active.
+    """
+    for scope in ("all", "prompts", "agents", "skills", "rules"):
+        seen = _record_runners(monkeypatch)
+        classified = suite.classify_changes(SCOPED_PATHS)
+        suite._run_evals(classified, _Args(scope))
+        planned = {
+            e["category"] for e in suite.build_routing_plan(classified, scope)
+            if e["runner"] is not None
+        }
+        # _run_evals reports skills and prompts under one key each.
+        actually_ran = set(seen)
+        planned_runners = {
+            "skills" if c in ("skills", "skill_references") else
+            "rules" if c in ("rules", "instructions") else c
+            for c in planned
+        }
+        assert planned_runners - {"prompts"} == actually_ran - {"prompts"}, (
+            f"scope {scope}: plan says {planned_runners}, _run_evals ran {actually_ran}"
+        )
+
+
+def test_category_in_scope_rejects_categories_with_no_runner() -> None:
+    for category in ("entrypoints", "references", "scenarios", "other"):
+        assert suite.category_in_scope(category, "all") is False
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation: the published plan must match what actually happened
+# ---------------------------------------------------------------------------
+
+def test_reconcile_promotes_an_evaluated_rule_to_scored() -> None:
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/rules/code-quality.md"]), "all"
+    )
+    assert plan[0]["evidence"] == suite.EVIDENCE_SCENARIO
+
+    results = {"rules": {"rules": {"code-quality": {"passed": True, "exit_code": 0}}}}
+    reconciled = suite.reconcile_routing_plan(plan, results)
+    assert reconciled[0]["evidence"] == suite.EVIDENCE_SCORED
+
+
+def test_reconcile_counts_a_failing_run_as_scored() -> None:
+    """Scored means a verdict exists, not that the verdict was positive."""
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/rules/code-quality.md"]), "all"
+    )
+    results = {"rules": {"rules": {"code-quality": {"passed": False, "exit_code": 1}}}}
+    assert suite.reconcile_routing_plan(plan, results)[0]["evidence"] == (
+        suite.EVIDENCE_SCORED
+    )
+
+
+def test_reconcile_leaves_a_skipped_rule_unscored() -> None:
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/rules/code-quality.md"]), "all"
+    )
+    results = {
+        "rules": {"rules": {"code-quality": {"skipped": True, "reason": "no scenario"}}}
+    }
+    assert suite.reconcile_routing_plan(plan, results)[0]["evidence"] == (
+        suite.EVIDENCE_SCENARIO
+    )
+
+
+def test_reconcile_leaves_a_scenarioless_rule_entry_untouched() -> None:
+    """A rules entry already at not_evaluated has nothing to promote."""
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/rules/canonical-source-mirror.md"]), "all"
+    )
+    assert plan[0]["evidence"] == suite.EVIDENCE_NONE
+    results = {"rules": {"rules": {"code-quality": {"passed": True}}}}
+    assert suite.reconcile_routing_plan(plan, results) == plan
+
+
+def test_reconcile_splits_a_mixed_entry_into_scored_and_unscored() -> None:
+    """Two scenario-backed rules where only one actually ran."""
+    plan = [{
+        "category": "rules",
+        "files": [".claude/rules/code-quality.md", ".claude/rules/universal.md"],
+        "runner": "eval-rule-activation.py",
+        "evidence": suite.EVIDENCE_SCENARIO,
+        "reason": "activation scenario defined; run without --dry-run to score",
+    }]
+    results = {"rules": {"rules": {"code-quality": {"passed": True, "exit_code": 0}}}}
+    reconciled = suite.reconcile_routing_plan(plan, results)
+    by_evidence = {e["evidence"]: e["files"] for e in reconciled}
+    assert by_evidence[suite.EVIDENCE_SCORED] == [".claude/rules/code-quality.md"]
+    assert by_evidence[suite.EVIDENCE_SCENARIO] == [".claude/rules/universal.md"]
+
+
+def test_reconcile_is_a_noop_without_rule_results() -> None:
+    plan = suite.build_routing_plan(suite.classify_changes(SCOPED_PATHS), "all")
+    assert suite.reconcile_routing_plan(plan, {}) == plan
+
+
+def test_reconcile_leaves_non_rule_categories_alone() -> None:
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/agents/implementer.md"]), "all"
+    )
+    results = {"rules": {"rules": {"code-quality": {"passed": True}}}}
+    assert suite.reconcile_routing_plan(plan, results) == plan
+
+
+# ---------------------------------------------------------------------------
 # End to end: the dry run the issue reproduced
 # ---------------------------------------------------------------------------
 
-def test_dry_run_exits_zero_and_emits_a_routing_plan() -> None:
-    """AC: a dry run exits successfully and prints a deterministic routing plan.
-
-    Pre-fix, this exited 3 because misrouted files reached eval-agents.py, which
-    exits 1 with empty stdout. A dry run now invokes no evaluator at all.
-    """
-    import json as _json
+def _git(repo: Path, *args: str) -> None:
     import subprocess as _subprocess
 
-    proc = _subprocess.run(
-        [sys.executable, str(EVAL_DIR / "eval-suite.py"), "--base-ref", "HEAD", "--dry-run"],
+    _subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _build_fixture_repo(tmp_path: Path) -> Path:
+    """A throwaway repo with a base commit and one changed file per category.
+
+    Built rather than reusing this checkout: a clean CI checkout has no diff
+    against HEAD, so a test pointed at the real repo skips itself and never
+    exercises the path it claims to cover.
+    """
+    repo = tmp_path / "fixture-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    tracked = {
+        ".claude/agents/implementer.md": "base agent\n",
+        ".claude/skills/analyze/SKILL.md": "base skill\n",
+        "src/copilot-cli/skills/analyze/references/deep.md": "base reference\n",
+        "src/copilot-cli/instructions/code-quality.instructions.md": "base mirror\n",
+        ".claude/rules/code-quality.md": "base rule\n",
+        "AGENTS.md": "base entrypoint\n",
+        "unrelated.txt": "base other\n",
+    }
+    for rel, body in tracked.items():
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+
+    # Change every tracked artifact so each category is populated.
+    for rel in tracked:
+        (repo / rel).write_text("changed\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "change every artifact")
+    return repo
+
+
+def _run_suite_in(repo: Path, *args: str):
+    """Run the suite against a fixture repo by pointing REPO_ROOT at it."""
+    import os
+    import subprocess as _subprocess
+
+    runner = (
+        "import importlib.util,sys;"
+        f"spec=importlib.util.spec_from_file_location('es',{str(EVAL_DIR / 'eval-suite.py')!r});"
+        "m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);"
+        f"m.REPO_ROOT=__import__('pathlib').Path({str(repo)!r});"
+        "sys.argv=['eval-suite']+sys.argv[1:];m.main()"
+    )
+    return _subprocess.run(
+        [sys.executable, "-c", runner, *args],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
         timeout=120,
-        cwd=str(REPO_ROOT),
-        env={**__import__("os").environ, "PYTHONPATH": str(EVAL_DIR)},
+        cwd=str(repo),
+        env={**os.environ, "PYTHONPATH": str(EVAL_DIR)},
     )
-    if proc.returncode == 0 and not proc.stdout.strip():
-        pytest.skip("no changes against HEAD, suite exited early")
 
-    assert proc.returncode == 0, proc.stderr[-2000:]
+
+def test_dry_run_over_a_real_diff_exits_zero_with_a_populated_plan(
+    tmp_path: Path,
+) -> None:
+    """AC: a dry run exits successfully and prints a deterministic routing plan.
+
+    Pre-fix this exited 3, because misrouted files reached the agent evaluator,
+    which exits 1 with empty stdout. A dry run now invokes no evaluator at all.
+    """
+    import json as _json
+
+    repo = _build_fixture_repo(tmp_path)
+    proc = _run_suite_in(repo, "--base-ref", "HEAD~1", "--dry-run")
+
+    assert proc.returncode == 0, proc.stderr[-3000:]
     payload = _json.loads(proc.stdout)
+
     assert payload["dry_run"] is True
     assert payload["passed"] is True
-    assert payload["results"] == {}
-    assert "routing_plan" in payload
-    for entry in payload["routing_plan"]:
+    assert payload["results"] == {}, "a dry run must invoke no evaluator"
+    assert "JSON parse failed" not in proc.stderr
+
+    plan = payload["routing_plan"]
+    assert plan, "fixture diff produced an empty routing plan"
+    by_category = {e["category"]: e for e in plan}
+    for expected in ("agents", "skills", "skill_references", "instructions", "rules"):
+        assert expected in by_category, f"{expected} missing from plan: {list(by_category)}"
+
+    # The four paths issue #4882 misrouted must not be under `agents`.
+    assert by_category["agents"]["files"] == [".claude/agents/implementer.md"]
+
+    for entry in plan:
         assert entry["reason"]
         assert entry["files"] == sorted(entry["files"])
-    assert "JSON parse failed" not in proc.stderr
+
+
+def test_dry_run_plan_honors_scope_over_a_real_diff(tmp_path: Path) -> None:
+    import json as _json
+
+    repo = _build_fixture_repo(tmp_path)
+    proc = _run_suite_in(repo, "--base-ref", "HEAD~1", "--dry-run", "--scope", "agents")
+
+    assert proc.returncode == 0, proc.stderr[-3000:]
+    plan = _json.loads(proc.stdout)["routing_plan"]
+    routed = {e["category"] for e in plan if e["runner"] is not None}
+    assert routed == {"agents"}
+    for entry in plan:
+        if entry["category"] in ("rules", "skills") and entry["runner"] is None:
+            assert entry["reason"] == "excluded by --scope agents"
+
+
+def test_dry_run_exits_config_on_a_malformed_scenario_file(tmp_path: Path) -> None:
+    """A broken scenario file must stop the run, not read as 'no scenario'.
+
+    Exit 2 is EXIT_CONFIG, matching the canonical coverage checker's exit code
+    for a scenario-file fault.
+    """
+    repo = _build_fixture_repo(tmp_path)
+    scenario_dir = repo / "tests" / "evals" / "rule-scenarios"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "broken.json").write_text("{not json", encoding="utf-8")
+
+    proc = _run_suite_in(repo, "--base-ref", "HEAD~1", "--dry-run")
+    assert proc.returncode == 2, (proc.returncode, proc.stdout[-500:], proc.stderr[-2000:])
+    assert "invalid JSON in scenario file" in proc.stderr
+
+
+def test_dry_run_is_deterministic_across_runs(tmp_path: Path) -> None:
+    import json as _json
+
+    repo = _build_fixture_repo(tmp_path)
+    first = _run_suite_in(repo, "--base-ref", "HEAD~1", "--dry-run")
+    second = _run_suite_in(repo, "--base-ref", "HEAD~1", "--dry-run")
+    assert first.returncode == 0 and second.returncode == 0
+    assert _json.loads(first.stdout)["routing_plan"] == (
+        _json.loads(second.stdout)["routing_plan"]
+    )

--- a/tests/eval/test_eval_suite_routing.py
+++ b/tests/eval/test_eval_suite_routing.py
@@ -29,6 +29,7 @@ Two classes of test here:
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -492,6 +493,26 @@ def test_find_rule_scenarios_raises_on_unreadable_file(
         suite.find_rule_scenarios()
 
 
+def test_find_rule_scenarios_raises_on_a_non_utf8_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """UnicodeDecodeError subclasses ValueError, not OSError.
+
+    An OSError-only guard lets a binary or mis-encoded scenario file escape as
+    an unhandled traceback instead of the documented config exit.
+    """
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "binary.json").write_bytes(b'{"rule_path": "\xff\xfe\x00\x81"}')
+    with pytest.raises(suite.ScenarioConfigError, match="cannot read scenario file"):
+        suite.find_rule_scenarios()
+
+
+def test_non_utf8_is_not_an_oserror() -> None:
+    """Pins the reason the guard needs a second exception type."""
+    assert not issubclass(UnicodeDecodeError, OSError)
+    assert issubclass(UnicodeDecodeError, ValueError)
+
+
 @pytest.mark.parametrize(
     "payload,match",
     [
@@ -593,9 +614,27 @@ def _output_path_from(cmd: list[str]) -> Path | None:
     return Path(cmd[cmd.index("--output") + 1])
 
 
+# A scored run, shaped like the real child's output. The verdict path is set by
+# `scripts/eval/eval-rule-activation.py:_process_scenario_file`:
+#
+#     all_results["rules"][rule_id] = result
+#     state.worst_exit = max(state.worst_exit, _classify_verdict(result["summary"]["verdict"]))
+#
+# The default must carry a verdict. An earlier default of `{"rules": {}}`
+# certified that "child produced zero verdicts" was a passing, scored shape,
+# which is the bug that shape is now a negative test for.
+_SCORED_PAYLOAD = json.dumps({
+    "schema_version": 1,
+    "model_id": "test-model",
+    "rules": {"code-quality": {"summary": {"verdict": "PASS"}}},
+})
+
+_NO_VERDICT_PAYLOAD = '{"schema_version": 1, "rules": {}}'
+
+
 def _stub_child(
     monkeypatch: pytest.MonkeyPatch,
-    file_payload: str | None = '{"schema_version": 1, "rules": {}}',
+    file_payload: str | None = _SCORED_PAYLOAD,
     returncode: int = 0,
 ) -> list[list[str]]:
     """Replace subprocess.run with a stub that honors the --output contract.
@@ -642,11 +681,129 @@ def test_run_rule_activation_reads_results_from_the_output_file_not_stdout(
     The child prints a table to stdout and serializes JSON only to --output.
     A runner that parsed stdout would fail on every real run.
     """
-    _stub_child(monkeypatch, file_payload='{"schema_version": 1, "rules": {"x": 1}}')
+    _stub_child(monkeypatch)
     result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
     entry = result["rules"]["code-quality"]
-    assert entry["results"] == {"schema_version": 1, "rules": {"x": 1}}
+    assert entry["results"]["rules"]["code-quality"]["summary"]["verdict"] == "PASS"
     assert entry["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Parseable is not scored: the verdict must actually be present
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "payload,ids",
+    [
+        (_NO_VERDICT_PAYLOAD, "empty_rules_map"),
+        ('{"schema_version": 1}', "no_rules_key"),
+        ('{"rules": []}', "rules_not_a_map"),
+        ('{"rules": {"other-rule": {"summary": {"verdict": "PASS"}}}}', "wrong_rule_id"),
+        ('{"rules": {"code-quality": "not an object"}}', "entry_not_object"),
+        ('{"rules": {"code-quality": {}}}', "no_summary"),
+        ('{"rules": {"code-quality": {"summary": {}}}}', "no_verdict"),
+        ('{"rules": {"code-quality": {"summary": {"verdict": ""}}}}', "blank_verdict"),
+        ('{"rules": {"code-quality": {"summary": {"verdict": 5}}}}', "verdict_not_string"),
+    ],
+    ids=lambda v: v if isinstance(v, str) and " " not in v and "{" not in v else "",
+)
+def test_a_parseable_payload_without_a_verdict_is_not_scored(
+    monkeypatch: pytest.MonkeyPatch, payload: str, ids: str
+) -> None:
+    """Valid JSON naming no verdict must not read as scored efficacy evidence."""
+    _stub_child(monkeypatch, file_payload=payload, returncode=0)
+    entry = suite.run_rule_activation(
+        [".claude/rules/code-quality.md"], "test-model"
+    )["rules"]["code-quality"]
+    assert entry["passed"] is False, ids
+    assert entry["evidence"] == suite.EVIDENCE_SCENARIO, ids
+    assert entry["exit_code"] == suite.EXIT_EXTERNAL, ids
+
+
+def test_a_present_verdict_is_scored_even_when_it_is_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = json.dumps(
+        {"rules": {"code-quality": {"summary": {"verdict": "FAIL"}}}}
+    )
+    _stub_child(monkeypatch, file_payload=payload, returncode=1)
+    entry = suite.run_rule_activation(
+        [".claude/rules/code-quality.md"], "test-model"
+    )["rules"]["code-quality"]
+    assert entry["evidence"] == suite.EVIDENCE_SCORED
+    assert entry["passed"] is False
+    assert entry["exit_code"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Exit-code precedence: keep the child's own refusal code
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "child_exit,expected",
+    [
+        (suite.EXIT_CONFIG, suite.EXIT_CONFIG),
+        (suite.EXIT_AUTH, suite.EXIT_AUTH),
+        (suite.EXIT_LOGIC, suite.EXIT_LOGIC),
+        (suite.EXIT_EXTERNAL, suite.EXIT_EXTERNAL),
+        # Claimed success and wrote nothing: that IS an external failure.
+        (suite.EXIT_OK, suite.EXIT_EXTERNAL),
+    ],
+    ids=["config", "auth", "logic", "external", "silent_success"],
+)
+def test_child_refusal_code_survives_a_missing_results_file(
+    monkeypatch: pytest.MonkeyPatch, child_exit: int, expected: int
+) -> None:
+    """The child exits 2 on a bad scenario and 4 on a missing key, writing no
+    file in either case. Flattening those to 3 would report an API failure for
+    a config or auth fault."""
+    _stub_child(monkeypatch, file_payload=None, returncode=child_exit)
+    entry = suite.run_rule_activation(
+        [".claude/rules/code-quality.md"], "test-model"
+    )["rules"]["code-quality"]
+    assert entry["exit_code"] == expected
+
+
+def test_worst_exit_code_keeps_the_most_specific_child_code() -> None:
+    results = {
+        "agents": {"agents": {"a": {"exit_code": suite.EXIT_EXTERNAL}}},
+        "rules": {"rules": {"r": {"exit_code": suite.EXIT_AUTH}}},
+    }
+    assert suite.worst_exit_code(results, any_failure=True) == suite.EXIT_AUTH
+
+
+def test_worst_exit_code_is_ok_without_failure() -> None:
+    results = {"rules": {"rules": {"r": {"exit_code": suite.EXIT_AUTH}}}}
+    assert suite.worst_exit_code(results, any_failure=False) == suite.EXIT_OK
+
+
+def test_worst_exit_code_floors_at_logic_when_no_code_was_recorded() -> None:
+    assert suite.worst_exit_code({"skills": {"passed": False}}, True) == suite.EXIT_LOGIC
+
+
+def test_worst_exit_code_ignores_zero_codes() -> None:
+    results = {"rules": {"rules": {"r": {"exit_code": suite.EXIT_OK}}}}
+    assert suite.worst_exit_code(results, any_failure=True) == suite.EXIT_LOGIC
+
+
+def test_worst_exit_code_walks_into_lists() -> None:
+    """`behavioral` results are a list, so codes nest inside one."""
+    results = {"behavioral": [{"exit_code": suite.EXIT_CONFIG}, {"skipped": True}]}
+    assert suite.worst_exit_code(results, any_failure=True) == suite.EXIT_CONFIG
+
+
+def test_worst_exit_code_ignores_non_integer_codes() -> None:
+    results = {"rules": {"rules": {"r": {"exit_code": "not an int"}}}}
+    assert suite.worst_exit_code(results, any_failure=True) == suite.EXIT_LOGIC
+
+
+def test_verdict_error_rejects_a_non_object_payload() -> None:
+    assert "not an object" in (suite._verdict_error(None, "code-quality") or "")
+
+
+def test_verdict_error_accepts_a_well_formed_payload() -> None:
+    payload = {"rules": {"code-quality": {"summary": {"verdict": "PASS"}}}}
+    assert suite._verdict_error(payload, "code-quality") is None
 
 
 def test_run_rule_activation_fails_when_no_results_file_is_written(
@@ -1054,7 +1211,17 @@ def test_reconcile_promotes_an_evaluated_rule_to_scored() -> None:
     )
     assert plan[0]["evidence"] == suite.EVIDENCE_SCENARIO
 
-    results = {"rules": {"rules": {"code-quality": {"passed": True, "exit_code": 0}}}}
+    results = {
+        "rules": {
+            "rules": {
+                "code-quality": {
+                    "passed": True,
+                    "exit_code": 0,
+                    "evidence": suite.EVIDENCE_SCORED,
+                }
+            }
+        }
+    }
     reconciled = suite.reconcile_routing_plan(plan, results)
     assert reconciled[0]["evidence"] == suite.EVIDENCE_SCORED
 
@@ -1064,7 +1231,17 @@ def test_reconcile_counts_a_failing_run_as_scored() -> None:
     plan = suite.build_routing_plan(
         suite.classify_changes([".claude/rules/code-quality.md"]), "all"
     )
-    results = {"rules": {"rules": {"code-quality": {"passed": False, "exit_code": 1}}}}
+    results = {
+        "rules": {
+            "rules": {
+                "code-quality": {
+                    "passed": False,
+                    "exit_code": 1,
+                    "evidence": suite.EVIDENCE_SCORED,
+                }
+            }
+        }
+    }
     assert suite.reconcile_routing_plan(plan, results)[0]["evidence"] == (
         suite.EVIDENCE_SCORED
     )
@@ -1080,6 +1257,41 @@ def test_reconcile_leaves_a_skipped_rule_unscored() -> None:
     assert suite.reconcile_routing_plan(plan, results)[0]["evidence"] == (
         suite.EVIDENCE_SCENARIO
     )
+
+
+@pytest.mark.parametrize(
+    "outcome,label",
+    [
+        ({"passed": False, "reason": "timeout (600s)"}, "timeout"),
+        (
+            {
+                "passed": False,
+                "exit_code": 3,
+                "evidence": "scenario_defined_not_scored",
+                "results": {"error": "no results file"},
+            },
+            "missing_verdict",
+        ),
+        ({"passed": True}, "passed_without_evidence_label"),
+    ],
+    ids=["timeout", "missing_verdict", "passed_without_evidence_label"],
+)
+def test_reconcile_never_promotes_a_run_that_produced_no_verdict(
+    outcome: dict, label: str
+) -> None:
+    """Promotion must key on the evidence label, not on `passed`.
+
+    `passed` is False for a failing verdict, a timeout, and an unreadable
+    result alike, so inferring from it would publish scored efficacy evidence
+    for runs that produced none.
+    """
+    plan = suite.build_routing_plan(
+        suite.classify_changes([".claude/rules/code-quality.md"]), "all"
+    )
+    results = {"rules": {"rules": {"code-quality": outcome}}}
+    assert suite.reconcile_routing_plan(plan, results)[0]["evidence"] == (
+        suite.EVIDENCE_SCENARIO
+    ), label
 
 
 def test_reconcile_leaves_a_scenarioless_rule_entry_untouched() -> None:
@@ -1101,7 +1313,17 @@ def test_reconcile_splits_a_mixed_entry_into_scored_and_unscored() -> None:
         "evidence": suite.EVIDENCE_SCENARIO,
         "reason": "activation scenario defined; run without --dry-run to score",
     }]
-    results = {"rules": {"rules": {"code-quality": {"passed": True, "exit_code": 0}}}}
+    results = {
+        "rules": {
+            "rules": {
+                "code-quality": {
+                    "passed": True,
+                    "exit_code": 0,
+                    "evidence": suite.EVIDENCE_SCORED,
+                }
+            }
+        }
+    }
     reconciled = suite.reconcile_routing_plan(plan, results)
     by_evidence = {e["evidence"]: e["files"] for e in reconciled}
     assert by_evidence[suite.EVIDENCE_SCORED] == [".claude/rules/code-quality.md"]

--- a/tests/eval/test_eval_suite_routing.py
+++ b/tests/eval/test_eval_suite_routing.py
@@ -1,0 +1,810 @@
+# taste-lint: ignore file-size, routing table and its negative controls stay paired.
+"""Routing tests for scripts/eval/eval-suite.py (issue #4882).
+
+The bug these pin: `AGENT_PATTERNS` carried a bare `src/copilot-cli/` prefix and
+the agent branch ran before the skill branch, so every Markdown file in that
+tree was routed to `eval-agents.py`. Measured on pristine
+`2628d8c1282277ad39bc605eb6a31131eff2d77e` with
+`eval-suite.py --base-ref HEAD~1 --dry-run --scope all`:
+
+    Changed files: 17
+    agents: 4 files
+    skills: 2 files
+    other: 11 files
+    Overall: FAIL
+    exit 3
+
+`eval-agents.py --agent canonical-source-mirror.instructions` exits 1 with empty
+stdout ("ERROR: Agent definition not found"), which `_parse_child_json` turns
+into EXIT_EXTERNAL. That is where the exit 3 came from.
+
+Two classes of test here:
+
+  * Behavioral: each supported path shape lands in its category.
+  * Structural: no row of ROUTING_RULES can be shadowed by an earlier row, and
+    a negative control replays the broad prefix to prove these tests would fail
+    if it were reintroduced.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_DIR = REPO_ROOT / "scripts" / "eval"
+
+
+def _load_suite():
+    added = False
+    if str(EVAL_DIR) not in sys.path:
+        sys.path.insert(0, str(EVAL_DIR))
+        added = True
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "eval_suite_routing", EVAL_DIR / "eval-suite.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if added and str(EVAL_DIR) in sys.path:
+            sys.path.remove(str(EVAL_DIR))
+
+
+suite = _load_suite()
+
+
+# ---------------------------------------------------------------------------
+# Positive routing: every supported artifact type reaches its category
+# ---------------------------------------------------------------------------
+
+# The four paths the issue measured as misrouted, plus one representative per
+# supported category. Keep the issue's paths verbatim.
+ROUTING_CASES = [
+    # Misrouted by the pre-fix table (issue #4882 reproduction).
+    ("src/copilot-cli/instructions/canonical-source-mirror.instructions.md", "instructions"),
+    ("src/copilot-cli/instructions/lsp-first.instructions.md", "instructions"),
+    ("src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md",
+     "skill_references"),
+    ("src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md",
+     "skill_references"),
+    # Silently dropped into `other` by the pre-fix table.
+    (".claude/rules/canonical-source-mirror.md", "rules"),
+    (".claude/rules/lsp-first.md", "rules"),
+    (".github/instructions/canonical-source-mirror.instructions.md", "instructions"),
+    (".github/instructions/lsp-first.instructions.md", "instructions"),
+    # Skills.
+    ("src/copilot-cli/skills/context-optimizer/SKILL.md", "skills"),
+    (".claude/skills/analyze/SKILL.md", "skills"),
+    (".claude/skills/analyze/references/deep-dive.md", "skill_references"),
+    # Agents, which must keep routing as agents.
+    (".claude/agents/implementer.md", "agents"),
+    ("src/claude/architect.md", "agents"),
+    ("src/copilot-cli/agents/implementer.agent.md", "agents"),
+    ("src/vs-code-agents/analyst.agent.md", "agents"),
+    # Agent-tree reference material: same failure shape as the skill case.
+    ("src/claude/security/references/threat-model-template.md", "references"),
+    # Entrypoints.
+    ("AGENTS.md", "entrypoints"),
+    ("CLAUDE.md", "entrypoints"),
+    ("src/copilot-cli/lib/github_core/CLAUDE.md", "entrypoints"),
+    # Prompts and scenarios, unchanged by this fix.
+    (".claude/commands/spec.md", "prompts"),
+    (".github/prompts/pr-quality-gate-architect.md", "prompts"),
+    ("tests/evals/rule-scenarios/code-quality.json", "scenarios"),
+    # Genuinely unclassified.
+    ("src/copilot-cli/docs/copilot-instructions.md", "other"),
+    ("scripts/eval/eval-suite.py", "other"),
+]
+
+
+@pytest.mark.parametrize("path,expected", ROUTING_CASES)
+def test_classify_path_routes_to_expected_category(path: str, expected: str) -> None:
+    assert suite.classify_path(path) == expected
+
+
+@pytest.mark.parametrize("path,expected", ROUTING_CASES)
+def test_classify_changes_agrees_with_classify_path(path: str, expected: str) -> None:
+    classified = suite.classify_changes([path])
+    assert classified[expected] == [path]
+
+
+# ---------------------------------------------------------------------------
+# Negative routing: nothing that is not an agent may reach eval-agents.py
+# ---------------------------------------------------------------------------
+
+NON_AGENT_PATHS = [p for p, category in ROUTING_CASES if category != "agents"]
+
+
+@pytest.mark.parametrize("path", NON_AGENT_PATHS)
+def test_non_agent_paths_never_route_to_the_agent_evaluator(path: str) -> None:
+    """AC: skill references and instruction mirrors must not reach eval-agents.py."""
+    category = suite.classify_path(path)
+    assert category != "agents"
+    assert suite.RUNNER_BY_CATEGORY.get(category) != "eval-agents.py"
+
+
+def test_agent_exclusions_are_preserved() -> None:
+    """README/INDEX/template files stay out of the agent category, as before."""
+    assert suite.classify_path("src/claude/README.md") == "other"
+    assert suite.classify_path(".claude/agents/INDEX.md") == "other"
+    assert suite.classify_path(".claude/agents/agent.template.md") == "other"
+
+
+def test_non_markdown_under_an_agent_tree_is_not_an_agent() -> None:
+    assert suite.classify_path("src/claude/.claude-plugin/plugin.json") == "other"
+
+
+# ---------------------------------------------------------------------------
+# Negative control: the broad prefix that caused the bug
+# ---------------------------------------------------------------------------
+
+# The pre-fix table, quoted from eval-suite.py at
+# 2628d8c1282277ad39bc605eb6a31131eff2d77e:
+#
+#     AGENT_PATTERNS = [
+#         ".claude/agents/",
+#         "src/claude/",
+#         "src/copilot-cli/",
+#         "src/vs-code-agents/",
+#     ]
+NAIVE_AGENT_PREFIXES = (
+    ".claude/agents/",
+    "src/claude/",
+    "src/copilot-cli/",
+    "src/vs-code-agents/",
+)
+
+MISROUTED_BY_NAIVE_PREFIX = [
+    "src/copilot-cli/instructions/canonical-source-mirror.instructions.md",
+    "src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md",
+    "src/copilot-cli/skills/context-optimizer/SKILL.md",
+    "src/claude/security/references/threat-model-template.md",
+]
+
+
+@pytest.mark.parametrize("path", MISROUTED_BY_NAIVE_PREFIX)
+def test_negative_control_broad_prefix_would_capture_these(path: str) -> None:
+    """Prove the broad prefix really does capture non-agents.
+
+    Without this, `test_non_agent_paths_never_route_to_the_agent_evaluator`
+    could pass against a table that never had the overlap in the first place.
+    """
+    assert any(path.startswith(prefix) for prefix in NAIVE_AGENT_PREFIXES)
+    assert path.endswith(".md")
+    assert Path(path).name not in suite.AGENT_EXCLUDED_BASENAMES
+
+
+@pytest.mark.parametrize("path", MISROUTED_BY_NAIVE_PREFIX)
+def test_shipped_table_does_not_capture_them(path: str) -> None:
+    assert suite.classify_path(path) != "agents"
+
+
+def test_agent_rows_no_longer_carry_the_broad_copilot_prefix() -> None:
+    """The specific prefix that caused issue #4882 must not come back."""
+    assert "src/copilot-cli/" not in suite.AGENT_PATTERNS
+    assert "src/copilot-cli/agents/" in suite.AGENT_PATTERNS
+
+
+def _classify_with(rules, path: str) -> str:
+    for rule in rules:
+        if rule.matches(path):
+            return rule.category
+    return "other"
+
+
+def test_negative_control_broad_prefix_placed_first_recreates_the_bug() -> None:
+    """Ordering is the defense; prove that losing it recreates issue #4882.
+
+    Narrowing AGENT_PATTERNS alone is not what protects skill references and
+    instruction mirrors: the rows for those categories sit ahead of the agent
+    rows. This control rebuilds the pre-fix table (broad prefix, agent rows
+    first) and asserts the exact misroutes the issue measured, so the ordering
+    claim above is tested rather than asserted.
+    """
+    broken = (
+        *(
+            suite.RoutingRule(
+                "agents",
+                prefix=prefix,
+                exclude_basenames=suite.AGENT_EXCLUDED_BASENAMES,
+                exclude_substrings=suite.AGENT_EXCLUDED_SUBSTRINGS,
+            )
+            for prefix in NAIVE_AGENT_PREFIXES
+        ),
+        *suite.ROUTING_RULES,
+    )
+
+    for path in MISROUTED_BY_NAIVE_PREFIX:
+        assert _classify_with(broken, path) == "agents", (
+            f"control did not reproduce the misroute for {path}"
+        )
+        assert suite.classify_path(path) != "agents"
+
+
+def test_negative_control_reordering_skills_after_agents_breaks_references() -> None:
+    """Moving the agent rows ahead of the reference rows misroutes references."""
+    agent_rows = tuple(r for r in suite.ROUTING_RULES if r.category == "agents")
+    rest = tuple(r for r in suite.ROUTING_RULES if r.category != "agents")
+    reordered = (*agent_rows, *rest)
+
+    path = "src/claude/security/references/threat-model-template.md"
+    assert _classify_with(reordered, path) == "agents"
+    assert suite.classify_path(path) == "references"
+
+
+# ---------------------------------------------------------------------------
+# Structural: ordering, reachability, and category bookkeeping
+# ---------------------------------------------------------------------------
+
+def _representative_path(rule) -> str:
+    """Build a path the rule is meant to claim."""
+    if rule.basenames:
+        return f"sample/{sorted(rule.basenames)[0]}"
+    segment = f"{rule.segment}/" if rule.segment else ""
+    suffix = rule.suffix or ".md"
+    return f"{rule.prefix}sample/{segment}sample{suffix}"
+
+
+@pytest.mark.parametrize(
+    "index", range(len(suite.ROUTING_RULES)), ids=lambda i: f"row{i}"
+)
+def test_no_routing_row_is_shadowed_by_an_earlier_row(index: int) -> None:
+    """Ordering invariant: every row wins for its own representative path.
+
+    This is the guard that fails if a broad prefix is moved ahead of a narrow
+    one, which is exactly how issue #4882 happened.
+    """
+    rule = suite.ROUTING_RULES[index]
+    path = _representative_path(rule)
+    assert rule.matches(path), f"representative path does not match its own row: {path}"
+    assert suite.classify_path(path) == rule.category, (
+        f"row {index} ({rule.category}, prefix={rule.prefix!r}) is shadowed; "
+        f"{path} resolved to {suite.classify_path(path)!r}"
+    )
+
+
+def test_references_rows_precede_the_trees_that_contain_them() -> None:
+    order = [rule.category for rule in suite.ROUTING_RULES]
+    assert order.index("skill_references") < order.index("skills")
+    assert order.index("references") < order.index("agents")
+
+
+def test_instruction_rows_precede_agent_rows() -> None:
+    order = [rule.category for rule in suite.ROUTING_RULES]
+    assert order.index("instructions") < order.index("agents")
+
+
+def test_every_category_is_either_routed_or_explicitly_not_evaluated() -> None:
+    """Required work item 2: no context-bearing category may fall silently."""
+    for category in suite.CATEGORIES:
+        routed = category in suite.RUNNER_BY_CATEGORY
+        excused = category in suite.NOT_EVALUATED_REASONS
+        assert routed != excused, (
+            f"{category} must appear in exactly one of RUNNER_BY_CATEGORY "
+            f"and NOT_EVALUATED_REASONS"
+        )
+
+
+def test_every_routing_row_names_a_known_category() -> None:
+    for rule in suite.ROUTING_RULES:
+        assert rule.category in suite.CATEGORIES
+
+
+def test_classify_changes_returns_every_category_key() -> None:
+    classified = suite.classify_changes([])
+    assert set(classified) == set(suite.CATEGORIES)
+
+
+# ---------------------------------------------------------------------------
+# RoutingRule matcher edges
+# ---------------------------------------------------------------------------
+
+def test_segment_matches_directories_only_not_the_basename() -> None:
+    rule = suite.RoutingRule("skill_references", prefix=".claude/skills/", segment="references")
+    assert rule.matches(".claude/skills/analyze/references/x.md")
+    # A file literally named `references.md` is not a reference directory.
+    assert not rule.matches(".claude/skills/analyze/references.md")
+
+
+def test_empty_suffix_disables_the_suffix_filter() -> None:
+    rule = suite.RoutingRule("skills", prefix=".claude/skills/", suffix="")
+    assert rule.matches(".claude/skills/analyze/scripts/run.py")
+
+
+def test_exclusions_reject_before_the_row_claims_the_path() -> None:
+    rule = suite.ROUTING_RULES[
+        [r.category for r in suite.ROUTING_RULES].index("agents")
+    ]
+    assert not rule.matches(f"{rule.prefix}README.md")
+    assert not rule.matches(f"{rule.prefix}agent.template.md")
+
+
+def test_empty_prefix_row_matches_at_any_depth() -> None:
+    rule = suite.RoutingRule("entrypoints", basenames=frozenset({"AGENTS.md"}))
+    assert rule.matches("AGENTS.md")
+    assert rule.matches("a/b/c/AGENTS.md")
+    assert not rule.matches("a/b/c/OTHER.md")
+
+
+# ---------------------------------------------------------------------------
+# Rule id resolution and scenario lookup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (".claude/rules/code-quality.md", "code-quality"),
+        (".github/instructions/code-quality.instructions.md", "code-quality"),
+        ("src/copilot-cli/instructions/code-quality.instructions.md", "code-quality"),
+        (".claude/agents/implementer.md", None),
+        ("scripts/eval/eval-suite.py", None),
+    ],
+)
+def test_rule_id_for_path(path: str, expected: str | None) -> None:
+    assert suite.rule_id_for_path(path) == expected
+
+
+def test_instruction_mirrors_resolve_to_the_same_rule_id() -> None:
+    """A rule and both of its generated mirrors are one artifact."""
+    ids = {
+        suite.rule_id_for_path(".claude/rules/universal.md"),
+        suite.rule_id_for_path(".github/instructions/universal.instructions.md"),
+        suite.rule_id_for_path("src/copilot-cli/instructions/universal.instructions.md"),
+    }
+    assert ids == {"universal"}
+
+
+def test_find_rule_scenarios_reads_rule_path_not_the_filename() -> None:
+    """Scenario files carrying skill_path must not claim a rule id.
+
+    `tests/evals/rule-scenarios/` holds ADR-088 reference scenarios whose target
+    key is `skill_path`. A stem convention would invent rule ids for them.
+    """
+    scenarios = suite.find_rule_scenarios()
+    assert scenarios, "no rule scenarios discovered"
+    for rule_id, scenario_path in scenarios.items():
+        assert (REPO_ROOT / ".claude" / "rules" / f"{rule_id}.md").is_file(), (
+            f"{scenario_path} claims rule id {rule_id!r}, which has no rule file"
+        )
+
+
+def test_known_rule_scenario_is_discovered() -> None:
+    scenarios = suite.find_rule_scenarios()
+    assert scenarios.get("code-quality") == "tests/evals/rule-scenarios/code-quality.json"
+
+
+# ---------------------------------------------------------------------------
+# Routing plan: three evidence states, no silent categories
+# ---------------------------------------------------------------------------
+
+def _plan_for(paths: list[str]) -> list[dict]:
+    return suite.build_routing_plan(suite.classify_changes(paths))
+
+
+def test_plan_marks_a_scenario_backed_rule_as_scenario_defined() -> None:
+    entries = _plan_for([".claude/rules/code-quality.md"])
+    assert len(entries) == 1
+    assert entries[0]["evidence"] == suite.EVIDENCE_SCENARIO
+    assert entries[0]["runner"] == "eval-rule-activation.py"
+
+
+def test_plan_marks_a_scenarioless_rule_as_not_evaluated() -> None:
+    entries = _plan_for([".claude/rules/canonical-source-mirror.md"])
+    assert len(entries) == 1
+    assert entries[0]["evidence"] == suite.EVIDENCE_NONE
+    assert entries[0]["runner"] is None
+    assert "no activation scenario" in entries[0]["reason"]
+
+
+def test_plan_splits_scenario_backed_and_scenarioless_rules() -> None:
+    entries = _plan_for([
+        ".claude/rules/code-quality.md",
+        ".claude/rules/canonical-source-mirror.md",
+    ])
+    by_evidence = {e["evidence"]: e["files"] for e in entries}
+    assert by_evidence[suite.EVIDENCE_SCENARIO] == [".claude/rules/code-quality.md"]
+    assert by_evidence[suite.EVIDENCE_NONE] == [".claude/rules/canonical-source-mirror.md"]
+
+
+def test_plan_never_leaves_a_populated_category_without_a_reason() -> None:
+    entries = _plan_for([path for path, _ in ROUTING_CASES])
+    covered = {e["category"] for e in entries}
+    classified = suite.classify_changes([path for path, _ in ROUTING_CASES])
+    populated = {k for k, v in classified.items() if v}
+    assert populated == covered
+    for entry in entries:
+        assert entry["reason"]
+        assert entry["evidence"] in {
+            suite.EVIDENCE_STRUCTURAL,
+            suite.EVIDENCE_SCENARIO,
+            suite.EVIDENCE_SCORED,
+            suite.EVIDENCE_NONE,
+        }
+        if entry["runner"] is None:
+            assert entry["evidence"] == suite.EVIDENCE_NONE
+
+
+def test_plan_is_deterministic_and_sorted() -> None:
+    paths = [path for path, _ in ROUTING_CASES]
+    first = _plan_for(paths)
+    second = _plan_for(list(reversed(paths)))
+    assert first == second
+    for entry in first:
+        assert entry["files"] == sorted(entry["files"])
+
+
+def test_plan_follows_category_order() -> None:
+    entries = _plan_for([path for path, _ in ROUTING_CASES])
+    seen = [e["category"] for e in entries]
+    ranks = [suite.CATEGORIES.index(c) for c in seen]
+    assert ranks == sorted(ranks)
+
+
+def test_empty_classification_yields_an_empty_plan() -> None:
+    assert suite.build_routing_plan(suite.classify_changes([])) == []
+
+
+# ---------------------------------------------------------------------------
+# find_rule_scenarios: defensive branches
+# ---------------------------------------------------------------------------
+
+def _scenario_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    scenario_dir = tmp_path / suite.RULE_SCENARIO_DIR
+    scenario_dir.mkdir(parents=True)
+    monkeypatch.setattr(suite, "REPO_ROOT", tmp_path)
+    return scenario_dir
+
+
+def test_find_rule_scenarios_returns_empty_when_the_directory_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(suite, "REPO_ROOT", tmp_path)
+    assert suite.find_rule_scenarios() == {}
+
+
+def test_find_rule_scenarios_skips_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "broken.json").write_text("{not json", encoding="utf-8")
+    (scenario_dir / "good.json").write_text(
+        '{"rule_path": ".claude/rules/good.md"}', encoding="utf-8"
+    )
+    assert suite.find_rule_scenarios() == {
+        "good": f"{suite.RULE_SCENARIO_DIR}/good.json"
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '["not", "an", "object"]',
+        '{"skill_path": ".claude/skills/analyze/SKILL.md"}',
+        '{"rule_path": ""}',
+        '{"rule_path": "   "}',
+        '{"rule_path": 42}',
+        "{}",
+    ],
+    ids=["list", "skill_target", "empty", "blank", "wrong_type", "no_keys"],
+)
+def test_find_rule_scenarios_ignores_non_rule_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str
+) -> None:
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
+    assert suite.find_rule_scenarios() == {}
+
+
+# ---------------------------------------------------------------------------
+# Dry-run output surface
+# ---------------------------------------------------------------------------
+
+def test_print_routing_plan_reports_nothing_to_route(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite._print_routing_plan([])
+    assert "(nothing to route)" in capsys.readouterr().err
+
+
+def test_print_routing_plan_names_category_runner_evidence_and_files(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite._print_routing_plan(_plan_for([".claude/rules/code-quality.md"]))
+    err = capsys.readouterr().err
+    assert "rules" in err
+    assert "eval-rule-activation.py" in err
+    assert suite.EVIDENCE_SCENARIO in err
+    assert ".claude/rules/code-quality.md" in err
+
+
+def test_print_routing_plan_shows_none_for_unrouted_categories(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite._print_routing_plan(_plan_for(["AGENTS.md"]))
+    err = capsys.readouterr().err
+    assert "(none)" in err
+    assert suite.EVIDENCE_NONE in err
+    assert suite.NOT_EVALUATED_REASONS["entrypoints"] in err
+
+
+# ---------------------------------------------------------------------------
+# run_rule_activation: reuses eval-rule-activation.py, never invents a harness
+# ---------------------------------------------------------------------------
+
+class _FakeCompleted:
+    def __init__(self, stdout: str, returncode: int) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+def _stub_child(
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: str = '{"verdict": "PASS"}',
+    returncode: int = 0,
+) -> list[list[str]]:
+    """Replace subprocess.run and record the argv of every invocation."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(stdout, returncode)
+
+    monkeypatch.setattr(suite.subprocess, "run", fake_run)
+    return calls
+
+
+def test_run_rule_activation_scores_a_scenario_backed_rule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_child(monkeypatch)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+
+    assert result["passed"] is True
+    entry = result["rules"]["code-quality"]
+    assert entry["evidence"] == suite.EVIDENCE_SCORED
+    assert entry["exit_code"] == 0
+    assert len(calls) == 1
+    assert "eval-rule-activation.py" in calls[0][1]
+    assert "--scenarios" in calls[0]
+    assert "tests/evals/rule-scenarios/code-quality.json" in calls[0]
+
+
+def test_run_rule_activation_dedupes_a_rule_and_its_two_mirrors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rule and both generated mirrors are one artifact, so one invocation."""
+    calls = _stub_child(monkeypatch)
+    result = suite.run_rule_activation(
+        [
+            ".claude/rules/code-quality.md",
+            ".github/instructions/code-quality.instructions.md",
+            "src/copilot-cli/instructions/code-quality.instructions.md",
+        ],
+        "test-model",
+    )
+    assert len(calls) == 1
+    assert set(result["rules"]) == {"code-quality"}
+
+
+def test_run_rule_activation_reports_a_scenarioless_rule_as_not_evaluated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_child(monkeypatch)
+    result = suite.run_rule_activation(
+        [".claude/rules/canonical-source-mirror.md"], "test-model"
+    )
+    entry = result["rules"]["canonical-source-mirror"]
+    assert entry["skipped"] is True
+    assert entry["evidence"] == suite.EVIDENCE_NONE
+    assert "no activation scenario" in entry["reason"]
+    assert calls == []
+    # A skipped rule must not flip the verdict to failure.
+    assert result["passed"] is True
+
+
+def test_run_rule_activation_reports_an_unresolvable_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_child(monkeypatch)
+    result = suite.run_rule_activation(["scripts/eval/eval-suite.py"], "test-model")
+    entry = result["rules"]["scripts/eval/eval-suite.py"]
+    assert entry["skipped"] is True
+    assert entry["evidence"] == suite.EVIDENCE_NONE
+
+
+def test_run_rule_activation_fails_when_the_child_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_child(monkeypatch, returncode=1)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    assert result["passed"] is False
+    entry = result["rules"]["code-quality"]
+    assert entry["exit_code"] == 1
+    assert entry["evidence"] == suite.EVIDENCE_SCENARIO
+
+
+def test_run_rule_activation_maps_unparseable_child_output_to_external(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The failure shape issue #4882 produced: empty stdout from the child."""
+    _stub_child(monkeypatch, stdout="", returncode=1)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    entry = result["rules"]["code-quality"]
+    assert entry["exit_code"] == suite.EXIT_EXTERNAL
+    assert entry["evidence"] == suite.EVIDENCE_SCENARIO
+    assert "error" in entry["results"]
+    assert suite._contains_external_failure(result) is True
+
+
+def test_run_rule_activation_handles_a_child_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, **_kwargs):
+        raise suite.subprocess.TimeoutExpired(cmd, 600)
+
+    monkeypatch.setattr(suite.subprocess, "run", fake_run)
+    result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    assert result["passed"] is False
+    assert result["rules"]["code-quality"]["reason"] == "timeout (600s)"
+
+
+def test_run_rule_activation_on_no_files_is_vacuously_passing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_child(monkeypatch)
+    result = suite.run_rule_activation([], "test-model")
+    assert result == {"rules": {}, "passed": True}
+    assert calls == []
+
+
+def test_run_rule_activation_pins_utf8_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Matches the constraint tests/eval/test_eval_prompt_change.py enforces."""
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        return _FakeCompleted('{"ok": true}', 0)
+
+    monkeypatch.setattr(suite.subprocess, "run", fake_run)
+    suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
+    assert seen["encoding"] == "utf-8"
+    assert seen["errors"] == "replace"
+    assert seen["capture_output"] is True
+
+
+# ---------------------------------------------------------------------------
+# _run_evals wiring
+# ---------------------------------------------------------------------------
+
+class _Args:
+    def __init__(self, scope: str) -> None:
+        self.scope = scope
+        self.dry_run = False
+        self.model = "test-model"
+        self.base_ref = "main"
+
+
+def _record_runners(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+    seen: dict[str, list[str]] = {}
+
+    def fake_skill(skills, _model, _dry_run):
+        seen["skills"] = list(skills)
+        return {"passed": True}
+
+    def fake_rules(files, _model):
+        seen["rules"] = list(files)
+        return {"passed": True}
+
+    def fake_agents(agents, _model, _dry_run):
+        seen["agents"] = list(agents)
+        return {"passed": True}
+
+    monkeypatch.setattr(suite, "run_skill_knowledge", fake_skill)
+    monkeypatch.setattr(suite, "run_rule_activation", fake_rules)
+    monkeypatch.setattr(suite, "run_agent_quality", fake_agents)
+    return seen
+
+
+def test_run_evals_sends_skill_references_to_the_skill_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _record_runners(monkeypatch)
+    classified = suite.classify_changes([
+        ".claude/skills/analyze/SKILL.md",
+        "src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md",
+    ])
+    suite._run_evals(classified, _Args("all"))
+    assert seen["skills"] == [
+        ".claude/skills/analyze/SKILL.md",
+        "src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md",
+    ]
+    assert "agents" not in seen
+
+
+def test_run_evals_sends_rules_and_instructions_to_the_rule_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _record_runners(monkeypatch)
+    classified = suite.classify_changes([
+        ".claude/rules/code-quality.md",
+        "src/copilot-cli/instructions/code-quality.instructions.md",
+    ])
+    suite._run_evals(classified, _Args("all"))
+    assert seen["rules"] == [
+        ".claude/rules/code-quality.md",
+        "src/copilot-cli/instructions/code-quality.instructions.md",
+    ]
+
+
+def test_rules_scope_runs_rules_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _record_runners(monkeypatch)
+    classified = suite.classify_changes([
+        ".claude/rules/code-quality.md",
+        ".claude/agents/implementer.md",
+    ])
+    suite._run_evals(classified, _Args("rules"))
+    assert "rules" in seen
+    assert "agents" not in seen
+
+
+def test_agents_scope_does_not_run_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _record_runners(monkeypatch)
+    classified = suite.classify_changes([
+        ".claude/rules/code-quality.md",
+        ".claude/agents/implementer.md",
+    ])
+    suite._run_evals(classified, _Args("agents"))
+    assert "agents" in seen
+    assert "rules" not in seen
+
+
+def test_rules_is_an_accepted_scope_value() -> None:
+    source = (EVAL_DIR / "eval-suite.py").read_text(encoding="utf-8")
+    assert '"prompts", "agents", "skills", "rules", "all"' in source
+
+
+# ---------------------------------------------------------------------------
+# End to end: the dry run the issue reproduced
+# ---------------------------------------------------------------------------
+
+def test_dry_run_exits_zero_and_emits_a_routing_plan() -> None:
+    """AC: a dry run exits successfully and prints a deterministic routing plan.
+
+    Pre-fix, this exited 3 because misrouted files reached eval-agents.py, which
+    exits 1 with empty stdout. A dry run now invokes no evaluator at all.
+    """
+    import json as _json
+    import subprocess as _subprocess
+
+    proc = _subprocess.run(
+        [sys.executable, str(EVAL_DIR / "eval-suite.py"), "--base-ref", "HEAD", "--dry-run"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        cwd=str(REPO_ROOT),
+        env={**__import__("os").environ, "PYTHONPATH": str(EVAL_DIR)},
+    )
+    if proc.returncode == 0 and not proc.stdout.strip():
+        pytest.skip("no changes against HEAD, suite exited early")
+
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    payload = _json.loads(proc.stdout)
+    assert payload["dry_run"] is True
+    assert payload["passed"] is True
+    assert payload["results"] == {}
+    assert "routing_plan" in payload
+    for entry in payload["routing_plan"]:
+        assert entry["reason"]
+        assert entry["files"] == sorted(entry["files"])
+    assert "JSON parse failed" not in proc.stderr

--- a/tests/eval/test_eval_suite_routing.py
+++ b/tests/eval/test_eval_suite_routing.py
@@ -243,8 +243,18 @@ def test_negative_control_reordering_skills_after_agents_breaks_references() -> 
 # Structural: ordering, reachability, and category bookkeeping
 # ---------------------------------------------------------------------------
 
+# Rows with a filesystem predicate cannot use a synthetic name, because the
+# predicate asks the tree a question about it. `spec` is a real command mirror:
+# `.claude/commands/spec.md` exists and `.claude/skills/spec/` does not.
+PREDICATE_ROW_REPRESENTATIVES = {
+    "command_mirrors": "src/copilot-cli/skills/spec/SKILL.md",
+}
+
+
 def _representative_path(rule) -> str:
     """Build a path the rule is meant to claim."""
+    if rule.predicate is not None:
+        return PREDICATE_ROW_REPRESENTATIVES[rule.category]
     if rule.basenames:
         return f"sample/{sorted(rule.basenames)[0]}"
     segment = f"{rule.segment}/" if rule.segment else ""
@@ -268,6 +278,102 @@ def test_no_routing_row_is_shadowed_by_an_earlier_row(index: int) -> None:
         f"row {index} ({rule.category}, prefix={rule.prefix!r}) is shadowed; "
         f"{path} resolved to {suite.classify_path(path)!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoints are identified by filename, so their row must win over prefixes
+# ---------------------------------------------------------------------------
+
+# Every one of these exists in the tree. Behind the prefix rows they were all
+# captured as prompts or skills.
+SHADOWED_ENTRYPOINTS = [
+    ".claude/commands/CLAUDE.md",
+    ".claude/skills/CLAUDE.md",
+    ".claude/skills/adr-review/CLAUDE.md",
+    ".claude/skills/adr-review/scripts/CLAUDE.md",
+    ".claude/skills/github/CLAUDE.md",
+    ".claude/skills/github/scripts/issue/CLAUDE.md",
+    ".claude/skills/memory/CLAUDE.md",
+    "src/copilot-cli/skills/adr-review/CLAUDE.md",
+    "src/copilot-cli/skills/github/CLAUDE.md",
+    ".claude/agents/AGENTS.md",
+    ".claude/agents/CLAUDE.md",
+]
+
+
+@pytest.mark.parametrize("path", SHADOWED_ENTRYPOINTS)
+def test_entrypoints_inside_prompt_and_skill_trees_are_not_shadowed(path: str) -> None:
+    """Exercised through classify_path, not the matcher in isolation.
+
+    The matcher always matched these; the bug was that broader prefix rows ran
+    first, so only the full ordered table reproduces it.
+    """
+    assert suite.classify_path(path) == "entrypoints"
+
+
+@pytest.mark.parametrize("path", SHADOWED_ENTRYPOINTS)
+def test_shadowed_entrypoints_exist_in_the_tree(path: str) -> None:
+    """Negative control: these must be real, or the test above proves nothing."""
+    assert (REPO_ROOT / path).is_file(), f"{path} is not in the tree"
+
+
+def test_entrypoint_row_is_first_in_the_table() -> None:
+    assert suite.ROUTING_RULES[0].category == "entrypoints"
+
+
+def test_negative_control_entrypoints_after_prefixes_recreates_the_shadowing() -> None:
+    """Move the row back where it was and the misroute returns."""
+    entry_row = suite.ROUTING_RULES[0]
+    rest = suite.ROUTING_RULES[1:]
+    shadowed = (*rest, entry_row)
+    assert _classify_with(shadowed, ".claude/commands/CLAUDE.md") == "prompts"
+    assert _classify_with(shadowed, ".claude/skills/github/CLAUDE.md") == "skills"
+    assert suite.classify_path(".claude/commands/CLAUDE.md") == "entrypoints"
+
+
+# ---------------------------------------------------------------------------
+# Command mirrors: same tree as skills, different generator
+# ---------------------------------------------------------------------------
+
+COMMAND_MIRROR_SKILLS = [
+    "build", "checkpoint", "context-hub-setup", "plan", "pr-autofix",
+    "pr-review", "push-pr", "research", "retro", "ship", "spec", "sync",
+    "test", "validate-pr-description",
+]
+
+
+@pytest.mark.parametrize("name", COMMAND_MIRROR_SKILLS)
+def test_command_mirror_skills_do_not_route_to_the_skill_evaluator(name: str) -> None:
+    """The skill evaluator resolves only .claude/skills/ and exits 1 otherwise."""
+    path = f"src/copilot-cli/skills/{name}/SKILL.md"
+    assert suite.classify_path(path) == "command_mirrors"
+    assert suite.RUNNER_BY_CATEGORY.get("command_mirrors") is None
+
+
+@pytest.mark.parametrize("name", COMMAND_MIRROR_SKILLS)
+def test_command_mirror_premise_holds_in_the_tree(name: str) -> None:
+    """Negative control for the premise: no Claude skill, but a Claude command."""
+    assert not (REPO_ROOT / ".claude" / "skills" / name).is_dir()
+    assert (REPO_ROOT / ".claude" / "commands" / f"{name}.md").is_file()
+
+
+@pytest.mark.parametrize("name", ["analyze", "github", "review", "planner"])
+def test_mirrored_claude_skills_still_route_as_skills(name: str) -> None:
+    """The narrowing must not capture ordinary mirrored skills."""
+    assert (REPO_ROOT / ".claude" / "skills" / name).is_dir()
+    assert suite.classify_path(f"src/copilot-cli/skills/{name}/SKILL.md") == "skills"
+
+
+def test_command_mirror_predicate_ignores_paths_outside_the_copilot_skill_tree() -> None:
+    assert suite.is_command_mirror_skill(".claude/skills/spec/SKILL.md") is False
+    assert suite.is_command_mirror_skill("src/copilot-cli/skills") is False
+    assert suite.is_command_mirror_skill("README.md") is False
+
+
+def test_command_mirror_reason_points_at_the_generating_command() -> None:
+    reason = suite.NOT_EVALUATED_REASONS["command_mirrors"]
+    assert ".claude/commands/" in reason
+    assert ".claude/skills/" in reason
 
 
 def test_references_rows_precede_the_trees_that_contain_them() -> None:
@@ -513,37 +619,79 @@ def test_non_utf8_is_not_an_oserror() -> None:
     assert issubclass(UnicodeDecodeError, ValueError)
 
 
-@pytest.mark.parametrize(
-    "payload,match",
-    [
-        ('["not", "an", "object"]', "must contain an object"),
-        ('{"rule_path": ""}', "non-empty string"),
-        ('{"rule_path": "   "}', "non-empty string"),
-        ('{"rule_path": 42}', "non-empty string"),
-    ],
-    ids=["list", "empty", "blank", "wrong_type"],
-)
-def test_find_rule_scenarios_raises_on_broken_rule_target(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str, match: str
+def test_find_rule_scenarios_raises_on_a_non_object_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     scenario_dir = _scenario_root(tmp_path, monkeypatch)
-    (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
-    with pytest.raises(suite.ScenarioConfigError, match=match):
+    (scenario_dir / "case.json").write_text('["not", "an", "object"]', encoding="utf-8")
+    with pytest.raises(suite.ScenarioConfigError, match="must contain an object"):
         suite.find_rule_scenarios()
 
 
+# Only the real ADR-088 shape is a legitimate skip. The canonical test is
+# `check_rule_activation_coverage.py:_is_reference_scenario`:
+#
+#     has_reference = isinstance(reference, str) and bool(reference.strip())
+#     has_skill = isinstance(skill, str) and bool(skill.strip())
+#     has_rule = isinstance(rule, str) and bool(rule.strip())
+#     if not (has_reference and has_skill and not has_rule):
+#         return False
+#
+# so an empty object, a lone skill_path, a lone reference_path, and a blank or
+# non-string rule_path are all malformed rather than reference scenarios.
 @pytest.mark.parametrize(
     "payload",
-    ['{"skill_path": ".claude/skills/analyze/SKILL.md"}', "{}"],
-    ids=["skill_target", "no_keys"],
+    [
+        "{}",
+        '{"skill_path": ".claude/skills/analyze/SKILL.md"}',
+        '{"reference_path": ".claude/skills/analyze/references/x.md"}',
+        '{"skill_path": "   ", "reference_path": "   "}',
+        '{"skill_path": ".claude/skills/analyze/SKILL.md", "reference_path": ""}',
+        '{"rule_path": ""}',
+        '{"rule_path": "   "}',
+        '{"rule_path": 42}',
+        '{"rule_path": null, "skill_path": ".claude/skills/analyze/SKILL.md"}',
+    ],
+    ids=[
+        "empty_object",
+        "lone_skill_path",
+        "lone_reference_path",
+        "blank_both",
+        "blank_reference",
+        "empty_rule_path",
+        "blank_rule_path",
+        "rule_path_not_a_string",
+        "null_rule_path_lone_skill",
+    ],
 )
-def test_find_rule_scenarios_skips_scenarios_with_no_rule_target(
+def test_malformed_scenarios_are_not_treated_as_reference_scenarios(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str
 ) -> None:
-    """ADR-088 skill scenarios live in the same directory and are not errors."""
     scenario_dir = _scenario_root(tmp_path, monkeypatch)
     (scenario_dir / "case.json").write_text(payload, encoding="utf-8")
+    with pytest.raises(suite.ScenarioConfigError):
+        suite.find_rule_scenarios()
+
+
+def test_a_real_adr_088_reference_scenario_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-empty skill_path AND reference_path, no rule_path: a valid skip."""
+    scenario_dir = _scenario_root(tmp_path, monkeypatch)
+    (scenario_dir / "ref.json").write_text(
+        json.dumps({
+            "skill_path": ".claude/skills/analyze/SKILL.md",
+            "reference_path": ".claude/skills/analyze/references/x.md",
+        }),
+        encoding="utf-8",
+    )
     assert suite.find_rule_scenarios() == {}
+
+
+def test_the_repositorys_own_scenarios_all_satisfy_the_stricter_shape() -> None:
+    """The tightened check must not reject any scenario already in the tree."""
+    scenarios = suite.find_rule_scenarios()
+    assert scenarios, "no rule scenarios discovered"
 
 
 def test_find_rule_scenarios_reads_a_valid_rule_target(
@@ -913,7 +1061,48 @@ def test_run_rule_activation_handles_a_child_timeout(
     monkeypatch.setattr(suite.subprocess, "run", fake_run)
     result = suite.run_rule_activation([".claude/rules/code-quality.md"], "test-model")
     assert result["passed"] is False
-    assert result["rules"]["code-quality"]["reason"] == "timeout (600s)"
+    entry = result["rules"]["code-quality"]
+    assert entry["reason"] == "timeout (600s)"
+    # A timeout is an external failure: the evaluator never ran to completion,
+    # so there is no logic verdict to report.
+    assert entry["exit_code"] == suite.EXIT_EXTERNAL
+
+
+def test_a_timed_out_child_reduces_to_exit_external(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The top-level code, not just the reason string.
+
+    Without an explicit code the timeout fell through worst_exit_code's
+    no-code default and surfaced as exit 1, reporting a content failure for an
+    evaluator that never finished.
+    """
+    def fake_run(cmd, **_kwargs):
+        raise suite.subprocess.TimeoutExpired(cmd, 600)
+
+    monkeypatch.setattr(suite.subprocess, "run", fake_run)
+    results = {"rules": suite.run_rule_activation(
+        [".claude/rules/code-quality.md"], "test-model"
+    )}
+    assert suite.worst_exit_code(results, any_failure=True) == suite.EXIT_EXTERNAL
+
+
+def test_every_timeout_path_records_an_external_exit_code() -> None:
+    """All five runners, not just the one review flagged.
+
+    `worst_exit_code` consumes every runner's records, so a sibling timeout
+    without a code would surface as exit 1 through the same default.
+    """
+    source = (EVAL_DIR / "eval-suite.py").read_text(encoding="utf-8")
+    timeout_blocks = source.count('"reason": "timeout (')
+    assert timeout_blocks == 5, f"expected 5 timeout records, found {timeout_blocks}"
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        if '"reason": "timeout (' not in line:
+            continue
+        window = source.splitlines()[max(0, line_no - 4):line_no]
+        assert any("EXIT_EXTERNAL" in w for w in window), (
+            f"timeout record at line {line_no} has no explicit exit code"
+        )
 
 
 def test_run_rule_activation_on_no_files_is_vacuously_passing(


### PR DESCRIPTION
# Pull Request

## Summary

### What

Replaces the eval suite's broad-prefix change classifier with an ordered `ROUTING_RULES` table, so Copilot skills, skill references, command mirrors, and instruction mirrors stop routing to evaluators that cannot handle them, and canonical rules and entrypoints stop falling silently into `other`.

### Why

`AGENT_PATTERNS` carried a bare `src/copilot-cli/` prefix and the agent branch ran before the skill branch, so every Markdown file under the Copilot plugin tree was classified as an agent. `.claude/rules/` and `.github/instructions/` matched no pattern at all.

Reproduced at the commit the issue names, `2628d8c1282277ad39bc605eb6a31131eff2d77e`, with the issue's own command. Output matched the issue body line for line, so the report was not stale:

```text
Changed files: 17
agents: 4 files
skills: 2 files
other: 11 files
Overall: FAIL
exit 3
```

The exit 3 has a concrete cause: a misrouted file yields an agent name that does not exist, the agent evaluator exits 1 with empty stdout, and `_parse_child_json` turns that into `EXIT_EXTERNAL`. The suite reported an external API failure for what was a routing bug.

Same reproduction, same commit, with this branch: exit 0 in 0.3s with a deterministic routing plan and no JSON parse failures.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4882 | fix(eval): route Copilot skills and instructions to the correct behavioral evaluator |

**This reference does not close its linked item.** See "Scope" below for exactly what remains and why.

## Changes

Four files change in this PR:

- `scripts/eval/eval-suite.py`. The routing fix.
- `tests/eval/test_eval_suite_routing.py` (new). 280 tests: routing, ordering negative controls, real-CLI contract, child-output validation.
- `.agents/retrospective/2026-09-01-issue-4882-eval-routing-fallthrough.md` (new). FM-10 classification, three follow-on failures, and an 18-row remediation table.
- `scripts/eval/README.md`. Documents the new scope value and dry-run behavior.

## Implementation notes

No file outside the four listed above is modified. Components named below are existing and unchanged.

**Routing table.** Ordered narrowest first, first match wins, per `.claude/rules/code-quality.md` section "Table-Driven Logic". Two rows are identified by something other than a directory prefix and run before every prefix row: `entrypoints`, named by filename, and `command_mirrors`, distinguished by a filesystem predicate. Then references precede the trees containing them, and instructions precede agents.

**Pattern narrowing.** The agent prefix set drops the bare Copilot tree in favour of its `agents/` subtree; the skill prefix set gains the Copilot `skills/` subtree, with command mirrors carved out ahead of it.

**Categories.** `skills`, `skill_references`, `command_mirrors`, `references`, `rules`, `instructions`, `entrypoints`, plus the pre-existing ones. Every category names a runner or carries an explicit `not_evaluated` reason.

**Runner reuse.** Rules and instruction mirrors resolve to a canonical rule id and dispatch to the existing rule-activation evaluator, reading results from `--output`. No parallel harness, per required work item 6.

**Dry run.** Invokes no child evaluator and parses no model output. Prints a deterministic, scope-filtered routing plan and exits 0.

**Exit codes.** A child's config (2) and auth (4) refusals survive to the caller; timeouts are external (3) at all five runner sites.

## Review rounds

Four rounds found real bugs, most of them in the fix itself. All are addressed; every thread has a reply and is resolved.

### Round two

**1. The rule runner was written against an imagined child contract.** It parsed the child's stdout as JSON, copying the three sibling runners. Verified by running it:

```text
$ eval-rule-activation.py --scenarios .../code-quality.json --dry-run --output /tmp/rr.json
exit=0
stdout: [DRY-RUN] code-quality: 4 scenarios x 3 mechanisms x 4 (call + judges) = 48 calls
/tmp/rr.json: No such file or directory
```

The child serializes JSON only to `--output`. Every real run would have failed to parse and returned `EXIT_EXTERNAL`, the same failure this PR set out to fix, one layer down. The mock hid it; two tests now invoke the real child.

**2. The dry-run plan ignored `--scope`.** **3. The plan was never reconciled with results.** **4. A malformed scenario file was swallowed as "no scenario".** **5. The end-to-end test could never have run** (it diffed against `HEAD`, so its skip branch always fired; it now builds an isolated fixture repo). **6. The retrospective lacked the required remediation table.**

### Round three

**7. Parseable is not scored.** `{"schema_version": 1, "rules": {}}` was accepted as passed and published as scored efficacy evidence for a run that produced none. The runner now requires a string at `rules.<rule_id>.summary.verdict`.

**8. Exit-code precedence.** The child exits 2 on an invalid scenario and 4 on a missing key without writing an output file, so mapping every missing file to external reported an API failure for a config or auth fault.

**9. `UnicodeDecodeError` subclasses `ValueError`, not `OSError`,** so a binary scenario file crashed instead of exiting 2.

**10. Reconciliation keyed on `passed`,** which is False for a failing verdict, a timeout, and an unreadable result alike, so a timeout was promoted to `scored`.

**11. The happy-path stub certified the bug** by defaulting to an empty `rules` map.

### Round four

**12. `src/copilot-cli/skills/` conflates two artifact kinds.** Fourteen entries mirror `.claude/commands/<name>.md` and have no Claude skill, and the skill evaluator resolves only `.claude/skills/`:

```text
$ eval-knowledge-integration.py --skill spec --dry-run
exit=1
ERROR: Skill directory not found for 'spec' in .../.claude/skills
```

This issue's exact failure shape, at a site my own fix created by widening a prefix to fix a widening bug. A `command_mirrors` row now carves them out.

**13. The `entrypoints` row was dead.** It sat behind the prefix rows, and every real path-local entrypoint lives inside a prefix that precedes it, so `.claude/commands/CLAUDE.md`, `.claude/skills/github/CLAUDE.md` and twenty more were classified as prompts or skills. Basename rows now run first.

**14. The ADR-088 reference-scenario skip was too permissive,** accepting `{}` and a lone `skill_path`. Canonical requires non-empty `skill_path` **and** `reference_path`. My earlier reply on that thread asserted the opposite; it was wrong, and the tests had codified it.

**15. A timeout recorded no exit code,** so the reducer's default surfaced it as exit 1. Fixed at all five runner sites, not only the one flagged.

Negative controls: reverting round three's four fixes fails 16 tests; reverting round four's fails 37.

## Acceptance criteria

- [x] Copilot `SKILL.md` files route as a skill, not an agent
- [x] Copilot skill reference files do not route to the agent evaluator
- [x] Copilot instructions, GitHub instruction mirrors, and canonical rules route to a rule evaluation path or an explicit `not evaluated` result
- [x] Claude agents, `src/claude` agents, and Copilot agents still route as agents, with existing exclusions preserved
- [x] A dry run over the audited `HEAD~1` diff exits successfully and prints a deterministic routing plan rather than JSON-parse failures
- [x] Tests cover overlapping prefixes and ordering so a broad agent pattern cannot capture skills or references again
- [ ] Coverage output distinguishes baseline exemption from scenario presence and scored efficacy evidence (partial, see Scope)
- [ ] #4871 can consume the output (not attempted, see Scope)

## Scope

This PR is the bounded routing fix. Two of the issue's eight criteria are not fully met, so this uses `Refs`, not `Fixes`.

**Partially done: three-state coverage output.** The three states exist and are emitted, but in the eval suite's own routing plan, not in the repository's rule-activation coverage checker. I deliberately left that checker alone: it is a live ratchet wired into pre-PR validation, its baseline gates CI, and changing its output shape is a separate concern from routing. Its baseline membership is never presented as efficacy here. Pre-PR validation still reports `[PASS] Rule Activation Coverage`.

**Not attempted: #4871 consumption.** The routing plan object is the surface that work would read; shaping it to that consumer needs requirements that do not exist yet.

**Not touched: #4853.** No parallel parity harness was created.

## Known red check: semgrep-cloud-platform

Every other check is green. `semgrep-cloud-platform/scan` reports one `dangerous-subprocess-use-tainted-env-args` finding that I cannot clear without violating another gate. **Full detail, evidence, and three options are in a dedicated comment on this PR.** In short: the finding is a false positive (list form, `shell=False`); the three pre-existing `nosemgrep` markers in this file are two lines above their calls and therefore suppress nothing, measured with a local probe; and repairing the placement requires adding a suppression line, which `security-suppressions-staged` refuses with no bypass available to me.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**:

1. **Row order in `ROUTING_RULES`.** It is the whole contract, and it is where three of the four round-four defects lived. Tests now drive order through real tree paths, with premise controls so they cannot pass vacuously, and with controls that move a row back and assert the misroute returns.

2. **The real-CLI contract tests and the child-output validation.** Both exist because the mocked versions shipped bugs.

3. **Behavior changes beyond the reported bug.** Path-local `AGENTS.md` and `CLAUDE.md` now land in `entrypoints` rather than being absorbed by whatever tree they sit in. Markdown under the Copilot `docs/` and `lib/` trees no longer routes as agents. Command-mirror skills are reported `not_evaluated` rather than sent to an evaluator that exits 1.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed

Commands run locally, with results:

```text
pytest tests/eval/test_eval_suite_routing.py -q      280 passed
pytest tests/eval/ -q                                2264 passed, 20 skipped
scripts/validation/pre_pr.py                         RESULT: All validations passed
```

Every line added by this PR is covered.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The eval suite is a contributor-facing script. It ships in no plugin. See "Known red check" above and the dedicated comment.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated
- [x] No new warnings introduced

Taste-lint advisories: this file was already over the 500-line threshold before this change (580 lines on `main`). Extracting the routing table would not clear it without also moving the runners, which is scope creep on an entrypoint. I declared the exemption the way a sibling eval CLI in the same directory already does, with a reason.

## Related Issues

Refs #4882