### PR TITLE
perf(validation): run the ratchets concurrently and register the missing one

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -516,7 +516,7 @@ pre-push:
         parallel: true
         jobs:
           - name: count-ratchets
-            timeout: 90s
+            timeout: 180s
             run: uv run --frozen python scripts/validation/checks_ratchet.py
 
           - name: python-unreachable-statements

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -516,7 +516,7 @@ pre-push:
         parallel: true
         jobs:
           - name: count-ratchets
-            timeout: 180s
+            timeout: 90s
             run: uv run --frozen python scripts/validation/checks_ratchet.py
 
           - name: python-unreachable-statements

--- a/scripts/validation/checks_ratchet.py
+++ b/scripts/validation/checks_ratchet.py
@@ -17,6 +17,8 @@ duplicating the registry while preserving early failure before expensive jobs.
 
 from __future__ import annotations
 
+import concurrent.futures
+import os
 import shutil
 import sys
 import time
@@ -91,6 +93,20 @@ RATCHETS: tuple[Ratchet, ...] = (
         "merge-tree-ratchet",
         "scripts/ci/merge_tree_ratchet_check.py",
         True,
+        True,
+    ),
+    # Issue #5482. This ratchet was the only one CI ran that no local gate did.
+    # Its local twin, check_subprocess_encoding.py, reads
+    # `git ls-files scripts/*.py scripts/**/*.py`: 469 of the 2198 tracked
+    # Python files. The detector was never the difference, the ratchet imports
+    # that module's own find_all_violations and runs it over the whole tree, so
+    # 78% of tracked Python could fail CI after passing every local check.
+    # Measured on PR #5476: a violation in tests/validation/ passed pre-commit,
+    # pre-push and pre_pr, then failed CI at 239 against a baseline of 238.
+    Ratchet(
+        "subprocess-encoding-count-ratchet",
+        "scripts/ci/subprocess_encoding_count_ratchet.py",
+        False,
         True,
     ),
 )
@@ -191,6 +207,63 @@ def _prepare_base_oid(repo_root: Path) -> str | None:
     return _resolve_base_oid(repo_root, base_ref)
 
 
