### PR TITLE
fix(validation): keep the QA binding across catch-up merges

### DIFF
--- a/.claude/lib/qa_report.py
+++ b/.claude/lib/qa_report.py
@@ -250,13 +250,70 @@ def non_evidence_paths(paths: list[str]) -> list[str]:
     ]
 
 
+def _qa_commit_on_first_parent_chain(
+    commit: str,
+    head: str,
+    *,
+    repo_root: Path,
+) -> bool:
+    """Report whether ``commit`` sits on ``head``'s first-parent chain.
+
+    Issue #5064. ``post_qa_code_changes`` may only narrow the walk to the first
+    parent when the QA commit is on that chain. Anything else, including an
+    unreadable history, returns False so the caller takes the conservative walk.
+    """
+    listing = subprocess.run(
+        ["git", "rev-list", "--first-parent", "--parents", f"{commit}..{head}"],
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+    )
+    if listing.returncode != 0:
+        return False
+    lines = [line for line in listing.stdout.splitlines() if line.strip()]
+    if not lines:
+        # Nothing between the two commits: head is the QA commit itself.
+        return True
+    oldest = lines[-1].split()
+    # "<sha> <first parent> [<other parents>...]"; a root commit has no parent.
+    return len(oldest) >= 2 and oldest[1] == commit
+
+
 def post_qa_code_changes(
     commit: str,
     head: str,
     *,
     repo_root: Path,
 ) -> list[str]:
