### PR TITLE
fix(post-merge): repair six defects found verifying the just-merged autofix PRs

### DIFF
--- a/.serena/memories/ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md
+++ b/.serena/memories/ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md
@@ -66,15 +66,30 @@ impossible.
 
 ## What the reviewers actually see
 
-Not the PR body. `scripts/ci/spec_prepare_context.py:177` builds the
-`additional-context` payload as `["## Specification Content", "", spec_content]`,
-sourced from `SPEC_FILE` alone. Steps 6 and 7 pass that payload with
-`context-type: pr-diff`.
+The spec, plus two optional blocks. `scripts/ci/spec_prepare_context.py:177`
+builds the `additional-context` payload in three pieces:
 
-So the comparison is **diff against the issue and spec acceptance criteria**. The
-PR description is not in the reviewers' context at all. `PR_BODY` is referenced in
-exactly one place in this workflow: step 8, `External-signal gate (observe)`, which
-is `continue-on-error: true` and decides nothing.
+```python
+context_parts = ["## Specification Content", "", spec_content]
+context_parts += _incremental_scope_block(incremental_scope)
+context_parts += _nonexecutable_criteria_block(pr_body)
+```
+
+Steps 6 and 7 pass that payload with `context-type: pr-diff`.
+
+So the comparison is **diff against the issue and spec acceptance criteria**, and
+the body reaches the reviewers only through that last block. `PR_BODY` is
+referenced in two places in this workflow, not one. Line 195 is step 8,
+`External-signal gate (observe)`, which is `continue-on-error: true` and decides
+nothing. Line 148 is step 5, `Prepare Spec Context`, which is not
+`continue-on-error` and feeds the payload both blocking reviewers read; the
+workflow comment above it says the body "carries the acceptance-criteria list the
+reviewer is graded against" (issue #5366).
+
+What stays true is the part that matters for a failing gate: prose in the body
+does not satisfy a criterion. Only `_nonexecutable_criteria_block` crosses over,
+and it carries criteria the diff cannot demonstrate, not an argument that the diff
+is fine. A persuasive description still cannot talk this gate into passing.
 
 Description-versus-diff is a different gate entirely:
 `scripts/validation/pr_description.py`, inside `pr-validation.yml`. The two are

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -125,7 +125,7 @@
 |gc_worktrees prune registered worktrees rescue branch admin directory unreachable commits: [workspace/gc-worktrees-report-then-apply](workspace/gc-worktrees-report-then-apply.md) (542)
 |validate PR check red advisory blocking signal DESCRIPTION_RESULT: [ci/ci-validate-pr-is-many-gates-only-some-read-the-body](ci/ci-validate-pr-is-many-gates-only-some-read-the-body.md) (3230)
 |workspace WSL native worktree uv network handshake mutation harness /mnt/c: [workspace/wsl-native-worktree-for-uv-network-access](workspace/wsl-native-worktree-for-uv-network-access.md) (352)
