### PR TITLE
fix(plugins): disable project-toolkit inside its own checkout

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
     "env": {
         "AI_AGENTS_PROJECT_REPO": "1"
     },
+    "enabledPlugins": {
+        "project-toolkit@ai-agents": false
+    },
     "permissions": {
         "deny": [
             "Bash(git *--output*)",

--- a/tests/test_plugin_self_disable_4871.py
+++ b/tests/test_plugin_self_disable_4871.py
@@ -5,9 +5,12 @@ with `"source": "./.claude"`. When cwd is this repository, Claude Code loads
 `.claude/agents`, `.claude/skills`, and `.claude/commands` natively at project
 scope AND a second time as the installed plugin, so every agent, skill, and
 command reaches the system prompt twice: bare (`analyst`) and prefixed
-(`project-toolkit:analyst`). Measured duplicate frontmatter payload: 33 agents
-(10,138 B) + 95 skills (40,269 B) + 26 commands (3,132 B) = 53,539 B, about
-13,385 tokens per session, all of it redundant here.
+(`project-toolkit:analyst`). Measured duplicate frontmatter payload, counting
+`name` plus `description` across the files that carry frontmatter: 31 agents
+(10,534 B) + 95 skills (42,182 B) + 25 commands (3,132 B) = 55,848 B, about
+13,962 tokens per session, all of it redundant here. The file counts are lower
+than a raw glob (33 agent files, 26 command files) because `AGENTS.md` and
+`CLAUDE.md` carry no frontmatter and load nothing.
 
 `.claude/settings.json` turns the plugin off at project scope, which is exactly
 the shape `.github/copilot/settings.json` already carries for the Copilot CLI

--- a/tests/test_plugin_self_disable_4871.py
+++ b/tests/test_plugin_self_disable_4871.py
@@ -1,0 +1,123 @@
+"""The project-toolkit plugin must stay disabled inside its own checkout.
+
+Issue #4871. `.claude-plugin/marketplace.json` publishes `project-toolkit`
+with `"source": "./.claude"`. When cwd is this repository, Claude Code loads
+`.claude/agents`, `.claude/skills`, and `.claude/commands` natively at project
+scope AND a second time as the installed plugin, so every agent, skill, and
+command reaches the system prompt twice: bare (`analyst`) and prefixed
+(`project-toolkit:analyst`). Measured duplicate frontmatter payload: 33 agents
+(10,138 B) + 95 skills (40,269 B) + 26 commands (3,132 B) = 53,539 B, about
+13,385 tokens per session, all of it redundant here.
+
+`.claude/settings.json` turns the plugin off at project scope, which is exactly
+the shape `.github/copilot/settings.json` already carries for the Copilot CLI
+(PR #4888 / issue #4885). Consumers are unaffected: the plugin stays published
+in the marketplace, and a settings.json shipped inside a plugin root is not a
+settings source for a consumer working in a different directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+COPILOT_SETTINGS = REPO_ROOT / ".github" / "copilot" / "settings.json"
+MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+PLUGIN_ID = "project-toolkit@ai-agents"
+
+
+def _plugin_is_disabled(settings: Any, plugin_id: str) -> bool:
+    """Return True iff `settings` turns `plugin_id` off at this scope.
+
+    Only a JSON boolean `false` counts. A missing key, a missing
+    `enabledPlugins` block, `true`, `null`, or the string `"false"` all leave
+    the plugin enabled, because Claude Code reads the value as JSON and any
+    non-`false` value falls through to the user-scope setting.
+    """
+    if not isinstance(settings, dict):
+        return False
+    enabled = settings.get("enabledPlugins")
+    if not isinstance(enabled, dict):
+        return False
+    return enabled.get(plugin_id) is False
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestShippedSettingsDisableTheSelfPlugin:
+    """Positive: the committed configuration disables the plugin."""
+
+    def test_claude_settings_disable_project_toolkit(self) -> None:
+        assert _plugin_is_disabled(_load(CLAUDE_SETTINGS), PLUGIN_ID), (
+            f"{CLAUDE_SETTINGS} must set "
+            f'"enabledPlugins": {{"{PLUGIN_ID}": false}} so the plugin does '
+            "not load a second time inside its own checkout (issue #4871)"
+        )
+
+    def test_copilot_settings_disable_project_toolkit(self) -> None:
+        assert _plugin_is_disabled(_load(COPILOT_SETTINGS), PLUGIN_ID), (
+            f"{COPILOT_SETTINGS} must keep the same disable (PR #4888)"
+        )
+
+    def test_claude_settings_parse_as_json_object(self) -> None:
+        settings = _load(CLAUDE_SETTINGS)
+        assert isinstance(settings, dict)
+        assert isinstance(settings["enabledPlugins"], dict)
+
+    def test_unrelated_settings_keys_survive(self) -> None:
+        settings = _load(CLAUDE_SETTINGS)
+        for key in ("env", "permissions", "hooks"):
+            assert key in settings, (
+                f"{key!r} disappeared from {CLAUDE_SETTINGS}; the "
+                "enabledPlugins edit must not displace existing config"
+            )
+
+    def test_marketplace_still_publishes_the_plugin(self) -> None:
+        """The disable is scope-local, not an unpublish."""
+        names = {plugin["name"] for plugin in _load(MARKETPLACE)["plugins"]}
+        assert "project-toolkit" in names, (
+            "consumers still install project-toolkit from this marketplace; "
+            "disabling it locally must not remove the published entry"
+        )
+
+
+class TestDisabledPredicateRejectsNonDisablingShapes:
+    """Negative and edge: every shape that leaves the plugin enabled."""
+
+    @pytest.mark.parametrize(
+        ("settings", "why"),
+        [
+            ({}, "no enabledPlugins block at all"),
+            ({"enabledPlugins": {}}, "block present but plugin unlisted"),
+            ({"enabledPlugins": {PLUGIN_ID: True}}, "explicitly enabled"),
+            ({"enabledPlugins": {PLUGIN_ID: None}}, "null is not false"),
+            ({"enabledPlugins": {PLUGIN_ID: "false"}}, "string is not false"),
+            ({"enabledPlugins": {PLUGIN_ID: 0}}, "zero is not false"),
+            ({"enabledPlugins": {"project-toolkit": False}}, "id missing marketplace"),
+            ({"enabledPlugins": {PLUGIN_ID.upper(): False}}, "ids are case sensitive"),
+            ({"enabledPlugins": [PLUGIN_ID]}, "list is the wrong type"),
+            ({"enabledPlugins": None}, "null block"),
+            ([{"enabledPlugins": {PLUGIN_ID: False}}], "settings is not an object"),
+            (None, "settings is null"),
+        ],
+    )
+    def test_non_disabling_shape_returns_false(self, settings: Any, why: str) -> None:
+        assert not _plugin_is_disabled(settings, PLUGIN_ID), why
+
+    def test_disabling_shape_returns_true(self) -> None:
+        """The predicate is not vacuously false."""
+        assert _plugin_is_disabled({"enabledPlugins": {PLUGIN_ID: False}}, PLUGIN_ID)
+
+    def test_other_plugins_are_left_alone(self) -> None:
+        """Disabling a sibling does not satisfy the check for this plugin."""
+        settings = {"enabledPlugins": {"caveman@caveman": False, PLUGIN_ID: True}}
+        assert not _plugin_is_disabled(settings, PLUGIN_ID)
+        assert _plugin_is_disabled(settings, "caveman@caveman")


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds one key to `.claude/settings.json`:

```json
"enabledPlugins": {
    "project-toolkit@ai-agents": false
}
```

Plus `tests/test_plugin_self_disable_4871.py` to keep it there.

### Why

`.claude-plugin/marketplace.json` publishes `project-toolkit` with `"source": "./.claude"`. The plugin's source directory is this repository's own project directory. With the plugin installed and enabled at user scope, working in this checkout loads `.claude/agents`, `.claude/skills`, and `.claude/commands` twice: natively at project scope, and again as the plugin. Every agent, skill, and command reaches the session system prompt under two names, bare (`analyst`) and prefixed (`project-toolkit:analyst`).

Consumers need both halves. This repository needs only the native one.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4871 | Plugin double-loads inside its own checkout |
| **Precedent** | `.github/copilot/settings.json` | Same disable for Copilot CLI (PR #4888 / issue #4885) |
| **Shape** | `.agents/analysis/claude-code-plugin-marketplaces.md:155` | Documented `enabledPlugins` shape |

This reference does not close its linked item. It closes the Claude Code half of #4871 only.

## Measurements

### Cost removed

```console
$ claude plugin details project-toolkit@ai-agents
Projected token cost
  Always-on:   ~19,193 tok   added to every session
```

Inside this checkout all of it is duplicate. An independent count of the frontmatter payload that drives that number (`name` plus `description` per file, across `.claude/agents/*.md`, `.claude/skills/**/SKILL.md`, `.claude/commands/**/*.md`) gives 31 agents (10,534 B) + 95 skills (42,182 B) + 25 commands (3,132 B) = 55,848 B, roughly 13,962 tokens. The two numbers differ because `plugin details` also counts manifest and routing overhead the frontmatter scan does not.

### Before and after

Command, run from the worktree root, `.../fix-4871-disable-plugin-double-load`:

```bash
claude plugin list --json | python3 -c "
import json,sys
for p in json.load(sys.stdin):
    if 'project-toolkit' in p['id']:
        print(p['id'], 'enabled=', p['enabled'], 'scope=', p['scope'])
"
```

| Run | cwd | Result |
|---|---|---|
| Before the edit | worktree root | `project-toolkit@ai-agents enabled= True scope= user` |
| After the edit | worktree root | `project-toolkit@ai-agents enabled= False scope= user` |
| Control, after the edit | empty temp directory | `project-toolkit@ai-agents enabled= True scope= user` |

The operator's user scope settings file still reads `"project-toolkit@ai-agents": true` after the edit. The disable is project scoped, exactly as intended: it applies in this checkout and nowhere else.

### Consumer leak probe

`.claude/settings.json` ships inside the plugin root, so a natural worry is that the `false` travels to consumers and disables the plugin they just installed. It does not.

Probe: injected `"enabledPlugins": {"project-toolkit@ai-agents": false, "graybeard@graybeard": false}` directly into the installed plugin root's own copy at `~/.claude/plugins/cache/ai-agents/project-toolkit/63409de5a1c9/settings.json`, then ran the same `claude plugin list --json` from an empty temp directory.

```
graybeard@graybeard enabled= True scope= user
project-toolkit@ai-agents enabled= True scope= user
```

Both stayed enabled. A settings.json inside a plugin root is not a settings source for a consumer working elsewhere. This reproduces the earlier `graybeard` probe and extends it to `project-toolkit` itself. The cache file was restored from a `cp -p` backup and verified with `diff -q` (clean), and a re-probe after restore confirmed both plugins still enabled.

## The one real cost

Six names become unreachable in this operator's environment. An earlier revision of this description said four. That count was wrong and is corrected here.

Measured by intersecting the 95 repository skill names and the 15 top level repository command names with the directory names under the operator's user scope skills directory:

| Prefixed name lost | Kind | Bare name already resolves to |
|---|---|---|
| `project-toolkit:autoplan` | skill | gstack `autoplan` |
| `project-toolkit:review` | skill | gstack `review` |
| `project-toolkit:checkpoint` | command | gstack `checkpoint` |
| `project-toolkit:research` | command | gstack `research` |
| `project-toolkit:retro` | command | gstack `retro` |
| `project-toolkit:ship` | command | gstack `ship` |

Each bare name already resolves to the user scope gstack copy, which shadows the project scope one, so the prefixed form was the only remaining way to reach this repository's version of those six.

`autoplan` is the one that stings. This repository's Claude instructions name it the canonical intent router (ADR-078), so after this change the only reachable `autoplan` in this environment is gstack's. That is a real loss of reach, not just a lost fallback, and it is the trade this description asks a reviewer to accept. Getting the repository's six back needs distinct names, which is separate work from this change.

Nothing else is lost today. `claude plugin details project-toolkit@ai-agents` reports 0 hooks, 0 MCP servers, and 0 LSP servers, and the repository hook manifest at HEAD carries 0 registrations. That is a property of the current source, not a guarantee: cached plugin revision `458028d2bb85` carried 4 registrations, so this plugin has shipped hooks before and can again. If it does, this checkout stops seeing them through the plugin and nothing guards that. The repository's own hooks come from `.claude/settings.json`, which is unchanged apart from the added key.

## Changes

- `.claude/settings.json`: added the top level `enabledPlugins` key. `env`, `permissions`, and `hooks` are untouched.
- `tests/test_plugin_self_disable_4871.py`: new regression guard, 19 tests.

### Considered and left alone

The marketplace manifest still publishes `project-toolkit`, so consumers install it unchanged. The gitignored local settings file was rejected as the home for the key because it would not bind other contributors. The operator's own user scope settings file was rejected because it is operator config, not repository config.

## Acceptance criteria

These are the criteria for this change, not the 14 boxes in issue #4871. #4871 asks for an effective context inventory per harness, always-on skill accounting, an `EVERY task` fixture, admission test rationales per always-on unit, a cross layer conflict report, frozen real CLI before and after tasks via #4853, and lowered budget ceilings. None of that is here. This change removes one measured duplicate load and stops there, which is why the keyword is `Refs #4871` and not `Fixes`.

- [x] `claude plugin list --json` from the repository root reports `project-toolkit@ai-agents` as disabled
- [x] The same command from an unrelated directory still reports it enabled
- [x] The operator's user scope settings file is unmodified and still enables the plugin
- [x] A `false` inside a plugin root does not disable that plugin for a consumer elsewhere
- [x] The marketplace still publishes `project-toolkit`
- [x] A regression test fails if the key is removed

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether losing the six `project-toolkit:`-prefixed names above, `autoplan` in particular, is an acceptable trade. That is the only judgment call here; everything else is measured.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

New guard: `tests/test_plugin_self_disable_4871.py`, 19 tests. Its module docstring carried a second, non reproducing count of the duplicate payload: raw file counts (33 agents, 26 commands) paired with description only bytes. Commit `fd1e82c15` recounts it with the method used above, so the tree and this description now agree on 55,848 B and about 13,962 tokens. The lower file counts are the correct ones: the extra Markdown files under those directories carry no frontmatter and load nothing.

```console
$ uv run --frozen pytest tests/test_plugin_self_disable_4871.py -q
19 passed in 0.17s
```

Per `.agents/governance/TESTING-RIGOR.md`, the changed unit is the `_plugin_is_disabled(settings, plugin_id)` predicate:

- Positive: `test_claude_settings_disable_project_toolkit`, `test_copilot_settings_disable_project_toolkit`, `test_disabling_shape_returns_true`.
- Negative and edge: `test_non_disabling_shape_returns_false`, 12 parameterized cases covering a missing `enabledPlugins` block, an empty block, `true`, `null`, the string `"false"`, `0`, a plugin id without its marketplace suffix, a case-shifted id, a list where an object is required, a null block, a non-object settings root, and a null settings root. Only a JSON boolean `false` counts, because any other value falls through to the user-scope setting.
- Guards against collateral damage: `test_unrelated_settings_keys_survive`, `test_marketplace_still_publishes_the_plugin`, `test_other_plugins_are_left_alone`.

The guard was proved to bite. Temporarily removing the key from `.claude/settings.json` and re-running gives:

```console
$ uv run --frozen pytest tests/test_plugin_self_disable_4871.py -q
FAILED ...::test_claude_settings_disable_project_toolkit
FAILED ...::test_claude_settings_parse_as_json_object
2 failed, 17 passed in 0.19s
```

The key was restored and verified with `diff -q` against a `cp -p` backup.

## What I did not verify

- **Session-level token savings.** I did not start a fresh Claude Code session in this checkout and diff the actual system prompt before and after. The `~19,193 tok` figure is what `claude plugin details` projects, not a measured prompt delta.
- **Other operators' environments.** The six shadowed names are shadowed because *this* operator has gstack installed at user scope. A contributor without gstack keeps bare `autoplan`, `review`, `checkpoint`, `research`, `retro`, and `ship` from the project scope copies, so for them this change costs nothing at all. I did not test a gstack-free environment.
- **Copilot CLI behavior.** I read `.github/copilot/settings.json` as precedent and assert its content in the test. I did not run the Copilot CLI to confirm its disable still works.
- **Consumer install end to end.** The leak probe injected a `false` into the already-cached plugin root. I did not run a fresh `/plugin install project-toolkit@ai-agents` from a clean cache after this commit lands to confirm the shipped `settings.json` is inert there too. The probe tests the same file at the same path, so I expect the same result, but the install path itself is untested.
- **CI.** The first CI run on this branch was red on one check, `Validate PR`, because this description named three unchanged files under a change claim heading. That is fixed in this revision. Every other check passed.

## Author Pre-flight

- [x] Pre-PR validation passed

```console
$ uv run --frozen python scripts/validation/pre_pr.py
RESULT: All validations passed
```

- [x] Lint clean, scoped to changed files

```console
$ uv run --frozen ruff check tests/test_plugin_self_disable_4871.py
All checks passed!
```

- [x] Self-review completed
- [x] No new warnings introduced

### Pre-push gate note

The pre-push hook rejected this branch six times on timeouts, not on findings, then accepted it on the seventh with every job green. Two jobs were involved and both pass when run alone:

```console
$ SKIP_AUTOFIX=1 AI_AGENTS_PRE_PR_FAST_STAGE_RAN=1 PRE_PR_OUTER_CAP_SECONDS=240 \
    uv run --frozen python scripts/validation/pre_pr.py
pre_pr validations passed (push outcome depends on sibling hook jobs).
real 3m27s          # lefthook cap: 4m

$ uv run --frozen python scripts/ci/merge_tree_ratchet_check.py
merge-tree-ratchet: cli exit contract ratchet: OK. 18 <= 18.
merge-tree-ratchet: OK. Merged tree passes all registered ratchets (base: origin/main).
exit 0
real 1m21s          # aggregate deadline in checks_ratchet.py: 85s
```

The machine was carrying a load average of 13.7 to 17.3 from three other agent sessions running their own pre-push suites. `scripts/validation/checks_ratchet.py:110-120` documents this exact failure as load dependent: "measured at load average 6.2 it reached 85.3s while every ratchet passed alone".

The push landed on a retry taken at load 8.90, with the full suite green:

```
=== attempt 3, load 8.90 13.83 14.71 ===
 * [new branch]          claude/fix-4871-disable-plugin-double-load -> claude/fix-4871-disable-plugin-double-load
PUSH LANDED on attempt 3
```

No hook was skipped or bypassed. `--no-verify`, `LEFTHOOK=0`, and `LEFTHOOK_EXCLUDE` were not used. Every rejected attempt was retried in full.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

One JSON key and one test file. No authentication, authorization, CI/CD, secret, or infrastructure surface is touched.

## Related Issues

Refs #4871

