### PR TITLE
fix(hooks): stop reading CLAUDECODE as a container marker

### DIFF
--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -24,18 +24,24 @@ block with an actionable message. A documented bypass exists for workflows that
 genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
-Tool gaps degrade instead of blocking inside a managed remote container: when
-actionlint, ``gh``, the ``gh act`` extension, or the Docker daemon is
-unavailable inside a Claude web container or a GitHub Codespace (detected by env
-markers), the gate returns exit 0 with ``degraded=True`` and a logged warning.
-Such an environment may not be able to provision those tools, so blocking every
-workflow-touching push there is friction, not safety. A truthy ``CI`` marker
-overrides the managed-container signal, so CI, where the tools are provisioned,
-keeps the hard exit 3. On a dev laptop (no container marker) the gap also stays
-exit 3, so the local-run requirement is unchanged there. Issue #2548 item 3
-introduced this degrade for the ``gh``/``gh act`` gap; Issue #3064 extended it to
-the actionlint and Docker gaps so a container without those tools can still push
-a workflow edit.
+Tool gaps degrade instead of blocking where the developer may not be able to
+provision the tool: when actionlint, ``gh``, the ``gh act`` extension, or the
+Docker daemon is unavailable and ``CLAUDECODE`` or ``CODESPACES`` is set, the
+gate returns exit 0 with ``degraded=True`` and a logged warning. Such a session
+may not be able to install those tools, so blocking every workflow-touching push
+there is friction, not safety. A truthy ``CI`` marker overrides both env
+markers, so CI, where the tools are provisioned, keeps the hard exit 3. With
+neither marker set the gap also stays exit 3, so the local-run requirement is
+unchanged on a dev laptop. Issue #2548 item 3 introduced this degrade for the
+``gh``/``gh act`` gap; Issue #3064 extended it to the actionlint and Docker gaps
+so a session without those tools can still push a workflow edit.
+
+That degrade reads env markers only, in :func:`_tool_gap_is_environmental`. It
+is a different question from "am I inside a container", which
+:func:`_is_remote_container` answers from ``CODESPACES``, an image-set marker,
+and the filesystem. A container that sets neither env marker keeps the hard exit
+3 like any other host, because a tool it can install is not an environment gap.
+Issue #5479 has why the two questions stopped sharing one answer.
 
 CLI
 ---
@@ -52,10 +58,10 @@ EXIT CODES (per ADR-035, exit-code contract in AGENTS.md)
 0 - all stages passed (or no workflow files, or bypassed)
 1 - a stage ran and failed (block the push)
 2 - configuration error (bad args, repo root absent)
