### PR TITLE
fix(ci): retry UNKNOWN mergeability before failing external

### DIFF
--- a/scripts/ci/check_pr_merge_state.py
+++ b/scripts/ci/check_pr_merge_state.py
@@ -56,7 +56,15 @@ def load_open_prs(repo: str, head_ref: str) -> tuple[int, list[PullRequest]]:
                 "--head",
                 head_ref,
                 "--json",
-                "number,title,url,mergeStateStatus,headRefName,baseRefName",
+                # `mergeable` is requested and never parsed, on purpose. GitHub
+                # computes mergeability lazily and asking for mergeStateStatus
+                # alone does not trigger that computation, so a query without
+                # `mergeable` can report UNKNOWN indefinitely and no amount of
+                # retrying converges. Measured on this repository: 46 open PRs
+                # read seconds apart returned UNKNOWN=40 without the field and a
+                # decided verdict for all 46 with it. See
+                # .serena/memories/ci/ci-mergeability-is-not-computed-until-you-ask.md
+                "number,title,url,mergeable,mergeStateStatus,headRefName,baseRefName",
             ]
         )
     except (FileNotFoundError, OSError) as exc:

--- a/scripts/ci/check_pr_merge_state.py
+++ b/scripts/ci/check_pr_merge_state.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import subprocess
 import sys
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
@@ -89,6 +91,43 @@ def load_open_prs(repo: str, head_ref: str) -> tuple[int, list[PullRequest]]:
     return EXIT_OK, prs
 
 
+
+def load_open_prs_with_retry(
+    repo: str, head_ref: str, max_attempts: int = 3
+) -> tuple[int, list[PullRequest]]:
+    """Load open PRs, retrying if merge state is UNKNOWN.
+
+    GitHub computes mergeability lazily. On the first query after a push,
+    mergeStateStatus may be UNKNOWN. This function retries the query up to
+    max_attempts times with random delays (10-20 seconds) between attempts,
+    allowing GitHub time to compute mergeability.
+
+    Only returns EXIT_EXTERNAL if all attempts return UNKNOWN.
+    """
+    retry_delay_min = 10
+    retry_delay_max = 20
+
+    for attempt in range(max_attempts):
+        rc, prs = load_open_prs(repo, head_ref)
+
+        # If the call failed (not EXIT_OK), return immediately
+        if rc != EXIT_OK:
+            return rc, prs
+
+        # Check if any PR has UNKNOWN status
+        has_unknown = any(pr.merge_state_status == "UNKNOWN" for pr in prs)
+
+        # If no UNKNOWN or this is the last attempt, return
+        if not has_unknown or attempt == max_attempts - 1:
+            return rc, prs
+
+        # Wait before retrying (random between 10-20 seconds)
+        wait_time = random.randint(retry_delay_min, retry_delay_max)
+        time.sleep(wait_time)
+
+    # Should not reach here, but return the last result just in case
+    return rc, prs
+
 def check_prs(prs: Sequence[PullRequest]) -> int:
     if not prs:
         print("PR merge state: no open PR for this branch.")
@@ -138,7 +177,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("error: --head-ref or GITHUB_REF_NAME is required", file=sys.stderr)
         return EXIT_CONFIG
 
-    rc, prs = load_open_prs(args.repo, args.head_ref)
+    rc, prs = load_open_prs_with_retry(args.repo, args.head_ref)
     if rc != EXIT_OK:
         return rc
     return check_prs(prs)

--- a/scripts/ci/check_pr_merge_state.py
+++ b/scripts/ci/check_pr_merge_state.py
@@ -91,7 +91,6 @@ def load_open_prs(repo: str, head_ref: str) -> tuple[int, list[PullRequest]]:
     return EXIT_OK, prs
 
 
-
 def load_open_prs_with_retry(
     repo: str, head_ref: str, max_attempts: int = 3
 ) -> tuple[int, list[PullRequest]]:
