### PR TITLE
fix(security): use full semgrep rule ids, not a broken family prefix

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,7 +1,0 @@
-rules:
-  - id: p/default
-    rules:
-      - id: python.lang.compatibility.python36
-        enabled: false
-      - id: python.lang.compatibility.python37
-        enabled: false

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,7 @@
+rules:
+  - id: p/default
+    rules:
+      - id: python.lang.compatibility.python36
+        enabled: false
+      - id: python.lang.compatibility.python37
+        enabled: false

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -106,7 +106,6 @@ ALLOWED_REPO_ROOT_ENTRIES = frozenset(
         ".mcp.json",
         ".python-version",
         ".qualityrc.json",
-        ".semgrep.yml",
         ".serena",
         ".vscode",
         ".worktreeinclude",
@@ -4930,13 +4929,19 @@ def _semgrep_command(
     # subprocess Popen(encoding=, errors=) that are valid on Python 3.6+.
     # This repo requires Python 3.14 (pyproject.toml python_requires >=3.14),
     # so those compatibility warnings are false positives here.
-    # Excluding the entire family rather than specific rules to catch all
-    # python36/37 compatibility findings (issue #4725).
+    # Full rule IDs required: prefix matching does not suppress with --exclude-rule
+    # on semgrep 1.159.0. Verified directly: passing the family prefix
+    # ("python.lang.compatibility.python36") still reports both Popen findings;
+    # only the full rule ID drops the count to zero (issue #4725).
     exclude_compat_rules = [
         "--exclude-rule",
-        "python.lang.compatibility.python36",
+        "python.lang.compatibility.python36.python36-compatibility-Popen1",
         "--exclude-rule",
-        "python.lang.compatibility.python37",
+        "python.lang.compatibility.python36.python36-compatibility-Popen2",
+        "--exclude-rule",
+        "python.lang.compatibility.python37.python37-compatibility-Popen1",
+        "--exclude-rule",
+        "python.lang.compatibility.python37.python37-compatibility-Popen2",
     ]
     # Semgrep's default 7 jobs can fail before scanning when io_uring cannot
     # allocate its worker queues. One job scanned 100 files in 93 seconds.

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -106,6 +106,7 @@ ALLOWED_REPO_ROOT_ENTRIES = frozenset(
         ".mcp.json",
         ".python-version",
         ".qualityrc.json",
+        ".semgrep.yml",
         ".serena",
         ".vscode",
         ".worktreeinclude",
@@ -4929,16 +4930,13 @@ def _semgrep_command(
     # subprocess Popen(encoding=, errors=) that are valid on Python 3.6+.
     # This repo requires Python 3.14 (pyproject.toml python_requires >=3.14),
     # so those compatibility warnings are false positives here.
-    # Full rule IDs required: prefix matching does not suppress with --exclude-rule.
+    # Excluding the entire family rather than specific rules to catch all
+    # python36/37 compatibility findings (issue #4725).
     exclude_compat_rules = [
         "--exclude-rule",
-        "python.lang.compatibility.python36.python36-compatibility-Popen1",
+        "python.lang.compatibility.python36",
         "--exclude-rule",
-        "python.lang.compatibility.python36.python36-compatibility-Popen2",
-        "--exclude-rule",
-        "python.lang.compatibility.python37.python37-compatibility-Popen1",
-        "--exclude-rule",
-        "python.lang.compatibility.python37.python37-compatibility-Popen2",
+        "python.lang.compatibility.python37",
     ]
     # Semgrep's default 7 jobs can fail before scanning when io_uring cannot
     # allocate its worker queues. One job scanned 100 files in 93 seconds.

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -4929,10 +4929,15 @@ def _semgrep_command(
     # subprocess Popen(encoding=, errors=) that are valid on Python 3.6+.
     # This repo requires Python 3.14 (pyproject.toml python_requires >=3.14),
     # so those compatibility warnings are false positives here.
-    # Full rule IDs required: prefix matching does not suppress with --exclude-rule
-    # on semgrep 1.159.0. Verified directly: passing the family prefix
-    # ("python.lang.compatibility.python36") still reports both Popen findings;
-    # only the full rule ID drops the count to zero (issue #4725).
+    # Full rule IDs are required: --exclude-rule does not match on a family
+    # prefix, so "python.lang.compatibility.python36" suppresses nothing.
+    # tests/test_lefthook_integration.py proves both halves against the
+    # installed semgrep binary (issue #4725).
+    # Scope: this covers the local semgrep-push hook only. The remote
+    # semgrep-cloud-platform/scan check runs a server-side ruleset that reads
+    # no repo-local flag or config file, so nothing here can turn it green.
+    # See .agents/governance/GOTCHAS.md, "The semgrep check in CI cannot be
+    # reproduced by the semgrep CLI".
     exclude_compat_rules = [
         "--exclude-rule",
         "python.lang.compatibility.python36.python36-compatibility-Popen1",

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -11151,3 +11151,50 @@ def test_root_scratch_policy_is_wired_into_pre_commit() -> None:
 
     assert str(job["run"]).endswith("git_hook_policy.py root-scratch {staged_files}")
     assert job["skip"] == ["merge"]
+
+
+def test_semgrep_excludes_python36_compatibility_on_real_file() -> None:
+    """Verify python36 compatibility rules are excluded when scanning the actual file.
+
+    The issue #4725 reports that python.lang.compatibility.python36.python36-compatibility-Popen1
+    and python36-compatibility-Popen2 fire false positives on run_workflow_local_test.py.
+    This test verifies they are excluded at the hook level.
+    """
+    test_file = policy.REPO_ROOT / "scripts" / "validation" / "run_workflow_local_test.py"
+    assert test_file.exists(), f"Test file not found: {test_file}"
+
+    content = test_file.read_text()
+    # Verify the file contains the subprocess.Popen call with encoding and errors arguments
+    assert "encoding=" in content, "File should contain encoding= argument"
+    assert "errors=" in content, "File should contain errors= argument"
+
+    # Verify the exclusion is in the command
+    cmd = policy._semgrep_command("auto", [str(test_file)])
+    exclude_values = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--exclude-rule"]
+
+    # Check that the python36 compatibility family is excluded
+    assert any("python.lang.compatibility.python36" in v for v in exclude_values), (
+        f"python36 compatibility family should be excluded. Got: {exclude_values}"
+    )
+
+
+def test_semgrep_configuration_file_excludes_compatibility_rules() -> None:
+    """Verify .semgrep.yml configuration file excludes compatibility rules.
+
+    The configuration file at repository root is used by semgrep-cloud-platform/scan
+    and other external scanners to configure rule exclusions.
+    """
+    semgrep_config = policy.REPO_ROOT / ".semgrep.yml"
+    assert semgrep_config.exists(), f"Semgrep configuration not found: {semgrep_config}"
+
+    config_text = semgrep_config.read_text()
+    # Verify that both python36 and python37 compatibility families are disabled
+    assert "python.lang.compatibility.python36" in config_text, (
+        "Configuration should disable python36 compatibility rules"
+    )
+    assert "python.lang.compatibility.python37" in config_text, (
+        "Configuration should disable python37 compatibility rules"
+    )
+    assert "enabled: false" in config_text, (
+        "Configuration should have rules disabled"
+    )

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -11050,6 +11050,38 @@ def test_semgrep_command_excludes_python37_compat_family() -> None:
     )
 
 
+def test_semgrep_command_excludes_full_rule_ids_not_family_prefix() -> None:
+    """--exclude-rule must carry the full rule id, not a family prefix.
+
+    Semgrep 1.159.0 does not suppress findings on a prefix like
+    "python.lang.compatibility.python36": passing that value still reports
+    both Popen findings when scanned directly. Only the full rule id
+    ("...python36.python36-compatibility-Popen1") drops the count to zero.
+    A regression back to the family prefix would keep this test's exact
+    list check red even though the two substring checks above stay green.
+    """
+    cmd = policy._semgrep_command("auto", ["path/to/file.py"])
+    exclude_values = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--exclude-rule"]
+    assert exclude_values == [
+        "python.lang.compatibility.python36.python36-compatibility-Popen1",
+        "python.lang.compatibility.python36.python36-compatibility-Popen2",
+        "python.lang.compatibility.python37.python37-compatibility-Popen1",
+        "python.lang.compatibility.python37.python37-compatibility-Popen2",
+    ], f"Expected full rule ids, got family-prefix or altered values: {exclude_values}"
+
+
+def test_semgrep_command_family_prefix_alone_is_insufficient(tmp_path: Path) -> None:
+    """Edge case: a bare family prefix must not appear as its own exclude value.
+
+    Guards against a partial fix that adds the full rule ids alongside the
+    broken prefix instead of replacing it.
+    """
+    cmd = policy._semgrep_command("auto", [str(tmp_path / "file.py")])
+    exclude_values = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--exclude-rule"]
+    assert "python.lang.compatibility.python36" not in exclude_values
+    assert "python.lang.compatibility.python37" not in exclude_values
+
+
 _ROOT_SCRATCH_CASES: tuple[tuple[str, list[str], list[str]], ...] = (
     ("investigation_dump", ["pr4147_threads.json"], ["pr4147_threads.json"]),
     ("timestamped_report", ["report.20260804.000717.json"], ["report.20260804.000717.json"]),
@@ -11153,48 +11185,45 @@ def test_root_scratch_policy_is_wired_into_pre_commit() -> None:
     assert job["skip"] == ["merge"]
 
 
+@pytest.mark.skipif(SEMGREP is None, reason="semgrep executable is unavailable")
 def test_semgrep_excludes_python36_compatibility_on_real_file() -> None:
-    """Verify python36 compatibility rules are excluded when scanning the actual file.
+    """Run the real security scan on the file issue #4725 names and assert zero
+    findings from the excluded rule ids.
 
-    The issue #4725 reports that python.lang.compatibility.python36.python36-compatibility-Popen1
-    and python36-compatibility-Popen2 fire false positives on run_workflow_local_test.py.
-    This test verifies they are excluded at the hook level.
+    A prefix like "python.lang.compatibility.python36" in --exclude-rule does not
+    suppress anything on semgrep 1.159.0; only the full rule id does. This test
+    executes semgrep against run_workflow_local_test.py (which calls
+    subprocess.Popen(encoding=, errors=)) so a regression to prefix matching fails
+    the test instead of passing on an argv string check alone.
     """
     test_file = policy.REPO_ROOT / "scripts" / "validation" / "run_workflow_local_test.py"
     assert test_file.exists(), f"Test file not found: {test_file}"
 
-    content = test_file.read_text()
-    # Verify the file contains the subprocess.Popen call with encoding and errors arguments
-    assert "encoding=" in content, "File should contain encoding= argument"
-    assert "errors=" in content, "File should contain errors= argument"
+    command = policy._semgrep_command("auto", [str(test_file)])
+    assert SEMGREP is not None
+    command[0] = SEMGREP
 
-    # Verify the exclusion is in the command
-    cmd = policy._semgrep_command("auto", [str(test_file)])
-    exclude_values = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--exclude-rule"]
-
-    # Check that the python36 compatibility family is excluded
-    assert any("python.lang.compatibility.python36" in v for v in exclude_values), (
-        f"python36 compatibility family should be excluded. Got: {exclude_values}"
+    result = subprocess.run(
+        command,
+        cwd=policy.REPO_ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
     )
 
-
-def test_semgrep_configuration_file_excludes_compatibility_rules() -> None:
-    """Verify .semgrep.yml configuration file excludes compatibility rules.
-
-    The configuration file at repository root is used by semgrep-cloud-platform/scan
-    and other external scanners to configure rule exclusions.
-    """
-    semgrep_config = policy.REPO_ROOT / ".semgrep.yml"
-    assert semgrep_config.exists(), f"Semgrep configuration not found: {semgrep_config}"
-
-    config_text = semgrep_config.read_text()
-    # Verify that both python36 and python37 compatibility families are disabled
-    assert "python.lang.compatibility.python36" in config_text, (
-        "Configuration should disable python36 compatibility rules"
+    assert result.returncode in {0, 1}, result.stderr
+    payload = json.loads(result.stdout)
+    excluded_prefixes = (
+        "python.lang.compatibility.python36",
+        "python.lang.compatibility.python37",
     )
-    assert "python.lang.compatibility.python37" in config_text, (
-        "Configuration should disable python37 compatibility rules"
-    )
-    assert "enabled: false" in config_text, (
-        "Configuration should have rules disabled"
+    compat_findings = [
+        finding["check_id"]
+        for finding in payload["results"]
+        if finding["check_id"].startswith(excluded_prefixes)
+    ]
+    assert compat_findings == [], (
+        f"python36/37 compatibility findings survived exclusion: {compat_findings}"
     )

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -3679,9 +3679,7 @@ def test_pushed_semgrep_scan_rejects_non_regular_type_change(
     monkeypatch.setattr(
         policy,
         "_run_semgrep_tree",
-        lambda *_args, **_kwargs: pytest.fail(
-            "Semgrep must not run on a non-regular snapshot"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("Semgrep must not run on a non-regular snapshot"),
     )
 
     assert policy.scan_pushed_heads(stream, repo) == 2
@@ -3706,9 +3704,7 @@ def test_pushed_semgrep_validates_all_paths_before_suffix_selection(
     monkeypatch.setattr(
         policy,
         "_scan_pushed_head",
-        lambda *_args, **_kwargs: pytest.fail(
-            "invalid pushed paths must not reach Semgrep"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("invalid pushed paths must not reach Semgrep"),
     )
 
     assert policy.scan_pushed_heads(io.StringIO(), tmp_path) == 2
@@ -3732,9 +3728,7 @@ def test_pushed_semgrep_detects_collision_with_unchanged_head_path(
     monkeypatch.setattr(
         policy,
         "_scan_pushed_head",
-        lambda *_args, **_kwargs: pytest.fail(
-            "colliding pushed trees must not reach Semgrep"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("colliding pushed trees must not reach Semgrep"),
     )
 
     assert policy.scan_pushed_heads(io.StringIO(), tmp_path) == 2
@@ -11185,45 +11179,116 @@ def test_root_scratch_policy_is_wired_into_pre_commit() -> None:
     assert job["skip"] == ["merge"]
 
 
-@pytest.mark.skipif(SEMGREP is None, reason="semgrep executable is unavailable")
-def test_semgrep_excludes_python36_compatibility_on_real_file() -> None:
-    """Run the real security scan on the file issue #4725 names and assert zero
-    findings from the excluded rule ids.
+# ---------------------------------------------------------------------------
+# Issue #4725: --exclude-rule needs full rule ids, proved against real semgrep
+# ---------------------------------------------------------------------------
 
-    A prefix like "python.lang.compatibility.python36" in --exclude-rule does not
-    suppress anything on semgrep 1.159.0; only the full rule id does. This test
-    executes semgrep against run_workflow_local_test.py (which calls
-    subprocess.Popen(encoding=, errors=)) so a regression to prefix matching fails
-    the test instead of passing on an argv string check alone.
+# Popen1 flags errors=, Popen2 flags encoding=, matching the two registry rules
+# quoted in issue #4725. The python37 family repeats the python36 pair.
+_COMPAT_RULES: tuple[tuple[str, str], ...] = (
+    ("python.lang.compatibility.python36.python36-compatibility-Popen1", "errors"),
+    ("python.lang.compatibility.python36.python36-compatibility-Popen2", "encoding"),
+    ("python.lang.compatibility.python37.python37-compatibility-Popen1", "errors"),
+    ("python.lang.compatibility.python37.python37-compatibility-Popen2", "encoding"),
+)
+
+_COMPAT_RULE_IDS: tuple[str, ...] = tuple(rule_id for rule_id, _ in _COMPAT_RULES)
+
+_COMPAT_FAMILY_PREFIXES: tuple[str, ...] = (
+    "python.lang.compatibility.python36",
+    "python.lang.compatibility.python37",
+)
+
+
+def _write_compat_ruleset(directory: Path) -> None:
+    """Write a local stand-in for the four python3{6,7} compatibility rules.
+
+    The production command passes ``--config auto``, which downloads a ruleset
+    from the Semgrep registry. A test that did the same would fail offline and
+    drift whenever the registry re-rolls its packs, so this reproduces only the
+    four rules under test, under their exact production ids.
+
+    The file must be named ``rules.yml`` and read from the process cwd. Semgrep
+    namespaces ids from a config file by that file's path, so
+    ``--config /tmp/x/rules.yml`` reports
+    ``tmp.x.python.lang.compatibility.python36...`` and no ``--exclude-rule``
+    value in ``_semgrep_command`` could ever match. A bare relative filename
+    resolved from the cwd keeps the id verbatim, which is why every caller runs
+    semgrep with ``cwd=directory``.
     """
-    test_file = policy.REPO_ROOT / "scripts" / "validation" / "run_workflow_local_test.py"
-    assert test_file.exists(), f"Test file not found: {test_file}"
+    rules = "".join(
+        f"  - id: {rule_id}\n"
+        f"    languages: [python]\n"
+        f"    severity: ERROR\n"
+        f"    message: the {keyword} argument to Popen needs a newer Python\n"
+        f"    pattern: subprocess.Popen(..., {keyword}=..., ...)\n"
+        for rule_id, keyword in _COMPAT_RULES
+    )
+    (directory / "rules.yml").write_text(f"rules:\n{rules}", encoding="utf-8")
 
-    command = policy._semgrep_command("auto", [str(test_file)])
+
+def _scan_compat_target(directory: Path, exclude_rules: Sequence[str] | None) -> set[str]:
+    """Scan the file issue #4725 names and return the check ids semgrep reports.
+
+    ``exclude_rules=None`` runs ``_semgrep_command`` exactly as the
+    ``semgrep-push`` hook builds it. Any sequence replaces the command's own
+    ``--exclude-rule`` pairs instead, so ``[]`` is the unexcluded control.
+    """
     assert SEMGREP is not None
+    _write_compat_ruleset(directory)
+    target = policy.REPO_ROOT / "scripts" / "validation" / "run_workflow_local_test.py"
+    assert target.exists(), f"target named by issue #4725 is missing: {target}"
+
+    command = policy._semgrep_command("rules.yml", [str(target)])
     command[0] = SEMGREP
+    if exclude_rules is not None:
+        stripped = [
+            argument
+            for index, argument in enumerate(command)
+            if argument != "--exclude-rule" and command[index - 1] != "--exclude-rule"
+        ]
+        replacement: list[str] = []
+        for rule in exclude_rules:
+            replacement += ["--exclude-rule", rule]
+        separator = stripped.index("--")
+        command = stripped[:separator] + replacement + stripped[separator:]
 
     result = subprocess.run(
         command,
-        cwd=policy.REPO_ROOT,
+        cwd=directory,
         text=True,
         encoding="utf-8",
         errors="replace",
         capture_output=True,
         check=False,
     )
+    assert result.returncode in {0, 1}, f"semgrep exited {result.returncode}: {result.stderr}"
+    return {finding["check_id"] for finding in json.loads(result.stdout)["results"]}
 
-    assert result.returncode in {0, 1}, result.stderr
-    payload = json.loads(result.stdout)
-    excluded_prefixes = (
-        "python.lang.compatibility.python36",
-        "python.lang.compatibility.python37",
-    )
-    compat_findings = [
-        finding["check_id"]
-        for finding in payload["results"]
-        if finding["check_id"].startswith(excluded_prefixes)
-    ]
-    assert compat_findings == [], (
-        f"python36/37 compatibility findings survived exclusion: {compat_findings}"
-    )
+
+@pytest.mark.skipif(SEMGREP is None, reason="semgrep executable is unavailable")
+def test_semgrep_compat_rules_fire_on_the_target_without_exclusion(tmp_path: Path) -> None:
+    """Control: the target emits all four findings when nothing is excluded.
+
+    Without this, a green exclusion test proves nothing. It would pass just as
+    well against a target that never triggered the rules, or against a ruleset
+    that stopped matching.
+    """
+    assert _scan_compat_target(tmp_path, []) == set(_COMPAT_RULE_IDS)
+
+
+@pytest.mark.skipif(SEMGREP is None, reason="semgrep executable is unavailable")
+def test_semgrep_family_prefix_exclusion_suppresses_nothing(tmp_path: Path) -> None:
+    """The broken form: --exclude-rule does not match on a family prefix.
+
+    This restores the defect issue #4725 hit, which is what proves the full ids
+    in ``_semgrep_command`` are load-bearing rather than a longer spelling of
+    the same thing. Both prefixes are passed and all four findings survive.
+    """
+    assert _scan_compat_target(tmp_path, _COMPAT_FAMILY_PREFIXES) == set(_COMPAT_RULE_IDS)
+
+
+@pytest.mark.skipif(SEMGREP is None, reason="semgrep executable is unavailable")
+def test_semgrep_command_exclusions_suppress_every_compat_rule(tmp_path: Path) -> None:
+    """The production command, unmodified, reports none of the four rules."""
+    assert _scan_compat_target(tmp_path, None) == set()


### PR DESCRIPTION
## Summary

### What

Regression tests for the semgrep `--exclude-rule` contract, plus a code
comment that bounds the exclusion to the hook it actually affects. No
runtime behavior changes.

### Why

The four full rule IDs in `_semgrep_command` are already on `main`. They
landed with the Popen call itself in commit `2e20c8771` (#4374). This
branch briefly replaced them with a family prefix, which suppresses
nothing, and then reverted. The diff that remains is the guard that would
have caught that swap, and it did not exist before.

`--exclude-rule` does not match on a family prefix. Passing
`python.lang.compatibility.python36` reports the same two Popen findings
as passing no exclusion at all. Only the full rule ID drops the count to
zero. Verified on semgrep 1.174.0, and now pinned by a test rather than
by a version number in a comment.

### What this does not do

This does not turn `semgrep-cloud-platform/scan` green, and the code
comment now says so. That check runs a server-side ruleset that reads no
repo-local flag and no repo-local config file, which
`.agents/governance/GOTCHAS.md` already records under "The semgrep check
in CI cannot be reproduced by the semgrep CLI". `_semgrep_command` feeds
the local `semgrep-push` hook only. Issue #4725 asks for the cloud check
to stop being permanently red, so this PR references it and leaves it
open.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4725 | semgrep python36 compatibility rules fire on a repository with a 3.14 floor |
| **Commit** | `2e20c8771` (#4374) | where the full rule IDs and the flagged Popen call both landed |

These references do not close their linked items: #4725 is about the
server-side `semgrep-cloud-platform/scan` check, and nothing in this diff
reaches it.

## Changes

- `tests/test_lefthook_integration.py`: replace
  `test_semgrep_excludes_python36_compatibility_on_real_file` with three
  tests over a local ruleset written to `tmp_path`.
- `scripts/validation/git_hook_policy.py`: comment only, inside
  `_semgrep_command`. State the local hook scope, and drop a semgrep
  version pin that no check can verify.

## Testing

The replaced test scanned with `--config auto`, so the default pytest
suite reached the live Semgrep registry. It failed offline or on a
transient registry outage even when the code was correct, and it had no
control: a green run would have passed just as well against a target that
never triggered the rules.

The three replacements use a local ruleset carrying the four production
rule IDs, so they need no network:

1. Control. No exclusions, all four rules fire on
   `scripts/validation/run_workflow_local_test.py`.
2. Defect restored. Both family prefixes excluded, all four still fire.
3. Production. `_semgrep_command` unmodified, none fire.

Semgrep namespaces rule IDs from a config file by that file's path, so an
absolute `--config` makes every ID unmatchable by `--exclude-rule`. A bare
relative filename read from the process cwd keeps the ID verbatim, which
is what makes the local substitution faithful to the registry IDs. The
`_write_compat_ruleset` docstring records this.

Discrimination probe. Reintroducing the family prefix in
`_semgrep_command` fails test 3 and leaves tests 1 and 2 green, so the set
fails on the exact defect rather than on an argv string:

    1 failed, 2 passed, 859 deselected in 9.22s

Restored, the file is byte identical to `HEAD` and the suite is green:

    uv run pytest tests/test_lefthook_integration.py -k semgrep -q
    102 passed, 760 deselected in 25.36s

    uv run ruff check scripts/validation/git_hook_policy.py tests/test_lefthook_integration.py
    All checks passed!

## Notes for Reviewers

Both open Copilot threads drove this revision. The thread on
`_semgrep_command` asked for either the change that fixes the cloud check
or an honest narrowing to `Refs #4725`; the cloud check is not reachable
from this repository, so this took the narrowing. The thread on the test
asked for a local config and an unexcluded control, which is tests 1
through 3 above.
