### PR TITLE
fix(build): exclude ignored directories by prefix and stop at git boundaries

### DIFF
--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Iterator, Sequence
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
@@ -922,6 +922,13 @@ def _ignored_paths(repo_root: Path, prefixes: tuple[str, ...]) -> set[Path]:
     Git location env vars (``GIT_DIR`` and friends) are stripped from the
     subprocess env so an inherited value cannot redirect ``ls-files`` away
     from ``repo_root`` (issue #2992 hook-execution context).
+
+    An entry here can be a directory rather than a file: ``ls-files``
+    reports an embedded git repository (a nested worktree checkout, for
+    example under ``.claude/worktrees/<name>/``) as one ignored directory,
+    not one entry per file inside it. Callers must treat each returned
+    path as a prefix, not just an exact key: see
+    :func:`_is_ignored_path`.
     """
     ignored: set[Path] = set()
     scrubbed_env = _git_scrubbed_env()
@@ -956,6 +963,21 @@ def _ignored_paths(repo_root: Path, prefixes: tuple[str, ...]) -> set[Path]:
             rel = os.fsdecode(raw)
             ignored.add(repo_root / rel)
     return ignored
+
+
+def _is_ignored_path(path: Path, ignored: set[Path]) -> bool:
+    """Return True if ``path`` is ignored, or nested under an ignored dir.
+
+    ``ignored`` (see :func:`_ignored_paths`) can hold directory entries: a
+    nested worktree checkout is reported as one ignored directory, not one
+    entry per file inside it. Matching ``ignored`` with plain set
+    membership therefore misses every file nested under such a directory,
+    which is what let a full worktree checkout get read into the
+    :func:`_snapshot_owned_prefixes` snapshot instead of skipped (issue
+    #5370, OOM reading 24+ nested worktrees under ``.claude/worktrees/``).
+    Treating each ignored entry as a path prefix closes that gap.
+    """
+    return path in ignored or any(parent in ignored for parent in path.parents)
 
 
 def _snapshot_owned_prefixes(
@@ -1012,7 +1034,9 @@ def _snapshot_owned_prefixes(
         for path in root.rglob("*"):
             if not path.is_file() or path.is_symlink():
                 continue
-            if path in ignored or (exclude_ignored and _is_bytecode_artifact(path)):
+            if _is_ignored_path(path, ignored) or (
+                exclude_ignored and _is_bytecode_artifact(path)
+            ):
                 continue
             try:
                 snapshot[path] = path.read_bytes()
@@ -1080,10 +1104,46 @@ def _restore_owned_prefixes(
     _prune_empty_dirs(repo_root, prefixes)
 
 
+def _iter_tree_skip_git_boundaries(root: Path) -> Iterator[tuple[Path, bool]]:
+    """Yield ``(path, is_dir)`` for every entry under ``root``.
+
+    Never descends into a directory that is itself a git repository
+    boundary (holds its own ``.git`` file or directory), the same shape
+    ``git worktree`` uses for a nested checkout under, for example,
+    ``.claude/worktrees/<name>/``. A boundary directory is not yielded
+    either, so callers never enumerate, prune, or (via
+    :func:`_restore_owned_prefixes`) delete anything inside one.
+
+    This is what keeps a future addition of ``.claude/`` to
+    :data:`OWNED_PREFIXES` from making :func:`_restore_owned_prefixes` walk
+    into, and delete, a nested worktree's own working tree (issue #5370).
+    """
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            is_dir = entry.is_dir()
+            if is_dir and (entry / ".git").exists():
+                continue  # git repository boundary; opaque, do not descend
+            yield entry, is_dir
+            if is_dir:
+                stack.append(entry)
+
+
 def _enumerate_files_under(
     repo_root: Path, prefixes: tuple[str, ...]
 ) -> set[Path]:
-    """Return every regular non-symlink file under any of ``prefixes``."""
+    """Return every regular non-symlink file under any of ``prefixes``.
+
+    Skips nested git repository boundaries; see
+    :func:`_iter_tree_skip_git_boundaries`.
+    """
     found: set[Path] = set()
     for prefix in prefixes:
         root = repo_root / prefix
@@ -1094,8 +1154,8 @@ def _enumerate_files_under(
             continue
         if not root.is_dir():
             continue
-        for path in root.rglob("*"):
-            if path.is_file() and not path.is_symlink():
+        for path, is_dir in _iter_tree_skip_git_boundaries(root):
+            if not is_dir:
                 found.add(path)
     return found
 
@@ -1104,7 +1164,8 @@ def _prune_empty_dirs(repo_root: Path, prefixes: tuple[str, ...]) -> None:
     """Remove empty directories the generator created under ``prefixes``.
 
     Walks bottom-up so child dirs go before parents. Never touches the
-    prefix root itself.
+    prefix root itself, and never descends into or removes a nested git
+    repository boundary; see :func:`_iter_tree_skip_git_boundaries`.
     """
     for prefix in prefixes:
         root = repo_root / prefix
@@ -1112,11 +1173,8 @@ def _prune_empty_dirs(repo_root: Path, prefixes: tuple[str, ...]) -> None:
             continue
         if not root.is_dir():
             continue
-        for dirpath in sorted(
-            (p for p in root.rglob("*") if p.is_dir()),
-            key=lambda p: len(p.parts),
-            reverse=True,
-        ):
+        dirs = [p for p, is_dir in _iter_tree_skip_git_boundaries(root) if is_dir]
+        for dirpath in sorted(dirs, key=lambda p: len(p.parts), reverse=True):
             try:
                 if not any(dirpath.iterdir()):
                     dirpath.rmdir()

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -1070,6 +1070,8 @@ def _restore_owned_prefixes(
     repo_root: Path,
     prefixes: tuple[str, ...],
     snapshot: dict[Path, bytes],
+    *,
+    preexisting_boundaries: set[Path] | None = None,
 ) -> None:
     """Restore the working tree to the snapshot state under ``prefixes``.
 
@@ -1084,8 +1086,21 @@ def _restore_owned_prefixes(
     After this returns, every file under ``prefixes`` matches its
     pre-run state. Pre-existing dirty state (uncommitted edits, untracked
     files) is preserved exactly because the snapshot captured it.
+
+    ``preexisting_boundaries`` is the set :func:`_git_boundaries_under`
+    recorded before the generators ran. Pass it whenever the caller holds
+    one. Detecting boundaries by shape here instead would read the
+    post-generation tree, so a tree the generator created with a ``.git``
+    entry inside it would look like a nested checkout and case 3 would
+    skip its files. Measured before this argument existed: a generator
+    creating ``owned/out/.git`` plus ``owned/out/generated.txt`` left both
+    on disk after a ``--check`` restore, breaking the read-only contract
+    of issue #2440. ``None`` keeps the shape test, which is correct for a
+    caller with no recorded baseline.
     """
-    current = _enumerate_files_under(repo_root, prefixes)
+    current = _enumerate_files_under(
+        repo_root, prefixes, opaque_boundaries=preexisting_boundaries
+    )
 
     # Cases 1 & 2: restore every file that was in the snapshot.
     for path, content in snapshot.items():
@@ -1119,10 +1134,35 @@ def _restore_owned_prefixes(
                 file=sys.stderr,
             )
 
-    _prune_empty_dirs(repo_root, prefixes)
+    _prune_empty_dirs(
+        repo_root, prefixes, opaque_boundaries=preexisting_boundaries
+    )
 
 
-def _iter_tree_skip_git_boundaries(root: Path) -> Iterator[tuple[Path, bool]]:
+def _is_opaque_boundary(entry: Path, opaque: set[Path] | None) -> bool:
+    """Return True if ``entry`` is a boundary the walk must not enter.
+
+    ``opaque`` of ``None`` means "detect boundaries by shape": any
+    directory holding its own ``.git`` file or directory. That is the
+    right question before a build, when nothing has been recorded yet.
+
+    A caller that passes a set is asking a different question: which
+    boundaries existed at a recorded moment. Shape is the wrong test
+    there, because a generator can create a ``.git`` entry during the
+    build, and treating that new tree as opaque would leave the
+    generator's own output on disk (see :func:`_restore_owned_prefixes`).
+    """
+    if opaque is None:
+        return (entry / ".git").exists()
+    return entry in opaque
+
+
+def _iter_tree_skip_git_boundaries(
+    root: Path,
+    *,
+    opaque_boundaries: set[Path] | None = None,
+    boundaries_seen: set[Path] | None = None,
+) -> Iterator[tuple[Path, bool]]:
     """Yield ``(path, is_dir)`` for every entry under ``root``.
 
     Never descends into a directory that is itself a git repository
@@ -1135,6 +1175,12 @@ def _iter_tree_skip_git_boundaries(root: Path) -> Iterator[tuple[Path, bool]]:
     This is what keeps a future addition of ``.claude/`` to
     :data:`OWNED_PREFIXES` from making :func:`_restore_owned_prefixes` walk
     into, and delete, a nested worktree's own working tree (issue #5370).
+
+    ``opaque_boundaries`` narrows that skip to a recorded set of paths;
+    see :func:`_is_opaque_boundary` for why the post-build walk cannot use
+    shape detection. ``boundaries_seen`` collects every boundary the walk
+    refused to enter, which is how :func:`_git_boundaries_under` records
+    the pre-build set without a second traversal shape.
     """
     stack = [root]
     while stack:
@@ -1147,20 +1193,51 @@ def _iter_tree_skip_git_boundaries(root: Path) -> Iterator[tuple[Path, bool]]:
             if entry.is_symlink():
                 continue
             is_dir = entry.is_dir()
-            if is_dir and (entry / ".git").exists():
-                continue  # git repository boundary; opaque, do not descend
+            if is_dir and _is_opaque_boundary(entry, opaque_boundaries):
+                # git repository boundary; opaque, do not descend
+                if boundaries_seen is not None:
+                    boundaries_seen.add(entry)
+                continue
             yield entry, is_dir
             if is_dir:
                 stack.append(entry)
 
 
-def _enumerate_files_under(
+def _git_boundaries_under(
     repo_root: Path, prefixes: tuple[str, ...]
+) -> set[Path]:
+    """Return the git repository boundaries under ``prefixes`` right now.
+
+    ``--check`` records this before any generator runs so
+    :func:`_restore_owned_prefixes` can tell a pre-existing nested
+    checkout, which it must leave alone, from a boundary-shaped tree a
+    generator created during the build, which is output and must be
+    removed like any other generator write (issue #2440).
+
+    The walk stops at each boundary, so this costs a directory traversal
+    and reads no file contents, which is the property issue #5370 needed.
+    """
+    boundaries: set[Path] = set()
+    for prefix in prefixes:
+        root = repo_root / prefix
+        if not root.is_dir():
+            continue
+        for _ in _iter_tree_skip_git_boundaries(root, boundaries_seen=boundaries):
+            pass
+    return boundaries
+
+
+def _enumerate_files_under(
+    repo_root: Path,
+    prefixes: tuple[str, ...],
+    *,
+    opaque_boundaries: set[Path] | None = None,
 ) -> set[Path]:
     """Return every regular non-symlink file under any of ``prefixes``.
 
     Skips nested git repository boundaries; see
-    :func:`_iter_tree_skip_git_boundaries`.
+    :func:`_iter_tree_skip_git_boundaries` and, for what
+    ``opaque_boundaries`` changes, :func:`_is_opaque_boundary`.
 
     ``path.is_file()`` is load-bearing, not a redundant re-check of
     ``not is_dir``. A FIFO, a unix socket, or a device node is neither a
@@ -1182,18 +1259,31 @@ def _enumerate_files_under(
             continue
         if not root.is_dir():
             continue
-        for path, is_dir in _iter_tree_skip_git_boundaries(root):
+        for path, is_dir in _iter_tree_skip_git_boundaries(
+            root, opaque_boundaries=opaque_boundaries
+        ):
             if not is_dir and path.is_file():
                 found.add(path)
     return found
 
 
-def _prune_empty_dirs(repo_root: Path, prefixes: tuple[str, ...]) -> None:
+def _prune_empty_dirs(
+    repo_root: Path,
+    prefixes: tuple[str, ...],
+    *,
+    opaque_boundaries: set[Path] | None = None,
+) -> None:
     """Remove empty directories the generator created under ``prefixes``.
 
     Walks bottom-up so child dirs go before parents. Never touches the
     prefix root itself, and never descends into or removes a nested git
     repository boundary; see :func:`_iter_tree_skip_git_boundaries`.
+
+    ``opaque_boundaries`` protects the same set
+    :func:`_enumerate_files_under` protects. Without it here, a
+    boundary-shaped tree a generator created would keep its now-empty
+    directories after case 3 deleted their files, which is still a
+    ``--check`` write.
     """
     for prefix in prefixes:
         root = repo_root / prefix
@@ -1201,7 +1291,13 @@ def _prune_empty_dirs(repo_root: Path, prefixes: tuple[str, ...]) -> None:
             continue
         if not root.is_dir():
             continue
-        dirs = [p for p, is_dir in _iter_tree_skip_git_boundaries(root) if is_dir]
+        dirs = [
+            p
+            for p, is_dir in _iter_tree_skip_git_boundaries(
+                root, opaque_boundaries=opaque_boundaries
+            )
+            if is_dir
+        ]
         for dirpath in sorted(dirs, key=lambda p: len(p.parts), reverse=True):
             try:
                 if not any(dirpath.iterdir()):
@@ -1240,7 +1336,12 @@ def run(
     # staleness diff is computed. This makes --check safe to call from
     # any worktree without dirtying it.
     snapshot: dict[Path, bytes] | None = None
+    boundaries: set[Path] | None = None
     if check:
+        # Record boundaries first. A generator that creates a .git entry
+        # during the build must not be mistaken for a pre-existing nested
+        # checkout when the restore pass decides what to delete.
+        boundaries = _git_boundaries_under(repo_root, OWNED_PREFIXES)
         snapshot = _snapshot_owned_prefixes(repo_root, OWNED_PREFIXES)
 
     # REQ-003-010 (issue #2613): snapshot the .claude/ tree before any
@@ -1263,7 +1364,12 @@ def run(
         # Otherwise a generator crash mid-build leaves partial writes
         # in the caller's worktree.
         if snapshot is not None:
-            _restore_owned_prefixes(repo_root, OWNED_PREFIXES, snapshot)
+            _restore_owned_prefixes(
+                repo_root,
+                OWNED_PREFIXES,
+                snapshot,
+                preexisting_boundaries=boundaries,
+            )
 
 
 def _run_generators(

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -716,7 +716,10 @@ def _git_scrubbed_env() -> dict[str, str]:
 
 
 def assert_no_claude_writes(
-    repo_root: Path, baseline: dict[Path, bytes]
+    repo_root: Path,
+    baseline: dict[Path, bytes],
+    *,
+    preexisting_boundaries: set[Path] | None = None,
 ) -> list[str]:
     """REQ-003-010: generators MUST NOT write under .claude/.
 
@@ -724,6 +727,20 @@ def assert_no_claude_writes(
     generator ran (see :func:`_snapshot_owned_prefixes`). This function
     re-reads the tree and returns the repo-relative paths the generators
     created, modified, or deleted relative to that baseline.
+
+    ``preexisting_boundaries`` is the set :func:`_git_boundaries_under`
+    recorded before the generators ran, and it MUST be the same set the
+    baseline snapshot used. Both walks stop at git repository boundaries.
+    Detecting those by shape at each end independently means a generator
+    can write a ``.git`` entry of its own and take the whole tree it
+    created out of the second walk, while the first walk never saw it
+    either, so the diff is empty and REQ-003-010 reports nothing.
+    Measured before this argument existed: a generator creating
+    ``.claude/out/.git`` plus ``.claude/out/leaked.md`` produced
+    ``violations reported: []`` with the file still on disk. Passing one
+    recorded set makes the two walks skip exactly the same trees, so a
+    boundary that appeared during the build is walked and reported like
+    any other generator write.
 
     Scoping to generator-attributable writes (not raw git diff) lets a
     legitimate pre-build sync of .claude/lib pass while still tripping on
@@ -741,7 +758,10 @@ def assert_no_claude_writes(
     ``.claude/lib/`` throughout (issue #3773).
     """
     current = _snapshot_owned_prefixes(
-        repo_root, CLAUDE_GUARD_PREFIX, exclude_ignored=True
+        repo_root,
+        CLAUDE_GUARD_PREFIX,
+        exclude_ignored=True,
+        opaque_boundaries=preexisting_boundaries,
     )
     offending: set[Path] = set()
     for path, content in current.items():
@@ -995,6 +1015,7 @@ def _snapshot_owned_prefixes(
     prefixes: tuple[str, ...],
     *,
     exclude_ignored: bool = False,
+    opaque_boundaries: set[Path] | None = None,
 ) -> dict[Path, bytes]:
     """Snapshot every file under ``prefixes`` into an in-memory dict.
 
@@ -1025,6 +1046,11 @@ def _snapshot_owned_prefixes(
     cache-eviction that makes the next run recompile inside the guard
     window: the exact race issue #3856 closes.
 
+    ``opaque_boundaries`` forwards to :func:`_iter_tree_skip_git_boundaries`;
+    see :func:`_is_opaque_boundary` for why a caller comparing two
+    snapshots must pass one recorded set to both rather than letting each
+    walk detect boundaries by shape.
+
     The walk always skips nested git repository boundaries (see
     :func:`_iter_tree_skip_git_boundaries`), regardless of
     ``exclude_ignored``. ``--check`` calls this with ``exclude_ignored=False``,
@@ -1049,7 +1075,9 @@ def _snapshot_owned_prefixes(
             continue
         if not root.is_dir():
             continue
-        for path, is_dir in _iter_tree_skip_git_boundaries(root):
+        for path, is_dir in _iter_tree_skip_git_boundaries(
+            root, opaque_boundaries=opaque_boundaries
+        ):
             if is_dir or not path.is_file():
                 continue
             if _is_ignored_path(path, ignored) or (
@@ -1347,6 +1375,19 @@ def run(
     # REQ-003-010 (issue #2613): snapshot the .claude/ tree before any
     # generator runs so the no-write guard attributes only writes the
     # generators made, not pre-build drift such as a .claude/lib sync.
+    # Record the boundaries the baseline walk is about to skip, so the
+    # post-generation re-read in assert_no_claude_writes skips that same
+    # set instead of re-deriving it from the post-generation tree. Without
+    # it, a generator can hide a .claude/ write behind a .git entry it
+    # wrote itself: the second walk skips a tree the first one never saw,
+    # so the diff is empty.
+    #
+    # The baseline below is deliberately NOT given the set. It runs on the
+    # same filesystem state _git_boundaries_under just read, so shape
+    # detection and set membership return the same answer here by
+    # construction. Passing it would be an argument no mutation can
+    # distinguish, which is an argument with no test holding it.
+    claude_boundaries = _git_boundaries_under(repo_root, CLAUDE_GUARD_PREFIX)
     claude_baseline = _snapshot_owned_prefixes(
         repo_root, CLAUDE_GUARD_PREFIX, exclude_ignored=True
     )
@@ -1358,6 +1399,7 @@ def run(
             check=check,
             audit_format=audit_format,
             claude_baseline=claude_baseline,
+            claude_boundaries=claude_boundaries,
         )
     finally:
         # #2440: ALWAYS restore on --check, including on exception paths.
@@ -1379,6 +1421,7 @@ def _run_generators(
     check: bool,
     audit_format: str,
     claude_baseline: dict[Path, bytes],
+    claude_boundaries: set[Path] | None = None,
 ) -> int:
     """Execute the generator pipeline and emit the audit log.
 
@@ -1414,7 +1457,9 @@ def _run_generators(
     audit.duration_s = time.monotonic() - started
 
     # REQ-003-010: enforce .claude/ no-write invariant.
-    claude_writes = assert_no_claude_writes(repo_root, claude_baseline)
+    claude_writes = assert_no_claude_writes(
+        repo_root, claude_baseline, preexisting_boundaries=claude_boundaries
+    )
     if claude_writes:
         for p in claude_writes:
             print(f"REQ-003-010 VIOLATION: generator wrote to {p}", file=sys.stderr)

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -1161,6 +1161,16 @@ def _enumerate_files_under(
 
     Skips nested git repository boundaries; see
     :func:`_iter_tree_skip_git_boundaries`.
+
+    ``path.is_file()`` is load-bearing, not a redundant re-check of
+    ``not is_dir``. A FIFO, a unix socket, or a device node is neither a
+    directory nor a regular file. :func:`_snapshot_owned_prefixes` drops
+    those with the same predicate (``if is_dir or not path.is_file():
+    continue``), so counting every non-directory entry here would put a
+    pre-existing special file in ``current - snapshot`` and case 3 of
+    :func:`_restore_owned_prefixes` would unlink it. That turns a
+    read-only ``--check`` into a delete. Symlinks are already dropped
+    upstream by :func:`_iter_tree_skip_git_boundaries`.
     """
     found: set[Path] = set()
     for prefix in prefixes:
@@ -1173,7 +1183,7 @@ def _enumerate_files_under(
         if not root.is_dir():
             continue
         for path, is_dir in _iter_tree_skip_git_boundaries(root):
-            if not is_dir:
+            if not is_dir and path.is_file():
                 found.add(path)
     return found
 

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -953,9 +953,19 @@ def _ignored_paths(repo_root: Path, prefixes: tuple[str, ...]) -> set[Path]:
                 timeout=30,
                 env=scrubbed_env,
             )
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(
+                f"WARN: git ls-files failed for {prefix!r}, ignore set may be "
+                f"incomplete: {exc}",
+                file=sys.stderr,
+            )
             continue
         if proc.returncode != 0:
+            print(
+                f"WARN: git ls-files exited {proc.returncode} for {prefix!r}, "
+                "ignore set may be incomplete",
+                file=sys.stderr,
+            )
             continue
         for raw in proc.stdout.split(b"\x00"):
             if not raw:
@@ -1014,6 +1024,14 @@ def _snapshot_owned_prefixes(
     pre-existing ``__pycache__`` under an owned prefix, which is the same
     cache-eviction that makes the next run recompile inside the guard
     window: the exact race issue #3856 closes.
+
+    The walk always skips nested git repository boundaries (see
+    :func:`_iter_tree_skip_git_boundaries`), regardless of
+    ``exclude_ignored``. ``--check`` calls this with ``exclude_ignored=False``,
+    so relying on ``_is_ignored_path`` alone would leave this snapshot pass
+    asymmetric with :func:`_enumerate_files_under`'s boundary skip: a nested
+    worktree would still be read here and then clobbered by
+    :func:`_restore_owned_prefixes` (issue #5370).
     """
     ignored = _ignored_paths(repo_root, prefixes) if exclude_ignored else set()
     snapshot: dict[Path, bytes] = {}
@@ -1031,8 +1049,8 @@ def _snapshot_owned_prefixes(
             continue
         if not root.is_dir():
             continue
-        for path in root.rglob("*"):
-            if not path.is_file() or path.is_symlink():
+        for path, is_dir in _iter_tree_skip_git_boundaries(root):
+            if is_dir or not path.is_file():
                 continue
             if _is_ignored_path(path, ignored) or (
                 exclude_ignored and _is_bytecode_artifact(path)

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -860,12 +860,18 @@ def test_snapshot_owned_prefixes_skips_git_boundary_directory(
     """The snapshot pass, not just the enumerate pass, must skip a nested
     git repository boundary, with ``exclude_ignored`` left at its default
     (``False``): that is the exact flag value ``run()`` passes for the
-    ``--check`` snapshot. ``build/scripts/build_all.py:1345`` reads::
+    ``--check`` snapshot. ``run()`` in ``build/scripts/build_all.py``
+    reads::
 
         snapshot = _snapshot_owned_prefixes(repo_root, OWNED_PREFIXES)
 
     with no ``exclude_ignored`` argument, so a gitignore-only guard
     (``_is_ignored_path``) would not cover it.
+
+    The quote is the anchor, not a line number. That call has moved five
+    times inside this one pull request as docstrings grew above it, and
+    ``check_citation_freshness.py`` failed the build on the stale number
+    twice. Grep the quoted line instead.
 
     Without routing this walk through
     :func:`_iter_tree_skip_git_boundaries`, a nested worktree under an
@@ -2099,7 +2105,8 @@ def test_snapshot_owned_prefixes_excludes_children_of_a_plain_ignored_dir(
 ) -> None:
     """Pin the prefix match at its call site, not just in the helper.
 
-    ``build/scripts/build_all.py:1055`` reads::
+    The walk inside ``_snapshot_owned_prefixes`` in
+    ``build/scripts/build_all.py`` reads::
 
         if _is_ignored_path(path, ignored) or (
 
@@ -2210,6 +2217,167 @@ def test_assert_no_claude_writes_still_flags_real_write_in_git_repo(
     assert build_all.assert_no_claude_writes(repo, baseline) == [
         ".claude/agents/leak.md"
     ]
+
+
+def test_assert_no_claude_writes_flags_a_write_behind_a_generated_git_marker(
+    tmp_path: Path,
+) -> None:
+    """A generator cannot hide a .claude/ write behind a ``.git`` it wrote.
+
+    Both walks the guard compares stop at git repository boundaries. When
+    each one detects those by shape independently, a generator that writes
+    ``.claude/out/.git`` alongside its output takes that whole tree out of
+    the post-generation walk, and the baseline walk never saw it either,
+    so the diff is empty. Measured before ``preexisting_boundaries``
+    existed: this exact sequence returned ``[]`` with
+    ``.claude/out/leaked.md`` still on disk, so REQ-003-010 passed and the
+    build could exit successfully with an undetected write.
+
+    Recording the boundary set once with ``_git_boundaries_under`` and
+    passing it to both walks makes them skip exactly the same trees, so a
+    boundary that appeared during the build is walked and reported.
+
+    The inverse is asserted in the same run. A live nested worktree that
+    existed before the build must stay invisible to the guard even when
+    its own owner edits a file inside it mid-build, which is the
+    false-positive REQ-003-010 was tuned against (issue #2992) and the
+    tree issue #5370 exists to keep out of these walks. Reporting the new
+    write is worthless if it also reports the neighbouring checkout.
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "--allow-empty", "-m", "init"],
+        check=True,
+    )
+    live_worktree = repo / ".claude" / "worktrees" / "wt-1"
+    live_worktree.mkdir(parents=True)
+    (live_worktree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    live_file = live_worktree / "live.txt"
+    live_file.write_text("before the build\n", encoding="utf-8")
+
+    boundaries = build_all._git_boundaries_under(
+        repo, build_all.CLAUDE_GUARD_PREFIX
+    )
+    assert boundaries == {live_worktree}
+    baseline = build_all._snapshot_owned_prefixes(
+        repo,
+        build_all.CLAUDE_GUARD_PREFIX,
+        exclude_ignored=True,
+        opaque_boundaries=boundaries,
+    )
+
+    # A generator writes output and a .git marker to shield it.
+    generated_tree = repo / ".claude" / "out"
+    generated_tree.mkdir()
+    (generated_tree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    (generated_tree / "leaked.md").write_text(
+        "generator wrote this\n", encoding="utf-8"
+    )
+    # The live worktree's own owner edits a file mid-build.
+    live_file.write_text("edited by the worktree owner\n", encoding="utf-8")
+
+    violations = build_all.assert_no_claude_writes(
+        repo, baseline, preexisting_boundaries=boundaries
+    )
+
+    assert violations == [".claude/out/.git", ".claude/out/leaked.md"]
+    assert not any(v.startswith(".claude/worktrees/") for v in violations)
+
+
+def test_run_flags_a_generator_write_hidden_behind_a_git_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Drive the guard through ``run()``, not by calling it directly.
+
+    The sibling test above passes ``preexisting_boundaries`` itself, so it
+    proves the guard honours the argument but not that anything supplies
+    it. Measured: dropping the argument at the one real call site, in
+    ``_run_generators``, left the sibling test and all 102 others green.
+    That is the same helper-tested-but-unwired gap the reviewer flagged
+    twice on this PR, so the wiring gets its own end-to-end case.
+
+    A stubbed generator writes ``.claude/out/leaked.md`` next to a
+    ``.git`` marker it also writes. ``run()`` must return 2 and name the
+    file, which only happens if the boundary set recorded before
+    generation reaches :func:`assert_no_claude_writes`.
+    """
+    monkeypatch.setattr(build_all, "_git_diff_paths", lambda repo_root: [])
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "skills").mkdir(parents=True)
+    _write_minimal_adr(repo / ".agents" / "architecture")
+    _write_skill(repo / ".claude" / "skills", "alpha")
+    _write_platform_with_skills(repo, provider="copilot-cli")
+
+    def leaking_agents(
+        repo_root: Path, cfg: object, platform: object
+    ) -> build_all.GeneratorResult:
+        hidden = repo_root / ".claude" / "out"
+        hidden.mkdir(parents=True, exist_ok=True)
+        (hidden / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+        (hidden / "leaked.md").write_text("generator wrote this\n", encoding="utf-8")
+        return build_all.GeneratorResult(
+            artifact="agents", platform="*", outputs=0, exit_code=0
+        )
+
+    monkeypatch.setattr(build_all, "_build_agents", leaking_agents)
+
+    rc = build_all.run(
+        repo, platform=None, check=False, clean=False, audit_format="md"
+    )
+
+    assert rc == 2
+    assert "REQ-003-010 VIOLATION: generator wrote to .claude/out/leaked.md" in (
+        capsys.readouterr().err
+    )
+
+
+def test_run_check_removes_a_generated_tree_behind_a_git_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the restore path through ``run()``, not by calling it directly.
+
+    ``test_restore_owned_prefixes_removes_a_boundary_tree_created_mid_build``
+    passes ``preexisting_boundaries`` itself, so it holds the helper but
+    not the one real call site in ``run()``. Measured: dropping that
+    argument from the ``run()`` restore call left that test and all 103
+    others green, the same helper-tested-but-unwired shape the reviewer
+    flagged twice on this PR.
+
+    A stubbed generator writes ``src/out/generated.txt`` next to a
+    ``.git`` marker under an owned prefix. ``--check`` must leave the
+    working tree as it found it, so both paths and the directory must be
+    gone once ``run()`` returns.
+    """
+    monkeypatch.setattr(build_all, "_git_diff_paths", lambda repo_root: [])
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "skills").mkdir(parents=True)
+    _write_minimal_adr(repo / ".agents" / "architecture")
+    _write_skill(repo / ".claude" / "skills", "alpha")
+    _write_platform_with_skills(repo, provider="copilot-cli")
+
+    def boundary_writing_agents(
+        repo_root: Path, cfg: object, platform: object
+    ) -> build_all.GeneratorResult:
+        hidden = repo_root / "src" / "out"
+        hidden.mkdir(parents=True, exist_ok=True)
+        (hidden / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+        (hidden / "generated.txt").write_text("output\n", encoding="utf-8")
+        return build_all.GeneratorResult(
+            artifact="agents", platform="*", outputs=0, exit_code=0
+        )
+
+    monkeypatch.setattr(build_all, "_build_agents", boundary_writing_agents)
+
+    build_all.run(
+        repo, platform=None, check=True, clean=False, audit_format="md"
+    )
+
+    assert not (repo / "src" / "out" / "generated.txt").exists()
+    assert not (repo / "src" / "out" / ".git").exists()
+    assert not (repo / "src" / "out").exists()
 
 
 # --- #3856: bytecode written inside the guard's snapshot window -----------

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -1731,14 +1731,27 @@ def test_ignored_paths_excludes_tracked_files(tmp_path: Path) -> None:
     assert tracked not in ignored
 
 
-def test_ignored_paths_empty_when_not_a_git_repo(tmp_path: Path) -> None:
-    """Outside a git repo, ls-files fails and the set is empty (safe fallback)."""
+def test_ignored_paths_empty_when_not_a_git_repo(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Outside a git repo, ls-files fails and the set is empty (safe fallback).
+
+    The stderr assertion is load-bearing. Measured: deleting the
+    ``proc.returncode != 0`` warning in ``_ignored_paths`` and leaving the
+    bare ``continue`` left all 99 tests green when this case checked only
+    the empty set. A silent empty set reads downstream as "nothing is
+    gitignored", which is how the REQ-003-010 guard starts reporting a
+    hook's own log write as a generator violation (issue #2992). The
+    diagnostic is the only signal that the query failed rather than
+    matched nothing, so it needs an assertion of its own.
+    """
     claude = tmp_path / ".claude" / "hooks"
     claude.mkdir(parents=True)
     (claude / "audit.log").write_text("noise\n", encoding="utf-8")
 
     ignored = build_all._ignored_paths(tmp_path, build_all.CLAUDE_GUARD_PREFIX)
     assert ignored == set()
+    assert "WARN: git ls-files exited" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
@@ -1976,6 +1989,60 @@ def test_snapshot_owned_prefixes_excludes_every_file_under_ignored_worktree(
         nested_worktree in path.parents or path == nested_worktree
         for path in snapshot
     )
+    assert sibling in snapshot
+
+
+def test_snapshot_owned_prefixes_excludes_children_of_a_plain_ignored_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the prefix match at its call site, not just in the helper.
+
+    ``build/scripts/build_all.py:1055`` reads::
+
+        if _is_ignored_path(path, ignored) or (
+
+    The sibling worktree test above cannot protect that line. Its nested
+    checkout comes from a real ``git worktree add``, so it carries a
+    ``.git`` file and ``_iter_tree_skip_git_boundaries`` drops it two
+    lines earlier, at ``if is_dir or not path.is_file():``, before
+    ``ignored`` is ever consulted. Measured: replacing the call above with
+    ``path in ignored`` (exact set membership, the pre-#5370 behavior)
+    left all 99 tests green. The helper unit test cannot catch it either,
+    because it calls ``_is_ignored_path`` directly and never exercises the
+    wiring.
+
+    So this case removes the boundary marker. ``_ignored_paths`` is
+    stubbed to report one plain ancestor directory, the shape git uses for
+    any ignored directory that is not a nested checkout: a build output
+    tree, a cache directory, any ``.gitignore`` line ending in ``/``. With
+    exact membership the directory itself is never yielded as a file, so
+    every descendant is snapshotted and the first assertion fails.
+    """
+    repo = tmp_path / "repo"
+    ignored_dir = repo / ".claude" / "cache"
+    ignored_dir.mkdir(parents=True)
+    assert not (ignored_dir / ".git").exists()
+    child = ignored_dir / "blob.bin"
+    child.write_text("cached\n", encoding="utf-8")
+    grandchild = ignored_dir / "sub" / "deep.bin"
+    grandchild.parent.mkdir(parents=True)
+    grandchild.write_text("deep cached\n", encoding="utf-8")
+    sibling = repo / ".claude" / "agents" / "real.md"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("# real agent\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        build_all,
+        "_ignored_paths",
+        lambda repo_root, prefixes: {ignored_dir},
+    )
+
+    snapshot = build_all._snapshot_owned_prefixes(
+        repo, build_all.CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
+
+    assert child not in snapshot
+    assert grandchild not in snapshot
     assert sibling in snapshot
 
 

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -809,13 +811,60 @@ def test_enumerate_files_under_skips_git_boundary_directory(tmp_path: Path) -> N
     assert sibling in found
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="os.mkfifo is POSIX only")
+def test_restore_owned_prefixes_never_unlinks_a_pre_existing_fifo(
+    tmp_path: Path,
+) -> None:
+    """A non-regular file is not generator output and must survive --check.
+
+    ``_snapshot_owned_prefixes`` keeps regular files only. In
+    ``build/scripts/build_all.py`` its walk reads::
+
+        if is_dir or not path.is_file():
+            continue
+
+    so a FIFO, a unix socket, or a device node is never in the snapshot.
+    If ``_enumerate_files_under`` counted every non-directory entry, that
+    FIFO would land in ``current - set(snapshot)`` and case 3 of
+    :func:`_restore_owned_prefixes` would unlink it, so a read-only
+    ``--check`` would destroy a path it never created.
+
+    Positive control: a file the generator really did create after the
+    snapshot is still deleted, so a mutant that empties
+    ``_enumerate_files_under`` fails here rather than passing.
+    """
+    owned = tmp_path / "owned"
+    owned.mkdir()
+    fifo = owned / "pipe"
+    os.mkfifo(fifo)
+    pre_existing = owned / "real.md"
+    pre_existing.write_text("# real\n", encoding="utf-8")
+
+    assert fifo not in build_all._enumerate_files_under(tmp_path, ("owned/",))
+
+    snapshot = build_all._snapshot_owned_prefixes(tmp_path, ("owned/",))
+    assert fifo not in snapshot
+    generated = owned / "generated.md"
+    generated.write_text("# generated\n", encoding="utf-8")
+
+    build_all._restore_owned_prefixes(tmp_path, ("owned/",), snapshot)
+
+    assert fifo.is_fifo()
+    assert not generated.exists()
+    assert pre_existing.read_text(encoding="utf-8") == "# real\n"
+
+
 def test_snapshot_owned_prefixes_skips_git_boundary_directory(
     tmp_path: Path,
 ) -> None:
     """The snapshot pass, not just the enumerate pass, must skip a nested
     git repository boundary, with ``exclude_ignored`` left at its default
     (``False``): that is the exact flag value ``run()`` passes for the
-    ``--check`` snapshot (build_all.py:1216), so a gitignore-only guard
+    ``--check`` snapshot. ``build/scripts/build_all.py:1244`` reads::
+
+        snapshot = _snapshot_owned_prefixes(repo_root, OWNED_PREFIXES)
+
+    with no ``exclude_ignored`` argument, so a gitignore-only guard
     (``_is_ignored_path``) would not cover it.
 
     Without routing this walk through
@@ -1690,6 +1739,43 @@ def test_ignored_paths_empty_when_not_a_git_repo(tmp_path: Path) -> None:
 
     ignored = build_all._ignored_paths(tmp_path, build_all.CLAUDE_GUARD_PREFIX)
     assert ignored == set()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError("git missing"),
+        subprocess.TimeoutExpired(cmd="git", timeout=30),
+    ],
+    ids=["oserror", "timeout"],
+)
+def test_ignored_paths_warns_and_falls_back_when_git_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    exc: Exception,
+) -> None:
+    """``subprocess.run`` raising must degrade to an empty set plus a warning.
+
+    ``_ignored_paths`` catches ``(OSError, subprocess.SubprocessError)``.
+    The nonzero-exit test covers only the ``returncode != 0`` branch, which
+    a missing ``git`` binary (``OSError``) or a hung ``git`` (a 30 second
+    ``TimeoutExpired``, a ``SubprocessError`` subclass) never reaches. Both
+    arms must fall back rather than crash the build, and both must say so
+    on stderr: a silent empty set reads as "nothing is gitignored" and
+    would let the REQ-003-010 guard report a hook's own log write as a
+    generator violation.
+    """
+
+    def boom(*args: object, **kwargs: object) -> object:
+        raise exc
+
+    monkeypatch.setattr(build_all.subprocess, "run", boom)
+
+    ignored = build_all._ignored_paths(tmp_path, build_all.CLAUDE_GUARD_PREFIX)
+
+    assert ignored == set()
+    assert "WARN: git ls-files failed" in capsys.readouterr().err
 
 
 def test_ignored_paths_ignores_inherited_git_dir_env(

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -781,6 +781,74 @@ def test_enumerate_files_under_handles_catalog_file(tmp_path: Path) -> None:
     assert found == {catalog}
 
 
+def test_enumerate_files_under_skips_git_boundary_directory(tmp_path: Path) -> None:
+    """A directory holding its own .git entry is a git repository boundary
+    (the same shape ``git worktree add`` produces) and must never be walked
+    into: it is not the enumerated prefix's own content.
+
+    A sibling file that is not behind a boundary is still found, as a
+    positive control that the skip is scoped to the boundary directory
+    and does not blind the walk to the rest of the prefix.
+    """
+    owned = tmp_path / "owned"
+    nested = owned / "worktrees" / "wt-1"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    nested_file = nested / "inside.txt"
+    nested_file.write_text("nested content\n", encoding="utf-8")
+    nested_subdir_file = nested / "sub" / "deep.txt"
+    nested_subdir_file.parent.mkdir(parents=True)
+    nested_subdir_file.write_text("deep nested content\n", encoding="utf-8")
+    sibling = owned / "real.md"
+    sibling.write_text("# real\n", encoding="utf-8")
+
+    found = build_all._enumerate_files_under(tmp_path, ("owned/",))
+
+    assert nested_file not in found
+    assert nested_subdir_file not in found
+    assert sibling in found
+
+
+def test_restore_owned_prefixes_never_deletes_git_boundary_contents(
+    tmp_path: Path,
+) -> None:
+    """Defense-in-depth for a future OWNED_PREFIXES entry that covers a
+    directory of nested worktrees: _restore_owned_prefixes's delete pass
+    (case 3: on disk and not in the snapshot -> unlink) must never reach a
+    file inside a directory that is itself a git repository boundary, even
+    in the worst case where the snapshot has nothing for that prefix at
+    all (an empty snapshot, as if the worktree post-dated the baseline).
+
+    Without the .git-boundary skip in _enumerate_files_under and
+    _prune_empty_dirs, this is exactly how a future ``.claude/`` entry in
+    OWNED_PREFIXES would let --check's read-only restore step delete a
+    nested worktree's own working tree (issue #5370).
+
+    Positive control: an ordinary generator-created file under the same
+    prefix, also absent from the snapshot, is still deleted, so the
+    boundary skip does not disable the real cleanup behavior.
+    """
+    owned = tmp_path / "owned"
+    nested = owned / "worktrees" / "wt-1"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    nested_file = nested / "inside.txt"
+    nested_file.write_text("nested content\n", encoding="utf-8")
+    generator_created = owned / "created.md"
+    generator_created.write_text("# generated\n", encoding="utf-8")
+
+    prefixes = ("owned/",)
+    found = build_all._enumerate_files_under(tmp_path, prefixes)
+    assert nested_file not in found
+    assert generator_created in found
+
+    build_all._restore_owned_prefixes(tmp_path, prefixes, snapshot={})
+
+    assert nested_file.is_file()
+    assert nested_file.read_text(encoding="utf-8") == "nested content\n"
+    assert not generator_created.exists()
+
+
 def test_build_agent_catalog_writes_docs_catalog(tmp_path: Path) -> None:
     templates = tmp_path / "templates" / "agents"
     _write_agent_template(templates, "alpha")
@@ -1668,6 +1736,102 @@ def test_snapshot_excludes_ignored_runtime_artifacts(tmp_path: Path) -> None:
     )
     assert audit not in snap
     assert owned_file in snap
+
+
+def test_is_ignored_path_treats_directory_entries_as_prefixes() -> None:
+    """Unit-level pin on the matching rule _snapshot_owned_prefixes relies on.
+
+    ``ignored`` can hold a directory (see :func:`_ignored_paths`), and a
+    path nested under that directory must match even though it is not
+    itself a key in the set. An unrelated path, and a path that merely
+    shares a string prefix without being a real path ancestor, must not.
+    """
+    ignored = {Path("/repo/.claude/worktrees/wt-1")}
+    assert build_all._is_ignored_path(
+        Path("/repo/.claude/worktrees/wt-1"), ignored
+    )  # exact match
+    assert build_all._is_ignored_path(
+        Path("/repo/.claude/worktrees/wt-1/sub/file.txt"), ignored
+    )  # nested under the ignored directory
+    assert not build_all._is_ignored_path(
+        Path("/repo/.claude/worktrees/wt-10/file.txt"), ignored
+    )  # sibling directory, not a real path ancestor
+    assert not build_all._is_ignored_path(
+        Path("/repo/.claude/agents/real.md"), ignored
+    )  # unrelated path
+
+
+def test_snapshot_owned_prefixes_excludes_every_file_under_ignored_worktree(
+    tmp_path: Path,
+) -> None:
+    """A whole ignored directory (a nested worktree) must exclude every file
+    under it, not just a path that matches it exactly.
+
+    ``git ls-files --others --ignored --exclude-standard`` reports a
+    registered git worktree as one ignored *directory* entry, not one entry
+    per file inside it (git's embedded-repository boundary; verified via
+    a real ``git worktree add`` in this fixture). Before this fix,
+    ``_snapshot_owned_prefixes`` matched ``ignored`` with plain set
+    membership, so every file inside the worktree still got read into the
+    snapshot: with dozens of real worktrees that is the OOM in issue #5370.
+
+    Positive control: a non-ignored sibling directory's file is still
+    captured, so the fix is scoped to the ignored directory and does not
+    silently swallow the whole ``.claude/`` prefix.
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text(
+        ".claude/worktrees/\n", encoding="utf-8"
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "add", ".gitignore"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "ignore"], check=True
+    )
+
+    worktrees = repo / ".claude" / "worktrees"
+    worktrees.mkdir(parents=True)
+    nested_worktree = worktrees / "wt-1"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-q",
+            str(nested_worktree),
+            "-b",
+            "wt-1-branch",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    nested_file = nested_worktree / "extra.txt"
+    nested_file.write_text("nested worktree content\n", encoding="utf-8")
+    nested_subdir_file = nested_worktree / "sub" / "deep.txt"
+    nested_subdir_file.parent.mkdir(parents=True)
+    nested_subdir_file.write_text("deep nested content\n", encoding="utf-8")
+
+    sibling = repo / ".claude" / "agents" / "real.md"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("# real agent\n", encoding="utf-8")
+
+    snapshot = build_all._snapshot_owned_prefixes(
+        repo, build_all.CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
+
+    assert nested_file not in snapshot
+    assert nested_subdir_file not in snapshot
+    assert not any(
+        nested_worktree in path.parents or path == nested_worktree
+        for path in snapshot
+    )
+    assert sibling in snapshot
 
 
 def test_assert_no_claude_writes_ignores_audit_log_churn(tmp_path: Path) -> None:

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -860,7 +860,7 @@ def test_snapshot_owned_prefixes_skips_git_boundary_directory(
     """The snapshot pass, not just the enumerate pass, must skip a nested
     git repository boundary, with ``exclude_ignored`` left at its default
     (``False``): that is the exact flag value ``run()`` passes for the
-    ``--check`` snapshot. ``build/scripts/build_all.py:1244`` reads::
+    ``--check`` snapshot. ``build/scripts/build_all.py:1345`` reads::
 
         snapshot = _snapshot_owned_prefixes(repo_root, OWNED_PREFIXES)
 
@@ -927,6 +927,108 @@ def test_restore_owned_prefixes_never_deletes_git_boundary_contents(
     assert nested_file.is_file()
     assert nested_file.read_text(encoding="utf-8") == "nested content\n"
     assert not generator_created.exists()
+
+
+def test_restore_owned_prefixes_removes_a_boundary_tree_created_mid_build(
+    tmp_path: Path,
+) -> None:
+    """A ``.git`` entry a generator writes is output, not a nested checkout.
+
+    Detecting boundaries by shape during the restore pass reads the
+    post-generation tree, so a directory the generator created with a
+    ``.git`` entry inside it looks identical to a pre-existing worktree
+    and case 3 of :func:`_restore_owned_prefixes` skips its files.
+    Measured before ``preexisting_boundaries`` existed: a generator
+    creating ``owned/out/.git`` plus ``owned/out/generated.txt`` left both
+    on disk after the restore, so ``--check`` was no longer read-only
+    (issue #2440).
+
+    :func:`_git_boundaries_under` records the boundary set before the
+    generators run, which separates the two cases by when they appeared
+    rather than by shape.
+
+    Both directions are asserted here on purpose. Removing the new tree is
+    worthless if it also removes a live nested worktree, which is the
+    deletion issue #5370 exists to prevent, so the pre-existing checkout
+    and its file are asserted intact in the same run.
+    """
+    owned = tmp_path / "owned"
+    owned.mkdir()
+    pre_existing_wt = owned / "worktrees" / "wt-1"
+    pre_existing_wt.mkdir(parents=True)
+    (pre_existing_wt / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    live_file = pre_existing_wt / "live.txt"
+    live_file.write_text("live worktree content\n", encoding="utf-8")
+    untouched = owned / "real.md"
+    untouched.write_text("# real\n", encoding="utf-8")
+
+    prefixes = ("owned/",)
+    boundaries = build_all._git_boundaries_under(tmp_path, prefixes)
+    assert boundaries == {pre_existing_wt}
+    snapshot = build_all._snapshot_owned_prefixes(tmp_path, prefixes)
+
+    # The generator now creates a boundary-shaped tree of its own.
+    generated_tree = owned / "out"
+    generated_tree.mkdir()
+    (generated_tree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    generated_file = generated_tree / "generated.txt"
+    generated_file.write_text("generator output\n", encoding="utf-8")
+
+    build_all._restore_owned_prefixes(
+        tmp_path, prefixes, snapshot, preexisting_boundaries=boundaries
+    )
+
+    assert not generated_file.exists()
+    assert not generated_tree.exists()
+    assert live_file.read_text(encoding="utf-8") == "live worktree content\n"
+    assert (pre_existing_wt / ".git").is_file()
+    assert untouched.read_text(encoding="utf-8") == "# real\n"
+
+
+def test_restore_owned_prefixes_prunes_a_generated_repo_shaped_tree(
+    tmp_path: Path,
+) -> None:
+    """Deleting the files is not enough when ``.git`` is a real directory.
+
+    The sibling test above writes ``.git`` as a file, so once case 3
+    unlinks it the tree stops looking like a boundary and shape detection
+    inside :func:`_prune_empty_dirs` would remove the empty directory
+    anyway. A cloned repository does not have that shape: ``.git`` is a
+    directory, and an emptied directory still satisfies
+    ``(entry / ".git").exists()``, so shape detection keeps treating the
+    tree as opaque and never prunes it.
+
+    Measured: dropping ``opaque_boundaries`` from the prune call left
+    ``owned/out`` and ``owned/out/.git`` on disk here while every other
+    test stayed green. Empty directories the run created are still a
+    ``--check`` write (issue #2440), so this case is what holds that
+    argument in place.
+    """
+    owned = tmp_path / "owned"
+    owned.mkdir()
+    untouched = owned / "real.md"
+    untouched.write_text("# real\n", encoding="utf-8")
+
+    prefixes = ("owned/",)
+    boundaries = build_all._git_boundaries_under(tmp_path, prefixes)
+    assert boundaries == set()
+    snapshot = build_all._snapshot_owned_prefixes(tmp_path, prefixes)
+
+    generated_tree = owned / "out"
+    (generated_tree / ".git").mkdir(parents=True)
+    (generated_tree / ".git" / "HEAD").write_text(
+        "ref: refs/heads/main\n", encoding="utf-8"
+    )
+    (generated_tree / "generated.txt").write_text(
+        "generator output\n", encoding="utf-8"
+    )
+
+    build_all._restore_owned_prefixes(
+        tmp_path, prefixes, snapshot, preexisting_boundaries=boundaries
+    )
+
+    assert not generated_tree.exists()
+    assert untouched.read_text(encoding="utf-8") == "# real\n"
 
 
 def test_prune_empty_dirs_never_rmdirs_inside_git_boundary(

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -809,6 +809,37 @@ def test_enumerate_files_under_skips_git_boundary_directory(tmp_path: Path) -> N
     assert sibling in found
 
 
+def test_snapshot_owned_prefixes_skips_git_boundary_directory(
+    tmp_path: Path,
+) -> None:
+    """The snapshot pass, not just the enumerate pass, must skip a nested
+    git repository boundary, with ``exclude_ignored`` left at its default
+    (``False``): that is the exact flag value ``run()`` passes for the
+    ``--check`` snapshot (build_all.py:1216), so a gitignore-only guard
+    (``_is_ignored_path``) would not cover it.
+
+    Without routing this walk through
+    :func:`_iter_tree_skip_git_boundaries`, a nested worktree under an
+    owned prefix gets read into the snapshot here while
+    :func:`_enumerate_files_under`'s delete pass skips it, and the
+    asymmetry lets :func:`_restore_owned_prefixes` overwrite the nested
+    worktree's own files with snapshot bytes (issue #5370).
+    """
+    owned = tmp_path / "owned"
+    nested = owned / "worktrees" / "wt-1"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    nested_file = nested / "inside.txt"
+    nested_file.write_text("nested content\n", encoding="utf-8")
+    sibling = owned / "real.md"
+    sibling.write_text("# real\n", encoding="utf-8")
+
+    snapshot = build_all._snapshot_owned_prefixes(tmp_path, ("owned/",))
+
+    assert nested_file not in snapshot
+    assert sibling in snapshot
+
+
 def test_restore_owned_prefixes_never_deletes_git_boundary_contents(
     tmp_path: Path,
 ) -> None:
@@ -847,6 +878,34 @@ def test_restore_owned_prefixes_never_deletes_git_boundary_contents(
     assert nested_file.is_file()
     assert nested_file.read_text(encoding="utf-8") == "nested content\n"
     assert not generator_created.exists()
+
+
+def test_prune_empty_dirs_never_rmdirs_inside_git_boundary(
+    tmp_path: Path,
+) -> None:
+    """_prune_empty_dirs's own boundary skip, not just the delete pass, must
+    hold: an empty directory inside a nested worktree (a ``build/`` or
+    ``logs/`` dir with nothing tracked in it) must survive
+    _restore_owned_prefixes.
+
+    Swapping ``_iter_tree_skip_git_boundaries`` back to plain
+    ``root.rglob("*")`` in _prune_empty_dirs leaves every other test in
+    this suite green because their fixture worktrees hold only non-empty
+    directories: the prune loop's ``if not any(dirpath.iterdir())`` never
+    fires either way. This fixture adds an empty directory under the
+    nested worktree so the mutation is caught (issue #5370).
+    """
+    owned = tmp_path / "owned"
+    nested = owned / "worktrees" / "wt-1"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    nested_empty_dir = nested / "empty_build_dir"
+    nested_empty_dir.mkdir()
+
+    prefixes = ("owned/",)
+    build_all._restore_owned_prefixes(tmp_path, prefixes, snapshot={})
+
+    assert nested_empty_dir.is_dir()
 
 
 def test_build_agent_catalog_writes_docs_catalog(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### What

Treat a directory returned by `git ls-files --others --ignored
--exclude-standard` as a path prefix rather than an exact-match key, so
every file under an ignored directory is excluded. Add a `.git` boundary
skip to `_enumerate_files_under`, `_snapshot_owned_prefixes`, and
`_prune_empty_dirs`.

### Why

`build_all.py --check` walked into nested worktrees and OOM-killed
itself. Issue #5370 measured 107,078 files and 1.35 GB read per snapshot,
twice per run. This checkout currently holds 24 nested worktrees under
`.claude/worktrees/` totalling 1.6 GB, so the walk is larger now than
when the issue was filed.

The boundary skip is not cosmetic. Without it, adding `.claude/` to
`OWNED_PREFIXES` in future would turn `_restore_owned_prefixes` case 3
into a delete of live worktree contents.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #5370 | build_all.py --check OOM-kills itself reading nested worktree contents |

## Testing

`test_snapshot_owned_prefixes_skips_git_boundary_directory` fails against
pre-fix code and passes after. Confirmed by mutating a scratch copy of
the file, never the working tree, and diffing it back to identical.

`test_prune_empty_dirs_never_rmdirs_inside_git_boundary` asserts an empty
directory under a nested worktree survives `_restore_owned_prefixes`.

Positive controls included: a non-ignored sibling's files are still
captured.

## Notes for Reviewers

Implemented by a sonnet-class agent, reviewed by an opus-class agent
given only the diff and the test output. Review found a blocking
asymmetry: `_enumerate_files_under` had the boundary skip but its sibling
`_snapshot_owned_prefixes` did not, so the delete pass was guarded while
the snapshot pass was not. The reviewer reproduced it directly:
`_snapshot_owned_prefixes(root, ("src/",))` returned the nested
worktree's files while `_enumerate_files_under` returned `[]`. This PR is
the remediated state.
