### PR TITLE
fix(test-selection): diff explicit pull-request base and head SHAs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -492,12 +492,26 @@ jobs:
       # combine always receives non-empty data. The full-vs-subset decision and
       # the partition argument lists live in the Python runner, not here, per
       # ADR-006.
+      #
+      # Both selection refs are immutable SHAs from the event payload, never a
+      # branch name. The head one is why (issue #5378): on pull_request the
+      # checkout above is `refs/pull/N/merge`, a synthetic commit whose first
+      # parent is the current base-branch tip, so diffing `base.sha...HEAD`
+      # attributes every base-branch commit made since `base.sha` to this pull
+      # request. Observed on PR #5341, where an unrelated
+      # `.github/workflows/claude.yml` entered the changed set and forced the
+      # full suite. `head.sha` is the pull request's own tip and reproduces
+      # GitHub's base-to-head file list. The `fetch-depth: 0` checkout above is
+      # what makes both commits readable: it fetches every branch plus the
+      # merge ref, whose second parent is `head.sha`. If either commit is
+      # missing the git diff fails and the runner runs the full suite.
       - name: Run pytest
         id: run-pytest
         env:
           PYTEST_NON_TMP_ROOT: ${{ runner.temp }}/ai-agents-pytest
           COVERAGE_FILE: ${{ matrix.coverage_file }}
           PYTEST_SELECT_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          PYTEST_SELECT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: >-
           uv run --frozen python scripts/ci/run_pytest_selected.py
           --partition ${{ matrix.partition }}

--- a/scripts/ci/run_pytest_selected.py
+++ b/scripts/ci/run_pytest_selected.py
@@ -10,6 +10,12 @@ events, any fail-safe verdict, and any partition with no affected test run the
 full partition unchanged, so coverage combine always receives non-empty data
 for every partition and the run is never less safe than today.
 