-    """Return non-evidence paths touched by any commit after QA."""
+    """Return non-evidence paths this branch authored after QA.
+
+    Issue #5064. The walk used to pass ``-m``, which asks git to diff a merge
+    commit against every parent separately. On a catch-up merge from the base
+    branch that emits every path the base moved since the last catch-up, so a
+    branch that authored nothing still failed as stale. Measured on this
+    repository at merge ``16fd4f6b1``: ``-m`` reported 32 paths for a merge
+    whose branch had authored 5 files and whose merge resolved nothing.
+
+    ``--first-parent`` keeps the walk on this branch's own history instead of
+    descending into the base branch's commits, and ``--cc`` reduces a merge to
+    the paths that differ from *every* parent. A path merged in cleanly matches
+    one parent and drops out; a path the author hand-resolved matches neither
+    and stays. That distinction is the point: a conflict resolution is authored
+    work and must still invalidate the binding.
+
+    ``--first-parent`` is only sound while the QA commit sits on the head's
+    first-parent chain. Ancestry alone does not guarantee that: a QA commit
+    reachable only through a second parent is skipped by the walk, which would
+    hide real post-QA work. Measured on a fixture where the QA branch was
+    merged in as the second parent, the first-parent walk reported 1 path and
+    missed an authored file the old walk caught. So the chain is checked, and
+    an off-chain QA commit falls back to the conservative all-parent walk,
+    which over-reports rather than under-reports.
+    """
     ancestor = subprocess.run(
         ["git", "merge-base", "--is-ancestor", commit, head],
         cwd=repo_root,
@@ -272,6 +329,12 @@ def post_qa_code_changes(
     if ancestor.returncode != 0:
         raise ValueError("Could not verify QA commit ancestry")
 
+    walk_flags = (
+        ["--first-parent", "--cc"]
+        if _qa_commit_on_first_parent_chain(commit, head, repo_root=repo_root)
+        else ["-m"]
+    )
+
     changes = subprocess.run(
         [
             "git",
@@ -279,7 +342,7 @@ def post_qa_code_changes(
             "--format=",
             "--name-only",
             "--no-renames",
-            "-m",
+            *walk_flags,
             "-z",
             f"{commit}..{head}",
         ],

--- a/src/copilot-cli/lib/qa_report.py
+++ b/src/copilot-cli/lib/qa_report.py
@@ -250,13 +250,70 @@ def non_evidence_paths(paths: list[str]) -> list[str]:
     ]
 
 
+def _qa_commit_on_first_parent_chain(
+    commit: str,
+    head: str,
+    *,
+    repo_root: Path,
+) -> bool:
+    """Report whether ``commit`` sits on ``head``'s first-parent chain.
+
+    Issue #5064. ``post_qa_code_changes`` may only narrow the walk to the first
+    parent when the QA commit is on that chain. Anything else, including an
+    unreadable history, returns False so the caller takes the conservative walk.
+    """
+    listing = subprocess.run(
+        ["git", "rev-list", "--first-parent", "--parents", f"{commit}..{head}"],
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+    )
+    if listing.returncode != 0:
+        return False
+    lines = [line for line in listing.stdout.splitlines() if line.strip()]
+    if not lines:
+        # Nothing between the two commits: head is the QA commit itself.
+        return True
+    oldest = lines[-1].split()
+    # "<sha> <first parent> [<other parents>...]"; a root commit has no parent.
+    return len(oldest) >= 2 and oldest[1] == commit
+
+
 def post_qa_code_changes(
     commit: str,
     head: str,
     *,
     repo_root: Path,
 ) -> list[str]:
-    """Return non-evidence paths touched by any commit after QA."""
+    """Return non-evidence paths this branch authored after QA.
+
+    Issue #5064. The walk used to pass ``-m``, which asks git to diff a merge
+    commit against every parent separately. On a catch-up merge from the base
+    branch that emits every path the base moved since the last catch-up, so a
+    branch that authored nothing still failed as stale. Measured on this
+    repository at merge ``16fd4f6b1``: ``-m`` reported 32 paths for a merge
+    whose branch had authored 5 files and whose merge resolved nothing.
+
+    ``--first-parent`` keeps the walk on this branch's own history instead of
+    descending into the base branch's commits, and ``--cc`` reduces a merge to
+    the paths that differ from *every* parent. A path merged in cleanly matches
+    one parent and drops out; a path the author hand-resolved matches neither
+    and stays. That distinction is the point: a conflict resolution is authored
+    work and must still invalidate the binding.
+
+    ``--first-parent`` is only sound while the QA commit sits on the head's
+    first-parent chain. Ancestry alone does not guarantee that: a QA commit
+    reachable only through a second parent is skipped by the walk, which would
+    hide real post-QA work. Measured on a fixture where the QA branch was
+    merged in as the second parent, the first-parent walk reported 1 path and
+    missed an authored file the old walk caught. So the chain is checked, and
+    an off-chain QA commit falls back to the conservative all-parent walk,
+    which over-reports rather than under-reports.
+    """
     ancestor = subprocess.run(
         ["git", "merge-base", "--is-ancestor", commit, head],
         cwd=repo_root,
@@ -272,6 +329,12 @@ def post_qa_code_changes(
     if ancestor.returncode != 0:
         raise ValueError("Could not verify QA commit ancestry")
 
+    walk_flags = (
+        ["--first-parent", "--cc"]
+        if _qa_commit_on_first_parent_chain(commit, head, repo_root=repo_root)
+        else ["-m"]
+    )
+
     changes = subprocess.run(
         [
             "git",
@@ -279,7 +342,7 @@ def post_qa_code_changes(
             "--format=",
             "--name-only",
             "--no-renames",
-            "-m",
+            *walk_flags,
             "-z",
             f"{commit}..{head}",
         ],

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -200,6 +200,7 @@ def test_accepts_qa_report_with_matching_session_and_commit(tmp_path: Path) -> N
     completed = [
         subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 0, "", ""),
     ]
     with mock.patch.object(_qa_report.subprocess, "run", side_effect=completed):
         report = validate_qa_report(
@@ -223,6 +224,7 @@ def test_accepts_qa_report_whose_commit_differs_but_only_evidence_changed(
 
     completed = [
         subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 0, ".agents/sessions/session.json\0", ""),
     ]
     with mock.patch.object(_qa_report.subprocess, "run", side_effect=completed):
@@ -243,6 +245,7 @@ def test_rejects_qa_report_for_stale_commit(tmp_path: Path) -> None:
     _write_qa_report(report_path, commit="b" * 40)
 
     completed = [
+        subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 0, "scripts/changed.py\0", ""),
     ]
@@ -521,6 +524,7 @@ def test_validator_accepts_configured_external_session_root(
 def test_detects_code_touched_then_reverted_after_qa(tmp_path: Path) -> None:
     completed = [
         subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess(
             [],
             0,
@@ -547,13 +551,15 @@ def test_detects_code_touched_then_reverted_after_qa(tmp_path: Path) -> None:
     assert changed == ["scripts/changed.py"]
     assert [call.args[0] for call in run.call_args_list] == [
         ["git", "merge-base", "--is-ancestor", "a" * 40, "b" * 40],
+        ["git", "rev-list", "--first-parent", "--parents", f"{'a' * 40}..{'b' * 40}"],
         [
             "git",
             "log",
             "--format=",
             "--name-only",
             "--no-renames",
-            "-m",
+            "--first-parent",
+            "--cc",
             "-z",
             f"{'a' * 40}..{'b' * 40}",
         ],
@@ -562,6 +568,7 @@ def test_detects_code_touched_then_reverted_after_qa(tmp_path: Path) -> None:
 
 def test_accepts_evidence_only_commits_after_qa(tmp_path: Path) -> None:
     completed = [
+        subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess(
             [],
@@ -630,6 +637,7 @@ def test_fails_closed_when_qa_ancestry_cannot_be_checked(tmp_path: Path) -> None
 def test_fails_closed_when_post_qa_commits_cannot_be_read(tmp_path: Path) -> None:
     completed = [
         subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 0, "", ""),
         subprocess.CompletedProcess([], 1, "", ""),
     ]
 
@@ -646,6 +654,205 @@ def test_fails_closed_when_post_qa_commits_cannot_be_read(tmp_path: Path) -> Non
             "b" * 40,
             repo_root=tmp_path,
         )
+
+
+def _qa_binding_repo(root: Path) -> Callable[..., str]:
+    """Return a git runner bound to a freshly initialised repo at ``root``."""
+
+    def git(*args: str, check: bool = True) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=check,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        return completed.stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    return git
+
+
+def test_clean_catch_up_merge_does_not_invalidate_the_binding(
+    tmp_path: Path,
+) -> None:
+    """Issue #5064: a catch-up merge authors nothing, so QA stays bound."""
+    git = _qa_binding_repo(tmp_path)
+    (tmp_path / "shared.py").write_text("base\n", encoding="utf-8")
+    (tmp_path / "main_only.py").write_text("base\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: base")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "feature.py").write_text("feature\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: feature work")
+    qa_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "-q", "main")
+    (tmp_path / "main_only.py").write_text("moved by main\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: main moves on")
+
+    git("checkout", "-q", "feature")
+    git("merge", "--no-edit", "main")
+    head = git("rev-parse", "HEAD")
+
+    assert head != qa_commit, "expected a real merge commit, not a fast-forward"
+    assert post_qa_code_changes(qa_commit, head, repo_root=tmp_path) == []
+
+
+def test_hand_resolved_merge_conflict_still_invalidates_the_binding(
+    tmp_path: Path,
+) -> None:
+    """Negative control: resolving a conflict is authored work, so it counts.
+
+    Skipping every merge would pass the sibling test above while silently
+    dropping this path. ``--cc`` is what keeps the two apart.
+    """
+    git = _qa_binding_repo(tmp_path)
+    (tmp_path / "shared.py").write_text("base\n", encoding="utf-8")
+    (tmp_path / "clean.py").write_text("base\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: base")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "shared.py").write_text("feature side\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: feature edits shared")
+    qa_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "-q", "main")
+    (tmp_path / "shared.py").write_text("main side\n", encoding="utf-8")
+    (tmp_path / "clean.py").write_text("main moved this\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: main edits shared and clean")
+
+    git("checkout", "-q", "feature")
+    git("merge", "--no-edit", "main", check=False)
+    (tmp_path / "shared.py").write_text("hand resolved\n", encoding="utf-8")
+    git("add", "shared.py")
+    git("commit", "-q", "-m", "test: resolve the conflict by hand")
+    head = git("rev-parse", "HEAD")
+
+    changed = post_qa_code_changes(qa_commit, head, repo_root=tmp_path)
+
+    assert changed == ["shared.py"], (
+        "the hand-resolved path must invalidate the binding, and the cleanly "
+        "merged path must not"
+    )
+
+
+def test_authored_commit_after_a_catch_up_merge_still_invalidates(
+    tmp_path: Path,
+) -> None:
+    """Negative control: the relaxation must not hide real post-QA work."""
+    git = _qa_binding_repo(tmp_path)
+    (tmp_path / "shared.py").write_text("base\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: base")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "feature.py").write_text("feature\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: feature work")
+    qa_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "-q", "main")
+    (tmp_path / "shared.py").write_text("moved by main\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: main moves on")
+
+    git("checkout", "-q", "feature")
+    git("merge", "--no-edit", "main")
+    (tmp_path / "authored_after_qa.py").write_text("new\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: real work after QA")
+    head = git("rev-parse", "HEAD")
+
+    assert post_qa_code_changes(qa_commit, head, repo_root=tmp_path) == [
+        "authored_after_qa.py"
+    ]
+
+
+def test_catch_up_merge_of_evidence_paths_only_stays_bound(
+    tmp_path: Path,
+) -> None:
+    """Edge: evidence-prefixed paths never invalidate, merged or authored."""
+    git = _qa_binding_repo(tmp_path)
+    (tmp_path / ".agents" / "qa").mkdir(parents=True)
+    (tmp_path / ".agents" / "qa" / "report.md").write_text(
+        "base\n", encoding="utf-8"
+    )
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: base")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "feature.py").write_text("feature\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: feature work")
+    qa_commit = git("rev-parse", "HEAD")
+
+    git("checkout", "-q", "main")
+    (tmp_path / ".agents" / "qa" / "report.md").write_text(
+        "main updated evidence\n", encoding="utf-8"
+    )
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: main updates evidence")
+
+    git("checkout", "-q", "feature")
+    git("merge", "--no-edit", "main")
+    head = git("rev-parse", "HEAD")
+
+    assert post_qa_code_changes(qa_commit, head, repo_root=tmp_path) == []
+
+
+def test_qa_commit_off_the_first_parent_chain_falls_back_to_full_walk(
+    tmp_path: Path,
+) -> None:
+    """Negative control: narrowing the walk must not hide off-chain work.
+
+    Being an ancestor is weaker than sitting on the first-parent chain. A QA
+    commit merged in as a second parent is invisible to ``--first-parent``, so
+    the guard falls back to the conservative all-parent walk rather than
+    under-reporting and letting a stale QA report pass.
+    """
+    git = _qa_binding_repo(tmp_path)
+    (tmp_path / "base.txt").write_text("base\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: base")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "feature.py").write_text("f\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: QA taken here")
+    qa_commit = git("rev-parse", "HEAD")
+
+    (tmp_path / "authored_after_qa.py").write_text("real\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: real work after QA")
+
+    git("checkout", "-q", "main")
+    (tmp_path / "main_only.py").write_text("m\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-q", "-m", "test: main moves")
+    git("merge", "--no-edit", "feature")
+    head = git("rev-parse", "HEAD")
+
+    assert git("rev-list", "--first-parent", head).splitlines().count(qa_commit) == 0, (
+        "fixture must place the QA commit off the first-parent chain"
+    )
+
+    changed = post_qa_code_changes(qa_commit, head, repo_root=tmp_path)
+
+    assert "authored_after_qa.py" in changed, (
+        "post-QA work reachable only through a second parent must still "
+        "invalidate the binding"
+    )
 
 
 def _make_complete_start_section(**overrides: dict) -> dict:
@@ -1624,6 +1831,7 @@ class TestValidateQaReportEvidence:
         completed = [
             subprocess.CompletedProcess([], 0, "", ""),
             subprocess.CompletedProcess([], 0, "", ""),
+            subprocess.CompletedProcess([], 0, "", ""),
         ]
 
         with (
@@ -1649,11 +1857,19 @@ class TestValidateQaReportEvidence:
             ["git", "merge-base", "--is-ancestor", qa_commit, older_head],
             [
                 "git",
+                "rev-list",
+                "--first-parent",
+                "--parents",
+                f"{qa_commit}..{older_head}",
+            ],
+            [
+                "git",
                 "log",
                 "--format=",
                 "--name-only",
                 "--no-renames",
-                "-m",
+                "--first-parent",
+                "--cc",
                 "-z",
                 f"{qa_commit}..{older_head}",
             ],


### PR DESCRIPTION
## Summary

### What

`post_qa_code_changes` now walks the post-QA range with `--first-parent --cc` instead of `-m`, and checks that the QA commit is on the head's first-parent chain before narrowing, falling back to the old conservative walk when it is not.

### Why

`-m` asks git to diff a merge commit against every parent. On a catch-up merge from the base branch that reports every path the base moved since the last catch-up, so a branch that authored nothing was declared stale and needed a bookkeeping commit, which then invalidated the next artifact. Measured on this repository at merge `16fd4f6b1`: the old walk reported 32 paths for a merge whose branch had authored 5 files and resolved no conflicts.

`--first-parent` stays on this branch's own history rather than descending into the base branch. `--cc` reduces a merge to paths differing from every parent, so a cleanly merged path drops out while a hand-resolved conflict stays. That distinction is the point: resolving a conflict is authored work and must still invalidate the binding.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5064 | fix(validation): QA and session evidence bindings do not survive catch-up merges |

This implements proposal 3 from the issue ("exempt merge commits from `post_qa_code_changes` so a catch-up merge alone never invalidates QA"), which the issue states as the acceptable minimum. Proposal 1 (patch-id binding) is the issue's preferred shape and is not attempted here; it needs a canonical-fingerprint decision that is out of scope for these acceptance criteria.

## Changes

- `.claude/lib/qa_report.py`: replace `-m` with `--first-parent --cc` in the post-QA walk; add `_qa_commit_on_first_parent_chain` and fall back to `-m` when the QA commit is off the chain; document both with the measured numbers.
- `src/copilot-cli/lib/qa_report.py`: regenerated mirror, byte-identical. Produced by `build/scripts/build_all.py --platform copilot-cli`, not hand-edited.
- `tests/test_validate_session_json.py`: five new tests, and six existing mocked tests updated for the added `git rev-list` call and the new argv.

## Acceptance criteria

- [x] A catch-up merge from main with no authored changes does not invalidate an existing QA report or session log binding
- [x] No bookkeeping commit is required after a merge from main on a PR whose authored diff is unchanged
- [x] Existing gate behavior for genuinely new authored commits is unchanged

Criterion 1 covers both bindings through one change: `session_qa_binding` resolves `endingCommit` / `comparison.head` into the same `QaBinding.commit` that `validate_qa_report` passes to the fixed walk at `.claude/lib/qa_report.py:236`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny, no rush.

**Focus areas**: this change **loosens a validation gate**, so every false negative lets a stale QA report pass. The two things worth your attention:

1. **Is `--first-parent --cc` sound for "paths this branch authored after QA"?** The risky case found during development: being an ancestor is weaker than sitting on the first-parent chain. A QA commit merged in as a second parent is invisible to `--first-parent`. On a fixture reproducing that shape the narrowed walk reported 1 path and missed an authored file the old walk caught. That is why the guard exists. Please check whether the guard's chain test (last entry of `git rev-list --first-parent --parents`, comparing its first parent to the QA commit) is correct for histories I did not think of.
2. **Whether exempting clean catch-up merges is the right semantics at all.** A merge can change behavior without changing this branch's authored diff, and QA taken before that merge arguably no longer describes the merged tree. The issue's acceptance criteria call for this exemption explicitly, so I implemented it, but the residual risk is real and belongs to whoever owns the gate.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Five new tests, all using real git fixtures rather than mocks:

| Test | Role |
|---|---|
| `test_clean_catch_up_merge_does_not_invalidate_the_binding` | positive, the fix |
| `test_hand_resolved_merge_conflict_still_invalidates_the_binding` | negative control, a naive skip-all-merges implementation would pass the row above and fail this one |
| `test_authored_commit_after_a_catch_up_merge_still_invalidates` | negative control, real post-QA work still counts |
| `test_qa_commit_off_the_first_parent_chain_falls_back_to_full_walk` | negative control for the guard |
| `test_catch_up_merge_of_evidence_paths_only_stays_bound` | edge, evidence prefixes |

Evidence:

- `uv run --frozen python -m pytest tests/test_validate_session_json.py -q` gives **387 passed**.
- Mutation check 1: restoring `-m` fails all four merge-behavior tests and leaves the rest green.
- Mutation check 2: removing the guard (forcing `--first-parent --cc` unconditionally) fails exactly `test_qa_commit_off_the_first_parent_chain_falls_back_to_full_walk` and nothing else.
- `ruff check` clean on all three files. `ruff format` was deliberately **not** run: it wants to reformat pre-existing lines this diff never touches, and the repo's gate is `ruff check`.
- All pre-push gates green, including `pre-pr-validation` (66s), `python-tests` (34s), `zero-collection-tests` (44s), `python-type-check`, and `security-scan`.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

This touches a validation gate rather than auth, secrets, or CI credentials. The gate-loosening risk is called out under Reviewer Expectations rather than treated as a security finding.

### Other Agent Reviews

- [x] QA verified test coverage

One independent adversarial review ran against the diff with a brief to find reasons it is wrong, and returned no blocking findings, having verified the git semantics, the docstring's numbers, test discrimination by mutation, and the mirror parity.

Disclosure on process: the campaign this PR came from calls for a GPT-5.6 Sol diff review. That has no transport in this environment (no Codex CLI, no third-party credential), so an independent Claude review was substituted. **No Sol verdict is claimed.**

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push gate)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5064

Noticed while working here, not fixed in this PR:

- This checkout was shallow and the pre-push `push-ref-policy` gate blocked on it. `git fetch --unshallow origin` cleared it, no hook was bypassed. Worth knowing that a shallow clone also makes `git merge-base` return empty and `git diff` report bogus cross-boundary deltas, which will mislead anyone assessing branch staleness.
- The always-on instruction budget is at 98,369 of 99,000 bytes for `.py`, 631 bytes of headroom. Green, but roughly one added paragraph from tripping. Related to #5400, which is blocked.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ)_