### PR TITLE
chore(repo): ignore the skill-pattern loader cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,11 @@ ENV/
 # Hook runtime logs and caches
 .claude/hooks/audit.log
 
+# Skill-pattern loader cache. Maps absolute source paths to float mtimes, so
+# every contributor's copy differs on every line. Matched under any hook event
+# directory, not just Stop/, so a second writer does not reopen the hole.
+.claude/hooks/**/.skill_pattern_cache.json
+
 # Scheduled-task runtime lock (held while ScheduleWakeup-managed loops run)
 .claude/scheduled_tasks.lock
 


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds one `.gitignore` pattern so the skill-pattern loader cache stops showing up as untracked.

### Why

`.claude/hooks/Stop/.skill_pattern_cache.json` was matched by no ignore rule, so `git status` listed `.claude/hooks/Stop/` as untracked and any `git add -A` would commit it. The file is 28KB of absolute filesystem paths mapped to float mtimes, both machine-local, so a committed copy leaks the operator's home directory layout into git history and conflicts on every line for every contributor.

The existing "Hook runtime logs and caches" block enumerates artifacts by exact path and predates this cache. The generic `.cache/` rule does not match a dotfile named `.skill_pattern_cache.json`.

The pattern matches under any hook event directory rather than `Stop/` alone, so a second writer under a different event does not reopen the hole.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5523 | chore(repo): .claude/hooks/Stop/.skill_pattern_cache.json is not gitignored |

## Changes

- Added one pattern to the existing "Hook runtime logs and caches" block in .gitignore, with a comment naming what the file holds and why the glob is event-agnostic.

## Acceptance criteria

- [x] git check-ignore -v resolves the cache path to a .gitignore line. Verified: resolves to .gitignore:117.
- [x] git status --porcelain no longer lists .claude/hooks/Stop/ as untracked on a checkout where the cache exists. Verified by copying the real cache into a fresh worktree; status then showed only the .gitignore edit.
- [x] No currently tracked file becomes ignored by the new pattern. Verified with git ls-files --ignored --exclude-standard -c; the 48 pre-existing entries are unchanged and none matches the new glob.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, low scrutiny, no rush

**Focus areas**: Whether the glob is scoped correctly. It matches any hook event directory, not only Stop/. If you would rather pin it to the one known writer, say so and I will narrow it.

## Testing

Deliverables in this PR:

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Manual verification is recorded under Acceptance criteria above, with the commands and their results. No automated test is added: the repository has no existing gate over .gitignore contents, and adding one for a single pattern would be a new enforcement surface out of scope for this issue.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

None. The change adds an ignore pattern and touches no executable path.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the lefthook pre-commit and pre-push suites on this branch; both green)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5523
