### PR TITLE
fix(tests): align the lefthook version assertion with the 2.1.12 pin

### DIFF
--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -1217,7 +1217,7 @@ def test_runtime_configuration_validates_with_pinned_lefthook() -> None:
     )
 
     assert config["lefthook"] == "uv run --frozen lefthook"
-    assert version.stdout.splitlines()[0] == "2.1.11"
+    assert version.stdout.splitlines()[0] == "2.1.12"
     assert validated.returncode == 0
     assert "All good" in validated.stdout
 


### PR DESCRIPTION
# Pull Request

## Summary

### What

Bumps one string literal in `tests/test_lefthook_integration.py` from `2.1.11` to `2.1.12` so it matches the lefthook version that `pyproject.toml` and `uv.lock` already pin. One line, one file.

### Why

`main` is red. Renovate PR #5554 (commit `ae4b3687b`) moved the lefthook pin from `2.1.11` to `2.1.12` in `pyproject.toml` and `uv.lock` and did not touch the test that asserts the resolved binary's version. `test_runtime_configuration_validates_with_pinned_lefthook` has failed on every commit since:

```text
assert '2.1.12' == '2.1.11'
```

Four required checks read that one failure: the bulk pytest job runs the test directly, the Windows path-contract job selects it through the `windows_path` marker, the mutation job hits it inside the sub-pytest for `test_ic_comment_only_change_survives`, and the aggregate rolls those up. Every open PR inherits all four, so nothing can merge until this lands.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **PR** | Refs #5554 | The Renovate bump that introduced the mismatch |
| **PR** | Refs #5547 | One of the open PRs blocked by it |

These references do not close their linked items: #5554 is already merged, and #5547 is a separate change that this only unblocks.

## Changes

- `tests/test_lefthook_integration.py`: the version assertion in `test_runtime_configuration_validates_with_pinned_lefthook` now reads `2.1.12`.

The two other `2.1.11` occurrences in the tree are prose recording a dated measurement, not assertions, so they are unchanged: a comment, see `scripts/validation/check_git_hook_health.py`, and the docstring above `test_lefthook_no_auto_install_isolates_sibling_runs` in the same test file. Rewriting a recorded measurement would falsify it.

## Acceptance criteria

- [x] `test_runtime_configuration_validates_with_pinned_lefthook` passes against the locked lefthook.
- [x] A negative control proves the failure is real: restoring `2.1.11` fails the same test.
- [x] The rest of `tests/test_lefthook_integration.py` still passes.
- [x] No production code, workflow, hook, or dependency pin changes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low scrutiny, blocks every open PR.

**Focus areas**:

1. **Whether the literal is the right shape at all.** A literal desyncs on every lefthook bump unless the bumping PR remembers to touch this test, which is what just failed. Deriving the expected version from the `lefthook==` specifier in `pyproject.toml` would make the test self-maintaining, and the assertion would still be a real contract: the binary `uv run --frozen` resolves must equal the pin. I kept the literal here because `main` is red now and the file's own convention is literals, as in the `min_version` assertion earlier in it. Worth a follow-up issue if you want the durable form.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed

Run in an external worktree checked out at `main` (`19a103eb0`) with `uv sync --frozen --extra dev`:

| Check | Command | Result |
|---|---|---|
| Resolved binary | `uv run --frozen lefthook version` | `2.1.12` |
| Negative control | that test with `2.1.11` restored | 1 failed, `assert '2.1.12' == '2.1.11'` |
| The fix | that test with this change | 1 passed |
| Whole file | `uv run --frozen pytest tests/test_lefthook_integration.py -q` | 862 passed, 1 skipped |
| Pre-PR suite | `uv run --frozen python scripts/validation/pre_pr.py` | RESULT: All validations passed |
| Pre-push suite | `git push` | all jobs green |

The negative control is what distinguishes this from a guess: the same command fails on unmodified `main` and passes with the one-character change, so the four red checks are attributed rather than assumed.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The diff is one string literal inside a test assertion. No authentication, authorization, workflow, git hook, secret, or dependency surface is touched. `lefthook.yml` and the hook policy scripts are unchanged; the lefthook pin itself was already moved by #5554.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced
- [x] Documentation updated (N/A, no behavior to document)

## Notes for Reviewers

Branch is cut from `main` at `19a103eb0` and carries this one commit, so it merges without a rebase.

Renovate will hit this again on the next lefthook release unless either its config learns to update the literal or the test derives the version from the pin. Focus area 1 above is that decision; I did not make it here because `main` being red is the urgent half and the durable form is the considered half.

## Related Issues

Refs #5554
Refs #5547

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144WjPjqFZWWQqhFXNNqheA

---
_Generated by [Claude Code](https://claude.ai/code/session_0144WjPjqFZWWQqhFXNNqheA)_