### PR TITLE
fix(github): route stacked-PR merges to the REST fallback

### DIFF
--- a/.claude/skills/github/scripts/pr/merge_pr.py
+++ b/.claude/skills/github/scripts/pr/merge_pr.py
@@ -34,7 +34,7 @@ import json
 import os
 import subprocess
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 _plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")
@@ -104,6 +104,11 @@ _STRATEGY_TO_REPO_FIELD = {
 _STRATEGY_PREFERENCE = ("squash", "merge", "rebase")
 
 _BLOCKED_KEYWORDS = ("BLOCKED", "branch protection", "required status check")
+
+# Issue #5473: GraphQL refuses outright for a PR GitHub considers part of a
+# stack and names the REST endpoint _rest_merge already calls. Retargeting the
+# child to break the stack is refused too, so REST is the only path.
+_STACK_KEYWORDS = ("part of a stack", "asynchronous merge REST API")
 
 
 def get_allowed_merge_methods(repo_flag: str) -> dict[str, bool]:
@@ -199,8 +204,13 @@ def _emit_error(
     error_type: str,
     output_format: str,
     pr: int,
-) -> None:
-    """Helper: emit envelope, then exit with the code."""
+) -> NoReturn:
+    """Helper: emit envelope, then exit with the code.
+
+    Annotated NoReturn because the body always raises SystemExit. Declaring
+    None made callers look like they fall through, so a narrowed value stayed
+    optional past the call (issue #5473).
+    """
     write_skill_error(
         message,
         code,
@@ -353,6 +363,31 @@ def _rest_merge(
     )
 
 
+def _pr_is_merged(pr: int, repo_flag: str) -> bool:
+    """Return True when GitHub reports the PR as merged.
+
+    Issue #5473: the asynchronous REST merge used for stacked PRs can return
+    success without ``merged: true`` in the body.  Treating a missing flag as
+    failure would report a completed merge as an error, so ask GitHub for the
+    PR's state instead of inferring it.  Any query failure returns False so an
+    unverified merge is never reported as a success.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--repo", repo_flag, "--json", "state"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        return bool(json.loads(result.stdout).get("state") == "MERGED")
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
 def _handle_merge_failure(
     merge_result: subprocess.CompletedProcess[str],
     pr: int,
@@ -375,17 +410,30 @@ def _handle_merge_failure(
     output = merge_result.stderr or merge_result.stdout
     if any(kw in output for kw in ("not mergeable", "cannot be merged", "conflicts")):
         _emit_error(f"PR #{pr} is not mergeable: {output}", 6, "General", output_format, pr)
-    if not auto and any(kw in output for kw in _BLOCKED_KEYWORDS):
-        # GraphQL refused with a BLOCKED policy error; retry via REST once.
+    is_stack = any(kw in output for kw in _STACK_KEYWORDS)
+    if not auto and (is_stack or any(kw in output for kw in _BLOCKED_KEYWORDS)):
+        # GraphQL refused with a BLOCKED policy or stack error; retry via REST once.
         rest_result = _rest_merge(pr, repo_flag, strategy, head_sha, subject, body)
         if rest_result.returncode == 0:
             try:
                 rest_data = json.loads(rest_result.stdout)
             except json.JSONDecodeError:
                 rest_data = {}
-            if rest_data.get("merged"):
+            # The asynchronous merge accepts the request without reporting
+            # merged=true, so a missing flag is not a failure. Confirm against
+            # the PR's own merged state instead of assuming either way.
+            if rest_data.get("merged") or _pr_is_merged(pr, repo_flag):
                 return
         # REST also failed; surface the original GraphQL error.
+        if is_stack:
+            _emit_error(
+                f"PR #{pr} is part of a stack and the asynchronous REST merge did "
+                f"not complete it: {output}",
+                6,
+                "General",
+                output_format,
+                pr,
+            )
         _emit_error(
             f"PR #{pr} is blocked by branch protection policy: {output}\n"
             "Hint: use --auto to enable auto-merge when checks pass.",

--- a/src/copilot-cli/skills/github/scripts/pr/merge_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/merge_pr.py
@@ -34,7 +34,7 @@ import json
 import os
 import subprocess
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 _plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")
@@ -104,6 +104,11 @@ _STRATEGY_TO_REPO_FIELD = {
 _STRATEGY_PREFERENCE = ("squash", "merge", "rebase")
 
 _BLOCKED_KEYWORDS = ("BLOCKED", "branch protection", "required status check")
+
+# Issue #5473: GraphQL refuses outright for a PR GitHub considers part of a
+# stack and names the REST endpoint _rest_merge already calls. Retargeting the
+# child to break the stack is refused too, so REST is the only path.
+_STACK_KEYWORDS = ("part of a stack", "asynchronous merge REST API")
 
 
 def get_allowed_merge_methods(repo_flag: str) -> dict[str, bool]:
@@ -199,8 +204,13 @@ def _emit_error(
     error_type: str,
     output_format: str,
     pr: int,
-) -> None:
-    """Helper: emit envelope, then exit with the code."""
+) -> NoReturn:
+    """Helper: emit envelope, then exit with the code.
+
+    Annotated NoReturn because the body always raises SystemExit. Declaring
+    None made callers look like they fall through, so a narrowed value stayed
+    optional past the call (issue #5473).
+    """
     write_skill_error(
         message,
         code,
@@ -353,6 +363,31 @@ def _rest_merge(
     )
 
 
+def _pr_is_merged(pr: int, repo_flag: str) -> bool:
+    """Return True when GitHub reports the PR as merged.
+
+    Issue #5473: the asynchronous REST merge used for stacked PRs can return
+    success without ``merged: true`` in the body.  Treating a missing flag as
+    failure would report a completed merge as an error, so ask GitHub for the
+    PR's state instead of inferring it.  Any query failure returns False so an
+    unverified merge is never reported as a success.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--repo", repo_flag, "--json", "state"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        return bool(json.loads(result.stdout).get("state") == "MERGED")
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
 def _handle_merge_failure(
     merge_result: subprocess.CompletedProcess[str],
     pr: int,
@@ -375,17 +410,30 @@ def _handle_merge_failure(
     output = merge_result.stderr or merge_result.stdout
     if any(kw in output for kw in ("not mergeable", "cannot be merged", "conflicts")):
         _emit_error(f"PR #{pr} is not mergeable: {output}", 6, "General", output_format, pr)
-    if not auto and any(kw in output for kw in _BLOCKED_KEYWORDS):
-        # GraphQL refused with a BLOCKED policy error; retry via REST once.
+    is_stack = any(kw in output for kw in _STACK_KEYWORDS)
+    if not auto and (is_stack or any(kw in output for kw in _BLOCKED_KEYWORDS)):
+        # GraphQL refused with a BLOCKED policy or stack error; retry via REST once.
         rest_result = _rest_merge(pr, repo_flag, strategy, head_sha, subject, body)
         if rest_result.returncode == 0:
             try:
                 rest_data = json.loads(rest_result.stdout)
             except json.JSONDecodeError:
                 rest_data = {}
-            if rest_data.get("merged"):
+            # The asynchronous merge accepts the request without reporting
+            # merged=true, so a missing flag is not a failure. Confirm against
+            # the PR's own merged state instead of assuming either way.
+            if rest_data.get("merged") or _pr_is_merged(pr, repo_flag):
                 return
         # REST also failed; surface the original GraphQL error.
+        if is_stack:
+            _emit_error(
+                f"PR #{pr} is part of a stack and the asynchronous REST merge did "
+                f"not complete it: {output}",
+                6,
+                "General",
+                output_format,
+                pr,
+            )
         _emit_error(
             f"PR #{pr} is blocked by branch protection policy: {output}\n"
             "Hint: use --auto to enable auto-merge when checks pass.",

--- a/tests/test_merge_pr.py
+++ b/tests/test_merge_pr.py
@@ -1155,3 +1155,144 @@ class TestRestRetryOnBlocked:
         assert rc == 0
         # Only two calls: state fetch and gh pr merge; no REST retry
         assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: REST retry on stacked PRs (issue #5473)
+# ---------------------------------------------------------------------------
+
+
+_STACK_ERROR = (
+    "GraphQL: This pull request is part of a stack and must be merged using the "
+    "asynchronous merge REST API. For more information, see "
+    "https://docs.github.com/rest/pulls/pulls#merge-a-pull-request-asynchronously "
+    "(mergePullRequest)\n"
+)
+
+
+class TestRestRetryOnStack:
+    """A stack refusal routes to the REST merge path (issue #5473).
+
+    GraphQL refuses a stacked PR outright and GitHub also refuses to retarget
+    the child, so REST is the only merge path. The refusal text contains none
+    of the BLOCKED keywords, so before this change the retry never ran.
+    """
+
+    _STATE = json.dumps({
+        "state": "OPEN", "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN", "headRefName": "feature",
+        "headRefOid": "abc123def456",
+    })
+
+    def _make_side_effect(self, rest_rc, rest_stdout="", view_state=None, view_rc=0):
+        """Sequence the state fetch, the GraphQL refusal, REST, and the state re-read."""
+        calls = []
+
+        def _side(cmd, **kwargs):
+            calls.append(cmd)
+            if len(calls) == 1:
+                return _completed(stdout=self._STATE, rc=0)
+            if len(calls) == 2:
+                return _completed(rc=1, stderr=_STACK_ERROR)
+            if len(calls) == 3:
+                return _completed(rc=rest_rc, stdout=rest_stdout)
+            # call 4: gh pr view --json state, the merged-state confirmation
+            return _completed(rc=view_rc, stdout=view_state or "")
+
+        return _side, calls
+
+    def _run(self, side, argv):
+        with patch("merge_pr.assert_gh_authenticated"), \
+             patch("merge_pr.resolve_repo_params", return_value=RepoInfo(owner="o", repo="r")), \
+             patch("merge_pr.get_allowed_merge_methods", return_value=_ALL_METHODS_ALLOWED), \
+             patch("subprocess.run", side_effect=side):
+            return main(argv)
+
+    def test_stack_error_retries_rest_and_succeeds(self, capsys):
+        """REST reporting merged=true needs no state confirmation."""
+        side, calls = self._make_side_effect(
+            rest_rc=0, rest_stdout=json.dumps({"merged": True, "sha": "abc123def456"}),
+        )
+        rc = self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["Data"]["state"] == "MERGED"
+        # State fetch, GraphQL merge, REST PUT. No confirmation call needed.
+        assert len(calls) == 3
+
+    def test_stack_error_routes_to_rest_put_endpoint(self):
+        """The retry must hit the REST endpoint the GraphQL error names."""
+        side, calls = self._make_side_effect(
+            rest_rc=0, rest_stdout=json.dumps({"merged": True}),
+        )
+        self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        rest_cmd = [str(part) for part in calls[2]]
+        assert "PUT" in rest_cmd
+        assert any("pulls/5470/merge" in part for part in rest_cmd)
+        assert any("abc123def456" in part for part in rest_cmd)
+
+    def test_async_response_without_merged_flag_confirms_state(self, capsys):
+        """An async accept omits merged=true; the PR state settles it."""
+        side, calls = self._make_side_effect(
+            rest_rc=0,
+            rest_stdout=json.dumps({"sha": "abc123def456"}),
+            view_state=json.dumps({"state": "MERGED"}),
+        )
+        rc = self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["Data"]["state"] == "MERGED"
+        # The fourth call is the merged-state confirmation.
+        assert len(calls) == 4
+
+    def test_async_response_with_unparseable_body_confirms_state(self):
+        """A non-JSON body is not evidence of failure; confirm the state."""
+        side, calls = self._make_side_effect(
+            rest_rc=0,
+            rest_stdout="Accepted",
+            view_state=json.dumps({"state": "MERGED"}),
+        )
+        assert self._run(side, ["--pull-request", "5470", "--strategy", "squash"]) == 0
+        assert len(calls) == 4
+
+    def test_async_accept_that_did_not_merge_exits_6(self, capsys):
+        """REST accepted but the PR is still open: report failure, not success."""
+        side, _ = self._make_side_effect(
+            rest_rc=0,
+            rest_stdout=json.dumps({"sha": "abc123def456"}),
+            view_state=json.dumps({"state": "OPEN"}),
+        )
+        with pytest.raises(SystemExit) as exc:
+            self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        assert exc.value.code == 6
+        assert "part of a stack" in capsys.readouterr().out
+
+    def test_state_confirmation_failure_is_not_a_merge(self):
+        """A failed confirmation query must never be read as merged."""
+        side, _ = self._make_side_effect(
+            rest_rc=0,
+            rest_stdout=json.dumps({"sha": "abc123def456"}),
+            view_rc=1,
+        )
+        with pytest.raises(SystemExit) as exc:
+            self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        assert exc.value.code == 6
+
+    def test_stack_rest_failure_exits_6_and_names_the_stack(self, capsys):
+        """A failed REST retry surfaces the stack cause, not a protection hint."""
+        side, _ = self._make_side_effect(rest_rc=1, rest_stdout="")
+        with pytest.raises(SystemExit) as exc:
+            self._run(side, ["--pull-request", "5470", "--strategy", "squash"])
+        assert exc.value.code == 6
+        out = capsys.readouterr().out
+        assert "part of a stack" in out
+        assert "branch protection policy" not in out
+
+    def test_auto_does_not_retry_rest_on_stack_error(self):
+        """--auto keeps its existing no-retry behavior for stack errors too."""
+        side, calls = self._make_side_effect(rest_rc=0, rest_stdout="")
+        with pytest.raises(SystemExit) as exc:
+            self._run(side, ["--pull-request", "5470", "--auto"])
+        assert exc.value.code == 3
+        # State fetch and gh pr merge only; no REST retry.
+        assert len(calls) == 2


### PR DESCRIPTION
## Problem

`merge_pr.py` dead-ends on any PR GitHub considers part of a stack. Hit live during a `pr-autofix` run: PRs #5470 and #5471 both classified T1, cleared every gate, then failed at the merge command with a message the script treated as terminal.

```
Failed to merge PR #5470: GraphQL: This pull request is part of a stack and must be
merged using the asynchronous merge REST API. (mergePullRequest)
```

Breaking the stack by retargeting the child is refused too:

```
GraphQL: Cannot change the base branch because the pull request is part of a stack. (updatePullRequest)
```

## Root cause of the dead end

`_rest_merge` was reachable only through one keyword gate:

```python
_BLOCKED_KEYWORDS = ("BLOCKED", "branch protection", "required status check")
...
if not auto and any(kw in output for kw in _BLOCKED_KEYWORDS):
```

The stack refusal contains none of those substrings, so no fallback ran at all and the operator got a GraphQL error with no next step.

## What this PR does, and what it does not

It routes the stack refusal to the existing `_rest_merge` retry and reports the outcome honestly. It does **not** make stacked PRs mergeable.

Measured after this change, against PR #5471 (T1, CLEAN, base `main`, parent already merged):

```
PR #5471 is part of a stack and the asynchronous REST merge did not complete it:
GraphQL: This pull request is part of a stack and must be merged using the
asynchronous merge REST API. (mergePullRequest)
```

So `PUT /repos/{owner}/{repo}/pulls/{n}/merge`, the endpoint `_rest_merge` calls, is not the asynchronous API GitHub's message points at. Identifying and wiring that API is follow-up work tracked on #5473; this PR deliberately stops at making the failure accurate and the retry path exist, rather than shipping an untested guess at a second endpoint.

The value delivered is narrower than "stacked PRs now merge":

- The operator gets a message naming the stack and stating the REST attempt was made and did not complete, instead of a raw GraphQL string that looks like a transient API error.
- The retry path exists and is covered, so wiring the correct endpoint later is a one-line change to `_rest_merge` rather than a re-plumb.

## Changes

- `_STACK_KEYWORDS` routes the stack refusal to the single `_rest_merge` retry.
- `_pr_is_merged` confirms the outcome against the PR's own state. An asynchronous merge can return success without `merged: true`, so a missing flag is not a failure; a failed confirmation query is not a success.
- A failed retry on a stack reports the stack cause instead of a branch-protection hint that does not apply.
- `_emit_error` is annotated `NoReturn`. Its body always raises `SystemExit`, but the `None` annotation made callers look like they fall through, which left `repo_settings` optional past the call and failed the mypy ratchet at line 465.

`not mergeable` and `--auto` keep their existing no-retry behavior.

## Verification

`tests/test_merge_pr.py::TestRestRetryOnStack`, 8 cases: REST-reports-merged, endpoint and SHA pinning, async accept without the flag, unparseable body, accept-that-did-not-merge, failed confirmation query, failed REST retry, and `--auto` no-retry.

Negative control: with the `merge_pr.py` change stashed, 7 of the 8 fail. The 8th (`--auto` no-retry) passes either way by design, since it pins behavior this change must not alter.

- `uv run pytest tests/test_merge_pr.py` : 59 passed
- `uv run mypy .claude/skills/github/scripts/pr/merge_pr.py` : clean
- `uv run ruff check` : clean
- `uv run python scripts/validation/pre_pr.py` : all validations passed
- Live run against PR #5471: routed to REST as designed, REST did not merge, exit 6 with the stack-specific message

## Noticed, not fixed

`tests/test_merge_pr.py` is 1298 lines and trips the advisory taste-lint file-size check at 500. It was already over at 1157 before this change. Splitting it is a separate change and would conflict with anyone else editing the file.

Refs #5473
