### PR TITLE
fix(rules): make the worktree placement rule actionable and external-only

### DIFF
--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -139,12 +139,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,382 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,382 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,498 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.claude/rules/universal.md
+++ b/.claude/rules/universal.md
@@ -68,7 +68,15 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. Git worktrees MUST be external.
+6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
+   or another external directory; never under it, never under `/tmp`.
+   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
+   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
+   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
+   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
+   reclaims without warning. Harness or plugin defaults nesting under the
+   clone (Claude Code's `.claude/worktrees/`, superpowers'
+   `.worktrees/`) do not override this rule.
 
 ## References
 

--- a/.claude/rules/universal.md
+++ b/.claude/rules/universal.md
@@ -68,15 +68,8 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
-   or another external directory; never under it, never under `/tmp`.
-   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
-   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
-   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
-   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
-   reclaims without warning. Harness or plugin defaults nesting under the
-   clone (Claude Code's `.claude/worktrees/`, superpowers'
-   `.worktrees/`) do not override this rule.
+6. Worktrees MUST be external: a sibling of the checkout or `~/worktrees/`,
+   never under the clone, never under `/tmp`.
 
 ## References
 

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,382 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,309 bytes
+**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,396 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,498 always-on) because `generate_rules.py`
+116 bytes larger in total (70,585 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,498-byte always-on corpus measured at source. `code-quality` and
+70,585-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,382 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -281,7 +281,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 8.6x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 8.6x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,382 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,382 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,498 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/.github/instructions/universal.instructions.md
+++ b/.github/instructions/universal.instructions.md
@@ -67,7 +67,15 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. Git worktrees MUST be external.
+6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
+   or another external directory; never under it, never under `/tmp`.
+   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
+   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
+   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
+   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
+   reclaims without warning. Harness or plugin defaults nesting under the
+   clone (Claude Code's `.claude/worktrees/`, superpowers'
+   `.worktrees/`) do not override this rule.
 
 ## References
 

--- a/.github/instructions/universal.instructions.md
+++ b/.github/instructions/universal.instructions.md
@@ -67,15 +67,8 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
-   or another external directory; never under it, never under `/tmp`.
-   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
-   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
-   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
-   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
-   reclaims without warning. Harness or plugin defaults nesting under the
-   clone (Claude Code's `.claude/worktrees/`, superpowers'
-   `.worktrees/`) do not override this rule.
+6. Worktrees MUST be external: a sibling of the checkout or `~/worktrees/`,
+   never under the clone, never under `/tmp`.
 
 ## References
 

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -19,14 +19,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 7 rules, 70,382 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,382 bytes |
+| `.github/instructions` | Copilot in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`,
 `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same seven
-rules measure 70,498 bytes at `.claude/rules/`, 116 more, because the generator
+rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator
 drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/docs/autonomous-pr-monitor.md
+++ b/docs/autonomous-pr-monitor.md
@@ -654,7 +654,7 @@ Distinguish stale cache from a real conflict before any refresh:
 PR=2334
 BRANCH="$(python3 .claude/skills/github/scripts/pr/get_pr_context.py --pull-request "$PR" | jq -r .Data.head_branch)"
 BASE="$(python3 .claude/skills/github/scripts/pr/get_pr_context.py --pull-request "$PR" | jq -r .Data.base_branch)"
-WT=".worktrees/pr-$PR"
+WT="../wt-pr-$PR"
 git worktree add "$WT" "$BRANCH"
 git -C "$WT" fetch origin "$BASE"
 
@@ -730,7 +730,7 @@ Workflow (substitute `PR=<number>`, `BRANCH=<branch-name>` as shell variables; a
 ```bash
 PR=2044
 BRANCH="$(python3 .claude/skills/github/scripts/pr/get_pr_context.py --pull-request "$PR" | jq -r .Data.head_branch)"
-WT=".worktrees/pr-$PR"
+WT="../wt-pr-$PR"
 git worktree add "$WT" "$BRANCH"
 git -C "$WT" fetch origin main
 git -C "$WT" merge origin/main --no-edit   # resolve conflicts via merge-resolver skill if needed

--- a/scripts/validation/check_tmp_worktrees.py
+++ b/scripts/validation/check_tmp_worktrees.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Report git worktrees living under the system temp directory, and a low temp floor.
 
-`.claude/rules/universal.md` MUST NOT 6 states the binding rule; its opening
-sentence, verbatim:
+`.claude/rules/universal.md` MUST NOT 6 states the binding rule verbatim:
 
-    Worktrees MUST go in a sibling of the checkout or another external
-    directory; never under it, never under `/tmp`.
+    Worktrees MUST be external: a sibling of the checkout or
+    `~/worktrees/`, never under the clone, never under `/tmp`.
 
 `.serena/memories/git/git-worktree-tmp-not-durable.md` carries the loss: a
 four-conflict resolution for PR #4003 was committed to `/tmp/wt_4003`, `/tmp`

--- a/scripts/validation/check_tmp_worktrees.py
+++ b/scripts/validation/check_tmp_worktrees.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Report git worktrees living under the system temp directory, and a low temp floor.
 
-`.claude/rules/universal.md` MUST NOT 6 states the binding rule verbatim:
+`.claude/rules/universal.md` MUST NOT 6 states the binding rule; its opening
+sentence, verbatim:
 
-    6. Git worktrees MUST be external.
+    Worktrees MUST go in a sibling of the checkout or another external
+    directory; never under it, never under `/tmp`.
 
 `.serena/memories/git/git-worktree-tmp-not-durable.md` carries the loss: a
 four-conflict resolution for PR #4003 was committed to `/tmp/wt_4003`, `/tmp`

--- a/scripts/validation/check_worktree_recipes.py
+++ b/scripts/validation/check_worktree_recipes.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Fail when a tracked prescription tells a reader to create a worktree in a bad place.
 
-`.claude/rules/universal.md` MUST NOT 6 states the binding rule verbatim:
+`.claude/rules/universal.md` MUST NOT 6 states the binding rule; its opening
+sentence, verbatim:
 
-    6. Git worktrees MUST be external.
+    Worktrees MUST go in a sibling of the checkout or another external
+    directory; never under it, never under `/tmp`.
 
 Two destinations break it, and this repository has paid for both:
 

--- a/scripts/validation/check_worktree_recipes.py
+++ b/scripts/validation/check_worktree_recipes.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Fail when a tracked prescription tells a reader to create a worktree in a bad place.
 
-`.claude/rules/universal.md` MUST NOT 6 states the binding rule; its opening
-sentence, verbatim:
+`.claude/rules/universal.md` MUST NOT 6 states the binding rule verbatim:
 
-    Worktrees MUST go in a sibling of the checkout or another external
-    directory; never under it, never under `/tmp`.
+    Worktrees MUST be external: a sibling of the checkout or
+    `~/worktrees/`, never under the clone, never under `/tmp`.
 
 Two destinations break it, and this repository has paid for both:
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after `session-logs
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 7 rules, 70,382 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,382 bytes |
+| `.github/instructions` | Copilot working in this repository | 7 rules, 70,469 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 7 rules, 70,469 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `code-quality`, `knowledge-persistence`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,498 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same seven rules measure 70,585 bytes at `.claude/rules/`, 116 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` or `alwaysApply:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 That agreement is recent and it is load bearing, so keep naming the tree with the number. Until issue #4317 closed, the generator universalized a rule whose scope was entirely internal, which made `governance`, `secret-redaction`, and `session-logs` always-on in the plugin and cost a vendor install 7,532 bytes a turn on three rules pointing at `.agents/` paths the installing repository does not have. PR #4426 replaced that fallback with an explicit skip, so those rules are now absent from the plugin tree rather than universalized in it. The plugin ships 23 instruction files against 28 in `.github/instructions`, and that gap is the fix rather than drift.
 

--- a/src/copilot-cli/instructions/universal.instructions.md
+++ b/src/copilot-cli/instructions/universal.instructions.md
@@ -67,7 +67,15 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. Git worktrees MUST be external.
+6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
+   or another external directory; never under it, never under `/tmp`.
+   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
+   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
+   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
+   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
+   reclaims without warning. Harness or plugin defaults nesting under the
+   clone (Claude Code's `.claude/worktrees/`, superpowers'
+   `.worktrees/`) do not override this rule.
 
 ## References
 

--- a/src/copilot-cli/instructions/universal.instructions.md
+++ b/src/copilot-cli/instructions/universal.instructions.md
@@ -67,15 +67,8 @@ These rules apply to every change in this repository.
    this pattern repeatedly (three corrections as of 2025-12-17). If a script
    grows a helper that emits such headers, delete the helper instead of
    calling it.
-6. **Worktree placement**. Worktrees MUST go in a sibling of the checkout
-   or another external directory; never under it, never under `/tmp`.
-   Convention: `../wt-<topic>`. In-checkout worktrees get walked by every
-   filesystem scan: issue #5370 (107,078 files, `.claude/worktrees/`, 24
-   worktrees/1.6 GB now) and `plugin-self-containment.md` (1,557,567
-   findings). A `/tmp` worktree holds the only unpushed copy, and `/tmp`
-   reclaims without warning. Harness or plugin defaults nesting under the
-   clone (Claude Code's `.claude/worktrees/`, superpowers'
-   `.worktrees/`) do not override this rule.
+6. Worktrees MUST be external: a sibling of the checkout or `~/worktrees/`,
+   never under the clone, never under `/tmp`.
 
 ## References
 

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -175,8 +175,8 @@ as an implementer.
 ## Where this repo stands
 
 Measured on this branch after `session-logs` dropped its optional-session-log mention from `knowledge-persistence`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 7 rules, 70,382 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,309 bytes
+**always-on corpus is 7 rules, 70,469 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,396 bytes
 across 11 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -190,7 +190,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-116 bytes larger in total (70,498 always-on) because `generate_rules.py`
+116 bytes larger in total (70,585 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -210,7 +210,7 @@ always-on file.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 14,152 always-on bytes of book-derived rule, 20.0% of the
-70,498-byte always-on corpus measured at source. `code-quality` and
+70,585-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -258,7 +258,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 7 rules and 70,382 bytes, matching
+`src/copilot-cli/instructions` carries 7 rules and 70,469 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -281,7 +281,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 8.6x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 8.6x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look


### PR DESCRIPTION
## Summary

### What

Make the worktree placement rule actionable and external-only, and fix
the one recipe in the repository that nested a worktree under the clone.

Stacked on #5470. Review that first; this PR's base is
`claude/remove-stale-handoff`.

### Why

`universal.md` MUST NOT 7 read, in full: "Git worktrees MUST be
external." Five words, no path convention, no rationale. That does not
survive contact with a harness default that says otherwise, and two
defaults do: Claude Code places worktrees at `.claude/worktrees/`, and
the superpowers plugin defaults to a project-local `.worktrees/`.

Measured in this checkout right now: `.claude/worktrees/` holds 24 nested
worktrees totalling 1.6 GB. 21 carry unpushed commits. That is the
mechanism behind issue #5370, which measured 107,078 files and 1.35 GB
per scan.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5370 | nested worktrees are what the build_all walk chokes on |
| **Issue** | Refs #5400 | the rule had to shed its evidence to fit the always-on ceiling |

These references do not close their linked items.

## The audit

Every `.md`, `.py`, `.ps1`, `.yaml`, `.yml`, and `.json` in the tree was
classified as guidance-to-nest, accommodation, already-external, or
unrelated.

One real violation: `docs/autonomous-pr-monitor.md:658,734` set
`WT=".worktrees/pr-$PR"` and then ran `git worktree add "$WT"`.

Everything else was already external: `pr-review.md` uses
`../wt-pr-{number}`, `git-advanced-workflows` uses `~/worktrees/`,
`merge-resolver` defaults `worktree_base_path` to `..`, and
`.agents/guides/git-worktree-operating-guide.md` already says never to
nest.

## A gate already exists, and it has a hole

`scripts/validation/check_worktree_recipes.py` is a blocking pre-PR gate
that scans for bad `git worktree add` destinations. It reported 0
violations in 3,155 files both before and after this fix. It missed the
one real violation because the destination was a shell variable rather
than an inline literal. Not changed here; worth its own issue.

## The rule is 122 bytes because that is all the budget allows

The evidence-carrying version measured 611 bytes. With it, the `.py`
instruction lane sat at 98,885 of 99,000 bytes, leaving 115 bytes of
headroom against a 600-byte merge reserve. `instruction_budget.py`
correctly refused it.

Trimmed to 122 bytes, the lane measures 98,396 with 604 bytes of
headroom. A rule can no longer carry its own citations. The dropped
evidence lives in `.claude/commands/pr-review.md:102-108` and in the two
git worktree Serena memories.

That is issue #5400's premise as a hard blocker rather than a
projection, and it is the strongest argument in this stack for doing that
work.

## Testing

`scripts/validation/pre_pr.py` reports "RESULT: All validations passed".
127 tests pass across the corpus-claims and instruction-budget suites.
`check_worktree_recipes.py` reports 0 violations in 3,155 files;
`check_tmp_worktrees.py` reports 0. Both instruction mirrors were
regenerated with `generate_rules.py`, never hand-edited.

Byte figures were updated in three places that hardcode them:
`model-context-doctrine.md`, `canonical-source-mirror.md`, and the
always-on-membership Serena memory.

## Also fixed here

The global operator preference now lives in the user's own instruction
file rather than the plugin cache, so a plugin upgrade cannot overwrite
it. The superpowers skill reads a declared preference before falling back
to `.worktrees/`, which is the supported override path.
