### PR TITLE
perf(tests): cache git local-env discovery per worker, not per test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,9 @@ _SUITE_OWNED_GIT_CONFIG = {
 _GIT_CONFIG_ENV_VARS = ("GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS")
 
 
+_LOCAL_ENV_VARS_CACHE: list[tuple[str, ...]] = []
+
+
 def _local_env_vars() -> tuple[str, ...]:
     """Every repository-scoped variable git itself honors.
 
@@ -142,8 +145,29 @@ def _local_env_vars() -> tuple[str, ...]:
     ``GIT_NO_REPLACE_OBJECTS``, and ``GIT_IMPLICIT_WORK_TREE``. Refs #4717.
 
     Falls back to the hand-written set if git is unavailable, since an
-    environment with no git cannot run the tests this protects anyway.
+    environment with no git cannot run the tests this protects anyway. Only a
+    successful discovery is memoized; the fallback is recomputed on every
+    call. A transient subprocess failure (a fork failure under load, a
+    30-second timeout) is not "git is not installed", and caching it would
+    pin the six-name fallback for the rest of the worker process even after
+    git starts answering again, silently dropping GIT_CONFIG and the other
+    five names the fallback lacks for every remaining test item in that
+    worker. Refs #5379.
+
+    Cached because the result depends only on the installed git version, not
+    on per-test state: the variable *names* git honors do not change between
+    test items, only the *values* the caller reads from ``os.environ`` do
+    (still re-read fresh on every test, see ``_sanitize_git_environment``).
+    Uncached, this spawned one ``git rev-parse`` subprocess per test item,
+    roughly 30,000 short-lived processes across a full run, multiplied across
+    xdist workers. Refs #5379.
+
+    Call ``_local_env_vars.cache_clear()`` to force rediscovery. This is the
+    supported seam for tests that need to change the installed git's reported
+    variable set mid-run.
     """
+    if _LOCAL_ENV_VARS_CACHE:
+        return _LOCAL_ENV_VARS_CACHE[0]
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--local-env-vars"],
@@ -155,7 +179,12 @@ def _local_env_vars() -> tuple[str, ...]:
     except (OSError, subprocess.SubprocessError):
         return _GIT_POINTER_VARS
     names = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
-    return names or _GIT_POINTER_VARS
+    discovered = names or _GIT_POINTER_VARS
+    _LOCAL_ENV_VARS_CACHE.append(discovered)
+    return discovered
+
+
+_local_env_vars.cache_clear = _LOCAL_ENV_VARS_CACHE.clear
 
 
 def _sanitize_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,21 +146,24 @@ def _local_env_vars() -> tuple[str, ...]:
 
     Falls back to the hand-written set if git is unavailable, since an
     environment with no git cannot run the tests this protects anyway. Only a
-    successful discovery is memoized; the fallback is recomputed on every
-    call. A transient subprocess failure (a fork failure under load, a
-    30-second timeout) is not "git is not installed", and caching it would
-    pin the six-name fallback for the rest of the worker process even after
-    git starts answering again, silently dropping GIT_CONFIG and the other
-    five names the fallback lacks for every remaining test item in that
+    successful discovery is memoized; every fallback path is recomputed on the
+    next call. That covers all three triggers: git missing (``OSError``), git
+    erroring (``CalledProcessError``), and git exiting 0 with empty stdout.
+    None of the three is "git will never answer again", and caching any of
+    them would pin the six-name fallback for the rest of the worker process
+    even after git starts answering, silently dropping GIT_CONFIG and the
+    other five names the fallback lacks for every remaining test item in that
     worker. Refs #5379.
 
     Cached because the result depends only on the installed git version, not
     on per-test state: the variable *names* git honors do not change between
     test items, only the *values* the caller reads from ``os.environ`` do
     (still re-read fresh on every test, see ``_sanitize_git_environment``).
-    Uncached, this spawned one ``git rev-parse`` subprocess per test item,
-    roughly 30,000 short-lived processes across a full run, multiplied across
-    xdist workers. Refs #5379.
+    Uncached, this spawned one ``git rev-parse`` subprocess per test item.
+    xdist splits items across workers rather than repeating them on each, so
+    the uncached total is the item count, roughly 30,000 short-lived processes
+    across a full run, however many workers share them. Cached, it is one per
+    worker process. Refs #5379.
 
     Call ``_local_env_vars_cache_clear()`` to force rediscovery. This is the
     supported seam for tests that need to change the installed git's reported
@@ -179,9 +182,10 @@ def _local_env_vars() -> tuple[str, ...]:
     except (OSError, subprocess.SubprocessError):
         return _GIT_POINTER_VARS
     names = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
-    discovered = names or _GIT_POINTER_VARS
-    _LOCAL_ENV_VARS_CACHE.append(discovered)
-    return discovered
+    if not names:
+        return _GIT_POINTER_VARS
+    _LOCAL_ENV_VARS_CACHE.append(names)
+    return names
 
 
 _local_env_vars_cache_clear = _LOCAL_ENV_VARS_CACHE.clear

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def _local_env_vars() -> tuple[str, ...]:
     roughly 30,000 short-lived processes across a full run, multiplied across
     xdist workers. Refs #5379.
 
-    Call ``_local_env_vars.cache_clear()`` to force rediscovery. This is the
+    Call ``_local_env_vars_cache_clear()`` to force rediscovery. This is the
     supported seam for tests that need to change the installed git's reported
     variable set mid-run.
     """
@@ -184,7 +184,7 @@ def _local_env_vars() -> tuple[str, ...]:
     return discovered
 
 
-_local_env_vars.cache_clear = _LOCAL_ENV_VARS_CACHE.clear
+_local_env_vars_cache_clear = _LOCAL_ENV_VARS_CACHE.clear
 
 
 def _sanitize_git_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_conftest_local_env_vars_cache.py
+++ b/tests/test_conftest_local_env_vars_cache.py
@@ -13,7 +13,7 @@ must not break:
    names and not just the hardcoded pointer-var tuple.
 3. All three fallback triggers (git missing, git erroring, git succeeding
    with empty stdout) still return the hand-written pointer-var tuple, and
-   the documented ``cache_clear()`` seam lets a test force rediscovery of a
+   the documented ``_local_env_vars_cache_clear()`` seam lets a test force rediscovery of a
    memoized successful result.
 4. A failed discovery is never memoized, so a transient subprocess failure
    does not permanently pin the fallback for the rest of the worker process.
@@ -264,7 +264,7 @@ class TestGitUnavailableFallback:
             first_result = module._local_env_vars()
         assert first_result == ("GIT_DIR",)
 
-        module._local_env_vars.cache_clear()
+        module._local_env_vars_cache_clear()
 
         with patch.object(
             module.subprocess,

--- a/tests/test_conftest_local_env_vars_cache.py
+++ b/tests/test_conftest_local_env_vars_cache.py
@@ -1,0 +1,275 @@
+"""Behavioral tests for caching ``_local_env_vars()`` (issue #5379).
+
+``_local_env_vars()`` shells out to ``git rev-parse --local-env-vars`` to
+discover the variable names git honors. That result depends only on the
+installed git version, not on per-test state, so a successful discovery is
+memoized in a module-level cache. This module proves four things the cache
+must not break:
+
+1. The subprocess runs once across many simulated pytest items, not once per
+   item.
+2. Environment sanitization (which reads the cached names but the *current*
+   ``os.environ`` values) still runs on every item, driven by the discovered
+   names and not just the hardcoded pointer-var tuple.
+3. All three fallback triggers (git missing, git erroring, git succeeding
+   with empty stdout) still return the hand-written pointer-var tuple, and
+   the documented ``cache_clear()`` seam lets a test force rediscovery of a
+   memoized successful result.
+4. A failed discovery is never memoized, so a transient subprocess failure
+   does not permanently pin the fallback for the rest of the worker process.
+
+Test approach mirrors ``tests/test_conftest_git_isolation.py``: load
+``tests/conftest.py`` as a standalone module per test so each test starts
+with a fresh, empty cache instead of sharing state with the real pytest
+session's ``tests/conftest.py`` import.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+import subprocess
+import types
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _load_tests_conftest() -> types.ModuleType:
+    path = Path(__file__).resolve().parent / "conftest.py"
+    spec = importlib.util.spec_from_file_location(
+        "tests_conftest_local_env_vars_cache_under_test", path
+    )
+    assert spec is not None
+    loader = spec.loader
+    assert isinstance(loader, importlib.abc.Loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def _get_autouse_fixture_fn(module: types.ModuleType) -> Callable[..., None]:
+    """Return the unwrapped function behind the tmp_path isolation fixture.
+
+    Mirrors ``tests/test_conftest_git_isolation.py``'s helper of the same
+    shape. Calling the real fixture function (instead of the bare
+    ``_sanitize_git_environment`` helper it wraps) is what proves a
+    regression reachable only through the fixture, not just through the
+    helper in isolation, still fails these tests.
+    """
+    fixture = module._isolate_tmp_path_from_parent_git_repo
+    unwrapped = getattr(fixture, "__wrapped__", fixture)
+    return cast("Callable[..., None]", unwrapped)
+
+
+class TestLocalEnvVarsCachedAcrossItems:
+    """The git subprocess must run once, not once per pytest item."""
+
+    def test_subprocess_runs_once_across_multiple_calls(self) -> None:
+        """Simulate several test items calling ``_local_env_vars()``.
+
+        A call counter on the mocked ``subprocess.run`` proves the real
+        ``git rev-parse`` process is invoked once no matter how many pytest
+        items (simulated here as repeated calls) ask for the variable names.
+        """
+        module = _load_tests_conftest()
+        call_count = 0
+
+        def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+            nonlocal call_count
+            call_count += 1
+            return SimpleNamespace(stdout="GIT_DIR\nGIT_WORK_TREE\n")
+
+        with patch.object(module.subprocess, "run", side_effect=fake_run):
+            # Simulate three separate pytest items each triggering discovery.
+            first_item = module._local_env_vars()
+            second_item = module._local_env_vars()
+            third_item = module._local_env_vars()
+
+        assert call_count == 1, (
+            f"git rev-parse ran {call_count} times across three simulated "
+            "test items; caching should limit it to one subprocess per "
+            "worker process."
+        )
+        assert first_item == second_item == third_item == (
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+        )
+
+    def test_result_is_cached_object_identity(self) -> None:
+        """Repeated calls return the cached tuple, not a freshly built one.
+
+        ``lru_cache`` returns the exact same object on a cache hit. Asserting
+        identity (not just equality) confirms the cache path is taken rather
+        than a coincidentally-equal recomputation.
+        """
+        module = _load_tests_conftest()
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="GIT_DIR\n"),
+        ):
+            first = module._local_env_vars()
+            second = module._local_env_vars()
+
+        assert first is second
+
+
+class TestSanitizationRunsEveryItem:
+    """Caching the variable *names* must not skip per-item value clearing."""
+
+    def test_delenv_called_on_every_simulated_item(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The discovered (not hardcoded) names are cleared on every item.
+
+        The stubbed discovery includes ``GIT_CONFIG``, a name that is absent
+        from the hardcoded ``_GIT_POINTER_VARS`` tuple. Asserting on it
+        (instead of ``GIT_DIR``/``GIT_WORK_TREE``, both already in that
+        hardcoded tuple) proves the *cached discovery result* drives
+        sanitization, not just the hardcoded fallback: a regression that
+        iterates only ``_GIT_POINTER_VARS`` would leave ``GIT_CONFIG``
+        untouched and this test would fail.
+
+        Two simulated pytest items go through the real autouse fixture
+        function (not the bare ``_sanitize_git_environment`` helper), each
+        setting a different hostile value for ``GIT_CONFIG``. Both items must
+        still see their value cleared, proving the cache only short-circuits
+        name discovery, not per-test sanitization. The outer ``monkeypatch``
+        fixture (distinct from the per-item mocks passed into the fixture
+        under test) guarantees the hostile values are restored even if an
+        assertion fails.
+        """
+        module = _load_tests_conftest()
+        fixture_fn = _get_autouse_fixture_fn(module)
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(
+                stdout="GIT_DIR\nGIT_WORK_TREE\nGIT_CONFIG\n"
+            ),
+        ):
+            # First simulated pytest item, no tmp_path fixture requested.
+            deleted_first: list[str] = []
+            mp_first = MagicMock()
+            mp_first.delenv.side_effect = lambda name, raising=True: (
+                deleted_first.append(name)
+            )
+            monkeypatch.setenv("GIT_CONFIG", "/hostile/first")
+            request_first = SimpleNamespace(fixturenames=[], getfixturevalue=lambda _: None)
+            fixture_fn(request_first, mp_first)
+            assert "GIT_CONFIG" in deleted_first
+            monkeypatch.delenv("GIT_CONFIG", raising=False)
+
+            # Second simulated pytest item, a different hostile value for the
+            # same discovered-only name. The cache (populated by the first
+            # item) is reused; sanitization must still run.
+            deleted_second: list[str] = []
+            mp_second = MagicMock()
+            mp_second.delenv.side_effect = lambda name, raising=True: (
+                deleted_second.append(name)
+            )
+            monkeypatch.setenv("GIT_CONFIG", "/hostile/second")
+            request_second = SimpleNamespace(fixturenames=[], getfixturevalue=lambda _: None)
+            fixture_fn(request_second, mp_second)
+            assert "GIT_CONFIG" in deleted_second
+            monkeypatch.delenv("GIT_CONFIG", raising=False)
+
+
+class TestGitUnavailableFallback:
+    """The fallback to the hand-written pointer-var tuple must still work."""
+
+    def test_falls_back_when_git_missing(self) -> None:
+        """``OSError`` from ``subprocess.run`` (git not on PATH) falls back."""
+        module = _load_tests_conftest()
+        with patch.object(
+            module.subprocess, "run", side_effect=OSError("git not found")
+        ):
+            result = module._local_env_vars()
+
+        assert result == module._GIT_POINTER_VARS
+
+    def test_falls_back_when_git_errors(self) -> None:
+        """A non-zero git exit (``CalledProcessError``) falls back too."""
+        module = _load_tests_conftest()
+        with patch.object(
+            module.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, ["git"]),
+        ):
+            result = module._local_env_vars()
+
+        assert result == module._GIT_POINTER_VARS
+
+    def test_falls_back_on_empty_stdout(self) -> None:
+        """A git that exits 0 with empty stdout falls back too.
+
+        ``git rev-parse --local-env-vars`` succeeding with no output is a
+        third trigger for the fallback, distinct from ``OSError`` (git
+        missing) and ``CalledProcessError`` (git erroring). Mutating
+        ``return names or _GIT_POINTER_VARS`` to ``return names`` would
+        return an empty tuple here instead of falling back, and this test
+        would fail.
+        """
+        module = _load_tests_conftest()
+        with patch.object(
+            module.subprocess, "run", return_value=SimpleNamespace(stdout="")
+        ):
+            result = module._local_env_vars()
+
+        assert result == module._GIT_POINTER_VARS
+
+    def test_transient_failure_is_not_cached(self) -> None:
+        """A failed call does not pin the fallback for the next call.
+
+        Caching a transient subprocess failure (a fork failure under load, a
+        timeout) would degrade the git-isolation guard for the rest of the
+        worker process even after git starts answering again. Proven here
+        without touching ``cache_clear()``: a failing call followed directly
+        by a succeeding call must return the discovered names, not the
+        fallback pinned by the first call.
+        """
+        module = _load_tests_conftest()
+
+        with patch.object(module.subprocess, "run", side_effect=OSError("no git")):
+            fallback_result = module._local_env_vars()
+        assert fallback_result == module._GIT_POINTER_VARS
+
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="GIT_DIR\n"),
+        ):
+            recovered_result = module._local_env_vars()
+        assert recovered_result == ("GIT_DIR",)
+
+    def test_cache_clear_seam_forces_rediscovery(self) -> None:
+        """``cache_clear()`` is the documented seam to force rediscovery.
+
+        A successful discovery is memoized. After ``cache_clear()`` a second
+        call must re-invoke the (now mocked-different) subprocess, proving
+        the cache does not permanently pin a stale successful result.
+        """
+        module = _load_tests_conftest()
+
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="GIT_DIR\n"),
+        ):
+            first_result = module._local_env_vars()
+        assert first_result == ("GIT_DIR",)
+
+        module._local_env_vars.cache_clear()
+
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="GIT_WORK_TREE\n"),
+        ):
+            rediscovered_result = module._local_env_vars()
+        assert rediscovered_result == ("GIT_WORK_TREE",)

--- a/tests/test_conftest_local_env_vars_cache.py
+++ b/tests/test_conftest_local_env_vars_cache.py
@@ -15,8 +15,9 @@ must not break:
    with empty stdout) still return the hand-written pointer-var tuple, and
    the documented ``_local_env_vars_cache_clear()`` seam lets a test force rediscovery of a
    memoized successful result.
-4. A failed discovery is never memoized, so a transient subprocess failure
-   does not permanently pin the fallback for the rest of the worker process.
+4. No fallback is ever memoized, so neither a transient subprocess failure
+   nor a one-off empty answer from git pins the six-name hand-written set for
+   the rest of the worker process.
 
 Test approach mirrors ``tests/test_conftest_git_isolation.py``: load
 ``tests/conftest.py`` as a standalone module per test so each test starts
@@ -103,9 +104,10 @@ class TestLocalEnvVarsCachedAcrossItems:
     def test_result_is_cached_object_identity(self) -> None:
         """Repeated calls return the cached tuple, not a freshly built one.
 
-        ``lru_cache`` returns the exact same object on a cache hit. Asserting
-        identity (not just equality) confirms the cache path is taken rather
-        than a coincidentally-equal recomputation.
+        The cache is a module-level list holding the discovered tuple, so a
+        hit returns that exact object. Asserting identity (not just equality)
+        confirms the cache path is taken rather than a coincidentally-equal
+        recomputation.
         """
         module = _load_tests_conftest()
         with patch.object(
@@ -222,6 +224,32 @@ class TestGitUnavailableFallback:
             result = module._local_env_vars()
 
         assert result == module._GIT_POINTER_VARS
+
+    def test_empty_stdout_is_not_cached(self) -> None:
+        """An empty-stdout answer does not pin the fallback either.
+
+        Empty stdout is a fallback, not a discovery, so memoizing it would
+        keep the six-name hand-written set for the rest of the worker process
+        and silently drop ``GIT_CONFIG`` and the other five discovered-only
+        names for every remaining item. Proven without ``cache_clear()``: an
+        empty call followed directly by a normal one must return the
+        discovered names.
+        """
+        module = _load_tests_conftest()
+
+        with patch.object(
+            module.subprocess, "run", return_value=SimpleNamespace(stdout="")
+        ):
+            fallback_result = module._local_env_vars()
+        assert fallback_result == module._GIT_POINTER_VARS
+
+        with patch.object(
+            module.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="GIT_DIR\nGIT_CONFIG\n"),
+        ):
+            recovered_result = module._local_env_vars()
+        assert recovered_result == ("GIT_DIR", "GIT_CONFIG")
 
     def test_transient_failure_is_not_cached(self) -> None:
         """A failed call does not pin the fallback for the next call.

--- a/tests/test_conftest_local_env_vars_xdist.py
+++ b/tests/test_conftest_local_env_vars_xdist.py
@@ -117,6 +117,12 @@ def _run_child_pytest(root: Path, count_dir: Path, extra_args: list[str]) -> Non
         env=env,
         capture_output=True,
         text=True,
+        # Pinned rather than left to the locale codec: on Windows the ANSI
+        # codepage rejects UTF-8 bytes that pytest and its plugins emit, and the
+        # decode failure would destroy the very output this assertion reports.
+        # Mirrors tests/test_lefthook_integration.py.
+        encoding="utf-8",
+        errors="replace",
         timeout=300,
     )
     assert completed.returncode == 0, (

--- a/tests/test_conftest_local_env_vars_xdist.py
+++ b/tests/test_conftest_local_env_vars_xdist.py
@@ -1,0 +1,182 @@
+"""Child-pytest proof that discovery runs once per worker (issue #5379).
+
+``tests/test_conftest_local_env_vars_cache.py`` proves the cache with repeated
+in-process calls. That is one pytest item calling a function three times, so it
+cannot observe what issue #5379 actually asks for: that *multiple collected
+items*, spread over *real xdist worker processes*, still trigger exactly one
+``git rev-parse --local-env-vars`` per worker.
+
+This module spawns a real child pytest over a generated project whose conftest
+re-exports the repository's autouse git-isolation fixture and counts the
+discovery subprocesses that fixture causes. It runs that child twice, serial
+and under ``-n 2``, and asserts the per-worker count from each run.
+
+The counter lives in the child's conftest rather than in the code under test,
+so nothing here changes how ``_local_env_vars()`` behaves. Counts are handed
+back through one JSON file per worker, written in ``pytest_sessionfinish``,
+because an xdist worker is a separate process with no shared memory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REAL_CONFTEST = REPO_ROOT / "tests" / "conftest.py"
+
+# Six is enough to make "once per item" and "once per worker" different numbers
+# under both run modes, and small enough that two child pytest runs stay cheap.
+_ITEM_COUNT = 6
+
+_CHILD_CONFTEST = '''
+"""Generated conftest: count git discovery calls the real fixture triggers."""
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+_REAL = Path(os.environ["LOCAL_ENV_VARS_REAL_CONFTEST"])
+_COUNT_DIR = Path(os.environ["LOCAL_ENV_VARS_COUNT_DIR"])
+
+_spec = importlib.util.spec_from_file_location("real_tests_conftest", _REAL)
+real = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(real)
+
+_counts = {"discovery": 0, "items": 0}
+
+
+class _CountingSubprocess:
+    """Stand-in for the ``subprocess`` module in the real conftest's globals.
+
+    ``_local_env_vars()`` resolves ``subprocess.run`` and ``subprocess`` error
+    types through its own module namespace, so rebinding that one name counts
+    the spawns without touching the function under test.
+    """
+
+    CalledProcessError = subprocess.CalledProcessError
+    SubprocessError = subprocess.SubprocessError
+    TimeoutExpired = subprocess.TimeoutExpired
+
+    @staticmethod
+    def run(args, **kwargs):
+        if "--local-env-vars" in args:
+            _counts["discovery"] += 1
+        return subprocess.run(args, **kwargs)
+
+
+real.subprocess = _CountingSubprocess
+
+# Re-exporting the fixture object registers it for this session, so the items
+# below go through the repository's real autouse isolation path.
+_isolate_tmp_path_from_parent_git_repo = real._isolate_tmp_path_from_parent_git_repo
+
+
+def pytest_runtest_call(item):
+    _counts["items"] += 1
+
+
+def pytest_sessionfinish(session, exitstatus):
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    _COUNT_DIR.mkdir(parents=True, exist_ok=True)
+    (_COUNT_DIR / (worker + ".json")).write_text(json.dumps(_counts), encoding="utf-8")
+'''
+
+
+def _write_child_project(root: Path) -> None:
+    """Generate a minimal pytest project with ``_ITEM_COUNT`` items."""
+    root.mkdir(parents=True, exist_ok=True)
+    # Its own ini file, so the repository's addopts and plugins do not apply.
+    (root / "pytest.ini").write_text("[pytest]\n", encoding="utf-8")
+    (root / "conftest.py").write_text(_CHILD_CONFTEST, encoding="utf-8")
+    bodies = "\n".join(f"def test_item_{index}():\n    pass\n" for index in range(_ITEM_COUNT))
+    (root / "test_items.py").write_text(bodies, encoding="utf-8")
+
+
+def _run_child_pytest(root: Path, count_dir: Path, extra_args: list[str]) -> None:
+    """Run the generated project in a child process and require a green run."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        # The parent session's own xdist and pytest coordinates would otherwise
+        # leak in and make the child believe it is already a worker.
+        if not key.startswith("PYTEST_") and key != "_PYTEST_BASETEMP"
+    }
+    env["LOCAL_ENV_VARS_REAL_CONFTEST"] = str(REAL_CONFTEST)
+    env["LOCAL_ENV_VARS_COUNT_DIR"] = str(count_dir)
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *extra_args],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, (
+        f"child pytest exited {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+
+
+def _read_counts(count_dir: Path) -> dict[str, dict[str, int]]:
+    return {
+        path.stem: json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(count_dir.glob("*.json"))
+    }
+
+
+def _assert_one_discovery_per_working_process(counts: dict[str, dict[str, int]]) -> None:
+    """Every process that ran items discovered exactly once; idle ones, zero."""
+    assert counts, "child pytest wrote no per-worker count files"
+    total_items = sum(entry["items"] for entry in counts.values())
+    assert total_items == _ITEM_COUNT, (
+        f"child ran {total_items} items, expected {_ITEM_COUNT}: {counts}"
+    )
+    for worker, entry in counts.items():
+        expected = 1 if entry["items"] else 0
+        assert entry["discovery"] == expected, (
+            f"worker {worker} ran {entry['discovery']} git discovery subprocesses "
+            f"for {entry['items']} items; caching should make that "
+            f"{expected}. Full counts: {counts}"
+        )
+
+
+def test_serial_run_discovers_once_for_many_items(tmp_path: Path) -> None:
+    """Six collected items in one process trigger one discovery subprocess."""
+    root = tmp_path / "serial"
+    count_dir = tmp_path / "counts-serial"
+    _write_child_project(root)
+
+    _run_child_pytest(root, count_dir, [])
+
+    counts = _read_counts(count_dir)
+    assert list(counts) == ["master"], f"expected a single serial process: {counts}"
+    _assert_one_discovery_per_working_process(counts)
+
+
+def test_xdist_run_discovers_once_per_worker(tmp_path: Path) -> None:
+    """Under ``-n 2`` each worker discovers once, not once per item it owns.
+
+    xdist distributes the six items across the workers rather than repeating
+    them, so the assertion is per worker: a worker that ran any item ran
+    exactly one discovery subprocess. The distribution itself is xdist's to
+    choose, so this does not pin how many items each worker gets.
+    """
+    pytest.importorskip("xdist", reason="pytest-xdist is required for the parallel proof")
+    root = tmp_path / "xdist"
+    count_dir = tmp_path / "counts-xdist"
+    _write_child_project(root)
+
+    _run_child_pytest(root, count_dir, ["-n", "2"])
+
+    counts = _read_counts(count_dir)
+    workers = [name for name in counts if name.startswith("gw")]
+    assert len(workers) == 2, f"expected two xdist workers, got {sorted(counts)}"
+    _assert_one_discovery_per_working_process(counts)


### PR DESCRIPTION
## Summary

### What

Cache git local-environment discovery in `tests/conftest.py` so
`git rev-parse --local-env-vars` runs once per worker instead of once per
test item. Only a successful discovery is memoized.

### Why

Uncached, this spawned one short-lived subprocess per test item. xdist splits
items across workers rather than repeating them on each, so the uncached total
is the item count, roughly 30,000 across a full run, however many workers share
them. Cached, it is one per worker process.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #5379 | perf(pytest): cache Git local-environment discovery once per worker |

## Testing

`tests/test_conftest_local_env_vars_cache.py`, 9 tests, in-process behavior:
one discovery across repeated calls, cache identity, sanitization still runs
per item and is driven by the discovered names, all three fallback triggers,
and the two non-caching guarantees (transient failure, empty stdout).

`tests/test_conftest_local_env_vars_xdist.py`, 2 tests, a real child pytest run
over a generated six-item project, serial and under `-n 2`. Its conftest
re-exports the repository autouse isolation fixture and counts the
`git rev-parse --local-env-vars` spawns that fixture causes, one JSON file per
worker. Control with the cache read deleted from `_local_env_vars()`: serial
reports 6 discoveries for 6 items, `-n 2` reports 3 for gw0 and 3 for gw1, and
both tests fail. With the cache, one per working process.

Existing isolation tests pass serial and under `-n 2`, 16 passed each way.

## Measurement

Before and after runs at 10,000 collected items, same machine, same
interpreter, same generated project. `before` is this PR's base commit
`9b61b34`, `after` is the branch tip. Serial, one worker, so the process counts
are directly comparable. Wall from `time.perf_counter`, CPU from
`resource.getrusage(RUSAGE_CHILDREN)`, forks from the `processes` counter in
`/proc/stat`, git spawns counted at the call site.

| Metric, 10,000 items | Before | After | Delta |
|---|---|---|---|
| `git rev-parse` processes | 10,000 | 1 | -9,999 |
| Wall, pass 1 | 39.159s | 13.267s | -25.892s |
| Wall, pass 2 | 41.590s | 18.223s | -23.367s |
| Child CPU user + sys, pass 1 | 34.602s | 13.167s | -21.435s |
| Child CPU user + sys, pass 2 | 36.652s | 17.241s | -19.411s |
| System-wide forks during run, pass 1 | 13,144 | 1,004 | -12,140 |
| System-wide forks during run, pass 2 | 13,824 | 2,300 | -11,524 |

Per item that is 2.3ms to 2.6ms of wall and 1.9ms to 2.1ms of CPU. The fork
delta is system-wide and so carries other load on the box; the 10,000 to 1
process count is the exact figure.

Caveats, stated because they bound the claim:

- Test bodies are `pass`. The measured quantity is the per-item fixture cost,
  which is additive and independent of the body, so the per-item delta carries
  to a real suite. Total suite wall time does not, because a real suite is
  dominated by its bodies.
- Serial. Under `-n N` the same total CPU saving divides across workers, so the
  wall-clock gain is roughly the total divided by N.
- The claim in this PR's first commit body (7m32.988s to 6m29.675s across
  12,310 items) was not reproducible and has been removed. It is not what these
  numbers say.

