### PR TITLE
fix(ci): run the subprocess-encoding count ratchet in the local gate

### DIFF
--- a/scripts/ci/subprocess_encoding_count_ratchet.py
+++ b/scripts/ci/subprocess_encoding_count_ratchet.py
@@ -55,17 +55,18 @@ MERGE_TREE_BACKED = False
 The other five count ratchets under ``scripts/ci`` are, so their branch-tree
 comparison may pass a branch that merely holds a number ``main`` lowered
 underneath it: ``scripts/ci/merge_tree_ratchet_check.py`` measures the merged
-result for them. This one has no such gate, and it runs only from
-``.github/workflows/pytest.yml`` (no lefthook job, no pr-validation step), so
-the ``--base-ref`` comparison is its whole stale-branch guard. Waiving it here
-would let a branch cut before a lowering carry its old ceiling over the base's
-current one: with baseline 238 against a tree of 234, four new violations
-measure 238, pass under the stale ceiling, and land above ``main``'s 234.
+result for them. This one has no such gate, so the ``--base-ref`` comparison is
+its whole stale-branch guard. Waiving it here would let a branch cut before a
+lowering carry its old ceiling over the base's current one: with baseline 238
+against a tree of 234, four new violations measure 238, pass under the stale
+ceiling, and land above ``main``'s 234.
 
-Registering it would be the other fix and is deliberately not taken here: it
-adds a sixth evaluation to the local count-ratchets aggregate and to
-pr-validation, which is a gate change (ci-scripts MUST-13) rather than a defect
-repair. Pinned against the registry by
+Registering the baseline in that registry would be the other fix and is still
+not taken. Issue #5482 was closed by registering this module in
+``scripts/validation/checks_ratchet.py::RATCHETS`` instead, which is what runs
+it at pre-push and in ``pre_pr.py``. That is a local gate, not a merged-tree
+evaluation, so it leaves the declaration above at False. Pinned against the
+merge-tree registry by
 ``tests/ci/test_merge_tree_backing_declarations.py``, so flipping this to True
 without registering the baseline fails.
 """

--- a/scripts/validation/checks_ratchet.py
+++ b/scripts/validation/checks_ratchet.py
@@ -8,15 +8,35 @@ pass, pushed, and learned about a 0.21 second failure 674 seconds later.
 
 Running them here converts that 674 second round trip into a local one that
 finishes before the suite starts. The registry has grown since, and the "about
-three seconds" this paragraph used to claim is long gone: the eight entries are
-dominated by merge-tree at 22.9s and cli-exit-contract at 15.6s, with the other
-six between 0.1s and 2.6s. That is 42.4s run one after another and about 23s
-run together on an idle machine, where the floor is the slowest single entry
-rather than the sum. Still far inside the 674 seconds it replaces, and inside
-the 90 second lefthook cap.
+three seconds" this paragraph used to claim is long gone: the nine entries are
+dominated by subprocess-encoding at 33.7s, merge-tree at 22.9s and
+cli-exit-contract at 15.6s, with the other six between 0.1s and 2.6s. Run
+together they measured 46.72s, 43.46s and 48.91s wall over three runs on this
+machine, where the floor is the slowest single entry rather than the sum.
+Still far inside the 674 seconds it replaces, and inside the 90 second
+lefthook cap.
+
+Every entry in :data:`RATCHETS` is spawned, including the five whose counters
+``scripts/ci/merge_tree_ratchet_check.py`` runs a second time against the
+merged tree. Issue #5510 asked for that second run to be dropped as duplicate
+work. It is not dropped, because the two runs answer different questions:
+``scripts/ci/count_ratchet.py::_base_ref_verdict`` says so in its own words,
+"this check reads the fork point, which the merge-tree gate never does, and it
+evaluates the branch's own tree rather than the merged one. Neither subsumes
+the other."
+
+Probed on this tree, with the merged pass called directly. A taste baseline of
+615 over a base of 575 with a count of 575 returns
+``(0, 'taste count ratchet: OK. 575 <= 575.')`` from
+``merge_tree_ratchet_check._check_one``, while the standalone run exits 1 with
+BASELINE ABOVE BASE. A ruff baseline of 130 over a tree measuring 118 returns
+``(0, 'ruff count ratchet: OK. 118 <= 130.')``, while
+``count_ratchet.baseline_health(118, 130)`` reports "a gap of 12 above the
+permitted 6". Dropping the spawn would leave both verdicts enforced in CI and
+in no local gate, which is the property issue #5482 exists to remove.
 
 The pre-push hook and pre-PR runner both delegate to this module. Keeping the
-ratchet set and command construction here avoids eight parallel hook jobs
+ratchet set and command construction here avoids nine parallel hook jobs
 duplicating the registry while preserving early failure before expensive jobs.
 """
 