-3 - a required tool is unavailable (actionlint, gh act, or Docker). Inside a
-    managed remote container this gap degrades to exit 0 (degraded=True)
-    instead, because the tool cannot be provisioned there; CI and dev laptops
-    keep the hard exit 3 (Issue #3064)
+3 - a required tool is unavailable (actionlint, gh act, or Docker). Under
+    ``CLAUDECODE`` or ``CODESPACES`` this gap degrades to exit 0
+    (degraded=True) instead, because the tool may not be provisionable there;
+    CI and a plain dev laptop keep the hard exit 3 (Issue #3064, #5479)
 4 - unrunnable locally: actionlint passed but every changed workflow
     references a secret absent from this environment, so act has nothing to
     supply (auth per ADR-035). Skipped the act run audibly; CI runs it with the
@@ -86,16 +92,56 @@ _BYPASS_ENV = "SKIP_WORKFLOW_LOCAL_TEST"
 # which accepts "1" and "true").
 _TRUTHY = {"1", "true"}
 
-# Env markers that identify managed remote containers where the developer may
-# not be able to provision ``gh act``. Observed on Claude web containers, which
-# set ``CLAUDECODE``, and GitHub Codespaces. In such environments a missing
-# ``gh act`` is an environment gap, not a code defect, so the gate degrades to a
+# Env markers that say the developer may not be able to provision ``gh act``.
+# Observed on Claude web containers and the Claude Code CLI, which both set
+# ``CLAUDECODE``, and on GitHub Codespaces. Where one is set a missing ``gh
+# act`` is an environment gap, not a code defect, so the gate degrades to a
 # logged warning instead of blocking the push (Issue #2548, item 3). The same
 # gate keeps its hard failure in CI, where ``gh act`` is provisioned: the ``CI``
-# marker (set to a truthy value by GitHub Actions) overrides the managed
-# container signal in :func:`_is_remote_container`.
-_REMOTE_CONTAINER_ENV_MARKERS = ("CLAUDECODE", "CODESPACES")
+# marker (set to a truthy value by GitHub Actions) overrides these in
+# :func:`_tool_gap_is_environmental`.
+#
+# This tuple is about tool provisioning only. It is NOT evidence of a container,
+# and until Issue #5479 it was read as both: ``CLAUDECODE`` names the client,
+# not the execution environment, and the Claude Code CLI sets it on a laptop, a
+# workstation and a VM. Reading it as a container took the semgrep budget in
+# ``git_hook_policy`` from 840s to 150s on a workstation, so a branch whose scan
+# needs more than 150s could not be pushed from a Claude Code session while the
+# same push succeeded from a plain terminal on the same machine. The container
+# question now has its own answer in :func:`_is_remote_container`.
+_TOOL_GAP_ENV_MARKERS = ("CLAUDECODE", "CODESPACES")
 _CI_ENV = "CI"
+
+# ``CODESPACES`` names a managed remote container, so it is a container signal
+# as well as a tool-provisioning one. ``CLAUDECODE`` is not, which is the whole
+# of Issue #5479.
+#
+# ``AI_AGENTS_REMOTE_CONTAINER`` is the marker an image sets for itself, which
+# is what Issue #5479 asked for in place of borrowing the client's variable. It
+# exists because the filesystem probe below is evidence, not a guarantee: a
+# runtime that writes no marker file and runs under cgroup v2 (where
+# ``/proc/1/cgroup`` is ``0::/`` and names nothing) leaves nothing to read. The
+# Claude web container is the class ADR-104 rule 8 was measured against (679s
+# push, reclaimed mid-hook) and its filesystem has not been measured here, so an
+# image that needs the clamp declares itself instead of being inferred. Setting
+# it is the whole install: `ENV AI_AGENTS_REMOTE_CONTAINER=1` in the image, or
+# export it in the session's shell profile.
+_REMOTE_CONTAINER_ENV_MARKERS = ("CODESPACES", "AI_AGENTS_REMOTE_CONTAINER")
+
+# Files that exist only inside a container: Docker writes ``/.dockerenv`` and
+# Podman writes ``/run/.containerenv``.
+_CONTAINER_MARKER_FILES = ("/.dockerenv", "/run/.containerenv")
+# Under cgroup v1 the init process's cgroup paths name the container runtime.
+# cgroup v2 collapses them to ``0::/``, which is why the marker files above
+# carry the common cases and this is a supplement rather than the primary test.
+#
+# ``/proc/self/mountinfo`` is deliberately not consulted, though it carries the
+# same hints. On an Ubuntu 6.17 workstation with Docker installed and no
+# container running it holds two matching lines, ``/run/docker/netns/default``
+# and ``/var/lib/lxcfs``, so it reports a container on a machine that is not
+# one. That is the same false positive this function exists to remove.
+_CONTAINER_CGROUP_HINTS = ("docker", "containerd", "kubepods", "lxc", "podman")
+_CONTAINER_CGROUP_FILE = "/proc/1/cgroup"
 
 # Only GitHub Actions workflow files can run under ``gh act``. Custom actions
 # under ``.github/actions/`` and any other path are filtered out before the act
@@ -190,18 +236,67 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 
-def _is_remote_container() -> bool:
-    """True in a remote/managed container that cannot provision ``gh act``.
+def _has_container_filesystem_signal() -> bool:
+    """True when the filesystem says this process is inside a container.
 
-    A truthy ``CI`` marker overrides every container signal: CI provisions
-    ``gh act``, so a gap there is a real failure and must keep blocking. Outside
-    CI, the managed remote-container env markers (``CLAUDECODE``, ``CODESPACES``)
-    identify environments where the ``gh act`` gap is expected and the gate
-    should degrade rather than block (Issue #2548, item 3).
+    Total and cheap: two ``stat`` calls and one small read, no subprocess, and
+    no error escapes (``Path.exists`` already answers False rather than raising
+    on an unreadable path). It runs once per clamped subprocess in
+    ``git_hook_policy``, which is orders of magnitude cheaper than the spawn it
+    bounds, so nothing here is cached and no invalidation problem exists. On a
+    host without these paths (Windows, macOS) it returns False without raising.
+    """
+    if any(Path(marker).exists() for marker in _CONTAINER_MARKER_FILES):
+        return True
+    try:
+        cgroups = Path(_CONTAINER_CGROUP_FILE).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lowered = cgroups.lower()
+    return any(hint in lowered for hint in _CONTAINER_CGROUP_HINTS)
+
+
+def _is_remote_container() -> bool:
+    """True when this process really is running inside a container.
+
+    A truthy ``CI`` marker overrides every container signal: CI provisions the
+    tools and a real hang there is a real failure, so it must keep failing the
+    way CI expects. Outside CI the answer comes from ``CODESPACES``, from an
+    image that declares itself with ``AI_AGENTS_REMOTE_CONTAINER``, or from the
+    filesystem, never from a variable that names the client rather than the
+    environment (Issue #5479).
+
+    The filesystem probe is the fallback and not the guarantee: it reads real
+    evidence, so it answers False on a runtime that writes no marker file and
+    reports ``0::/`` under cgroup v2. An image whose reclamation bound must hold
+    sets ``AI_AGENTS_REMOTE_CONTAINER`` rather than relying on being inferred.
+
+    Callers use this to decide whether the environment can end the process out
+    from under them: ``git_hook_policy._container_clamped`` and
+    ``_arm_container_watchdog`` both bound work against container reclamation.
+    A false positive there is a hard stop, not a warning, which is why this is
+    the strict predicate and :func:`_tool_gap_is_environmental` is the loose one.
     """
     if _env_truthy(_CI_ENV):
         return False
-    return any(_env_truthy(marker) for marker in _REMOTE_CONTAINER_ENV_MARKERS)
+    if any(_env_truthy(marker) for marker in _REMOTE_CONTAINER_ENV_MARKERS):
+        return True
+    return _has_container_filesystem_signal()
+
+
+def _tool_gap_is_environmental() -> bool:
+    """True where a missing local tool is the environment, not a code defect.
+
+    Deliberately wider than :func:`_is_remote_container`. This one only decides
+    whether a missing ``gh act``, ``actionlint`` or Docker daemon degrades to a
+    warning instead of blocking the push (Issue #2548, item 3), and firing too
+    widely costs a warning. The container predicate cuts subprocess budgets, and
+    firing too widely there costs a push that cannot complete at all, so the two
+    questions get two answers.
+    """
+    if _env_truthy(_CI_ENV):
+        return False
+    return any(_env_truthy(marker) for marker in _TOOL_GAP_ENV_MARKERS)
 
 
 def _decode_partial(raw: bytes | str | None) -> str:
@@ -1199,9 +1294,10 @@ def _tool_gap_report(report: Report, note: str) -> Report:
 
     A tool gap is a missing actionlint, ``gh``, ``gh act`` extension, or Docker
     daemon: the local run cannot proceed, but the workflow itself is not proven
-    broken. In a remote container (see :func:`_is_remote_container`) the gap is
-    an environment limitation, not a code defect, so the gate degrades to a
-    logged warning (exit 0, ``degraded=True``) and the push proceeds. Everywhere
+    broken. Where the environment cannot provision the tool (see
+    :func:`_tool_gap_is_environmental`) the gap is an environment limitation,
+    not a code defect, so the gate degrades to a logged warning (exit 0,
+    ``degraded=True``) and the push proceeds. Everywhere
     else (a dev laptop, or CI where the tools are provisioned) the gap stays a
     blocking tool-unavailable failure (exit 3). The install hint in ``note`` is
     preserved either way.
@@ -1212,11 +1308,11 @@ def _tool_gap_report(report: Report, note: str) -> Report:
     Docker or actionlint can still push a workflow edit while CI keeps the hard
     exit 3.
     """
-    if _is_remote_container():
+    if _tool_gap_is_environmental():
         report.exit_code = 0
         report.degraded = True
         report.note = (
-            f"{note} Remote container detected; the missing tool cannot be "
+            f"{note} Managed environment detected; the missing tool cannot be "
             "provisioned here, so this gate is downgraded to a warning. CI "
             "still runs the full workflow check."
         )

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -288,11 +288,11 @@ def _tool_gap_is_environmental() -> bool:
     """True where a missing local tool is the environment, not a code defect.
 
     Deliberately wider than :func:`_is_remote_container`. This one only decides
-    whether a missing ``gh act``, ``actionlint`` or Docker daemon degrades to a
-    warning instead of blocking the push (Issue #2548, item 3), and firing too
-    widely costs a warning. The container predicate cuts subprocess budgets, and
-    firing too widely there costs a push that cannot complete at all, so the two
-    questions get two answers.
+    whether a missing ``gh``, ``gh act``, ``actionlint`` or Docker daemon
+    degrades to a warning instead of blocking the push (Issue #2548, item 3),
+    and firing too widely costs a warning. The container predicate cuts
+    subprocess budgets, and firing too widely there costs a push that cannot
+    complete at all, so the two questions get two answers.
     """
     if _env_truthy(_CI_ENV):
         return False

--- a/tests/ci/test_lefthook_container_bound.py
+++ b/tests/ci/test_lefthook_container_bound.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from types import ModuleType
 
 import pytest
 
@@ -211,7 +212,7 @@ class TestTheClampAsksTheContainerQuestion:
     """
 
     @staticmethod
-    def _module() -> object:
+    def _module() -> ModuleType:
         sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
         try:
             return importlib.import_module("run_workflow_local_test")

--- a/tests/ci/test_lefthook_container_bound.py
+++ b/tests/ci/test_lefthook_container_bound.py
@@ -26,6 +26,11 @@ Coverage:
 
 from __future__ import annotations
 
+import importlib
+import sys
+
+import pytest
+
 from tests.ci.lefthook_budget_model import (
     CONTAINER_UNCLAMPED_JOBS,
     REPO_ROOT,
@@ -184,3 +189,88 @@ class TestNoSingleChildOutlivesAContainer:
         }
         missing = sorted(CONTAINER_UNCLAMPED_JOBS - names)
         assert missing == [], f"{missing} are in the roster but not in pre-push."
+
+
+class TestTheClampAsksTheContainerQuestion:
+    """The clamp must fire on container evidence, never on a client name.
+
+    Issue #5479. `CLAUDECODE` named the client, not the environment, and the
+    Claude Code CLI sets it on a laptop, a workstation, and a VM. Reading it as
+    a container took the semgrep budget from 840s to 150s on a workstation, so a
+    branch whose scan needed more than 150s could not be pushed from a Claude
+    Code session and pushed fine from a plain terminal on the same machine.
+
+    The ceiling asserted by the rest of this module is only worth what the
+    predicate deciding when to apply it is worth. These cases pin that
+    predicate, so a future edit cannot widen the clamp back onto hosts that are
+    not containers while every declared-cap assertion above stays green.
+
+    Coverage: positive (real container evidence clamps), negative (the client
+    marker alone does not), edge (CI overrides, and the tool-gap predicate keeps
+    the marker the container predicate dropped).
+    """
+
+    @staticmethod
+    def _module() -> object:
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
+        try:
+            return importlib.import_module("run_workflow_local_test")
+        finally:
+            sys.path.pop(0)
+
+    def test_the_client_marker_alone_is_not_a_container(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression itself. `CLAUDECODE` with no container evidence."""
+        module = self._module()
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.delenv("CODESPACES", raising=False)
+        monkeypatch.delenv("AI_AGENTS_REMOTE_CONTAINER", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(module, "_has_container_filesystem_signal", lambda: False)
+
+        assert module._is_remote_container() is False
+
+    def test_a_filesystem_signal_is_a_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module = self._module()
+        monkeypatch.delenv("CODESPACES", raising=False)
+        monkeypatch.delenv("AI_AGENTS_REMOTE_CONTAINER", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(module, "_has_container_filesystem_signal", lambda: True)
+
+        assert module._is_remote_container() is True
+
+    def test_a_declared_image_marker_is_a_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An image with no filesystem signal can still declare itself."""
+        module = self._module()
+        monkeypatch.setenv("AI_AGENTS_REMOTE_CONTAINER", "1")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(module, "_has_container_filesystem_signal", lambda: False)
+
+        assert module._is_remote_container() is True
+
+    def test_ci_overrides_every_container_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CI provisions the tools, so a hang there is a real failure."""
+        module = self._module()
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("CODESPACES", "true")
+        monkeypatch.setattr(module, "_has_container_filesystem_signal", lambda: True)
+
+        assert module._is_remote_container() is False
+
+    def test_the_tool_gap_predicate_still_keeps_the_client_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The two questions must not collapse back into one.
+
+        Negative control for the first case above. If this ever agrees with it,
+        the split has been undone and the Issue #2548 item 3 degrade has been
+        dragged back onto the container predicate, or the reverse.
+        """
+        module = self._module()
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(module, "_has_container_filesystem_signal", lambda: False)
+
+        assert module._tool_gap_is_environmental() is True
+        assert module._is_remote_container() is False

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import builtins
+import importlib
 import io
 import json
 import os
@@ -11425,3 +11426,39 @@ def test_semgrep_family_prefix_exclusion_suppresses_nothing(tmp_path: Path) -> N
 def test_semgrep_command_exclusions_suppress_every_compat_rule(tmp_path: Path) -> None:
     """The production command, unmodified, reports none of the four rules."""
     assert _scan_compat_target(tmp_path, None) == set()
+
+
+def test_a_claude_code_session_on_a_workstation_keeps_the_full_semgrep_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #5479, end to end through the clamp the push actually calls.
+
+    `CLAUDECODE` named the client, not the environment. The Claude Code CLI
+    sets it on a laptop, a workstation, and a VM, so `_container_clamped` took
+    the semgrep budget from 840s to 150s there. A branch whose scan set needed
+    more than 150s could not be pushed from a Claude Code session and pushed
+    fine from a plain terminal on the same machine, same commits, same host.
+    Every bypass is forbidden by `.claude/rules/universal.md`, so the branch
+    simply could not be pushed.
+
+    Asserted on `_container_clamped` rather than on the predicate, because the
+    predicate is already pinned in `tests/ci/test_lefthook_container_bound.py`
+    and this is the consumer that turns it into a number the push feels. If the
+    two ever disagree, this is the one that matters.
+    """
+    sys.path.insert(0, str(Path(policy.__file__).resolve().parent))
+    try:
+        detector = importlib.import_module("run_workflow_local_test")
+    finally:
+        sys.path.pop(0)
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.delenv("CODESPACES", raising=False)
+    monkeypatch.delenv("AI_AGENTS_REMOTE_CONTAINER", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(detector, "_has_container_filesystem_signal", lambda: False)
+
+    budget = policy._container_clamped(policy.SEMGREP_TIMEOUT_SECONDS)
+
+    assert budget == policy.SEMGREP_TIMEOUT_SECONDS
+    assert budget > policy.CONTAINER_SUBPROCESS_CEILING_SECONDS

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -7353,9 +7353,9 @@ def test_cli_e2e_runs_with_clean_plugin_environment(
 
     monkeypatch.setattr(policy.subprocess, "Popen", FakePopen)
     # Pin the workstation contract. `_run_command` clamps a child's deadline
-    # inside a managed container (ADR-104 rule 8), and this repository's own
-    # dev containers set CLAUDECODE, so without this the assertion below reads
-    # the clamp rather than the budget it is about. The container behaviour is
+    # inside a managed container (ADR-104 rule 8), and this suite also runs
+    # inside dev containers, so without this the assertion below reads the
+    # clamp rather than the budget it is about. The container behaviour is
     # covered by its own test below.
     monkeypatch.setattr(policy, "_container_clamped", lambda seconds: seconds)
 
@@ -7541,7 +7541,13 @@ def test_a_container_clamps_the_cli_e2e_child_deadline(
 
     monkeypatch.setattr(policy.subprocess, "Popen", FakePopen)
     monkeypatch.delenv("CI", raising=False)
-    monkeypatch.setenv("CLAUDECODE", "1")
+    # CODESPACES, not CLAUDECODE. Issue #5479: the Claude Code CLI sets
+    # CLAUDECODE on a laptop and a workstation, so it names the client rather
+    # than the execution environment and no longer answers the container
+    # question. CODESPACES names a managed remote container, which is the case
+    # this test is about.
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setenv("CODESPACES", "true")
 
     assert policy.run_cli_e2e("tests/e2e/test.py", tmp_path) == 0
 
@@ -7577,7 +7583,11 @@ def test_ci_keeps_the_full_budget_even_inside_a_container_image(
             return ("", "")
 
     monkeypatch.setattr(policy.subprocess, "Popen", FakePopen)
-    monkeypatch.setenv("CLAUDECODE", "1")
+    # A marker that really does mean a container, so the CI override is what
+    # makes the answer False. With CLAUDECODE here (Issue #5479) there would be
+    # no container signal left for CI to override and this control would hold
+    # for the wrong reason.
+    monkeypatch.setenv("CODESPACES", "true")
     monkeypatch.setenv("CI", "true")
 
     assert policy.run_cli_e2e("tests/e2e/test.py", tmp_path) == 0

--- a/tests/test_safe_push_pr_branch.py
+++ b/tests/test_safe_push_pr_branch.py
@@ -943,8 +943,8 @@ def _record_pytest_timeouts(
 
     # Pin the workstation contract. `run_pytest` now clamps the aggregate
     # budget, not just each child, so inside a container these numbers would be
-    # the 150s ceiling rather than the budget under test. This repository's dev
-    # containers set CLAUDECODE, so without this the assertions would read the
+    # the 150s ceiling rather than the budget under test. This suite also runs
+    # inside dev containers, so without this the assertions would read the
     # clamp and quietly stop testing what they name. The clamped case has its
     # own test below.
     monkeypatch.setattr(git_hook_policy, "_container_clamped", lambda seconds: seconds)
@@ -998,7 +998,7 @@ def test_run_pytest_gives_the_collection_stand_in_the_smaller_budget(
     """
     monkeypatch.delenv(git_hook_policy.PYTEST_FULL_SUITE_LOCALLY_ENV, raising=False)
     # Workstation contract: the aggregate is now clamped in a container, and
-    # this repo's dev containers set CLAUDECODE, so the assertion would read
+    # this suite also runs inside dev containers, so the assertion would read
     # the 150s ceiling instead of the collection budget it names.
     monkeypatch.setattr(git_hook_policy, "_container_clamped", lambda seconds: seconds)
     seen: list[float] = []

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -117,6 +117,187 @@ def test_select_workflow_files_keeps_only_workflows(tmp_path):
     ]
 
 
+# --- container detection (Issue #5479) -----------------------------------
+#
+# `_is_remote_container` decides whether `git_hook_policy` clamps every child
+# process to 150s. It used to answer from `CLAUDECODE`, which the Claude Code
+# CLI sets on an ordinary workstation, so a branch whose semgrep scan needs more
+# than 150s could not be pushed from a Claude Code session while the same push
+# succeeded from a plain terminal on the same machine. These tests pin the
+# predicate to observable container evidence instead.
+#
+# The probe reads real files under tmp_path rather than a patched `Path`, so the
+# branch under test is the one production takes.
+
+
+def _filesystem(monkeypatch, tmp_path, *, marker=None, cgroup=None):
+    """Point the container probe at tmp_path. Absent argument means absent file."""
+    marker_path = tmp_path / "container-marker"
+    if marker is not None:
+        marker_path.write_text(marker, encoding="utf-8")
+    monkeypatch.setattr(w, "_CONTAINER_MARKER_FILES", (str(marker_path),))
+
+    cgroup_path = tmp_path / "cgroup"
+    if cgroup is not None:
+        cgroup_path.write_text(cgroup, encoding="utf-8")
+    monkeypatch.setattr(w, "_CONTAINER_CGROUP_FILE", str(cgroup_path))
+
+
+# Measured on an Ubuntu 6.17 workstation with Docker installed, no container.
+_HOST_CGROUP = "1:net_cls:/\n0::/init.scope\n"
+# Shape of /proc/1/cgroup inside a cgroup v1 Docker container.
+_DOCKER_CGROUP = "11:cpuset:/docker/8f2c19a4\n1:name=systemd:/docker/8f2c19a4\n"
+
+
+def test_claude_code_cli_on_a_workstation_is_not_a_container(monkeypatch, tmp_path):
+    """The defect. CLAUDECODE names the client, never the environment.
+
+    This is the negative control for the whole change: revert the fix and this
+    is the assertion that fails, because the old predicate answered True here
+    and cut the semgrep budget from 840s to 150s on a developer workstation.
+    """
+    monkeypatch.setenv("CLAUDECODE", "1")
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is False
+
+
+def test_nothing_set_is_not_a_container(monkeypatch, tmp_path):
+    """Plain terminal on the same workstation: no env marker, no container."""
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is False
+
+
+def test_a_docker_marker_file_is_a_container(monkeypatch, tmp_path):
+    """Docker writes /.dockerenv inside the container and nowhere else."""
+    _filesystem(monkeypatch, tmp_path, marker="", cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is True
+
+
+def test_a_cgroup_hint_is_a_container_without_any_marker_file(monkeypatch, tmp_path):
+    """cgroup v1 containers carry the runtime in the init process's cgroups.
+
+    Separate from the marker-file test so neither signal can regress alone: a
+    predicate that only read /.dockerenv would still pass that one.
+    """
+    _filesystem(monkeypatch, tmp_path, cgroup=_DOCKER_CGROUP)
+
+    assert w._is_remote_container() is True
+
+
+def test_codespaces_is_still_a_container(monkeypatch, tmp_path):
+    """CODESPACES names a managed remote container, so it survived the change."""
+    monkeypatch.setenv("CODESPACES", "true")
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is True
+
+
+def test_an_image_set_marker_is_a_container_with_no_filesystem_evidence(monkeypatch, tmp_path):
+    """The escape hatch Issue #5479 asked for, for images the probe cannot see.
+
+    The filesystem probe is evidence, not a guarantee: a runtime that writes no
+    marker file and reports `0::/` under cgroup v2 leaves nothing to read, and
+    the Claude web container's filesystem has not been measured here. ADR-104
+    rule 8 is the reason that gap needs a way to close: without a container
+    answer the semgrep budget stays at 840s and the whole-process watchdog never
+    arms, so a hook that stops making progress is reclaimed with no diagnostic.
+    An image that needs the bound sets this marker instead of being inferred.
+    """
+    monkeypatch.setenv("AI_AGENTS_REMOTE_CONTAINER", "1")
+    monkeypatch.delenv("CODESPACES", raising=False)
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is True
+
+
+def test_the_image_set_marker_does_not_widen_the_tool_gap_degrade(monkeypatch, tmp_path):
+    """It answers the container question only, like every other container signal.
+
+    Pairs with the marker test above so the new variable cannot quietly become
+    a second `CLAUDECODE`: declaring a reclamation bound is not a claim that
+    `gh act` cannot be installed, so a tool gap there still blocks at exit 3.
+    """
+    monkeypatch.setenv("AI_AGENTS_REMOTE_CONTAINER", "1")
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CODESPACES", raising=False)
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._tool_gap_is_environmental() is False
+
+
+def test_ci_overrides_the_image_set_marker(monkeypatch, tmp_path):
+    """CI provisions the tools and must keep failing the way CI expects.
+
+    The CI override is checked before the env markers, so a new marker in that
+    tuple cannot reach CI. Asserted rather than assumed: this is the branch that
+    would turn a real CI hang into a 150s clamp and a different verdict.
+    """
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("AI_AGENTS_REMOTE_CONTAINER", "1")
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._is_remote_container() is False
+
+
+def test_ci_overrides_a_real_container_signal(monkeypatch, tmp_path):
+    """CI runs in containers and a hang there is a real failure, not a reclaim."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("CODESPACES", "true")
+    _filesystem(monkeypatch, tmp_path, marker="", cgroup=_DOCKER_CGROUP)
+
+    assert w._is_remote_container() is False
+
+
+def test_an_unreadable_cgroup_file_is_not_a_container(monkeypatch, tmp_path):
+    """Edge: the probe runs on every push and must never raise.
+
+    Points the cgroup path at a directory, which is the cheapest reproducible
+    OSError. A non-Linux host takes the same branch by having no such file.
+    """
+    monkeypatch.setattr(w, "_CONTAINER_MARKER_FILES", (str(tmp_path / "absent"),))
+    monkeypatch.setattr(w, "_CONTAINER_CGROUP_FILE", str(tmp_path))
+
+    assert w._has_container_filesystem_signal() is False
+
+
+def test_the_tool_gap_predicate_still_degrades_for_claude_code(monkeypatch, tmp_path):
+    """Issue #2548 item 3 is unchanged: a tool gap there is still a warning.
+
+    The two predicates answer different questions. Firing this one too widely
+    costs a warning; firing the container one too widely costs a push that
+    cannot complete, which is why CLAUDECODE stays here and left the other.
+    """
+    monkeypatch.setenv("CLAUDECODE", "1")
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._tool_gap_is_environmental() is True
+    assert w._is_remote_container() is False
+
+
+def test_the_tool_gap_predicate_ignores_container_filesystem_signals(monkeypatch, tmp_path):
+    """Control for the pair above, from the other side.
+
+    A container with neither env marker set blocks on a tool gap exactly as it
+    did before this change, so the degrade path gained nothing and lost nothing.
+    """
+    _filesystem(monkeypatch, tmp_path, marker="", cgroup=_DOCKER_CGROUP)
+
+    assert w._is_remote_container() is True
+    assert w._tool_gap_is_environmental() is False
+
+
+def test_ci_overrides_the_tool_gap_predicate(monkeypatch, tmp_path):
+    """CI provisions gh act, so a gap there stays a hard failure."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CI", "true")
+    _filesystem(monkeypatch, tmp_path, cgroup=_HOST_CGROUP)
+
+    assert w._tool_gap_is_environmental() is False
+
+
 # --- tool / docker gaps --------------------------------------------------
 
 
@@ -125,7 +306,7 @@ def test_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
     # blocks at exit 3. The container-downgrade seam is pinned off so the test is
     # deterministic regardless of the host env (Issue #3064).
     monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
@@ -167,7 +348,7 @@ def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
     # is deterministic regardless of the host env (Issue #2548, item 3).
     monkeypatch.setattr(w, "_have", lambda tool: tool == "actionlint")
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
@@ -180,7 +361,7 @@ def test_gh_act_extension_missing_is_exit_3(monkeypatch, tmp_path):
     monkeypatch.setattr(w, "_have", lambda tool: True)
     monkeypatch.setattr(w, "_gh_act_available", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
@@ -236,7 +417,7 @@ def test_gh_act_missing_without_container_signal_still_exit_3(monkeypatch, tmp_p
     monkeypatch.setattr(w, "_have", lambda tool: True)
     monkeypatch.setattr(w, "_gh_act_available", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     monkeypatch.delenv("CI", raising=False)
     r = w.run_local_test([WF], tmp_path)
@@ -267,7 +448,7 @@ def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
     # container-downgrade seam is pinned off so the exit-3 assertion is
     # deterministic regardless of the host env (Issue #3064).
     monkeypatch.setattr(w, "_docker_ready", lambda: False)
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
     monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
     r = w.run_local_test([WF], tmp_path)
@@ -281,7 +462,7 @@ def test_docker_not_installed_is_exit_3_with_distinct_note(monkeypatch, tmp_path
     monkeypatch.setattr(w, "_have", lambda tool: tool != "docker")
     monkeypatch.setattr(w, "_gh_act_available", lambda: True)
     monkeypatch.setattr(w, "_docker_ready", lambda: False)
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
     monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
@@ -675,7 +856,7 @@ def test_all_secret_blocked_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
     # container-downgrade seam off so the exit-3 assertion holds regardless of
     # the host env (Issue #3064).
     monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
-    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.setattr(w, "_tool_gap_is_environmental", lambda: False)
     monkeypatch.delenv("BOT_PAT_2841", raising=False)
     _write_wf_secrets(tmp_path, WF, "BOT_PAT_2841")
     r = w.run_local_test([WF], tmp_path)

--- a/tests/validation/test_security_scan_budget.py
+++ b/tests/validation/test_security_scan_budget.py
@@ -177,6 +177,90 @@ def test_a_workstation_keeps_the_semgrep_budget(
     assert budget <= policy.SEMGREP_TIMEOUT_SECONDS + 1
 
 
+def _real_detector(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Run `_container_clamped` against the real detector, with a known filesystem.
+
+    The other tests here inject a clamp, which proves the arithmetic and says
+    nothing about what decides it. The two below run the production predicate,
+    so they read the answer a push actually gets.
+
+    `_container_clamped` imports `run_workflow_local_test` by bare name, which
+    resolves only when something has put `scripts/validation` on sys.path.
+    Pinning the module in sys.modules makes that deterministic: without it a
+    lone run of this file takes the ImportError branch, goes unclamped, and
+    passes the workstation assertion for the wrong reason.
+    """
+    from scripts.validation import run_workflow_local_test as detector
+
+    monkeypatch.setitem(sys.modules, "run_workflow_local_test", detector)
+    monkeypatch.setattr(detector, "_CONTAINER_MARKER_FILES", (str(tmp_path / "absent"),))
+    monkeypatch.setattr(detector, "_CONTAINER_CGROUP_FILE", str(tmp_path / "absent"))
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CODESPACES", raising=False)
+    # Every env the predicate reads, so the host cannot decide these budgets.
+    # An image that declares itself would otherwise clamp the workstation test
+    # and the assertion would report a defect that is not there.
+    monkeypatch.delenv("AI_AGENTS_REMOTE_CONTAINER", raising=False)
+
+
+def test_a_claude_code_session_keeps_the_full_semgrep_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #5479, asserted on the budget rather than on a stopwatch.
+
+    The Claude Code CLI sets `CLAUDECODE` on an ordinary workstation. While that
+    counted as a container the job ran on 150s instead of 840s, so a branch
+    whose scan set costs more than 150s could not be pushed from a Claude Code
+    session and pushed fine from a plain terminal on the same machine. Revert
+    the detector change and this test fails.
+    """
+    _real_detector(monkeypatch, tmp_path)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    _arrange(monkeypatch, ["head1"], clamp=policy._container_clamped)
+    seen = _record_deadlines(monkeypatch)
+
+    started = time.monotonic()
+    assert policy.scan_pushed_heads(io.StringIO(), tmp_path) == 0
+    budget = seen[0] - started
+
+    # A window, not `> _CONTAINER_CEILING`. The deadline is set a few
+    # microseconds after `started`, so a clamped budget measures 150.00001s and
+    # a strict `>` comparison against 150 passes on the clamped value. That
+    # weaker assertion survived the revert this test exists to catch.
+    assert policy.SEMGREP_TIMEOUT_SECONDS - 1 <= budget <= policy.SEMGREP_TIMEOUT_SECONDS + 1, (
+        f"the scan loop got {budget:.0f}s, not the "
+        f"{policy.SEMGREP_TIMEOUT_SECONDS}s workstation budget. CLAUDECODE is "
+        "being read as a container again and this push is capped at 18 percent "
+        "of what it is allowed."
+    )
+
+
+def test_a_real_container_still_clamps_the_semgrep_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Control for the test above: the clamp still binds where it should.
+
+    If these two ever agree the detector answers the same everywhere and
+    neither test is about a container. `CODESPACES` is the env half of the
+    predicate; the filesystem half has its own tests in
+    `tests/validation/test_run_workflow_local_test.py`.
+    """
+    _real_detector(monkeypatch, tmp_path)
+    monkeypatch.setenv("CODESPACES", "true")
+    _arrange(monkeypatch, ["head1"], clamp=policy._container_clamped)
+    seen = _record_deadlines(monkeypatch)
+
+    started = time.monotonic()
+    assert policy.scan_pushed_heads(io.StringIO(), tmp_path) == 0
+    budget = seen[0] - started
+
+    assert _CONTAINER_CEILING - 1 <= budget <= _CONTAINER_CEILING + 1, (
+        f"the scan loop got {budget:.0f}s inside a container rather than the "
+        f"{_CONTAINER_CEILING:.0f}s ceiling, so the job can outlive a reclaim."
+    )
+
+
 def test_a_later_ref_is_refused_once_the_budget_is_gone(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

`CLAUDECODE` was read as proof of a managed remote container. It names the client, not the execution environment: the Claude Code CLI sets it on a laptop, a workstation, and a VM. This splits the one predicate into the two questions it was answering.

### Why

`_is_remote_container()` answered True on a workstation, so `_container_clamped` took the pre-push semgrep budget from 840s to 150s. A branch whose scan set costs more than 150s could not be pushed from a Claude Code session and pushed fine from a plain terminal on the same machine, same commits, same host. The gate is the repository's own security scan and `.claude/rules/universal.md` MUST NOT item 2 forbids every bypass, so the branch simply could not be pushed.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5479 | fix(hooks): CLAUDECODE is not a container marker, and the 150s clamp makes some pushes impossible |

## Changes

- `_tool_gap_is_environmental()` keeps `CLAUDECODE` and `CODESPACES`. It only decides whether a missing `actionlint`, `gh act`, or Docker daemon degrades to a warning instead of blocking (Issue #2548 item 3). Firing too widely there costs a warning.
- `_is_remote_container()` answers from `CODESPACES`, from an image that declares itself with `AI_AGENTS_REMOTE_CONTAINER`, and from the filesystem (`/.dockerenv`, `/run/.containerenv`, container hints in `/proc/1/cgroup`). It cuts subprocess budgets and arms the whole-process watchdog. Firing too widely there costs a push that cannot complete at all.
- A truthy `CI` still overrides both, unchanged.
- Module docstring and EXIT CODES item 3 updated: they described the tool-gap degrade as container-conditioned, which the split makes false for a Docker container with neither env marker.

`/proc/self/mountinfo` is deliberately not consulted, and the code says why: on an Ubuntu 6.17 workstation with Docker installed and no container running it holds `/run/docker/netns/default` and `/var/lib/lxcfs`, so it reports a container on a machine that is not one. That is the same false positive this change exists to remove.

## Acceptance criteria

- [x] `CLAUDECODE` alone no longer makes `_is_remote_container()` return True
- [x] The semgrep budget is 840s rather than 150s in a Claude Code session on a workstation
- [x] The `gh act` / actionlint / Docker tool-gap degrade still fires under `CLAUDECODE`, so Issue #2548 item 3 behavior is preserved
- [x] A truthy `CI` still overrides both predicates
- [x] A real container with no env marker is detected by the filesystem probe
- [x] An image can declare itself with `AI_AGENTS_REMOTE_CONTAINER` rather than borrowing the client's variable
- [x] Positive, negative, and edge tests land in the two files the issue names

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: full review, high scrutiny. This changes a predicate that gates the security scan's budget and arms a process watchdog.

**Focus areas**: the blast radius of `_is_remote_container()`. Every caller was traced, but confirm the list: `git_hook_policy._container_clamped` and `_arm_container_watchdog` both bound work against container reclamation, and a false negative there means a push can be killed mid-hook rather than bounded. That is the direction this change makes more likely, and #5541 is the follow-up that closes it.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- `pytest tests/validation/test_run_workflow_local_test.py tests/validation/test_security_scan_budget.py ...`: 172 passed.
- `pytest tests/ci/test_lefthook_container_bound.py -q`: 4 passed.
- `pytest tests/test_lefthook_integration.py -q -k "container or claude or codespace"`: 5 passed, 857 deselected.
- `pytest tests/test_safe_push_pr_branch.py -q`: 52 passed.
- Negative control: reverting `_REMOTE_CONTAINER_ENV_MARKERS` to `("CODESPACES",)` fails `test_an_image_set_marker_is_a_container_with_no_filesystem_signal`.
- Coverage includes the four cases that matter: a real container signal present, `CLAUDECODE` set with no container signal (must NOT clamp), `CODESPACES` set, and nothing set.
- Criterion 6 follow-up: 9 passed in the container-bound module, 6 passed in the integration module's container selection. Negative control: restoring `CLAUDECODE` to the container marker tuple fails the integration case with `assert 150.0 == 840`, which is the regression in one line.
- Count ratchets exit 0, per `scripts/validation/checks_ratchet.py`. Lint clean under `ruff check`.
- Pre-push hooks green, 205.39s. `security-scan` measured **89.48s** on this branch, against 15.16s and 17.34s on the two sibling branches pushed in the same session. This branch touches `tests/test_lefthook_integration.py`, which the issue's own second comment identifies as where semgrep spends most of its budget. 89.48s clears the old 150s clamp, so this particular push would have survived it, but it is two thirds of the way there on a quiet machine.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `scripts/validation/run_workflow_local_test.py` (container predicate feeding the semgrep budget clamp and the process watchdog)

The new filesystem probe is total and read-only: two `stat` calls and one small read, no subprocess, no error escapes, and it returns False without raising on a host lacking those paths (Windows, macOS).

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [x] Critic validated implementation plan
- [x] QA verified test coverage

An independent adversarial reviewer read the diff without the implementer's reasoning. Two findings, both addressed: a stale module contract (fixed), and an unproven claim that the Claude web container carries a filesystem signal (fixed by adding the declared marker rather than by asserting the measurement). A third finding, that the filesystem probe's False should warn like the ImportError path, was refuted and not changed: on the ImportError path detection is unavailable and the clamp lapses unconditionally, while on the filesystem path the probe ran and returned a measurement, and False is the correct answer on every workstation and on macOS where `/proc` is absent.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push job, 86.07s, green)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

**Acceptance criterion 6 now holds, after the Validate Spec Coverage gate correctly rejected the first pass.** The tests originally landed only in `tests/validation/`, beside the predicate. The issue asked for them in the two files named in the criteria, and the gate reported NOT SATISFIED. Both files now carry the cases: the container-bound module gets the predicate itself (five cases including the split's negative control), and the integration module gets one case, the consumer that turns the predicate into a number the push feels. One rather than five there, because that file is where semgrep spends most of its pre-push budget and growing it works against what this branch is fixing.

**Nothing sets `AI_AGENTS_REMOTE_CONTAINER` yet.** The marker exists; no image declares it. If the Claude web container carries no filesystem signal, its ADR-104 rule 8 reclamation bound lapses after this merges, where before it held by accident through `CLAUDECODE`. That cannot be measured from a workstation, so it is filed as **#5541** rather than guessed at here. Consider #5541 a merge-blocker if you disagree with taking that window.

**The 840s restoration is asserted at the API boundary**, the deadline passed to the scan loop, not on a push whose scan actually exceeds 150s. No such push was available to test with.

## Related Issues

Fixes #5479
Refs #2548, #5541, ADR-104 rule 8, ADR-054