## Notes for Reviewers

Round 1, implemented by a sonnet-class agent and reviewed by an opus-class
agent given only the diff and the test output. Three findings, all accepted:

1. `functools.lru_cache` memoized the git-unavailable fallback, so one
   transient fork failure or 30-second timeout permanently degraded the
   git-isolation guard for the rest of the worker. Replaced with a manual cache
   that only memoizes a successful `subprocess.run`.
2. `test_delenv_called_on_every_simulated_item` passed even when the sanitizer
   ignored `_local_env_vars()` entirely, because it asserted only on two
   hardcoded names. Rewritten.
3. The timing claim above.

Round 2, from the Copilot review. Five findings, all accepted:

1. The empty-stdout path still cached the fallback: `names or _GIT_POINTER_VARS`
   was appended, contradicting the docstring, so one empty answer pinned the
   six-name set for the rest of the worker. Fixed in `53f09645`, guarded by
   `test_empty_stdout_is_not_cached`, which fails against the old body.
2. The cache proof was one item making three calls, which crosses no collection
   or process boundary. Added the child-pytest xdist test in `8d11ee4e`.
3. The docstring said the uncached subprocess total was multiplied across xdist
   workers. It is not; xdist splits items. Corrected, and the control run
   measures it: 3 plus 3, not 6 plus 6.
4. A test docstring still explained `lru_cache`, which this PR replaced.
   Updated to describe the list-backed cache.
5. The suppressed comment asked for the process, CPU, and wall benchmark the
   issue requires. See Measurement above.

This guard enforces git isolation per issues #4287 and #4717, so a mistake here
disarms it silently. That is why the cache is hand-rolled rather than a
decorator.