@@ -102,7 +101,10 @@ def load_open_prs_with_retry(
     max_attempts times with random delays (10-20 seconds) between attempts,
     allowing GitHub time to compute mergeability.
 
-    Only returns EXIT_EXTERNAL if all attempts return UNKNOWN.
+    Returns whatever load_open_prs last returned: an early non-EXIT_OK on a
+    gh failure, or EXIT_OK with the PR list on the final attempt, UNKNOWN
+    merge state included if every attempt stayed UNKNOWN. Deciding whether
+    UNKNOWN should fail the run is check_prs's job, not this function's.
     """
     retry_delay_min = 10
     retry_delay_max = 20
@@ -127,6 +129,7 @@ def load_open_prs_with_retry(
 
     # Should not reach here, but return the last result just in case
     return rc, prs
+
 
 def check_prs(prs: Sequence[PullRequest]) -> int:
     if not prs:

--- a/scripts/ci/check_pr_merge_state.py
+++ b/scripts/ci/check_pr_merge_state.py
@@ -21,6 +21,9 @@ EXIT_EXTERNAL = 3
 PASS_STATES = {"BEHIND", "BLOCKED", "CLEAN", "HAS_HOOKS", "UNSTABLE"}
 FAIL_STATES = {"DIRTY"}
 
+RETRY_DELAY_MIN_SECONDS = 10
+RETRY_DELAY_MAX_SECONDS = 20
+
 
 @dataclass(frozen=True, slots=True)
 class PullRequest:
@@ -99,43 +102,62 @@ def load_open_prs(repo: str, head_ref: str) -> tuple[int, list[PullRequest]]:
     return EXIT_OK, prs
 
 
+def has_no_verdict(merge_state_status: str) -> bool:
+    """True when GitHub gave no authoritative merge verdict for this status.
+
+    UNKNOWN is what GitHub reports while mergeability is still being computed,
+    but it is not the only status outside the decided sets: an unlisted or
+    newly-added status lands here too. check_prs and load_open_prs_with_retry
+    share this predicate so that every status which can fail the run is also a
+    status the retry will wait on. A stricter retry predicate would let an
+    unlisted status skip the wait and still exit 3.
+    """
+    return merge_state_status not in PASS_STATES | FAIL_STATES
+
+
 def load_open_prs_with_retry(
     repo: str, head_ref: str, max_attempts: int = 3
 ) -> tuple[int, list[PullRequest]]:
-    """Load open PRs, retrying if merge state is UNKNOWN.
+    """Load open PRs, re-reading while GitHub reports no merge verdict yet.
 
-    GitHub computes mergeability lazily. On the first query after a push,
-    mergeStateStatus may be UNKNOWN. This function retries the query up to
-    max_attempts times with random delays (10-20 seconds) between attempts,
-    allowing GitHub time to compute mergeability.
+    GitHub computes mergeability lazily, so the first read after a push can
+    come back without a verdict. This makes up to max_attempts reads, sleeping
+    a random RETRY_DELAY_MIN_SECONDS to RETRY_DELAY_MAX_SECONDS between them,
+    and never sleeps after the final read.
 
-    Returns whatever load_open_prs last returned: an early non-EXIT_OK on a
-    gh failure, or EXIT_OK with the PR list on the final attempt, UNKNOWN
-    merge state included if every attempt stayed UNKNOWN. Deciding whether
-    UNKNOWN should fail the run is check_prs's job, not this function's.
+    Returns whatever load_open_prs last returned: an early non-EXIT_OK on a gh
+    failure, or EXIT_OK with the PR list from the last read, a verdict-less
+    merge state included if every read stayed that way. Deciding whether a
+    missing verdict should fail the run is check_prs's job, not this one's.
+
+    Raises ValueError when max_attempts is not an integer of 1 or more. A zero
+    or negative budget previously skipped the loop and then read unassigned
+    locals; a non-integer raised out of range().
+
+    Canonical bound, scripts/validate_pr_review_config.py:284-290, quoted:
+
+        retries = il.get("completion_gate_max_retries")
+        if retries is not None and (
+            not isinstance(retries, int) or isinstance(retries, bool) or retries < 0
+        ):
+            errors.append(
+                "invocation_limits.completion_gate_max_retries must be an integer >= 0"
+            )
+
+    Stricter than canonical: the floor here is 1, not 0, because this counts
+    attempts rather than retries and zero attempts reads nothing. The bool
+    exclusion is carried over unchanged, so max_attempts=True is rejected rather
+    than silently meaning one attempt.
     """
-    retry_delay_min = 10
-    retry_delay_max = 20
+    if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
+        raise ValueError(f"max_attempts must be an integer >= 1, got {max_attempts!r}")
 
-    for attempt in range(max_attempts):
+    rc, prs = load_open_prs(repo, head_ref)
+    for _ in range(max_attempts - 1):
+        if rc != EXIT_OK or not any(has_no_verdict(pr.merge_state_status) for pr in prs):
+            return rc, prs
+        time.sleep(random.randint(RETRY_DELAY_MIN_SECONDS, RETRY_DELAY_MAX_SECONDS))
         rc, prs = load_open_prs(repo, head_ref)
-
-        # If the call failed (not EXIT_OK), return immediately
-        if rc != EXIT_OK:
-            return rc, prs
-
-        # Check if any PR has UNKNOWN status
-        has_unknown = any(pr.merge_state_status == "UNKNOWN" for pr in prs)
-
-        # If no UNKNOWN or this is the last attempt, return
-        if not has_unknown or attempt == max_attempts - 1:
-            return rc, prs
-
-        # Wait before retrying (random between 10-20 seconds)
-        wait_time = random.randint(retry_delay_min, retry_delay_max)
-        time.sleep(wait_time)
-
-    # Should not reach here, but return the last result just in case
     return rc, prs
 
 
@@ -145,7 +167,7 @@ def check_prs(prs: Sequence[PullRequest]) -> int:
         return EXIT_OK
 
     blocked = [pr for pr in prs if pr.merge_state_status in FAIL_STATES]
-    unknown = [pr for pr in prs if pr.merge_state_status not in PASS_STATES | FAIL_STATES]
+    unknown = [pr for pr in prs if has_no_verdict(pr.merge_state_status)]
     if blocked:
         for pr in blocked:
             print(

--- a/tests/ci/test_check_pr_merge_state.py
+++ b/tests/ci/test_check_pr_merge_state.py
@@ -98,3 +98,56 @@ def test_python_workflow_runs_merge_state_on_branch_pushes():
     assert "github.event_name == 'push'" in workflow
     assert "python scripts/ci/check_pr_merge_state.py" in workflow
     assert "push:\n    branches:\n      - main" not in workflow
+
+
+def test_unknown_pr_retries_and_resolves_to_clean(monkeypatch):
+    """Test that UNKNOWN is retried and eventually resolves to CLEAN."""
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            # First two attempts return UNKNOWN
+            return checker.EXIT_OK, [_pr("UNKNOWN")]
+        # Third attempt returns CLEAN
+        return checker.EXIT_OK, [_pr("CLEAN")]
+
+    # Mock time.sleep so tests run fast
+    def fake_sleep(seconds):
+        pass
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert rc == checker.EXIT_OK
+    assert call_count == 3
+    assert len(prs) == 1
+    assert prs[0].merge_state_status == "CLEAN"
+
+
+def test_unknown_pr_exhausts_retries_and_fails(monkeypatch):
+    """Test that UNKNOWN is retried and fails after exhausting retries."""
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        # All attempts return UNKNOWN
+        return checker.EXIT_OK, [_pr("UNKNOWN")]
+
+    # Mock time.sleep so tests run fast
+    def fake_sleep(seconds):
+        pass
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert rc == checker.EXIT_OK
+    assert call_count == 3
+    assert len(prs) == 1
+    assert prs[0].merge_state_status == "UNKNOWN"

--- a/tests/ci/test_check_pr_merge_state.py
+++ b/tests/ci/test_check_pr_merge_state.py
@@ -128,8 +128,10 @@ def test_unknown_pr_retries_and_resolves_to_clean(monkeypatch):
     assert prs[0].merge_state_status == "CLEAN"
 
 
-def test_unknown_pr_exhausts_retries_and_fails(monkeypatch):
-    """Test that UNKNOWN is retried and fails after exhausting retries."""
+def test_retry_exhausted_still_returns_ok_with_unknown_prs(monkeypatch):
+    """load_open_prs_with_retry returns EXIT_OK (the gh call succeeded);
+    it does not itself decide pass/fail on UNKNOWN. That decision belongs
+    to check_prs, exercised separately below via main()."""
     call_count = 0
 
     def fake_load_open_prs(repo, head_ref):
@@ -151,3 +153,26 @@ def test_unknown_pr_exhausts_retries_and_fails(monkeypatch):
     assert call_count == 3
     assert len(prs) == 1
     assert prs[0].merge_state_status == "UNKNOWN"
+
+
+def test_main_exits_external_after_retries_exhausted_on_unknown(monkeypatch):
+    """End-to-end: main() must route through load_open_prs_with_retry, not
+    the bare load_open_prs. Mocking load_open_prs (the retry loop's inner
+    call) and counting invocations catches a regression that wires main()
+    back to the un-retried call: call_count would drop from 3 to 1."""
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        return checker.EXIT_OK, [_pr("UNKNOWN")]
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "rjmurillo/ai-agents")
+    monkeypatch.setenv("GITHUB_REF_NAME", "feature")
+
+    rc = checker.main([])
+
+    assert rc == checker.EXIT_EXTERNAL
+    assert call_count == 3

--- a/tests/ci/test_check_pr_merge_state.py
+++ b/tests/ci/test_check_pr_merge_state.py
@@ -265,6 +265,34 @@ def test_invalid_max_attempts_is_rejected_before_any_read(monkeypatch, budget):
     assert reads == []
 
 
+def test_a_single_attempt_budget_reads_once_and_never_waits(monkeypatch):
+    """Pin the documented valid lower bound, not only the rejected values.
+
+    Every case in the parametrization above is invalid, so none of them passes
+    1. Tightening the guard from `< 1` to `< 2` would reject this legitimate
+    budget while that suite stayed green. One read, no wait, first payload
+    returned unchanged.
+    """
+    clock = _RetryClock()
+    clock.install(monkeypatch)
+    reads = []
+
+    def fake_load_open_prs(repo, head_ref):
+        reads.append(head_ref)
+        return checker.EXIT_OK, [_pr("UNKNOWN")]
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+
+    rc, prs = checker.load_open_prs_with_retry(
+        "rjmurillo/ai-agents", "feature", max_attempts=1
+    )
+
+    assert rc == checker.EXIT_OK
+    assert reads == ["feature"]
+    assert clock.sleeps == []
+    assert [pr.merge_state_status for pr in prs] == ["UNKNOWN"]
+
+
 def test_an_unlisted_status_is_retried_the_same_as_unknown(monkeypatch):
     """The retry predicate must match the predicate that fails the run.
 

--- a/tests/ci/test_check_pr_merge_state.py
+++ b/tests/ci/test_check_pr_merge_state.py
@@ -3,18 +3,41 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scripts.ci import check_pr_merge_state as checker
 
 
-def _pr(state: str) -> checker.PullRequest:
+def _pr(state: str, number: int = 123) -> checker.PullRequest:
     return checker.PullRequest(
-        number=123,
+        number=number,
         title="Test PR",
-        url="https://github.com/rjmurillo/ai-agents/pull/123",
+        url=f"https://github.com/rjmurillo/ai-agents/pull/{number}",
         merge_state_status=state,
         head_ref_name="feature",
         base_ref_name="main",
     )
+
+
+class _RetryClock:
+    """Records the retry waits instead of discarding them.
+
+    Substituting a no-op sleep hides the delay from the test, so removing it,
+    or adding one after the final read, leaves the suite green. This keeps both
+    the randint bounds and every slept value observable.
+    """
+
+    def __init__(self) -> None:
+        self.randint_calls: list[tuple[int, int]] = []
+        self.sleeps: list[int] = []
+
+    def install(self, monkeypatch) -> None:
+        def fake_randint(low: int, high: int) -> int:
+            self.randint_calls.append((low, high))
+            return high
+
+        monkeypatch.setattr(checker.random, "randint", fake_randint)
+        monkeypatch.setattr(checker.time, "sleep", self.sleeps.append)
 
 
 def test_clean_pr_passes(capsys):
@@ -125,6 +148,8 @@ def test_python_workflow_runs_merge_state_on_branch_pushes():
 
 def test_unknown_pr_retries_and_resolves_to_clean(monkeypatch):
     """Test that UNKNOWN is retried and eventually resolves to CLEAN."""
+    clock = _RetryClock()
+    clock.install(monkeypatch)
     call_count = 0
 
     def fake_load_open_prs(repo, head_ref):
@@ -136,12 +161,7 @@ def test_unknown_pr_retries_and_resolves_to_clean(monkeypatch):
         # Third attempt returns CLEAN
         return checker.EXIT_OK, [_pr("CLEAN")]
 
-    # Mock time.sleep so tests run fast
-    def fake_sleep(seconds):
-        pass
-
     monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
-    monkeypatch.setattr("time.sleep", fake_sleep)
 
     rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
 
@@ -155,6 +175,8 @@ def test_retry_exhausted_still_returns_ok_with_unknown_prs(monkeypatch):
     """load_open_prs_with_retry returns EXIT_OK (the gh call succeeded);
     it does not itself decide pass/fail on UNKNOWN. That decision belongs
     to check_prs, exercised separately below via main()."""
+    clock = _RetryClock()
+    clock.install(monkeypatch)
     call_count = 0
 
     def fake_load_open_prs(repo, head_ref):
@@ -163,12 +185,7 @@ def test_retry_exhausted_still_returns_ok_with_unknown_prs(monkeypatch):
         # All attempts return UNKNOWN
         return checker.EXIT_OK, [_pr("UNKNOWN")]
 
-    # Mock time.sleep so tests run fast
-    def fake_sleep(seconds):
-        pass
-
     monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
-    monkeypatch.setattr("time.sleep", fake_sleep)
 
     rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
 
@@ -178,11 +195,137 @@ def test_retry_exhausted_still_returns_ok_with_unknown_prs(monkeypatch):
     assert prs[0].merge_state_status == "UNKNOWN"
 
 
+def test_retry_waits_the_promised_bounds_and_never_after_the_last_read(monkeypatch):
+    """Pin the delay itself, not just that a delay function was importable.
+
+    Three reads means exactly two waits, each drawn from the promised 10-to-20
+    second window. Deleting the sleep empties clock.sleeps, adding one after the
+    final read makes it three, and moving the bounds fails the literal below.
+    """
+    clock = _RetryClock()
+    clock.install(monkeypatch)
+    monkeypatch.setattr(
+        checker,
+        "load_open_prs",
+        lambda repo, head_ref: (checker.EXIT_OK, [_pr("UNKNOWN")]),
+    )
+
+    checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert (checker.RETRY_DELAY_MIN_SECONDS, checker.RETRY_DELAY_MAX_SECONDS) == (10, 20)
+    assert clock.randint_calls == [(10, 20), (10, 20)]
+    assert clock.sleeps == [20, 20]
+
+
+def test_gh_failure_mid_retry_returns_at_once_without_further_reads(monkeypatch):
+    """The early return on a gh failure must not be retried or swallowed.
+
+    A gh crash is not a lazily-computed verdict, so waiting cannot help. The
+    second read fails, the third never happens, and the failing code reaches
+    the caller unchanged.
+    """
+    clock = _RetryClock()
+    clock.install(monkeypatch)
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return checker.EXIT_OK, [_pr("UNKNOWN")]
+        return checker.EXIT_EXTERNAL, []
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+
+    rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert rc == checker.EXIT_EXTERNAL
+    assert prs == []
+    assert call_count == 2
+    assert clock.sleeps == [20]
+
+
+@pytest.mark.parametrize("budget", [0, -1, "3", 2.5, None, True])
+def test_invalid_max_attempts_is_rejected_before_any_read(monkeypatch, budget):
+    """Guard the public parameter, and prove it fires before the first read.
+
+    pytest.raises alone would pass if the function read once and then blew up
+    on range(), so the isolating assertion is that no read happened at all.
+    """
+    reads = []
+    monkeypatch.setattr(
+        checker,
+        "load_open_prs",
+        lambda repo, head_ref: (reads.append(head_ref), (checker.EXIT_OK, []))[1],
+    )
+
+    with pytest.raises(ValueError, match="max_attempts"):
+        checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature", max_attempts=budget)
+
+    assert reads == []
+
+
+def test_an_unlisted_status_is_retried_the_same_as_unknown(monkeypatch):
+    """The retry predicate must match the predicate that fails the run.
+
+    check_prs exits 3 on any status outside PASS_STATES | FAIL_STATES, not just
+    the literal UNKNOWN. A retry that waited only on UNKNOWN would let a new or
+    unlisted GitHub status skip the wait and still fail the check, so both sides
+    share has_no_verdict. With the narrower predicate this reads once, not twice.
+    """
+    clock = _RetryClock()
+    clock.install(monkeypatch)
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return checker.EXIT_OK, [_pr("MERGEABILITY_PENDING")]
+        return checker.EXIT_OK, [_pr("CLEAN")]
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+
+    rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert checker.check_prs([_pr("MERGEABILITY_PENDING")]) == checker.EXIT_EXTERNAL
+    assert rc == checker.EXIT_OK
+    assert call_count == 2
+    assert clock.sleeps == [20]
+    assert prs[0].merge_state_status == "CLEAN"
+
+
+def test_one_verdictless_pr_retries_even_when_a_sibling_is_decided(monkeypatch):
+    """A mixed list retries the whole batch, because the verdict-less member is
+    the one that would fail the run."""
+    clock = _RetryClock()
+    clock.install(monkeypatch)
+    call_count = 0
+
+    def fake_load_open_prs(repo, head_ref):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return checker.EXIT_OK, [_pr("CLEAN", number=1), _pr("UNKNOWN", number=2)]
+        return checker.EXIT_OK, [_pr("CLEAN", number=1), _pr("CLEAN", number=2)]
+
+    monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
+
+    rc, prs = checker.load_open_prs_with_retry("rjmurillo/ai-agents", "feature")
+
+    assert rc == checker.EXIT_OK
+    assert call_count == 2
+    assert clock.sleeps == [20]
+    assert [pr.merge_state_status for pr in prs] == ["CLEAN", "CLEAN"]
+
+
 def test_main_exits_external_after_retries_exhausted_on_unknown(monkeypatch):
     """End-to-end: main() must route through load_open_prs_with_retry, not
     the bare load_open_prs. Mocking load_open_prs (the retry loop's inner
     call) and counting invocations catches a regression that wires main()
     back to the un-retried call: call_count would drop from 3 to 1."""
+    clock = _RetryClock()
+    clock.install(monkeypatch)
     call_count = 0
 
     def fake_load_open_prs(repo, head_ref):
@@ -191,7 +334,6 @@ def test_main_exits_external_after_retries_exhausted_on_unknown(monkeypatch):
         return checker.EXIT_OK, [_pr("UNKNOWN")]
 
     monkeypatch.setattr(checker, "load_open_prs", fake_load_open_prs)
-    monkeypatch.setattr("time.sleep", lambda seconds: None)
     monkeypatch.setenv("GITHUB_REPOSITORY", "rjmurillo/ai-agents")
     monkeypatch.setenv("GITHUB_REF_NAME", "feature")
 

--- a/tests/ci/test_check_pr_merge_state.py
+++ b/tests/ci/test_check_pr_merge_state.py
@@ -92,6 +92,29 @@ def test_gh_malformed_pr_item_is_external_error(monkeypatch, capsys):
     assert "malformed PR item" in captured.err
 
 
+def test_pr_list_requests_mergeable_so_github_computes_the_verdict(monkeypatch):
+    """The retry loop is inert unless the query forces the lazy computation.
+
+    GitHub computes mergeability on demand. `mergeStateStatus` alone does not
+    ask for it, so every retry re-reads the same UNKNOWN. `mergeable` is the
+    field that triggers the computation, so it is pinned at the argv level:
+    dropping it from the --json list fails here, not three retries later in
+    production.
+    """
+    seen = {}
+
+    def fake_run_gh(argv):
+        seen["argv"] = list(argv)
+        return subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(checker, "run_gh", fake_run_gh)
+    checker.load_open_prs("rjmurillo/ai-agents", "feature")
+
+    json_fields = seen["argv"][seen["argv"].index("--json") + 1].split(",")
+    assert "mergeable" in json_fields
+    assert "mergeStateStatus" in json_fields
+
+
 def test_python_workflow_runs_merge_state_on_branch_pushes():
     workflow = Path(".github/workflows/pytest.yml").read_text(encoding="utf-8")
     assert "pr-merge-state:" in workflow


### PR DESCRIPTION
## Summary

### What

Make `check_pr_merge_state` wait for a merge verdict instead of failing on the
first read. Two files, `scripts/ci/check_pr_merge_state.py` and
`tests/ci/test_check_pr_merge_state.py`.

1. Ask for `mergeable` in the `gh pr list --json` field list. That field is what
   makes GitHub compute mergeability. Without it the retry re-reads the same
   UNKNOWN.
2. Retry up to three reads, 10 to 20 seconds apart, and exit 3 only when the
   last read still has no verdict.
3. Validate `max_attempts` before the first read.
4. Share one predicate, `has_no_verdict`, between the retry loop and
   `check_prs`, so every status that can fail the run is a status the retry
   waits on.

### Why

GitHub computes mergeability asynchronously. A check run seconds after a push
reads UNKNOWN and the script exits 3, so an agent treats a healthy PR as
externally broken and burns a manual rerun. Two such reruns were recorded on a
single PR in one evening.

The retry alone does not fix that. `mergeStateStatus` does not trigger the
computation, so three reads of a query that omits `mergeable` return the same
UNKNOWN three times. Measured on this repository, 46 open PRs read seconds
apart: `UNKNOWN=40` from the query without the field, a decided `mergeable`
value for all 46 from the query with it
(`.serena/memories/ci/ci-mergeability-is-not-computed-until-you-ask.md`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

No public interface changes, no new dependencies, no workflow changes.

## Changes

- `scripts/ci/check_pr_merge_state.py`, `load_open_prs`: `--json` field list gains `mergeable`. The field is never
  parsed; the comment above it says why and cites the measurement, so the next
  reader does not delete it as unused.
- New `has_no_verdict(merge_state_status)`. `check_prs` used
  `not in PASS_STATES | FAIL_STATES` inline while the retry matched the literal
  `"UNKNOWN"`, so an unlisted status skipped the wait and still exited 3. Both
  call sites now share the predicate.
- `load_open_prs_with_retry`: raises `ValueError` when `max_attempts` is not an
  integer of 1 or more. The docstring quotes the canonical bound at
  `scripts/validate_pr_review_config.py:284-290` and names the one divergence,
  a floor of 1 rather than 0, because this counts attempts rather than retries.
  The loop was restructured to one return path, so the unassigned-locals path
  on a zero budget is gone along with the dead trailing return.
- `RETRY_DELAY_MIN_SECONDS` and `RETRY_DELAY_MAX_SECONDS` promoted from function
  locals to module constants so tests can name them.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #5339 | check_pr_merge_state exits 3 on UNKNOWN when run seconds after a push |

## Testing

`tests/ci/test_check_pr_merge_state.py` goes from 9 test functions on `main` to
19, collecting 24 cases because the invalid-budget test is parametrized over six
values.

- `test_pr_list_requests_mergeable_so_github_computes_the_verdict` reads the gh
  argv and asserts `mergeable` is in the `--json` list. The field is never
  parsed, so nothing else would notice its removal.
- `test_retry_waits_the_promised_bounds_and_never_after_the_last_read` records
  the `randint` bounds and every slept value through a `_RetryClock` helper.
  Three reads means exactly two waits, each drawn from 10 to 20 seconds. Every
  retry test routes through that helper, so no test stubs the delay away.
- `test_gh_failure_mid_retry_returns_at_once_without_further_reads` covers the
  early return on a gh failure: the second read fails, the third never happens.
- `test_invalid_max_attempts_is_rejected_before_any_read` covers 0, -1, "3",
  2.5, None, and True, and asserts no read happened before the raise.
- `test_a_single_attempt_budget_reads_once_and_never_waits` pins the valid lower
  bound the guard allows. Every case above it is invalid, so tightening the
  guard from `< 1` to `< 2` would reject a legitimate budget and leave the rest
  of the suite green.
- `test_an_unlisted_status_is_retried_the_same_as_unknown` pins the shared
  predicate: `check_prs` exits 3 on the same status the retry now waits on.
- `test_one_verdictless_pr_retries_even_when_a_sibling_is_decided` covers a
  mixed list.
- `test_main_exits_external_after_retries_exhausted_on_unknown` drives `main()`
  and asserts both `EXIT_EXTERNAL` and three reads, so wiring `main()` back to
  the un-retried call fails the suite.

Verified by mutation, five discriminating mutants plus one inverted control:

| Mutant | Outcome | Required |
|--------|---------|----------|
| `has_no_verdict` narrowed to `== "UNKNOWN"` | DEAD | DEAD |
| `max_attempts` guard replaced with `pass` | DEAD | DEAD |
| `max_attempts < 1` tightened to `< 2` | DEAD | DEAD |
| `time.sleep` call deleted | DEAD | DEAD |
| `RETRY_DELAY_MAX_SECONDS` moved to 45 | DEAD | DEAD |
| comment reworded, no behavior change | SURVIVED | SURVIVED |

Each mutant was confirmed applied before its run and the file confirmed
byte-identical after restore. Local run on the head commit: 24 passed, ruff
clean, mypy clean, `pre_pr.py` reported all validations passed.

## Notes for Reviewers

The first two commits shipped the retry without the `mergeable` field, so the
loop could not change its own input. Review caught it against the repository's
own measured memory. That is the substantive fix in the last two commits; the
validated budget, the shared predicate, and the observed delays close the rest
of the review round.