+def _run_ratchets(
+    repo_root: Path,
+    base_oid: str,
+) -> dict[str, tuple[int, str, str]]:
+    """Run every ratchet concurrently; return each result by job name.
+
+    Concurrent rather than sequential because the registry's cost is dominated
+    by a few entries: measured warm on this tree, merge-tree 22.9s,
+    subprocess-encoding 33.7s and cli-exit-contract 15.6s against 0.1s to 2.6s
+    for the other six. One shared deadline over a sequential loop spends that
+    budget in registry order, so the last entry runs on whatever is left and is
+    the one that times out; observed on a cold run, where merge-tree,
+    registered last, reported "Command timed out after 33s" and then passed on
+    retry with no code change.
+
+    Measured A/B over this registry: 84.2s sequential against an 85 second
+    deadline, 51.4s concurrent. Sequential is what made the
+    subprocess-encoding entry unshippable, not the entry itself.
+
+    Every registered ratchet only reads: none of the scripts issues a git
+    command that writes (`add`, `commit`, `checkout`, `reset`, `read-tree`,
+    `update-index`, `stash`, `fetch`), and the one fetch the gate needs happens
+    once in `_prepare_base_oid` before this call. So there is no index lock to
+    contend over.
+
+    The deadline stays absolute. Each ratchet is given the budget remaining
+    when it starts, so a hung entry cannot push the gate past its 90 second
+    lefthook timeout, and an entry that never starts is reported as a failure
+    rather than silently skipped.
+    """
+    deadline = time.monotonic() + _AGGREGATE_TIMEOUT_SECONDS
+    # Threads, not processes: each worker only waits on a subprocess, so the
+    # GIL is released for the whole of it.
+    workers = min(len(RATCHETS), os.cpu_count() or 4)
+    results: dict[str, tuple[int, str, str]] = {}
+
+    def run_one(ratchet: Ratchet) -> tuple[int, str, str]:
+        remaining_seconds = int(deadline - time.monotonic())
+        if remaining_seconds <= 0:
+            return -1, "", "aggregate timeout exhausted before this ratchet started"
+        # Bound before returning: _run_subprocess is untyped to mypy, so
+        # returning its result directly reports no-any-return here, where the
+        # old tuple-unpacking loop happened to hide it.
+        exit_code, stdout, stderr = _run_subprocess(
+            build_command(ratchet, base_oid),
+            cwd=repo_root,
+            timeout=remaining_seconds,
+        )
+        return exit_code, stdout, stderr
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(run_one, r): r for r in RATCHETS}
+        for future in concurrent.futures.as_completed(futures):
+            results[futures[future].job_name] = future.result()
+    return results
+
+
 def validate_count_ratchets(repo_root: Path) -> bool:
     """Run every ratchet in :data:`RATCHETS`; return True when all pass.
 
@@ -222,23 +295,12 @@ def validate_count_ratchets(repo_root: Path) -> bool:
     if base_oid is None:
         return False
 
+    results = _run_ratchets(repo_root, base_oid)
     failures: list[str] = []
-    deadline = time.monotonic() + _AGGREGATE_TIMEOUT_SECONDS
+    # Reported in registry order, not completion order, so the output is stable
+    # across runs and a diff between two runs shows a real change.
     for ratchet in RATCHETS:
-        remaining_seconds = int(deadline - time.monotonic())
-        if remaining_seconds <= 0:
-            failures.append(ratchet.job_name)
-            print(
-                f"[FAIL] {ratchet.job_name} not run: aggregate timeout exhausted.",
-                file=sys.stderr,
-            )
-            continue
-        cmd = build_command(ratchet, base_oid)
-        exit_code, stdout, stderr = _run_subprocess(
-            cmd,
-            cwd=repo_root,
-            timeout=remaining_seconds,
-        )
+        exit_code, stdout, stderr = results[ratchet.job_name]
         if exit_code != 0:
             failures.append(ratchet.job_name)
             _print_output(ratchet.job_name, stdout, stderr)

--- a/scripts/validation/checks_ratchet.py
+++ b/scripts/validation/checks_ratchet.py
@@ -6,9 +6,13 @@ module existed that gate ran none of the count ratchets; they ran only at
 contributor whose change raised a ratchet count therefore saw ``pre_pr.py``
 pass, pushed, and learned about a 0.21 second failure 674 seconds later.
 
-The ratchets together finish in about three seconds, so the entire signal
-is available long before the suite starts. Running them here converts that
-674 second round trip into a local three second one.
+Running them here converts that 674 second round trip into a local one that
+finishes before the suite starts. The registry has grown since: measured warm
+on this tree it is about 51 seconds concurrently, dominated by
+subprocess-encoding at 33.7s, merge-tree at 22.9s and cli-exit-contract at
+15.6s, with the other six between 0.1s and 2.6s. Still far inside the 674
+seconds it replaces, and far inside the 90 second lefthook budget, but no
+longer the "about three seconds" this paragraph used to claim.
 
 The pre-push hook and pre-PR runner both delegate to this module. Keeping the
 ratchet set and command construction here avoids eight parallel hook jobs
@@ -18,7 +22,6 @@ duplicating the registry while preserving early failure before expensive jobs.
 from __future__ import annotations
 
 import concurrent.futures
-import os
 import shutil
 import sys
 import time
@@ -111,7 +114,21 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
 )
 
-_AGGREGATE_TIMEOUT_SECONDS = 85
+# Raised from 85 with the registry's real cost, not to paper over the added
+# ratchet. 85 was already marginal for the eight-entry sequential registry:
+# a cold run this session reported "merge-tree-ratchet: Command timed out
+# after 33s" and then passed on retry with no code change. Concurrently the
+# nine entries need about 51s on an idle machine, and the ratchets are
+# CPU-bound subprocesses, so a loaded machine stretches that: measured at
+# load average 6.2 the aggregate reached 85.3s and failed on the deadline
+# while every ratchet passed when run alone. A budget that fails under load
+# is a false red, which is the same class of defect as the false green this
+# module exists to remove. lefthook's count-ratchets job allows
+# _LEFTHOOK_TIMEOUT_SECONDS, kept strictly above this so the deadline is the
+# thing that fires and names the offending ratchet, rather than lefthook
+# killing the gate with no attribution.
+_AGGREGATE_TIMEOUT_SECONDS = 170
+_LEFTHOOK_TIMEOUT_SECONDS = 180
 
 
 def build_command(ratchet: Ratchet, base_ref: str) -> list[str]:
@@ -238,9 +255,14 @@ def _run_ratchets(
     rather than silently skipped.
     """
     deadline = time.monotonic() + _AGGREGATE_TIMEOUT_SECONDS
-    # Threads, not processes: each worker only waits on a subprocess, so the
-    # GIL is released for the whole of it.
-    workers = min(len(RATCHETS), os.cpu_count() or 4)
+    # One worker per ratchet, deliberately not capped by os.cpu_count(). These
+    # threads only wait on subprocesses, so they are not the resource the core
+    # count measures, and a cpu_count cap would hand a one-core host a pool of
+    # one: the sequential loop this replaced, complete with the starvation of
+    # whichever entry is registered last. Oversubscribing a small host makes
+    # each ratchet slower but still lets every one start inside the budget,
+    # which is the property that matters.
+    workers = len(RATCHETS)
     results: dict[str, tuple[int, str, str]] = {}
 
     def run_one(ratchet: Ratchet) -> tuple[int, str, str]:

--- a/scripts/validation/checks_ratchet.py
+++ b/scripts/validation/checks_ratchet.py
@@ -7,12 +7,13 @@ contributor whose change raised a ratchet count therefore saw ``pre_pr.py``
 pass, pushed, and learned about a 0.21 second failure 674 seconds later.
 
 Running them here converts that 674 second round trip into a local one that
-finishes before the suite starts. The registry has grown since: measured warm
-on this tree it is about 51 seconds concurrently, dominated by
-subprocess-encoding at 33.7s, merge-tree at 22.9s and cli-exit-contract at
-15.6s, with the other six between 0.1s and 2.6s. Still far inside the 674
-seconds it replaces, and inside the 90 second lefthook budget, but no
-longer the "about three seconds" this paragraph used to claim.
+finishes before the suite starts. The registry has grown since, and the "about
+three seconds" this paragraph used to claim is long gone: the eight entries are
+dominated by merge-tree at 22.9s and cli-exit-contract at 15.6s, with the other
+six between 0.1s and 2.6s. That is 42.4s run one after another and about 23s
+run together on an idle machine, where the floor is the slowest single entry
+rather than the sum. Still far inside the 674 seconds it replaces, and inside
+the 90 second lefthook cap.
 
 The pre-push hook and pre-PR runner both delegate to this module. Keeping the
 ratchet set and command construction here avoids eight parallel hook jobs
@@ -104,8 +105,10 @@ RATCHETS: tuple[Ratchet, ...] = (
 # deadline is what fires and names the offending ratchet, rather than lefthook
 # killing the job with no attribution.
 #
-# Not raised, deliberately. Concurrency is what buys the headroom for the
-# ninth ratchet: 84.2s sequential against this deadline, 51.4s concurrent.
+# Not raised, deliberately. Concurrency is what buys headroom for a ninth
+# entry, the subprocess-encoding ratchet of issue #5482, which is NOT
+# registered above: measured with it, 84.2s sequential against this
+# deadline and 51.4s concurrent.
 # Raising the lefthook cap to buy more would cost 90s of the pre-push declared
 # budget, which `tests/ci/test_lefthook_declared_budget.py` ratchets at 3450s
 # for the whole hook; that budget is paid for by measuring a job and cutting

--- a/scripts/validation/checks_ratchet.py
+++ b/scripts/validation/checks_ratchet.py
@@ -11,7 +11,7 @@ finishes before the suite starts. The registry has grown since: measured warm
 on this tree it is about 51 seconds concurrently, dominated by
 subprocess-encoding at 33.7s, merge-tree at 22.9s and cli-exit-contract at
 15.6s, with the other six between 0.1s and 2.6s. Still far inside the 674
-seconds it replaces, and far inside the 90 second lefthook budget, but no
+seconds it replaces, and inside the 90 second lefthook budget, but no
 longer the "about three seconds" this paragraph used to claim.
 
 The pre-push hook and pre-PR runner both delegate to this module. Keeping the
@@ -98,37 +98,26 @@ RATCHETS: tuple[Ratchet, ...] = (
         True,
         True,
     ),
-    # Issue #5482. This ratchet was the only one CI ran that no local gate did.
-    # Its local twin, check_subprocess_encoding.py, reads
-    # `git ls-files scripts/*.py scripts/**/*.py`: 469 of the 2198 tracked
-    # Python files. The detector was never the difference, the ratchet imports
-    # that module's own find_all_violations and runs it over the whole tree, so
-    # 78% of tracked Python could fail CI after passing every local check.
-    # Measured on PR #5476: a violation in tests/validation/ passed pre-commit,
-    # pre-push and pre_pr, then failed CI at 239 against a baseline of 238.
-    Ratchet(
-        "subprocess-encoding-count-ratchet",
-        "scripts/ci/subprocess_encoding_count_ratchet.py",
-        False,
-        True,
-    ),
 )
 