@@ -87,6 +107,16 @@ RATCHETS: tuple[Ratchet, ...] = (
         False,
         True,
     ),
+    # Issue #5482: before this entry existed the counter ran only in
+    # .github/workflows/pytest.yml, so a violation in any of the 1729 tracked
+    # Python files outside scripts/ passed every local gate and failed CI.
+    # Measured live on PR #5476.
+    Ratchet(
+        "subprocess-encoding-count-ratchet",
+        "scripts/ci/subprocess_encoding_count_ratchet.py",
+        False,
+        True,
+    ),
     Ratchet(
         "memory-index-token-ratchet",
         "scripts/ci/memory_index_token_ratchet.py",
@@ -105,20 +135,28 @@ RATCHETS: tuple[Ratchet, ...] = (
 # deadline is what fires and names the offending ratchet, rather than lefthook
 # killing the job with no attribution.
 #
-# Not raised, deliberately. Concurrency is what buys headroom for a ninth
-# entry, the subprocess-encoding ratchet of issue #5482, which is NOT
-# registered above: measured with it, 84.2s sequential against this
-# deadline and 51.4s concurrent.
-# Raising the lefthook cap to buy more would cost 90s of the pre-push declared
+# Not raised, deliberately. The subprocess-encoding ratchet of issue #5482 was
+# held out of this registry because a sequential loop did not fit it: 84.2s
+# sequential and 51.4s concurrent against this deadline. Concurrency is what
+# paid for it, and the nine-entry set was re-measured here with it registered,
+# load average 0.73 to 2.09: 46.72s, 43.46s and 48.91s wall, 92.4s to 100.7s of
+# user CPU, all three exit 0. The slowest run is 58% of this deadline and
+# leaves 36s. Wall clock is what this deadline and the lefthook cap measure,
+# and its floor is the slowest single entry either way, so the five counters
+# the merge-tree pass also runs cost CPU here rather than wall clock. That is the
+# trade issue #5510 asked to close and it is not taken; the module docstring
+# above records the two verdict classes dropping those spawns would move to CI
+# only.
+# Raising the lefthook cap instead would cost 90s of the pre-push declared
 # budget, which `tests/ci/test_lefthook_declared_budget.py` ratchets at 3450s
 # for the whole hook; that budget is paid for by measuring a job and cutting
 # another cap (ci-scripts.md MUST-16), which is separate work from this
 # change. Under heavy load the aggregate can still exhaust this budget:
 # measured at load average 6.2 it reached 85.3s while every ratchet passed
-# alone. That failure mode predates this change (a cold run this session
-# reported "merge-tree-ratchet: Command timed out after 33s" with the eight
-# entry registry, then passed on retry), and concurrency makes it rarer than
-# the sequential loop did, but it is not eliminated.
+# alone. That failure mode predates this change (a cold run reported
+# "merge-tree-ratchet: Command timed out after 33s" with the eight entry
+# registry, then passed on retry), and concurrency makes it rarer than the
+# sequential loop did, but it is not eliminated.
 _AGGREGATE_TIMEOUT_SECONDS = 85
 _LEFTHOOK_TIMEOUT_SECONDS = 90
 
@@ -223,19 +261,13 @@ def _run_ratchets(
     """Run every ratchet concurrently; return each result by job name.
 
     Concurrent rather than sequential because the registry's cost is dominated
-    by a few entries: measured warm on this tree, merge-tree 22.9s and
-    cli-exit-contract 15.6s against 0.1s to 2.6s for the other six. One
-    shared deadline over a sequential loop spends that budget in registry order, so the last entry
-    runs on whatever is left and is
-    the one that times out; observed on a cold run, where merge-tree,
-    registered last, reported "Command timed out after 33s" and then passed on
-    retry with no code change.
-
-    Measured A/B, with the subprocess-encoding ratchet issue #5482 wants to
-    add: 84.2s sequential against an 85 second deadline, 51.4s concurrent.
-    That entry is not registered here yet, because even concurrently it does
-    not fit the budget on a loaded machine; the headroom this creates is a
-    precondition for it, not a delivery of it.
+    by a few entries: measured warm on this tree, subprocess-encoding 33.7s,
+    merge-tree 22.9s and cli-exit-contract 15.6s against 0.1s to 2.6s for the
+    other six. One shared
+    deadline over a sequential loop spends that budget in registry order, so
+    the last entry runs on whatever is left and is the one that times out;
+    observed on a cold run, where merge-tree, registered last, reported
+    "Command timed out after 33s" and then passed on retry with no code change.
 
     Every registered ratchet only reads: none of the scripts issues a git
     command that writes (`add`, `commit`, `checkout`, `reset`, `read-tree`,

--- a/tests/ci/test_lefthook_ratchet_wiring.py
+++ b/tests/ci/test_lefthook_ratchet_wiring.py
@@ -208,18 +208,26 @@ class TestEveryCountRatchetIsGatedLocally:
         )
 
 
-def spawned_scripts(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+def spawned_scripts(monkeypatch: pytest.MonkeyPatch, *, skip: str | None = None) -> list[str]:
     """Every ratchet script one ``validate_count_ratchets`` run launches.
 
     Reads the argv the gate hands ``_run_subprocess`` rather than the registry
     it was built from. A declaration the gate never launches is the failure
     this helper exists to see, and a registry-derived expectation cannot see it.
     Duplicates are kept so a script launched twice is visible too.
+
+    ``skip`` drops one script from the recorded list while still returning an OK
+    result for it, which models a gate that declares an entry and never spawns
+    it. It leaves ``RATCHETS`` untouched on purpose: removing the entry from the
+    registry would move the declared set and the launched set together, and the
+    regression under test is the two disagreeing.
     """
     launched: list[str] = []
 
     def record(args: list[str], **_kwargs: object) -> tuple[int, str, str]:
-        launched.append(args[args.index("python") + 1])
+        script = args[args.index("python") + 1]
+        if script != skip:
+            launched.append(script)
         return 0, "", ""
 
     monkeypatch.setattr(
@@ -277,14 +285,19 @@ class TestEveryDeclaredRatchetIsLaunched:
     def test_a_skipped_entry_is_reported(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Negative control: a registry the gate only partly launches."""
+        """Negative control: the gate declares the entry and never launches it.
+
+        The entry stays in ``RATCHETS``. Only the spawn is suppressed, so the
+        declared set and the launched set disagree by exactly one script, which
+        is the shape ``test_every_baseline_owning_ratchet_is_launched`` exists
+        to catch.
+        """
         target = "scripts/ci/taste_count_ratchet.py"
-        monkeypatch.setattr(
-            checks_ratchet,
-            "RATCHETS",
-            tuple(r for r in checks_ratchet.RATCHETS if r.script != target),
+        assert target in [r.script for r in checks_ratchet.RATCHETS], (
+            f"{target} must stay declared for this control to model "
+            f"declared-but-never-launched"
         )
-        launched = set(spawned_scripts(monkeypatch))
+        launched = set(spawned_scripts(monkeypatch, skip=target))
 
         assert [s for s in ci_baseline_ratchet_scripts() if s not in launched] == [
             target

--- a/tests/ci/test_lefthook_ratchet_wiring.py
+++ b/tests/ci/test_lefthook_ratchet_wiring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -132,3 +133,167 @@ class TestAggregateBudgetIsConsistentWithLefthook:
             checks_ratchet._LEFTHOOK_TIMEOUT_SECONDS
             == self._count_ratchets_timeout_seconds()
         )
+
+
+def ci_baseline_ratchet_scripts() -> list[str]:
+    """Every count ratchet that owns a baseline under ``scripts/ci``.
+
+    Derived from the baseline files rather than a hand-written list, so the
+    next ratchet is covered on the day its baseline lands. The name mapping is
+    the repository's own convention, ``<name>_baseline.txt`` beside
+    ``<name>_ratchet.py``; a module that breaks it is caught by
+    ``test_every_derived_ratchet_script_exists`` rather than silently dropping
+    out of the inventory.
+    """
+    ci_dir = REPO_ROOT / "scripts" / "ci"
+    return sorted(
+        f"scripts/ci/{path.name.removesuffix('_baseline.txt')}_ratchet.py"
+        for path in ci_dir.glob("*_baseline.txt")
+    )
+
+
+def unregistered_ratchet_scripts(registered: set[str]) -> list[str]:
+    """Baseline-owning ratchets that no local registry entry runs."""
+    return [script for script in ci_baseline_ratchet_scripts() if script not in registered]
+
+
+class TestEveryCountRatchetIsGatedLocally:
+    """A ratchet enforced only in CI costs a push and a full CI cycle (#5482).
+
+    ``subprocess_encoding_count_ratchet.py`` ran in
+    ``.github/workflows/pytest.yml`` and in no local gate, so a violation in
+    any of the 1729 tracked Python files outside ``scripts/`` passed
+    pre-commit, pre-push, and ``pre_pr.py``, then failed CI. Measured live on
+    PR #5476.
+
+    Coverage: positive, every baseline-owning ratchet is in the local
+    registry; negative, dropping one from the registry is reported by name,
+    which is the pre-fix state; edge, the inventory is non-empty and every
+    derived script exists, so the check cannot pass vacuously.
+    """
+
+    def test_every_baseline_owning_ratchet_runs_in_the_local_registry(self) -> None:
+        registered = {ratchet.script for ratchet in checks_ratchet.RATCHETS}
+        missing = unregistered_ratchet_scripts(registered)
+
+        assert not missing, (
+            f"count ratchet(s) enforced in CI and in no local gate: {missing}. "
+            f"Add a Ratchet(...) entry in scripts/validation/checks_ratchet.py."
+        )
+
+    def test_dropping_a_ratchet_from_the_registry_is_reported(self) -> None:
+        """Negative control: the pre-fix registry, which omitted this one."""
+        target = "scripts/ci/subprocess_encoding_count_ratchet.py"
+        pre_fix = {
+            ratchet.script for ratchet in checks_ratchet.RATCHETS
+        } - {target}
+
+        assert unregistered_ratchet_scripts(pre_fix) == [target]
+
+    def test_the_inventory_is_not_empty(self) -> None:
+        """Edge: a glob that matched nothing would make the check vacuous."""
+        assert ci_baseline_ratchet_scripts()
+
+    def test_every_derived_ratchet_script_exists(self) -> None:
+        """Edge: a baseline whose module breaks the naming convention fails here."""
+        missing = [
+            script
+            for script in ci_baseline_ratchet_scripts()
+            if not (REPO_ROOT / script).is_file()
+        ]
+
+        assert not missing, (
+            f"baseline file(s) with no matching *_ratchet.py module: {missing}. "
+            f"Fix the name, or teach ci_baseline_ratchet_scripts the mapping."
+        )
+
+
+def spawned_scripts(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Every ratchet script one ``validate_count_ratchets`` run launches.
+
+    Reads the argv the gate hands ``_run_subprocess`` rather than the registry
+    it was built from. A declaration the gate never launches is the failure
+    this helper exists to see, and a registry-derived expectation cannot see it.
+    Duplicates are kept so a script launched twice is visible too.
+    """
+    launched: list[str] = []
+
+    def record(args: list[str], **_kwargs: object) -> tuple[int, str, str]:
+        launched.append(args[args.index("python") + 1])
+        return 0, "", ""
+
+    monkeypatch.setattr(
+        checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"
+    )
+    monkeypatch.setattr(checks_ratchet, "_refresh_remote_base", lambda *_a: "")
+    monkeypatch.setattr(checks_ratchet, "_resolve_base_oid", lambda *_a: "a" * 40)
+    monkeypatch.setattr(checks_ratchet, "_run_subprocess", record)
+    assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is True
+    return launched
+
+
+class TestEveryDeclaredRatchetIsLaunched:
+    """Declaring a ratchet is not running it (issues #5482, #5510).
+
+    Issue #5510 asked for the five counters ``merge_tree_ratchet_check.py``
+    also runs to stop being launched here, on the reading that the merged-tree
+    pass makes the standalone run redundant. It does not.
+    ``count_ratchet.py::_base_ref_verdict`` states the opposite in its own
+    words, "this check reads the fork point, which the merge-tree gate never
+    does, and it evaluates the branch's own tree rather than the merged one.
+    Neither subsumes the other." Two verdict classes are the difference, and
+    both were probed against the real code: with base 575, merged baseline 615
+    and count 575, ``merge_tree_ratchet_check._check_one`` returns
+    ``(0, 'taste count ratchet: OK. 575 <= 575.')`` where the standalone run
+    exits 1 with BASELINE ABOVE BASE; with baseline 130 over a tree of 118 it
+    returns OK where ``count_ratchet.baseline_health`` reports a stale
+    baseline. Dropping those launches leaves both classes enforced in CI and
+    in no local gate, which is the #5482 defect this same change set repairs.
+
+    Coverage: positive, every declared entry and every baseline-owning ratchet
+    is launched; negative, an entry the gate skips is reported by name; edge,
+    no script is launched twice, so the assertion cannot pass on a duplicate.
+    """
+
+    def test_every_declared_ratchet_is_launched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        launched = spawned_scripts(monkeypatch)
+        declared = [ratchet.script for ratchet in checks_ratchet.RATCHETS]
+
+        assert sorted(launched) == sorted(declared)
+
+    def test_every_baseline_owning_ratchet_is_launched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        launched = set(spawned_scripts(monkeypatch))
+        missing = [s for s in ci_baseline_ratchet_scripts() if s not in launched]
+
+        assert not missing, (
+            f"count ratchet(s) declared but never launched: {missing}. "
+            f"A declaration no gate runs is enforcement in CI only."
+        )
+
+    def test_a_skipped_entry_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Negative control: a registry the gate only partly launches."""
+        target = "scripts/ci/taste_count_ratchet.py"
+        monkeypatch.setattr(
+            checks_ratchet,
+            "RATCHETS",
+            tuple(r for r in checks_ratchet.RATCHETS if r.script != target),
+        )
+        launched = set(spawned_scripts(monkeypatch))
+
+        assert [s for s in ci_baseline_ratchet_scripts() if s not in launched] == [
+            target
+        ]
+
+    def test_no_script_is_launched_twice(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge: one process per entry, so the set comparison cannot hide one."""
+        launched = spawned_scripts(monkeypatch)
+
+        assert sorted({s for s in launched if launched.count(s) > 1}) == []

--- a/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
+++ b/tests/ci/test_pre_pr_runs_lefthook_ratchets.py
@@ -74,6 +74,12 @@ _EXPECTED_RATCHETS = (
         True,
     ),
     (
+        "subprocess-encoding-count-ratchet",
+        "scripts/ci/subprocess_encoding_count_ratchet.py",
+        False,
+        True,
+    ),
+    (
         "memory-index-token-ratchet",
         "scripts/ci/memory_index_token_ratchet.py",
         False,
@@ -241,7 +247,7 @@ class TestValidatorBehaviour:
         assert checks_ratchet.validate_count_ratchets(REPO_ROOT) is True
 
     def test_runs_every_declared_ratchet(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Positive: the gate invokes all four, not just the first."""
+        """Positive: the gate invokes every registered entry, not just the first."""
         seen: list[list[str]] = []
         monkeypatch.setattr(
             checks_ratchet, "_resolve_default_base_ref", lambda _root: "origin/main"


### PR DESCRIPTION
# Pull Request

## Summary

### What

Registers `subprocess_encoding_count_ratchet.py` in `checks_ratchet.RATCHETS`, so it runs at pre-push and in `pre_pr.py` rather than only in CI. Adds two test classes that fail if any baseline-owning ratchet is declared but never launched.

### Why

`check_subprocess_encoding.py` globs `scripts/*.py` and `scripts/**/*.py`, which is 469 of 2198 tracked Python files. The CI ratchet imports `find_all_violations` from that same module and runs it over the whole tree. Only the file set differed, so a violation in any of the other 1729 files (78%) passed pre-commit, pre-push, and `pre_pr.py`, then failed CI.

Measured live on PR #5476: a `subprocess.run(..., encoding="utf-8")` without `errors=` in `tests/validation/` cleared every local gate, then failed CI with `REGRESSION. 239 violations > baseline 238 (+1)`. One push and one full CI cycle to learn something a local gate already had the detector for.

Blind roots on `origin/main`: `tests/` 1056, `.claude/` 294, `src/` 281, `build/` 34, `.github/` 20.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5482 | subprocess-encoding ratchet runs only in CI: 78% of tracked Python fails after push, not before |
| **Issue** | Refs #5510 | count-ratchets still runs 5 counters twice per push after #5483's concurrency fix |

## Changes

- `scripts/validation/checks_ratchet.py`: one new `Ratchet` entry. Docstring and budget comments corrected against fresh measurements.
- `scripts/ci/subprocess_encoding_count_ratchet.py`: the module docstring said this ratchet runs from the CI workflow only, see `.github/workflows/pytest.yml`, and that registering it was deliberately not taken. Both statements are now false; updated.
- `tests/ci/test_lefthook_ratchet_wiring.py`, `tests/ci/test_pre_pr_runs_lefthook_ratchets.py`: new classes reading the argv the gate actually issues, so a declaration nothing launches fails red.

## Acceptance criteria

- [x] The subprocess-encoding ratchet runs in a local gate, covering the whole tree rather than `scripts/` only
- [x] The nine-entry aggregate still fits inside the 85s deadline and the 90s lefthook cap, measured rather than asserted
- [x] A test fails if a count ratchet enforced in CI is registered in no local gate
- [x] A test fails if a ratchet is declared in the registry but never launched, with a negative control proving it discriminates
- [x] Stale comments claiming this ratchet is deliberately unregistered are corrected

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: full review, high scrutiny on the budget. This adds roughly 20s to a gate with a 5s margin between its own deadline and lefthook's cap.

**Focus areas**: whether 48.43s of an 85s deadline is enough headroom. See the measurement below, and note the pre-existing admission in `checks_ratchet.py` that the aggregate reached 85.3s at load average 6.2 before this change. This makes that tail worse, not better.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- `pytest tests/ci/test_lefthook_ratchet_wiring.py tests/ci/test_pre_pr_runs_lefthook_ratchets.py ...`: 73 passed.
- `pytest tests/ci/test_subprocess_encoding_count_ratchet.py ...`: 43 passed.
- `pytest tests/test_lefthook_gate_config.py tests/ci/test_ruff_local_*`: 48 passed.
- `mypy`: Success, no issues in 2 source files. `ruff check`: All checks passed.
- Negative control: patching `checks_ratchet` to skip the five merge-tree-backed scripts gives `3 failed, 1 passed` with `count ratchet(s) declared but never launched: [...]`.
- Budget, measured in-process across four runs at load average 0.73 to 2.09: **46.72s, 43.46s, 48.91s, 45.32s** wall, all exit 0, against an 85s deadline.
- Budget, measured on the real push that created this branch: `count-ratchets` **48.43s**, against 29.67s and 27.43s on two sibling branches pushed in the same session without this entry. So the added ratchet costs about 20s and lands at 57% of the deadline.
- Pre-push hooks green end to end, 165.51s.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes

**Files requiring security review:**

- No change to the semgrep budget path, see `scripts/validation/git_hook_policy.py`. The file this PR changes is `scripts/validation/checks_ratchet.py`, the pre-push gate's registry.

Fail-open hunt came back clean and is recorded: `_prepare_base_oid` returns None on an unresolvable base, a failed fetch, or an unresolvable remote HEAD, and `validate_count_ratchets` returns False on each. A missing script is a hard False. A merge-tree conflict is exit 100 and an unreadable base is exit 3, both nonzero, both failing the gate. No bare `except`, no guard returning True on error.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [x] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push job, green)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

**This PR does not fix #5510, and #5510's premise is refuted here.** That work was implemented, adversarially reviewed, and reverted. The record matters more than the diff:

#5510 asks for the five counters that `merge_tree_ratchet_check.py` also runs to stop being launched standalone, as duplicate work. They are not duplicates. `merge_tree_ratchet_check._check_one` only asks `count <= min(base_baseline, merged_baseline)`. It never runs `count_ratchet.baseline_health` (STALE BASELINE) and never reads the fork point (`_base_ref_verdict`: BASELINE ABOVE BASE). `count_ratchet.py::_base_ref_verdict` says so in its own words: *"this check reads the fork point, which the merge-tree gate never does, and it evaluates the branch's own tree rather than the merged one. Neither subsumes the other."*

Probed directly, not reasoned about:

- A taste baseline raised 575 to 615 over a base of 575 with a count of 575 returns `(0, 'taste count ratchet: OK. 575 <= 575.')` from `_check_one`, while the standalone run exits 1 with BASELINE ABOVE BASE.
- A ruff baseline of 130 over a tree measuring 118 returns `(0, 'ruff count ratchet: OK. 118 <= 130.')`, while `count_ratchet.baseline_health(118, 130)` reports "a gap of 12 above the permitted 6".

Dropping those launches would leave both verdict classes enforced in CI and in no local gate, which is the exact defect this PR exists to remove. Only taste has a pytest backstop (`tests/ci/test_count_ratchet_against_real_git.py:90-94` is parametrized on `taste_count_baseline.txt` alone); ruff, type-ignore, memory-index, and cli-exit-contract have none.

**The dependency between #5510 and #5482 also does not exist.** `checks_ratchet.py:109` claimed this ratchet was held out because of the 85s budget, implying the dedup was a precondition. Measured: the nine-entry set runs 43.5s to 48.9s wall, the same band the four-entry deduped set was recorded at (42.5s, 46.7s). The duplicate launches cost CPU (92s to 101s user), not wall clock, and wall clock is what the deadline and the lefthook cap measure. That comment is corrected in this diff.

The obvious alternative repair, moving the two lost verdicts into `_check_one`, was evaluated and rejected. The raised-baseline half is safe. The stale-baseline half is not: merged slack is the sum of the base side's slack and the branch's own unrecorded improvements, so the ceiling would not mean what `baseline_health` means.

**Recommendation:** close #5510 as refuted, or re-scope it to the verdict-parity question. Left open and untouched here; that is a maintainer call, not mine.

**Found on the path, filed separately:** #5539, `merge_tree_materialization._initialize_repo` snapshots with `git add -A` and no `--force`, so the merged tree's own `.gitignore` shrinks what the ratchet measures. 48 tracked-but-ignored files today, 42 `.md` and 0 `.py`, so no counter undercounts on the current tree. It matters more after this PR, because the merge-tree pass is now the only local count for those five counters. Also #5542, a Serena memory asserting `baseline_health` has no production call site, which `count_ratchet.py:1023` refutes.

**Not run:** the full pytest suite. Coverage is the nine test files above plus mypy and ruff on the changed files; the merge-group gate remains the full-suite backstop.

## Related Issues

Fixes #5482
Refs #5510, #5441, #5483, #5539, #5542