+The comparison reads two immutable SHAs from `PYTEST_SELECT_BASE` and
+`PYTEST_SELECT_HEAD`, which the workflow fills from the event payload. On
+`pull_request` both must be present or the run falls back to the full suite:
+Actions checks out a merge commit there, so diffing against the checkout's HEAD
+credits this pull request with base-branch changes (issue #5378).
+
 Exit codes follow the repository contract: 0 ok, 2 config, 3 external.
 """
 
@@ -31,6 +37,11 @@ except ModuleNotFoundError:  # pragma: no cover - exercised via direct file exec
     from scripts.test_selection import select_tests
 
 _PARALLEL = ["-n", "auto", "--dist", "loadfile"]
+
+# Only for events that carry no base SHA in their payload (workflow_dispatch, a
+# local invocation). Every event the selection actually narrows supplies an
+# immutable SHA, so this branch name is never the comparison authority there.
+_DEFAULT_BASE = "origin/main"
 
 # Full argument lists per partition, mirrored from the pytest.yml matrix. These
 # are the single source of truth now that the matrix no longer carries
@@ -142,25 +153,39 @@ def resolve_partition_args(
     event_name: str,
     base_ref: str,
     repo_root: Path,
+    head_ref: str = "",
 ) -> tuple[list[str], str]:
     """Return the pytest args for ``partition`` and a one-line reason.
 
     The full partition args are used unless a certain, non-empty subset applies.
+
+    ``base_ref`` and ``head_ref`` are the event's immutable SHAs when CI has
+    them. On `pull_request` both are required: the checkout's HEAD is the
+    synthetic merge commit, so an implicit HEAD would attribute base-branch
+    changes to this pull request (issue #5378). Missing either one there falls
+    back to the full suite rather than diffing the wrong pair of commits.
     """
     full = _PARTITION_FULL_ARGS[partition]
     if event_name == "merge_group":
         return full, "full: merge_group runs the whole suite"
-    changed = select_tests.changed_from_git(repo_root, base_ref)
+    if event_name == "pull_request" and not (base_ref and head_ref):
+        return full, "full: pull_request without explicit base and head SHAs"
+    base = base_ref or _DEFAULT_BASE
+    head = head_ref or "HEAD"
+    span = f"{base}...{head}"
+    changed = select_tests.changed_from_git(repo_root, base, head)
     if changed is None:
-        return full, f"full: could not diff against {base_ref}"
+        return full, f"full: could not diff {span}"
     selection = select_tests.select(changed, repo_root)
     if selection.full:
-        return full, f"full: {selection.reason}"
+        return full, f"full: {selection.reason} [{span}]"
     mine = _partition_subset(partition, selection.tests)
     if mine is None:
-        return full, "full: no affected test owned by this partition (or unpartitioned test)"
+        return full, (
+            f"full: no affected test owned by this partition (or unpartitioned test) [{span}]"
+        )
     flags = _PARALLEL if partition in _PARALLEL_PARTITIONS else []
-    return [*flags, *mine], f"subset: {len(mine)} affected test file(s)"
+    return [*flags, *mine], f"subset: {len(mine)} affected test file(s) [{span}]"
 
 
 def _emit_summary(partition: str, mode: str, reason: str) -> None:
@@ -177,9 +202,12 @@ def main(argv: list[str] | None = None) -> int:
     known, passthrough = parser.parse_known_args(argv)
 
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")
-    base_ref = os.environ.get("PYTEST_SELECT_BASE", "").strip() or "origin/main"
+    base_ref = os.environ.get("PYTEST_SELECT_BASE", "").strip()
+    head_ref = os.environ.get("PYTEST_SELECT_HEAD", "").strip()
 
-    args, reason = resolve_partition_args(known.partition, event_name, base_ref, _PROJECT_ROOT)
+    args, reason = resolve_partition_args(
+        known.partition, event_name, base_ref, _PROJECT_ROOT, head_ref
+    )
     mode = "subset" if reason.startswith("subset") else "full"
     _emit_summary(known.partition, mode, reason)
 

--- a/scripts/test_selection/select_tests.py
+++ b/scripts/test_selection/select_tests.py
@@ -164,11 +164,25 @@ def select(
     return Selection(full=False, reason="import-graph subset", tests=tests)
 
 
-def changed_from_git(repo_root: Path, base: str) -> list[str] | None:
-    """Files this branch changed versus ``base`` (three-dot diff), or None."""
+def changed_from_git(repo_root: Path, base: str, head: str = "HEAD") -> list[str] | None:
+    """Files ``head`` changed versus ``base`` (three-dot diff), or None.
+
+    ``head`` defaults to the checkout's own HEAD, which is what a developer and
+    a `push` run want. On `pull_request`, Actions checks out the synthetic
+    `refs/pull/N/merge` commit, so HEAD carries every base-branch commit made
+    since the event's `base.sha` as well as the author's. Measured on the shape
+    issue #5378 reports: with `base.sha` at the fork point and the merge commit
+    as HEAD, the diff listed an unrelated `.github/workflows/claude.yml` from
+    the base branch and forced the full suite. Passing the pull request's own
+    `head.sha` reproduces GitHub's base-to-head file list instead.
+
+    Returns None when git cannot compute the diff, which includes an unfetched
+    or unknown SHA. Every caller treats None as "run everything", so a checkout
+    too shallow to hold both commits fails closed.
+    """
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            ["git", "diff", "--name-only", f"{base}...{head}"],
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/tests/ci/test_run_pytest_selected.py
+++ b/tests/ci/test_run_pytest_selected.py
@@ -113,6 +113,141 @@ def test_serial_partition_subset_has_no_parallel_flags(monkeypatch: pytest.Monke
     assert args == ["tests/test_safe_push_pr_branch.py"]
 
 
+def _capture_diff_args(monkeypatch: pytest.MonkeyPatch, changed: list[str]) -> list[tuple]:
+    """Record every changed_from_git call and answer with ``changed``."""
+    calls: list[tuple] = []
+
+    def _fake(*args: object) -> list[str]:
+        calls.append(args)
+        return changed
+
+    monkeypatch.setattr(mod.select_tests, "changed_from_git", _fake)
+    return calls
+
+
+def test_pull_request_diffs_the_explicit_base_and_head_shas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base, head = "a" * 40, "b" * 40
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.select_tests,
+        "select",
+        lambda *_a, **_k: Selection(full=False, reason="subset", tests=("tests/test_leaf.py",)),
+    )
+    args, reason = mod.resolve_partition_args("bulk", "pull_request", base, _REPO_ROOT, head)
+    assert args == ["-n", "auto", "--dist", "loadfile", "tests/test_leaf.py"]
+    assert calls == [(_REPO_ROOT, base, head)]
+    assert reason == f"subset: 1 affected test file(s) [{base}...{head}]"
+
+
+def test_pull_request_without_head_sha_runs_full_without_diffing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    args, reason = mod.resolve_partition_args("bulk", "pull_request", "a" * 40, _REPO_ROOT, "")
+    assert args == mod._PARTITION_FULL_ARGS["bulk"]
+    assert reason == "full: pull_request without explicit base and head SHAs"
+    assert calls == []
+
+
+def test_pull_request_without_base_sha_runs_full_without_diffing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    args, reason = mod.resolve_partition_args("bulk", "pull_request", "", _REPO_ROOT, "b" * 40)
+    assert args == mod._PARTITION_FULL_ARGS["bulk"]
+    assert reason == "full: pull_request without explicit base and head SHAs"
+    assert calls == []
+
+
+def test_push_without_head_sha_still_diffs_against_the_checkout_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.select_tests,
+        "select",
+        lambda *_a, **_k: Selection(full=False, reason="subset", tests=("tests/test_leaf.py",)),
+    )
+    _, reason = mod.resolve_partition_args("bulk", "push", "c" * 40, _REPO_ROOT)
+    assert calls == [(_REPO_ROOT, "c" * 40, "HEAD")]
+    assert reason.endswith(f"[{'c' * 40}...HEAD]")
+
+
+def test_empty_base_falls_back_to_the_default_branch_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.select_tests, "select", lambda *_a, **_k: Selection(full=True, reason="non-Python")
+    )
+    args, reason = mod.resolve_partition_args("bulk", "workflow_dispatch", "", _REPO_ROOT)
+    assert args == mod._PARTITION_FULL_ARGS["bulk"]
+    assert calls == [(_REPO_ROOT, mod._DEFAULT_BASE, "HEAD")]
+    assert reason == f"full: non-Python [{mod._DEFAULT_BASE}...HEAD]"
+
+
+def test_unfetchable_commit_names_both_ends_of_the_span(monkeypatch: pytest.MonkeyPatch) -> None:
+    base, head = "a" * 40, "b" * 40
+    monkeypatch.setattr(mod.select_tests, "changed_from_git", lambda *_: None)
+    args, reason = mod.resolve_partition_args("bulk", "pull_request", base, _REPO_ROOT, head)
+    assert args == mod._PARTITION_FULL_ARGS["bulk"]
+    assert reason == f"full: could not diff {base}...{head}"
+
+
+def test_main_reads_the_head_sha_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    base, head = "a" * 40, "b" * 40
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("PYTEST_SELECT_BASE", base)
+    monkeypatch.setenv("PYTEST_SELECT_HEAD", head)
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.select_tests,
+        "select",
+        lambda *_a, **_k: Selection(full=False, reason="subset", tests=("tests/test_leaf.py",)),
+    )
+    monkeypatch.setattr(mod.run_pytest_non_tmp, "main", lambda _argv: 0)
+    assert mod.main(["--partition", "bulk"]) == 0
+    assert calls == [(mod._PROJECT_ROOT, base, head)]
+
+
+def test_main_runs_full_when_the_pull_request_head_sha_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("PYTEST_SELECT_BASE", "a" * 40)
+    monkeypatch.delenv("PYTEST_SELECT_HEAD", raising=False)
+    calls = _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.run_pytest_non_tmp, "main", lambda argv: captured.setdefault("argv", argv) and 0 or 0
+    )
+    assert mod.main(["--partition", "bulk"]) == 0
+    assert captured["argv"] == mod._PARTITION_FULL_ARGS["bulk"]
+    assert calls == []
+
+
+def test_main_reports_the_span_and_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    base, head = "a" * 40, "b" * 40
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("PYTEST_SELECT_BASE", base)
+    monkeypatch.setenv("PYTEST_SELECT_HEAD", head)
+    _capture_diff_args(monkeypatch, ["pkg/x.py"])
+    monkeypatch.setattr(
+        mod.select_tests,
+        "select",
+        lambda *_a, **_k: Selection(full=False, reason="subset", tests=("tests/test_leaf.py",)),
+    )
+    monkeypatch.setattr(mod.run_pytest_non_tmp, "main", lambda _argv: 0)
+    mod.main(["--partition", "bulk"])
+    err = capsys.readouterr().err
+    assert "mode=subset" in err
+    assert f"{base}...{head}" in err
+
+
 def test_main_returns_runner_failure_code(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_EVENT_NAME", "merge_group")
     monkeypatch.setattr(mod.run_pytest_non_tmp, "main", lambda _argv: 3)

--- a/tests/test_selection/test_select_tests.py
+++ b/tests/test_selection/test_select_tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from scripts.test_selection import select_tests
@@ -187,6 +188,86 @@ def test_load_runtime_read_patterns_skips_comments_and_blanks(tmp_path: Path) ->
 
 def test_changed_from_git_returns_none_outside_repo(tmp_path: Path) -> None:
     assert select_tests.changed_from_git(tmp_path, "origin/main") is None
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _pull_request_fixture(root: Path) -> tuple[str, str]:
+    """A local repo shaped like a pull_request checkout. Returns base and head.
+
+    Models issue #5378 and the PR #5341 report: the pull request branches from
+    the base at ``base``, adds ``pkg/x.py``, and the base branch then advances
+    on its own with ``.github/workflows/claude.yml``. HEAD is left on the
+    synthetic merge commit Actions checks out for `refs/pull/N/merge`, whose
+    parents are the advanced base tip and the pull request head. No network:
+    every commit is local.
+    """
+    _git(root, "init", "-q", "-b", "main", ".")
+    _git(root, "config", "user.email", "test@example.invalid")
+    _git(root, "config", "user.name", "test")
+    _write(root, "README.md", "start\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "base fork point")
+    base = _git(root, "rev-parse", "HEAD")
+
+    _git(root, "checkout", "-q", "-b", "pr")
+    _write(root, "pkg/x.py", "VALUE = 1\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "pull request change")
+    head = _git(root, "rev-parse", "HEAD")
+
+    _git(root, "checkout", "-q", "main")
+    _write(root, ".github/workflows/claude.yml", "on: push\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "unrelated base-branch change")
+
+    _git(root, "checkout", "-q", "-b", "merge-ref", "main")
+    _git(root, "merge", "-q", "--no-ff", "pr", "-m", "Merge pr into main")
+    return base, head
+
+
+def test_changed_from_git_excludes_base_branch_change_when_head_is_explicit(
+    tmp_path: Path,
+) -> None:
+    base, head = _pull_request_fixture(tmp_path)
+    assert select_tests.changed_from_git(tmp_path, base, head) == ["pkg/x.py"]
+
+
+def test_changed_from_git_leaks_base_branch_change_without_explicit_head(
+    tmp_path: Path,
+) -> None:
+    """Negative control: the pre-#5378 call shape is what pulled the leak in.
+
+    This is the behavior PR #5341 observed. Revert the explicit head argument
+    and the assertion above produces this list instead, so the unrelated
+    workflow file forces the full suite.
+    """
+    base, _ = _pull_request_fixture(tmp_path)
+    assert select_tests.changed_from_git(tmp_path, base) == [
+        ".github/workflows/claude.yml",
+        "pkg/x.py",
+    ]
+
+
+def test_changed_from_git_returns_none_for_unfetchable_head(tmp_path: Path) -> None:
+    base, _ = _pull_request_fixture(tmp_path)
+    assert select_tests.changed_from_git(tmp_path, base, "0" * 40) is None
+
+
+def test_changed_from_git_returns_none_for_unfetchable_base(tmp_path: Path) -> None:
+    _, head = _pull_request_fixture(tmp_path)
+    assert select_tests.changed_from_git(tmp_path, "0" * 40, head) is None
 
 
 def test_cli_prints_full_suite_sentinel(tmp_path: Path, capsys) -> None:

--- a/tests/test_selection/test_select_tests.py
+++ b/tests/test_selection/test_select_tests.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scripts.test_selection import select_tests
+
+# Every test below that calls _pull_request_fixture shells out to git with
+# check=True, so a host without git would fail them for a reason unrelated to
+# selection logic. Same guard the repo already uses in tests/ci.
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
 
 
 def _write(root: Path, rel: str, text: str) -> None:
@@ -237,6 +245,7 @@ def _pull_request_fixture(root: Path) -> tuple[str, str]:
     return base, head
 
 
+@requires_git
 def test_changed_from_git_excludes_base_branch_change_when_head_is_explicit(
     tmp_path: Path,
 ) -> None:
@@ -244,6 +253,7 @@ def test_changed_from_git_excludes_base_branch_change_when_head_is_explicit(
     assert select_tests.changed_from_git(tmp_path, base, head) == ["pkg/x.py"]
 
 
+@requires_git
 def test_changed_from_git_leaks_base_branch_change_without_explicit_head(
     tmp_path: Path,
 ) -> None:
@@ -260,11 +270,13 @@ def test_changed_from_git_leaks_base_branch_change_without_explicit_head(
     ]
 
 
+@requires_git
 def test_changed_from_git_returns_none_for_unfetchable_head(tmp_path: Path) -> None:
     base, _ = _pull_request_fixture(tmp_path)
     assert select_tests.changed_from_git(tmp_path, base, "0" * 40) is None
 
 
+@requires_git
 def test_changed_from_git_returns_none_for_unfetchable_base(tmp_path: Path) -> None:
     _, head = _pull_request_fixture(tmp_path)
     assert select_tests.changed_from_git(tmp_path, "0" * 40, head) is None

--- a/tests/workflows/test_pytest_xdist_parallelism.py
+++ b/tests/workflows/test_pytest_xdist_parallelism.py
@@ -227,6 +227,32 @@ class TestRunPytestStep:
         assert "github.event.pull_request.base.sha" in base
         assert "github.event.before" in base
 
+    def test_run_step_passes_selection_head(self) -> None:
+        """Issue #5378: without the pull request's own head SHA the diff would
+        run against the synthetic merge commit and credit this pull request
+        with base-branch changes."""
+        steps = _job_steps("test")
+        run_step = [s for s in steps if s.get("name") == _MAIN_STEP][0]
+        head = run_step.get("env", {}).get("PYTEST_SELECT_HEAD", "")
+        assert "github.event.pull_request.head.sha" in head
+        assert "github.sha" in head
+
+    def test_selection_refs_are_shas_not_branch_names(self) -> None:
+        steps = _job_steps("test")
+        run_step = [s for s in steps if s.get("name") == _MAIN_STEP][0]
+        env = run_step.get("env", {})
+        for name in ("PYTEST_SELECT_BASE", "PYTEST_SELECT_HEAD"):
+            value = env.get(name, "")
+            assert "base_ref" not in value, f"{name} must not use a mutable branch name"
+            assert "ref_name" not in value, f"{name} must not use a mutable branch name"
+
+    def test_checkout_depth_can_reach_both_selection_commits(self) -> None:
+        """A shallow checkout cannot hold base.sha and head.sha, so the diff
+        would fail and every run would fall back to the full suite."""
+        steps = _job_steps("test")
+        checkout = [s for s in steps if "actions/checkout" in s.get("uses", "")][0]
+        assert checkout.get("with", {}).get("fetch-depth") == 0
+
     def test_run_step_uses_matrix_coverage_file(self) -> None:
         steps = _job_steps("test")
         run_step = [s for s in steps if s.get("name") == _MAIN_STEP][0]


### PR DESCRIPTION
# Pull Request

## Summary

### What

Impact selection diffed `<base>...HEAD`. On `pull_request`, Actions checks out the synthetic `refs/pull/N/merge` commit, so HEAD carries every base-branch commit landed since the event's `base.sha`. This passes the pull request's own head SHA instead.

### Why

PR #5341 saw an unrelated `.github/workflows/claude.yml` enter the changed set and force the full suite. The file was a base-branch change the author never made. Every such leak costs a full-matrix run instead of a subset.

This is phase 1 of the repository's pytest-efficiency delivery plan. It has no blockers and it unblocks #5318, which unblocks #5376 and #5377.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5378 | ci(test-selection): diff explicit pull-request base and head SHAs |

## Changes

- `scripts/test_selection/select_tests.py`: `changed_from_git` takes a `head` argument, defaulting to `HEAD` so the pre-push and `push` paths are untouched.
- `scripts/ci/run_pytest_selected.py`: reads `PYTEST_SELECT_HEAD`, and on `pull_request` fails closed to the full suite when either SHA is missing. Every selection reason line now carries both full SHAs, so the telemetry names immutable commits.
- `.github/workflows/pytest.yml`: fills `PYTEST_SELECT_HEAD` from `github.event.pull_request.head.sha`, falling back to `github.sha` off `pull_request`.

## Acceptance criteria

- [x] On `pull_request`, selection compares the event's explicit base and head SHAs rather than the checkout's HEAD
- [x] A base-branch change made after `base.sha` does not enter the changed set
- [x] A missing or unfetchable SHA on `pull_request` falls back to the full suite rather than diffing the wrong pair
- [x] The non-`pull_request` path (push, workflow_dispatch, local invocation) is unchanged
- [x] Selection telemetry records both full SHAs

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush. It unblocks #5318 so the chain behind it is waiting.

**Focus areas**: the fail-closed guard in `resolve_partition_args`. On `pull_request` a missing base or head SHA returns the full partition. Confirm you agree that is the safe direction, and that no legitimate `pull_request` run reaches it in the normal case.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- `pytest tests/test_selection/test_select_tests.py -q`: 27 passed.
- `pytest tests/ci/test_run_pytest_selected.py -q`: 28 passed.
- `pytest tests/workflows -q`: 422 passed.
- `pytest tests/validation/test_pytest_import_selection.py tests/validation/test_collection*.py`: 86 passed.
- Negative control 1: reverting `f"{base}...{head}"` to `f"{base}...HEAD"` fails `test_changed_from_git_excludes_base_branch_change_when_head_is_explicit`.
- Negative control 2: dropping the head passthrough and the fail-closed guard gives 7 failed, 21 passed; restoring gives 28 passed.
- A local git fixture reproduces the reported defect: `A...HEAD(merge)` returns `.github/workflows/claude.yml` plus `pkg/x.py`, while `A...P` returns only `pkg/x.py`, and a missing SHA produces `fatal: Invalid...` so the diff fails and the caller runs everything.
- Pre-push hooks green, 137.82s, including `count-ratchets` 29.67s and `pre-pr-validation`.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

**Files requiring security review:**

- `.github/workflows/pytest.yml` (adds one `env:` entry from the event payload; no new permissions, no new secret access)

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [x] Critic validated implementation plan
- [x] QA verified test coverage

An independent adversarial reviewer read the diff without the implementer's reasoning and returned no blocking defects.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push job, green)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

Two deliberate omissions, stated so the boxes above are not read as more than they are:

1. **No `--head` flag on the `select_tests` CLI.** `python scripts/test_selection/select_tests.py --from-git BASE` still diffs against the checkout's HEAD, so a CI `pull_request` decision cannot be reproduced by hand. No caller uses that path except tests, and no acceptance criterion names the CLI, so adding the flag would be an unused knob. Say so if you want it anyway.
2. **`PYTEST_SELECT_BASE` still uses `github.event.before` on push.** The issue's line about separate explicit comparison semantics for push arguably reopens this. Left as is because `event.before` is already an immutable SHA, a normal push makes the three-dot diff identical to two-dot, a force-push over-selects (safe), and a branch-creation all-zeros SHA fails the diff and runs everything.

**Not verified:** no real Actions run was observed. The claim that `actions/checkout` with `fetch-depth: 0` leaves `github.event.pull_request.head.sha` in the object database is reasoning from the merge commit's second parent, not a measured CI run. If it is wrong the diff fails and the run falls back to the full suite, which is the pre-fix behavior, so the failure direction is safe. The CI run on this PR is itself the first measurement.

## Related Issues

Fixes #5378