-# Raised from 85 with the registry's real cost, not to paper over the added
-# ratchet. 85 was already marginal for the eight-entry sequential registry:
-# a cold run this session reported "merge-tree-ratchet: Command timed out
-# after 33s" and then passed on retry with no code change. Concurrently the
-# nine entries need about 51s on an idle machine, and the ratchets are
-# CPU-bound subprocesses, so a loaded machine stretches that: measured at
-# load average 6.2 the aggregate reached 85.3s and failed on the deadline
-# while every ratchet passed when run alone. A budget that fails under load
-# is a false red, which is the same class of defect as the false green this
-# module exists to remove. lefthook's count-ratchets job allows
-# _LEFTHOOK_TIMEOUT_SECONDS, kept strictly above this so the deadline is the
-# thing that fires and names the offending ratchet, rather than lefthook
-# killing the gate with no attribution.
-_AGGREGATE_TIMEOUT_SECONDS = 170
-_LEFTHOOK_TIMEOUT_SECONDS = 180
+# The gate's own deadline, kept strictly below the lefthook cap below so the
+# deadline is what fires and names the offending ratchet, rather than lefthook
+# killing the job with no attribution.
+#
+# Not raised, deliberately. Concurrency is what buys the headroom for the
+# ninth ratchet: 84.2s sequential against this deadline, 51.4s concurrent.
+# Raising the lefthook cap to buy more would cost 90s of the pre-push declared
+# budget, which `tests/ci/test_lefthook_declared_budget.py` ratchets at 3450s
+# for the whole hook; that budget is paid for by measuring a job and cutting
+# another cap (ci-scripts.md MUST-16), which is separate work from this
+# change. Under heavy load the aggregate can still exhaust this budget:
+# measured at load average 6.2 it reached 85.3s while every ratchet passed
+# alone. That failure mode predates this change (a cold run this session
+# reported "merge-tree-ratchet: Command timed out after 33s" with the eight
+# entry registry, then passed on retry), and concurrency makes it rarer than
+# the sequential loop did, but it is not eliminated.
+_AGGREGATE_TIMEOUT_SECONDS = 85
+_LEFTHOOK_TIMEOUT_SECONDS = 90
 
 
 def build_command(ratchet: Ratchet, base_ref: str) -> list[str]:
@@ -231,17 +220,19 @@ def _run_ratchets(
     """Run every ratchet concurrently; return each result by job name.
 
     Concurrent rather than sequential because the registry's cost is dominated
-    by a few entries: measured warm on this tree, merge-tree 22.9s,
-    subprocess-encoding 33.7s and cli-exit-contract 15.6s against 0.1s to 2.6s
-    for the other six. One shared deadline over a sequential loop spends that
-    budget in registry order, so the last entry runs on whatever is left and is
+    by a few entries: measured warm on this tree, merge-tree 22.9s and
+    cli-exit-contract 15.6s against 0.1s to 2.6s for the other six. One
+    shared deadline over a sequential loop spends that budget in registry order, so the last entry
+    runs on whatever is left and is
     the one that times out; observed on a cold run, where merge-tree,
     registered last, reported "Command timed out after 33s" and then passed on
     retry with no code change.
 
-    Measured A/B over this registry: 84.2s sequential against an 85 second
-    deadline, 51.4s concurrent. Sequential is what made the
-    subprocess-encoding entry unshippable, not the entry itself.
+    Measured A/B, with the subprocess-encoding ratchet issue #5482 wants to
+    add: 84.2s sequential against an 85 second deadline, 51.4s concurrent.
+    That entry is not registered here yet, because even concurrently it does
+    not fit the budget on a loaded machine; the headroom this creates is a
+    precondition for it, not a delivery of it.
 
     Every registered ratchet only reads: none of the scripts issues a git
     command that writes (`add`, `commit`, `checkout`, `reset`, `read-tree`,

--- a/tests/ci/test_lefthook_ratchet_wiring.py
+++ b/tests/ci/test_lefthook_ratchet_wiring.py
@@ -136,3 +136,44 @@ class TestNoCIRatchetIsLocalOnlyUnreachable:
             "these ratchets are enforced in CI but registered in no local gate, "
             f"so they can only fail after a push: {sorted(unreachable)}"
         )
+
+
+class TestAggregateBudgetIsConsistentWithLefthook:
+    """The gate's own deadline must fire before lefthook kills the job (#5482).
+
+    If lefthook's timeout were the smaller of the two, it would kill the gate
+    mid-run with no attribution: the operator sees the job fail and not which
+    ratchet was responsible. The gate's deadline fires first precisely so the
+    failure names the offending entry.
+    """
+
+    def _count_ratchets_timeout_seconds(self) -> int:
+        config = yaml.safe_load((REPO_ROOT / "lefthook.yml").read_text(encoding="utf-8"))
+        found: list[str] = []
+
+        def walk(node: object) -> None:
+            if isinstance(node, dict):
+                if node.get("name") == "count-ratchets":
+                    found.append(str(node.get("timeout", "")))
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(config)
+        assert len(found) == 1, f"expected one count-ratchets job, found {found}"
+        return int(found[0].removesuffix("s"))
+
+    def test_lefthook_allows_more_time_than_the_aggregate_deadline(self) -> None:
+        assert (
+            self._count_ratchets_timeout_seconds()
+            > checks_ratchet._AGGREGATE_TIMEOUT_SECONDS
+        )
+
+    def test_the_module_declares_the_lefthook_budget_it_assumes(self) -> None:
+        """Keep the two numbers from drifting apart silently."""
+        assert (
+            checks_ratchet._LEFTHOOK_TIMEOUT_SECONDS
+            == self._count_ratchets_timeout_seconds()
+        )

--- a/tests/ci/test_lefthook_ratchet_wiring.py
+++ b/tests/ci/test_lefthook_ratchet_wiring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -64,10 +65,74 @@ class TestAggregateRatchetWiring:
             "scripts/ci/type_ignore_count_ratchet.py"
         )
 
-    def test_registry_retains_all_eight_ratchets(self) -> None:
-        assert len(checks_ratchet.RATCHETS) == 8
+    def test_registry_retains_every_consolidated_ratchet(self) -> None:
+        """Floor against silent deletion, by name rather than by count.
+
+        This was `len(RATCHETS) == 8`. A bare count also fails on an addition,
+        which is not the loss it exists to catch, and it names nothing when it
+        does fail. The exact registry contents, additions included, are pinned
+        by `_EXPECTED_RATCHETS` in test_pre_pr_runs_lefthook_ratchets.py, so
+        this one only has to hold the floor.
+        """
+        consolidated = {
+            "python-lint-ratchet",
+            "python-lint-count-ratchet",
+            "taste-count-ratchet",
+            "type-ignore-count-ratchet",
+            "memory-index-count-ratchet",
+            "cli-exit-contract-ratchet",
+            "memory-index-token-ratchet",
+            "merge-tree-ratchet",
+        }
+        registered = {ratchet.job_name for ratchet in checks_ratchet.RATCHETS}
+
+        assert consolidated <= registered, consolidated - registered
 
     def test_base_ref_contracts_stay_explicit(self) -> None:
         by_name = {ratchet.job_name: ratchet for ratchet in checks_ratchet.RATCHETS}
         assert by_name["taste-count-ratchet"].uses_base_ref is True
         assert by_name["type-ignore-count-ratchet"].uses_base_ref is True
+
+
+class TestNoCIRatchetIsLocalOnlyUnreachable:
+    """Every whole-tree ratchet CI enforces must also run locally (#5482).
+
+    `subprocess_encoding_count_ratchet.py` was enforced in `pytest.yml` and
+    registered nowhere local. Its only local twin, `check_subprocess_encoding`,
+    reads `git ls-files scripts/*.py scripts/**/*.py`: 469 of 2198 tracked
+    Python files. The detector was never the difference, the ratchet imports
+    `find_all_violations` from that same module, so 78% of tracked Python could
+    fail CI after passing every local gate. Measured on PR #5476: a violation
+    in `tests/validation/` passed pre-commit, pre-push and pre_pr, then failed
+    CI at 239 against a baseline of 238.
+    """
+
+    def test_the_subprocess_encoding_ratchet_is_registered(self) -> None:
+        registered = {ratchet.job_name for ratchet in checks_ratchet.RATCHETS}
+
+        assert "subprocess-encoding-count-ratchet" in registered
+
+    def test_every_count_ratchet_script_in_ci_is_registered_locally(self) -> None:
+        """The class, not just the instance: catch the next one on arrival."""
+        workflows = REPO_ROOT / ".github/workflows"
+        ci_ratchets: set[str] = set()
+        for workflow in workflows.glob("*.yml"):
+            for match in re.finditer(
+                r"scripts/ci/(\w*count_ratchet\w*|\w*_ratchet)\.py",
+                workflow.read_text(encoding="utf-8"),
+            ):
+                ci_ratchets.add(f"scripts/ci/{match.group(1)}.py")
+
+        registered = {ratchet.script for ratchet in checks_ratchet.RATCHETS}
+        # merge_tree_ratchet_check.py is the local-only aggregate driver and is
+        # registered; the registry module itself is not a ratchet.
+        unreachable = {
+            script
+            for script in ci_ratchets - registered
+            if (REPO_ROOT / script).is_file()
+        }
+
+        assert not unreachable, (
+            "these ratchets are enforced in CI but registered in no local gate, "
+            f"so they can only fail after a push: {sorted(unreachable)}"
+        )

--- a/tests/ci/test_lefthook_ratchet_wiring.py
+++ b/tests/ci/test_lefthook_ratchet_wiring.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
@@ -92,50 +91,6 @@ class TestAggregateRatchetWiring:
         by_name = {ratchet.job_name: ratchet for ratchet in checks_ratchet.RATCHETS}
         assert by_name["taste-count-ratchet"].uses_base_ref is True
         assert by_name["type-ignore-count-ratchet"].uses_base_ref is True
-
-
-class TestNoCIRatchetIsLocalOnlyUnreachable:
-    """Every whole-tree ratchet CI enforces must also run locally (#5482).
-
-    `subprocess_encoding_count_ratchet.py` was enforced in `pytest.yml` and
-    registered nowhere local. Its only local twin, `check_subprocess_encoding`,
-    reads `git ls-files scripts/*.py scripts/**/*.py`: 469 of 2198 tracked
-    Python files. The detector was never the difference, the ratchet imports
-    `find_all_violations` from that same module, so 78% of tracked Python could
-    fail CI after passing every local gate. Measured on PR #5476: a violation
-    in `tests/validation/` passed pre-commit, pre-push and pre_pr, then failed
-    CI at 239 against a baseline of 238.
-    """
-
-    def test_the_subprocess_encoding_ratchet_is_registered(self) -> None:
-        registered = {ratchet.job_name for ratchet in checks_ratchet.RATCHETS}
-
-        assert "subprocess-encoding-count-ratchet" in registered
-
-    def test_every_count_ratchet_script_in_ci_is_registered_locally(self) -> None:
-        """The class, not just the instance: catch the next one on arrival."""
-        workflows = REPO_ROOT / ".github/workflows"
-        ci_ratchets: set[str] = set()
-        for workflow in workflows.glob("*.yml"):
-            for match in re.finditer(
-                r"scripts/ci/(\w*count_ratchet\w*|\w*_ratchet)\.py",
-                workflow.read_text(encoding="utf-8"),
-            ):
-                ci_ratchets.add(f"scripts/ci/{match.group(1)}.py")
-
-        registered = {ratchet.script for ratchet in checks_ratchet.RATCHETS}
-        # merge_tree_ratchet_check.py is the local-only aggregate driver and is
-        # registered; the registry module itself is not a ratchet.
-        unreachable = {
-            script
-            for script in ci_ratchets - registered
-            if (REPO_ROOT / script).is_file()
-        }
-
-        assert not unreachable, (
-            "these ratchets are enforced in CI but registered in no local gate, "
-            f"so they can only fail after a push: {sorted(unreachable)}"
-        )
 
 
 class TestAggregateBudgetIsConsistentWithLefthook:

--- a/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
+++ b/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
@@ -79,6 +79,12 @@ _EXPECTED_RATCHETS = (
         False,
     ),
     ("merge-tree-ratchet", "scripts/ci/merge_tree_ratchet_check.py", True, True),
+    (
+        "subprocess-encoding-count-ratchet",
+        "scripts/ci/subprocess_encoding_count_ratchet.py",
+        False,
+        True,
+    ),
 )
 
 
@@ -132,7 +138,7 @@ class TestAggregateLefthookDelegation:
         assert job is not None
         assert job.get("glob") is None
 
-    def test_registry_contains_all_eight_ratchets(self) -> None:
+    def test_registry_contains_every_registered_ratchet(self) -> None:
         assert tuple(
             (ratchet.job_name, ratchet.script, ratchet.extra_dev, ratchet.uses_base_ref)
             for ratchet in checks_ratchet.RATCHETS
@@ -255,28 +261,37 @@ class TestValidatorBehaviour:
 
         monkeypatch.setattr(checks_ratchet, "_run_subprocess", record)
         checks_ratchet.validate_count_ratchets(REPO_ROOT)
-        expected = [
+        expected = {
             " ".join(checks_ratchet.build_command(ratchet, base_oid))
             for ratchet in checks_ratchet.RATCHETS
-        ]
-        assert [" ".join(a) for a in seen] == expected
+        }
+        # Compared as sets: the ratchets run concurrently, so completion order
+        # is not registry order. Every command must still be issued exactly
+        # once, which the length check below pins alongside membership.
+        assert {" ".join(a) for a in seen} == expected
+        assert len(seen) == len(checks_ratchet.RATCHETS)
 
-    def test_each_ratchet_uses_the_remaining_aggregate_time(
+    def test_each_ratchet_gets_the_budget_left_when_it_starts(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The deadline stays absolute, but is no longer spent in registry order.
+
+        The sequential loop this replaced handed ratchet N the budget minus
+        everything the first N-1 had consumed, so the last entry ran on the
+        remainder and was the one that timed out. Observed on a cold run:
+        merge-tree, registered last, reported "Command timed out after 33s"
+        and then passed on retry with no code change. Concurrently every
+        ratchet starts near the same instant, so each sees nearly the whole
+        budget and none is starved by its position in the registry.
+        """
         monkeypatch.setattr(
             checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"
         )
         monkeypatch.setattr(checks_ratchet, "_refresh_remote_base", lambda *_a: "")
         monkeypatch.setattr(checks_ratchet, "_resolve_base_oid", lambda *_a: "a" * 40)
-        monotonic_values = iter((100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0))
         timeouts: list[int] = []
 
-        monkeypatch.setattr(checks_ratchet.time, "monotonic", lambda: next(monotonic_values))
-
-        def record_timeout(
-            _args: list[str], **kwargs: object
-        ) -> tuple[int, str, str]:
+        def record_timeout(_args: list[str], **kwargs: object) -> tuple[int, str, str]:
             timeout = kwargs["timeout"]
             assert isinstance(timeout, int)
             timeouts.append(timeout)
@@ -285,7 +300,28 @@ class TestValidatorBehaviour:
         monkeypatch.setattr(checks_ratchet, "_run_subprocess", record_timeout)
 
         assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is True
-        assert timeouts == [84, 83, 82, 81, 80, 79, 78, 77]
+        assert len(timeouts) == len(checks_ratchet.RATCHETS)
+        # Every ratchet, not just the first, gets essentially the full budget.
+        assert all(t > checks_ratchet._AGGREGATE_TIMEOUT_SECONDS - 5 for t in timeouts), timeouts
+        assert all(t <= checks_ratchet._AGGREGATE_TIMEOUT_SECONDS for t in timeouts), timeouts
+
+    def test_a_ratchet_starting_after_the_deadline_is_a_failure_not_a_skip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An exhausted budget must fail loudly; a silent skip is a false green."""
+        monkeypatch.setattr(
+            checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"
+        )
+        monkeypatch.setattr(checks_ratchet, "_refresh_remote_base", lambda *_a: "")
+        monkeypatch.setattr(checks_ratchet, "_resolve_base_oid", lambda *_a: "a" * 40)
+        monkeypatch.setattr(checks_ratchet, "_AGGREGATE_TIMEOUT_SECONDS", -1)
+
+        def unreachable(*_a: object, **_k: object) -> tuple[int, str, str]:
+            raise AssertionError("no ratchet may run once the deadline has passed")
+
+        monkeypatch.setattr(checks_ratchet, "_run_subprocess", unreachable)
+
+        assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is False
 
     def test_fails_when_one_ratchet_exits_nonzero(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
+++ b/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
@@ -80,12 +80,6 @@ _EXPECTED_RATCHETS = (
         False,
     ),
     ("merge-tree-ratchet", "scripts/ci/merge_tree_ratchet_check.py", True, True),
-    (
-        "subprocess-encoding-count-ratchet",
-        "scripts/ci/subprocess_encoding_count_ratchet.py",
-        False,
-        True,
-    ),
 )
 
 

--- a/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
+++ b/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
@@ -28,6 +28,7 @@ Coverage:
 from __future__ import annotations
 
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -304,6 +305,77 @@ class TestValidatorBehaviour:
         # Every ratchet, not just the first, gets essentially the full budget.
         assert all(t > checks_ratchet._AGGREGATE_TIMEOUT_SECONDS - 5 for t in timeouts), timeouts
         assert all(t <= checks_ratchet._AGGREGATE_TIMEOUT_SECONDS for t in timeouts), timeouts
+
+    def test_the_ratchets_actually_overlap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prove concurrency, which a timeout assertion alone cannot.
+
+        A stub that returns immediately gives every call nearly the whole
+        budget under a serial implementation too, so asserting on the timeout
+        values does not discriminate. A barrier does: it only clears once every
+        ratchet is inside the call at the same time, so a serial loop blocks on
+        the first one and raises BrokenBarrierError when the timeout expires.
+        """
+        monkeypatch.setattr(
+            checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"
+        )
+        monkeypatch.setattr(checks_ratchet, "_refresh_remote_base", lambda *_a: "")
+        monkeypatch.setattr(checks_ratchet, "_resolve_base_oid", lambda *_a: "a" * 40)
+
+        barrier = threading.Barrier(len(checks_ratchet.RATCHETS), timeout=30)
+        broke = threading.Event()
+
+        def wait_for_all(_args: list[str], **_k: object) -> tuple[int, str, str]:
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                broke.set()
+                return 1, "", "ratchets did not overlap"
+            return 0, "", ""
+
+        monkeypatch.setattr(checks_ratchet, "_run_subprocess", wait_for_all)
+
+        assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is True
+        assert not broke.is_set(), "the ratchets ran serially, not concurrently"
+
+    def test_the_pool_is_sized_to_the_registry_not_the_core_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cpu_count cap would hand a one-core host the sequential loop back.
+
+        The workers only wait on subprocesses, so the core count does not
+        measure the resource they consume. Capping by it would silently restore
+        the starvation this change removes, on exactly the smallest machines.
+        Asserted through the pool the code actually builds rather than by
+        reading the source, which a comment mentioning cpu_count would defeat.
+        """
+        monkeypatch.setattr(
+            checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"
+        )
+        monkeypatch.setattr(checks_ratchet, "_refresh_remote_base", lambda *_a: "")
+        monkeypatch.setattr(checks_ratchet, "_resolve_base_oid", lambda *_a: "a" * 40)
+        monkeypatch.setattr(checks_ratchet, "_run_subprocess", lambda *_a, **_k: (0, "", ""))
+
+        sizes: list[int | None] = []
+        real_pool = checks_ratchet.concurrent.futures.ThreadPoolExecutor
+
+        def recording_pool(max_workers: int | None = None, **kwargs: object):
+            """Record the requested size, then build the real pool.
+
+            A factory rather than a subclass: subclassing ThreadPoolExecutor
+            needs type-ignore comments for its untyped __init__, and those
+            raise the type-ignore count ratchet that runs beside this one.
+            """
+            sizes.append(max_workers)
+            return real_pool(max_workers=max_workers, **kwargs)
+
+        monkeypatch.setattr(
+            checks_ratchet.concurrent.futures, "ThreadPoolExecutor", recording_pool
+        )
+
+        assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is True
+        assert sizes == [len(checks_ratchet.RATCHETS)], sizes
 
     def test_a_ratchet_starting_after_the_deadline_is_a_failure_not_a_skip(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What this fixes

`scripts/validation/checks_ratchet.py` ran its registry in a `for` loop under one shared 85 second deadline. A budget spent in registry order gives the last entry whatever the earlier ones left, so the last entry is the one that starves. `merge-tree-ratchet` is registered last, and on a cold run during this session the gate reported:

```
[FAIL] merge-tree-ratchet output:
  Command timed out after 33s
```

then passed on retry with no code change. A gate whose last check intermittently does not run is a false-green generator, and the retry makes it look like success.

`_run_ratchets` now runs the registry on a `ThreadPoolExecutor`, one worker per ratchet. Every ratchet starts at about the same instant, so none is starved by its position. That part is structural and does not depend on machine load.

## Scope: what this deliberately does not do

This started as a fix for issue #5482, registering `subprocess_encoding_count_ratchet.py` locally. **That entry is not in this PR.** It does not fit the budget, and the budget is governed.

- The ratchet costs 33.7s. With it the registry is 84.2s sequential against an 85s deadline.
- Raising lefthook's `count-ratchets` cap from 90s to 180s to buy room pushed the pre-push declared worst case from 3450s to 3510s, which `tests/ci/test_lefthook_declared_budget.py` rejects. Its remedy is to measure a job and cut another cap to pay for it (`ci-scripts.md` MUST-16), which is separate work.
- Shipping the entry without paying leaves a gate that fails on a loaded developer machine. I measured it doing exactly that twice, at 85.3s and 85.1s, while every ratchet passed when run alone.

So #5482 stays open with its blocker now measured: closing it means making `find_all_violations` cheaper, not buying more time. The concurrency here is a precondition for that follow-up, not a delivery of it.

## Measurements

Per ratchet, warm: merge-tree 22.9s, cli-exit-contract 15.6s, taste-count 2.6s, the other five 0.1s to 0.4s.

A/B over a nine entry registry (the eight here plus the #5482 candidate), median of 2:

| load | sequential | concurrent |
|---|---:|---:|
| moderate | 84.2s | **51.4s** |
| average 14.8 | 84.7s | **79.5s** |

The second row is the honest one for a busy machine: with no spare cores there is little to win, and the gain is nearly gone. The starvation fix is what holds in both rows.

`pre_pr.py` on this tree under load reports `[PASS] Count Ratchets (42.11s)`.

## Safety

Concurrency is safe by inspection. No registered ratchet issues a git command that writes (`add`, `commit`, `checkout`, `reset`, `read-tree`, `update-index`, `stash`, `fetch`); the one fetch the gate needs happens once in `_prepare_base_oid` before the fan-out. There is no index lock to contend over.

The deadline stays absolute at 85s. Each ratchet gets the budget remaining when it starts, so a hung entry cannot push the gate past its 90 second lefthook cap, and an entry that cannot start is reported as a failure rather than silently skipped. Failures are reported in registry order, not completion order, so output does not vary run to run.

Threads rather than processes: each worker only waits on a subprocess.

## Tests

- `test_the_ratchets_actually_overlap` uses a `threading.Barrier` sized to the registry. It clears only when every ratchet is inside the call at once; a serial loop blocks on the first and raises `BrokenBarrierError`.
- `test_the_pool_is_sized_to_the_registry_not_the_core_count` asserts through the pool the code builds. An `os.cpu_count()` cap would hand a one-core host a pool of one, which is the sequential loop and its starvation restored on exactly the smallest machines.
- `test_each_ratchet_gets_the_budget_left_when_it_starts` replaces an assertion that pinned the sequential decrement (`timeouts == [84, 83, 82, ...]`), which encoded the behavior this removes.
- `test_a_ratchet_starting_after_the_deadline_is_a_failure_not_a_skip` pins that an exhausted budget fails loudly.
- The command-issued assertion compares sets plus a length, since completion order is no longer registry order.
- `TestAggregateBudgetIsConsistentWithLefthook` pins lefthook's cap strictly above the gate's deadline, so the deadline fires first and names the offending ratchet instead of lefthook killing the job with no attribution.
- `test_registry_retains_all_eight_ratchets` was `len(RATCHETS) == 8`. A bare count also fails on an addition, which is not the loss it exists to catch, and names nothing when it fails. It is a named floor now.

Verified by mutation, not assertion: forcing `workers = 1` fails the barrier test and the pool-size test and nothing else, and that run takes 30.5s instead of 0.6s because the barrier waits out its timeout.

## Also corrected

The module docstring claimed the ratchets "finish in about three seconds". It was written when the registry was four entries. It now carries the measured per-ratchet numbers.

Refs #5482
