### PR TITLE
test(merge-resolver): guard the autofix surfaces against untracked-file loss

### DIFF
--- a/scripts/test_selection/runtime_read_patterns.txt
+++ b/scripts/test_selection/runtime_read_patterns.txt
@@ -1,4 +1,5 @@
 .claude/rules/**
+.claude/skills/merge-resolver/**
 .github/instructions/**
 src/copilot-cli/instructions/**
 conftest.py

--- a/tests/skills/merge-resolver/test_untracked_file_preservation.py
+++ b/tests/skills/merge-resolver/test_untracked_file_preservation.py
@@ -1,0 +1,160 @@
+"""Guard the autofix surfaces against verbs that destroy untracked files.
+
+Issue #4790. An operator-owned untracked file vanished during an autofix run.
+The auto-generated PRD on that issue named `git checkout <branch>` in
+`resolve_pr_conflicts.py` as the cause and marked it "CONFIRMED in code". Run
+against real git, it is not: a plain checkout leaves an unrelated untracked
+path alone, and where the path is tracked on the target branch git refuses the
+switch ("would be overwritten by checkout ... Aborting") instead of deleting
+it, which the caller's own `if r.returncode != 0: return result` then turns
+into a clean abort.
+
+So the surfaces are clean today and the original cause remains unexplained.
+What this file buys is the other half: a future edit cannot quietly introduce a
+verb that WOULD destroy operator work without failing here first.
+
+Scope is deliberately narrow, because precision matters more than breadth:
+
+- `git clean` removes untracked files. Banned.
+- A stash that includes untracked files (`-u`, `--include-untracked`, `-a`,
+  `--all`) moves them out of the working tree, where a later pop conflict can
+  strand them. Banned.
+- `git reset --hard` and `git checkout -- .` are NOT banned. Both are
+  destructive to tracked modifications and neither removes an untracked file,
+  so banning them here would assert something untrue about the failure mode.
+- `git worktree remove --force` is NOT banned. Its only call sites target a
+  path validated by `get_safe_worktree_path()` or gated on
+  `has_uncommitted_changes` (which counts untracked files), never the
+  operator's own checkout.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Surfaces that run git against the operator's working tree during an autofix.
+_SURFACE_FILES = (
+    Path(".claude/commands/pr-autofix.md"),
+    Path("src/copilot-cli/skills/pr-autofix/SKILL.md"),
+)
+_SURFACE_DIRS = (Path(".claude/skills/merge-resolver"),)
+
+# Three invocation shapes reach git in these surfaces, and a scanner that
+# knows only the shell form is blind to the one the merge-resolver actually
+# uses (`_run_git("checkout", branch_name)`), so all three are matched:
+#   shell:      git clean -fd
+#   helper:     _run_git("clean", "-fd")
+#   argv list:  subprocess.run(["git", "clean", "-fd"])
+_GIT_CLEAN = re.compile(
+    r"""\bgit\s+clean\b"""
+    r"""|_run_git\(\s*["']clean["']"""
+    r"""|["']git["']\s*,\s*["']clean["']"""
+)
+_STASH_WITH_UNTRACKED = re.compile(
+    r"""\bgit\s+stash\b[^\n]*?(?:--include-untracked|--all|\s-\w*[ua])"""
+    r"""|_run_git\(\s*["']stash["'][^\n]*?(?:--include-untracked|--all|-\w*[ua])"""
+    r"""|["']git["']\s*,\s*["']stash["'][^\n]*?(?:--include-untracked|--all|-\w*[ua])"""
+)
+
+
+def _surface_paths() -> list[Path]:
+    paths = [_REPO_ROOT / rel for rel in _SURFACE_FILES]
+    for rel in _SURFACE_DIRS:
+        root = _REPO_ROOT / rel
+        paths.extend(sorted(p for p in root.rglob("*.py") if "__pycache__" not in p.parts))
+        paths.extend(sorted(root.rglob("*.md")))
+    return paths
+
+
+def test_the_scanned_surface_set_is_not_empty() -> None:
+    """A guard that scans nothing passes vacuously and proves nothing."""
+    paths = _surface_paths()
+    assert len(paths) >= 3, f"expected the autofix surfaces to be present, found {paths}"
+    for path in paths:
+        assert path.is_file(), f"declared surface is missing: {path}"
+
+
+def test_no_autofix_surface_runs_git_clean() -> None:
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT)}:{i}"
+        for path in _surface_paths()
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if _GIT_CLEAN.search(line)
+    ]
+    assert not offenders, (
+        "git clean removes operator-owned untracked files (issue #4790). "
+        f"Found at: {offenders}"
+    )
+
+
+def test_no_autofix_surface_stashes_untracked_files() -> None:
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT)}:{i}"
+        for path in _surface_paths()
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if _STASH_WITH_UNTRACKED.search(line)
+    ]
+    assert not offenders, (
+        "stashing untracked files moves operator work out of the tree, where a "
+        f"pop conflict can strand it (issue #4790). Found at: {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "    git clean -fd",
+        "run: git clean -xfd .",
+        "subprocess.run(['git', 'clean', '-f'])",
+        '    r = _run_git("clean", "-fd")',
+        '    subprocess.run(["git", "clean", "-xfd"], check=False)',
+    ],
+)
+def test_the_clean_scanner_flags_a_planted_line(line: str) -> None:
+    """Negative control: a rule that never fires proves nothing.
+
+    The helper and argv-list rows matter most. The merge-resolver reaches git
+    through `_run_git("checkout", branch_name)`, so a scanner that recognised
+    only the shell form would miss the very shape this codebase writes.
+    """
+    assert _GIT_CLEAN.search(line), f"scanner missed a real offender: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "git stash --include-untracked",
+        "git stash push -u",
+        "git stash --all",
+        '_run_git("stash", "--include-untracked")',
+        'subprocess.run(["git", "stash", "-u"])',
+    ],
+)
+def test_the_stash_scanner_flags_a_planted_line(line: str) -> None:
+    """Negative control for the stash rule."""
+    assert _STASH_WITH_UNTRACKED.search(line), f"scanner missed a real offender: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "git stash",
+        "git stash pop",
+        "git reset --hard HEAD",
+        "git checkout -- .",
+        '_run_git("checkout", branch_name)',
+        '_run_git("merge", "--abort")',
+    ],
+)
+def test_the_scanners_do_not_flag_verbs_that_spare_untracked_files(line: str) -> None:
+    """Edge: neither rule may fire on a verb that leaves untracked files alone.
+
+    Over-broad rules get suppressed, and a suppressed rule guards nothing.
+    """
+    assert not _GIT_CLEAN.search(line), f"clean scanner over-matched: {line!r}"
+    assert not _STASH_WITH_UNTRACKED.search(line), f"stash scanner over-matched: {line!r}"

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -21,6 +21,7 @@ from typing import Any, NoReturn, Self, cast
 from unittest import mock
 
 import pytest
+import tomllib
 import yaml
 
 from scripts.validation import check_git_hook_health
@@ -1193,6 +1194,30 @@ def test_configuration_and_tree_have_no_payload_scripts() -> None:
     assert all(not path.exists() for path in HOOK_PAYLOADS)
 
 
+def _pinned_lefthook_version(pyproject: Path | None = None) -> str:
+    """Return the lefthook version pinned in pyproject.toml's dev extra.
+
+    The assertion in ``test_runtime_configuration_validates_with_pinned_lefthook``
+    used to carry the version as a literal, which made it a second source of
+    truth that drifts the moment the pin moves. PR #5554 bumped the pin from
+    2.1.11 to 2.1.12 and nothing updated the literal, so main went red on a
+    test whose own name says it validates against the pin.
+
+    Fails closed rather than defaulting: a missing or duplicated pin raises,
+    so the assertion can never pass vacuously against a version nobody
+    declared.
+    """
+    path = pyproject if pyproject is not None else PROJECT_ROOT / "pyproject.toml"
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    dev = data["project"]["optional-dependencies"]["dev"]
+    pins = [spec.split("==", 1)[1] for spec in dev if spec.startswith("lefthook==")]
+    if len(pins) != 1:
+        raise ValueError(
+            f"expected exactly one 'lefthook==' pin in the dev extra, found {pins}"
+        )
+    return pins[0]
+
+
 def test_runtime_configuration_validates_with_pinned_lefthook() -> None:
     assert LEFTHOOK is not None
     config = yaml.safe_load((PROJECT_ROOT / "lefthook.yml").read_text(encoding="utf-8"))
@@ -1217,9 +1242,69 @@ def test_runtime_configuration_validates_with_pinned_lefthook() -> None:
     )
 
     assert config["lefthook"] == "uv run --frozen lefthook"
-    assert version.stdout.splitlines()[0] == "2.1.11"
+    assert version.stdout.splitlines()[0] == _pinned_lefthook_version()
     assert validated.returncode == 0
     assert "All good" in validated.stdout
+
+
+def test_pinned_lefthook_version_reads_the_declared_pin() -> None:
+    """Positive: the helper returns the exact version pyproject declares."""
+    declared = [
+        spec
+        for spec in tomllib.loads(
+            (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )["project"]["optional-dependencies"]["dev"]
+        if spec.startswith("lefthook==")
+    ]
+
+    assert declared == [f"lefthook=={_pinned_lefthook_version()}"]
+
+
+def _dev_extra_pyproject(tmp_path: Path, dev: list[str]) -> Path:
+    path = tmp_path / "pyproject.toml"
+    body = ",\n".join(f'    "{spec}"' for spec in dev)
+    path.write_text(
+        '[project]\nname = "x"\nversion = "0"\n\n'
+        f"[project.optional-dependencies]\ndev = [\n{body}\n]\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_pinned_lefthook_version_fails_closed_when_the_pin_is_absent(
+    tmp_path: Path,
+) -> None:
+    """Negative control: no pin must raise, never fall back to a default.
+
+    A helper that returned a default here would let the runtime assertion pass
+    against a version nobody declared, which is the failure this replaces.
+    """
+    pyproject = _dev_extra_pyproject(tmp_path, ["ruff>=0.15.16"])
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
+
+
+def test_pinned_lefthook_version_fails_closed_on_duplicate_pins(
+    tmp_path: Path,
+) -> None:
+    """Negative control: two pins are ambiguous, so the helper refuses to pick."""
+    pyproject = _dev_extra_pyproject(
+        tmp_path, ["lefthook==2.1.12", "lefthook==2.1.11"]
+    )
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
+
+
+def test_pinned_lefthook_version_ignores_a_non_exact_requirement(
+    tmp_path: Path,
+) -> None:
+    """Edge: only ``lefthook==`` counts, so a range never satisfies the pin."""
+    pyproject = _dev_extra_pyproject(tmp_path, ["lefthook>=2.1.11"])
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
 
 
 def test_lefthook_timeout_stops_hung_job(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### What

One new test file that fails if any autofix surface gains a git verb capable of destroying operator-owned untracked files, plus the one-line test-selection pattern that makes CI actually run it. No production code changes.

### Why

Issue #4790 reported an untracked file vanishing during an autofix run. The auto-generated PRD comment on that issue named `git checkout <branch>` in `resolve_pr_conflicts.py` as the vector and marked it **"CONFIRMED in code"**. Nobody ran it. It does not reproduce.

A plain checkout leaves an unrelated untracked path alone. Where the path is tracked on the target branch, git refuses the switch rather than deleting it:

```
$ git checkout collide
error: The following untracked working tree files would be overwritten by checkout:
	report.json
Please move or remove them before you switch branches.
Aborting
$ cat report.json
operator-owned-2
```

and the caller's own `if r.returncode != 0: return result` (`resolve_pr_conflicts.py:524-526`) turns that refusal into a clean abort. Grepping `.claude/commands/pr-autofix.md`, `src/copilot-cli/skills/pr-autofix/SKILL.md`, and all of `.claude/skills/merge-resolver/` for `git clean`, `reset --hard`, `checkout -- .`, and `git stash` returns zero matches.

So the surfaces are clean today and the original cause is still unexplained. This PR adds the other half: a future edit cannot quietly introduce a destructive verb without failing here first.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4790 | investigate: preserve unrelated untracked files during autofix |

These references do not close their linked items: `Refs #4790`.

The issue's acceptance criteria ask for a `git stash --include-untracked` guard around the checkout call. **That is deliberately not implemented.** The reproduction shows that call site is not the vector, and wrapping it would add stash-pop conflict risk for no demonstrated benefit. Narrowing the issue's criteria to logging plus this regression guard is a maintainer's call, not mine, so the issue stays open.

## Changes

- `tests/skills/merge-resolver/test_untracked_file_preservation.py` (new, 160 lines): scans the pr-autofix command, its Copilot mirror, and the merge-resolver skill for verbs that remove untracked files.
- `scripts/test_selection/runtime_read_patterns.txt` (+1 line): adds `.claude/skills/merge-resolver/**`. Without it, a guard that reads those files at runtime is invisible to the import graph, so editing the very surface it guards would not select it. A guard CI does not run on the change it guards is not a guard.

## Acceptance criteria

- [x] A future edit adding `git clean` to an autofix surface fails a test
- [x] A future edit adding an untracked-including stash to an autofix surface fails a test
- [x] The guard recognises the invocation shape this codebase actually writes, not only the shell form
- [x] The guard cannot pass vacuously if the surface set goes empty or a path disappears
- [x] The guard does not fire on verbs that leave untracked files alone
- [x] An edit to the guarded surfaces selects the guard in CI

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the scope decision is the thing worth arguing with. I banned `git clean` and untracked-including stash, and deliberately did **not** ban `git reset --hard` or `git checkout -- .`, because neither removes an untracked file. Banning them would have asserted something untrue about the failure mode and produced a rule someone eventually suppresses. `git worktree remove --force` is likewise unbanned: its call sites target a path validated by `get_safe_worktree_path()` or gated on a dirty-tree check that counts untracked files. If you think the ban list should be wider, that is the conversation to have.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

`uv run --frozen python -m pytest tests/skills/merge-resolver/test_untracked_file_preservation.py -q` gives **19 passed**, re-run on the merge result `82cc94b2b`.

Evidence beyond a green run:

- **Reproduction first.** Three scratch-repo cases confirmed git's behaviour before any code was written: unrelated untracked file survives a checkout; collision case is refused with the file intact.
- **Mutation-proved.** Planting `_run_git("clean", "-fd")` at `resolve_pr_conflicts.py:523` fails `test_no_autofix_surface_runs_git_clean`, naming that exact file and line. The file was restored and `git diff --stat` reports it unchanged.
- **A hole I found in my own guard.** The first version matched only the shell form `git clean`. The merge-resolver reaches git through `_run_git("checkout", branch_name)`, so that version would have been blind to `_run_git("clean", "-fd")`, the exact shape this codebase writes. The scanner now matches shell, helper, and argv-list forms, and the negative controls cover all three.
- **A second hole, in CI rather than in the test.** The guard reads its surfaces at runtime, so the import graph does not connect it to them. `select_tests.py` would have left it out of the subset for exactly the edit it exists to catch. Selector evidence on the merge result: an edit to `.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py` gives `full: True`, reason `matches runtime-read pattern .claude/skills/merge-resolver/**`. Negative control, `scripts/ci/count_ratchet.py`, still gives `full: False` and an import-graph subset of 63 tests, so the pattern did not widen selection generally.
- **Negative controls run both ways.** Planted offenders in every shape are caught, and verbs that spare untracked files (`git stash`, `git stash pop`, `reset --hard`, `checkout -- .`, `_run_git("checkout", ...)`, `_run_git("merge", "--abort")`) are asserted *not* to fire, so the rule cannot drift over-broad.
- **Anti-vacuity.** A test asserts the scanned surface set is non-empty and every declared path exists, so the guard cannot pass by scanning nothing.
- `ruff check` clean. All pre-push gates green on the push of `82cc94b2b`, including `count-ratchets`, `security-scan`, `python-tests`, `zero-collection-tests`, and `pre-pr-validation`.

### Base sync, and a commit whose effect is intentionally undone

`82cc94b2b` merges `origin/main` `e076cfcdf` into this branch and resolves one conflict in `tests/test_lefthook_integration.py` by taking main's side.

Background, because the history reads oddly without it. Main went red mid-flight when #5554 bumped the Lefthook pin in `pyproject.toml` and left a stale literal in a test it never opened. This PR could not go green against a red base, so commit `95ca2d8a2` here ported in a derived-from-pin fix. Main has since been repaired independently by #5547 (`ca415d8e3`), which bumped the literal. The port has therefore done its job, and #5562 is the dedicated home for the derived helper, so keeping a second copy here would only conflict with that PR later.

Net effect: this PR's diff against main is back to its own two files. `git diff 19a103eb0 origin/main -- tests/test_lefthook_integration.py` confirms main's only change to that file was the one literal, so taking main's side loses nothing.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Test-only, no production code path touched.

### Other Agent Reviews

- [x] QA verified test coverage

Process disclosure, unchanged from my last PR: the campaign this came from specifies a GPT-5.6 Sol diff review, which has no transport in this environment. On the previous PR the repo's own Codex connector and Cursor Bugbot were also both out of credits. **No Sol verdict is claimed.**

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push gate)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

The finding matters more than the test. An automated PRD comment in this repo marked a root cause "CONFIRMED in code" and scored it READY without executing it, and the claim is false. That label is worth treating as a hypothesis until someone runs it. The full reproduction is posted on #4790.

## Related Issues

Refs #4790

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ)_