-|linking an issue Closes Fixes Resolves Implements Refs: [ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff](ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md) (1554)
+|linking an issue Closes Fixes Resolves Implements Refs: [ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff](ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md) (1710)
 |QA report filename issue-N pr-N rename first push glob: [ci/ci-qa-report-may-be-named-for-the-issue-not-the-pr](ci/ci-qa-report-may-be-named-for-the-issue-not-the-pr.md) (1221)
 |job name collision duplicate check name ambiguous red: [ci/ci-job-names-collide-so-a-red-check-name-is-ambiguous](ci/ci-job-names-collide-so-a-red-check-name-is-ambiguous.md) (1490)
 |AI quality gate Aggregate Results all agents NEEDS_REVIEW: [ci/ci-ai-gate-blocks-when-the-security-review-did-not-run](ci/ci-ai-gate-blocks-when-the-security-review-did-not-run.md) (2000)

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -19,8 +19,8 @@ logic that only fails at execution time (the class of defect that slipped
 through static checks in PR #2120's CI runner).
 
 Tool / environment gaps are reported, not silently skipped: a missing
-actionlint, gh act, or Docker daemon yields exit 3 (external) so the caller can
-block with an actionable message. A documented bypass exists for workflows that
+actionlint, gh, gh act, or Docker daemon yields exit 3 (external) so the caller
+can block with an actionable message. A documented bypass exists for workflows that
 genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
@@ -58,7 +58,7 @@ EXIT CODES (per ADR-035, exit-code contract in AGENTS.md)
 0 - all stages passed (or no workflow files, or bypassed)
 1 - a stage ran and failed (block the push)
 2 - configuration error (bad args, repo root absent)
-3 - a required tool is unavailable (actionlint, gh act, or Docker). Under
+3 - a required tool is unavailable (actionlint, gh, gh act, or Docker). Under
     ``CLAUDECODE`` or ``CODESPACES`` this gap degrades to exit 0
     (degraded=True) instead, because the tool may not be provisionable there;
     CI and a plain dev laptop keep the hard exit 3 (Issue #3064, #5479)

--- a/tests/mutation/test_mutation_selectors_resolve.py
+++ b/tests/mutation/test_mutation_selectors_resolve.py
@@ -22,7 +22,7 @@ harness that adds them later is covered on arrival.
 from __future__ import annotations
 
 import ast
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 
@@ -137,11 +137,23 @@ def unresolved_selectors(source: str, repo_root: Path) -> list[str]:
         # onto repo_root discards repo_root entirely under pathlib, and a ".."
         # segment walks out of the tree, so either would make this helper read a
         # file the scan was never pointed at. Report instead of reading.
-        rel_path = Path(rel)
-        if rel_path.is_absolute() or ".." in rel_path.parts:
+        #
+        # The check must not go through bare Path, which is platform-dependent:
+        # PureWindowsPath("/tmp/x.py").is_absolute() is False, so on Windows a
+        # rooted-but-driveless selector passes and still escapes, because
+        # PureWindowsPath("C:/repo") / that yields "C:/tmp/x.py". Ask both
+        # flavours instead, so the verdict is the same on every host. The posix
+        # arm catches a leading slash, the Windows anchor arm catches a drive
+        # letter and a UNC share.
+        rel_posix = PurePosixPath(rel)
+        if (
+            rel_posix.is_absolute()
+            or PureWindowsPath(rel).anchor
+            or ".." in rel_posix.parts
+        ):
             problems.append(f"line {lineno}: {selector} (not a repo-relative path: {rel})")
             continue
-        target = repo_root / rel_path
+        target = repo_root / rel
         if not target.is_file():
             problems.append(f"line {lineno}: {selector} (no such file: {rel})")
             continue
@@ -215,15 +227,21 @@ class TestTheRuleDiscriminates:
 
     @pytest.mark.parametrize(
         "rel",
-        ["/tmp/outside_test.py", "../outside/sample_test.py"],
-        ids=["absolute", "parent-escape"],
+        ["/tmp/outside_test.py", "C:/outside_test.py", "../outside/sample_test.py"],
+        ids=["rooted", "windows-drive", "parent-escape"],
     )
     def test_a_selector_escaping_the_repo_is_reported(self, rel: str, tmp_path: Path) -> None:
         """Neither shape may be joined onto repo_root and read.
 
-        Both heads end in ``.py`` on purpose: :func:`_selectors` only collects a
+        Every head ends in ``.py`` on purpose: :func:`_selectors` only collects a
         string whose head does, so a selector that fails that rule never reaches
-        the guard and would make this control pass for the wrong reason.
+        the guard, collects nothing, and fails this control on an empty
+        ``problems`` list rather than on the behaviour under test.
+
+        ``windows-drive`` is here because the guard is host-independent by
+        construction. A drive-letter head is not absolute to posix pathlib, and a
+        rooted-but-driveless head is not absolute to Windows pathlib, so a check
+        written against bare ``Path`` passes one of them on each platform.
         """
         source = f'NODE = "{rel}::TestThing::test_x"\n'
         problems = unresolved_selectors(source, tmp_path)

--- a/tests/test_selection/test_select_tests.py
+++ b/tests/test_selection/test_select_tests.py
@@ -10,11 +10,6 @@ import pytest
 
 from scripts.test_selection import select_tests
 
-# Every test below that calls _pull_request_fixture shells out to git with
-# check=True, so a host without git would fail them for a reason unrelated to
-# selection logic. Same guard the repo already uses in tests/ci.
-requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
-
 
 def _write(root: Path, rel: str, text: str) -> None:
     path = root / rel
@@ -199,6 +194,19 @@ def test_changed_from_git_returns_none_outside_repo(tmp_path: Path) -> None:
 
 
 def _git(root: Path, *args: str) -> str:
+    """Run one git command in ``root``, skipping the test when git is absent.
+
+    The guard lives here rather than on each test because this is the only
+    function in the module that shells out, and ``_pull_request_fixture`` is its
+    only caller. A per-test decorator has to be remembered by whoever adds the
+    next test on that fixture; this cannot be forgotten.
+
+    A missing binary raises ``FileNotFoundError`` from ``subprocess.run`` before
+    ``check=True`` is ever consulted, so the failure would not even look like a
+    git error.
+    """
+    if shutil.which("git") is None:
+        pytest.skip("git is not installed")
     result = subprocess.run(
         ["git", *args],
         cwd=root,
@@ -245,7 +253,6 @@ def _pull_request_fixture(root: Path) -> tuple[str, str]:
     return base, head
 
 
-@requires_git
 def test_changed_from_git_excludes_base_branch_change_when_head_is_explicit(
     tmp_path: Path,
 ) -> None:
@@ -253,7 +260,6 @@ def test_changed_from_git_excludes_base_branch_change_when_head_is_explicit(
     assert select_tests.changed_from_git(tmp_path, base, head) == ["pkg/x.py"]
 
 
-@requires_git
 def test_changed_from_git_leaks_base_branch_change_without_explicit_head(
     tmp_path: Path,
 ) -> None:
@@ -270,13 +276,11 @@ def test_changed_from_git_leaks_base_branch_change_without_explicit_head(
     ]
 
 
-@requires_git
 def test_changed_from_git_returns_none_for_unfetchable_head(tmp_path: Path) -> None:
     base, _ = _pull_request_fixture(tmp_path)
     assert select_tests.changed_from_git(tmp_path, base, "0" * 40) is None
 
 
-@requires_git
 def test_changed_from_git_returns_none_for_unfetchable_base(tmp_path: Path) -> None:
     _, head = _pull_request_fixture(tmp_path)
     assert select_tests.changed_from_git(tmp_path, "0" * 40, head) is None


### PR DESCRIPTION
## Problem

An adversarial verification pass over #5533, #5536, #5544 and #5545 ran while
those PRs were merging and found six defects, all in changes I authored during
the `/pr-autofix` run that produced them. Five are code or documentation; the
sixth is two thread replies whose fixes were right and whose justifications were
not. Every claim below was independently reproduced before this PR was written.

## Changes

### A merged memory asserts the opposite of the workflow it documents

`.serena/memories/ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md`
claimed the `additional-context` payload is "sourced from `SPEC_FILE` alone",
that "the PR description is not in the reviewers' context at all", and that
`PR_BODY` is referenced "in exactly one place in this workflow: step 8 [...]
which is `continue-on-error: true` and decides nothing".

`grep -n 'PR_BODY:' .github/workflows/ai-spec-validation.yml` returns 148 and
195. Line 148 is step 5, `Prepare Spec Context`, which is not
`continue-on-error`, and the workflow comment above it reads "the body carries
the acceptance-criteria list the reviewer is graded against" (issue #5366). The
payload is built in three pieces:

```python
context_parts = ["## Specification Content", "", spec_content]
context_parts += _incremental_scope_block(incremental_scope)
context_parts += _nonexecutable_criteria_block(pr_body)
```

That payload is `additional-context` for the analyst and critic steps, whose
verdicts the authoritative `Check for Failures` step reads. The section now
quotes the assembly and keeps the claim that survives: only non-executable
criteria cross over, so prose in the body still cannot satisfy a criterion.

This is the same class of overstatement the PR was written to correct, one
section below the part that got fixed.

### The path-escape guard leaked on Windows

The guard added in #5536 used bare `Path`, which resolves to the host flavour:

```
>>> PureWindowsPath('/tmp/outside_test.py').is_absolute()
False
>>> PureWindowsPath('C:/repo') / PureWindowsPath('/tmp/outside_test.py')
PureWindowsPath('C:/tmp/outside_test.py')
```

So a rooted-but-driveless selector passed the guard on Windows and still escaped,
and the `absolute` control would have failed there. The repository runs a
`Run Windows path-contract tests` job, so that platform is in scope.

It now asks both flavours. Posix `is_absolute` catches a leading slash, the
Windows anchor catches a drive letter and a UNC share, and `..` is checked on the
posix parts. Measured on this host, the four escape shapes are rejected and the
two repo-relative shapes pass:

```text
REJECT  /tmp/outside_test.py
REJECT  C:/outside_test.py
REJECT  ../outside/sample_test.py
REJECT  //srv/share/example.py
allow   tests/sample_test.py
allow   tests/sub/example.py
```

A `windows-drive` control is added.

An inverted sentence in that control's docstring is corrected in the same commit:
a non-`.py` head makes the control fail on an empty `problems` list, it does not
make it "pass for the wrong reason".

### The tool-gap docstring fix was too narrow

#5545 added `gh` to `_tool_gap_is_environmental` but left the same three-tool
list twice in the module docstring of the same file, in the tool-gap paragraph
and in the exit-3 contract. Both are corrected here.

## Changes

- `.serena/memories/ci/ci-linking-an-issue-arms-an-ai-gate-against-your-diff.md`
- `tests/mutation/test_mutation_selectors_resolve.py`
- `scripts/validation/run_workflow_local_test.py`
- `tests/test_selection/test_select_tests.py` `_have("gh")` routes through the same degrade, so
both were short by one.

### The git skip guard was per-test

#5544 decorated four tests. `_git` is the only function in that module that
shells out and `_pull_request_fixture` is its only caller, so a fifth test on
that fixture reintroduces the failure silently. The guard moves into `_git`,
where it cannot be forgotten. Its docstring records the exception the earlier
commit message named wrongly: a missing binary raises `FileNotFoundError` from
`subprocess.run`, before `check=True` is consulted.

## Verification

`uv run pytest` on each touched test module: 32 passed (mutation), 27 passed
(selection). `ruff check` clean on every touched file. `pre_pr.py` reports
`RESULT: All validations passed`, no BLOCKING findings.

The escape guard is mutation-tested: collapsing its condition to `False` fails
all three controls, and restoring it returns 32 passed.

## Flagging, not fixing

`pre_pr.py` failed once on the first run in a fresh worktree with
`subprocess-encoding-count-ratchet: Command timed out after 84s`. The warm re-run
passed at 81.9s against that same 84s budget, a 2.5 percent margin. The generic
wrapper message says "A baseline may only fall; lower the count rather than
raising the baseline", which points at a count violation that did not occur, so
a timeout here reads as a ratchet failure. #5546 added this ratchet to the local
gate, which is what pushed the step near its limit. Out of scope for this PR.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5552 | The five code and documentation defects. |

The thread-reply corrections in #5552 item 6 are posted on #5533 and #5544
directly; the commit messages themselves are in merged history and are not
rewritable.

