### PR TITLE
fix(test): derive the expected Lefthook version from the pin

### DIFF
--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -21,6 +21,7 @@ from typing import Any, NoReturn, Self, cast
 from unittest import mock
 
 import pytest
+import tomllib
 import yaml
 
 from scripts.validation import check_git_hook_health
@@ -1193,6 +1194,30 @@ def test_configuration_and_tree_have_no_payload_scripts() -> None:
     assert all(not path.exists() for path in HOOK_PAYLOADS)
 
 
+def _pinned_lefthook_version(pyproject: Path | None = None) -> str:
+    """Return the lefthook version pinned in pyproject.toml's dev extra.
+
+    The assertion in ``test_runtime_configuration_validates_with_pinned_lefthook``
+    used to carry the version as a literal, which made it a second source of
+    truth that drifts the moment the pin moves. PR #5554 bumped the pin from
+    2.1.11 to 2.1.12 and nothing updated the literal, so main went red on a
+    test whose own name says it validates against the pin.
+
+    Fails closed rather than defaulting: a missing or duplicated pin raises,
+    so the assertion can never pass vacuously against a version nobody
+    declared.
+    """
+    path = pyproject if pyproject is not None else PROJECT_ROOT / "pyproject.toml"
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    dev = data["project"]["optional-dependencies"]["dev"]
+    pins = [spec.split("==", 1)[1] for spec in dev if spec.startswith("lefthook==")]
+    if len(pins) != 1:
+        raise ValueError(
+            f"expected exactly one 'lefthook==' pin in the dev extra, found {pins}"
+        )
+    return pins[0]
+
+
 def test_runtime_configuration_validates_with_pinned_lefthook() -> None:
     assert LEFTHOOK is not None
     config = yaml.safe_load((PROJECT_ROOT / "lefthook.yml").read_text(encoding="utf-8"))
@@ -1217,9 +1242,69 @@ def test_runtime_configuration_validates_with_pinned_lefthook() -> None:
     )
 
     assert config["lefthook"] == "uv run --frozen lefthook"
-    assert version.stdout.splitlines()[0] == "2.1.11"
+    assert version.stdout.splitlines()[0] == _pinned_lefthook_version()
     assert validated.returncode == 0
     assert "All good" in validated.stdout
+
+
+def test_pinned_lefthook_version_reads_the_declared_pin() -> None:
+    """Positive: the helper returns the exact version pyproject declares."""
+    declared = [
+        spec
+        for spec in tomllib.loads(
+            (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )["project"]["optional-dependencies"]["dev"]
+        if spec.startswith("lefthook==")
+    ]
+
+    assert declared == [f"lefthook=={_pinned_lefthook_version()}"]
+
+
+def _dev_extra_pyproject(tmp_path: Path, dev: list[str]) -> Path:
+    path = tmp_path / "pyproject.toml"
+    body = ",\n".join(f'    "{spec}"' for spec in dev)
+    path.write_text(
+        '[project]\nname = "x"\nversion = "0"\n\n'
+        f"[project.optional-dependencies]\ndev = [\n{body}\n]\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_pinned_lefthook_version_fails_closed_when_the_pin_is_absent(
+    tmp_path: Path,
+) -> None:
+    """Negative control: no pin must raise, never fall back to a default.
+
+    A helper that returned a default here would let the runtime assertion pass
+    against a version nobody declared, which is the failure this replaces.
+    """
+    pyproject = _dev_extra_pyproject(tmp_path, ["ruff>=0.15.16"])
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
+
+
+def test_pinned_lefthook_version_fails_closed_on_duplicate_pins(
+    tmp_path: Path,
+) -> None:
+    """Negative control: two pins are ambiguous, so the helper refuses to pick."""
+    pyproject = _dev_extra_pyproject(
+        tmp_path, ["lefthook==2.1.12", "lefthook==2.1.11"]
+    )
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
+
+
+def test_pinned_lefthook_version_ignores_a_non_exact_requirement(
+    tmp_path: Path,
+) -> None:
+    """Edge: only ``lefthook==`` counts, so a range never satisfies the pin."""
+    pyproject = _dev_extra_pyproject(tmp_path, ["lefthook>=2.1.11"])
+
+    with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
+        _pinned_lefthook_version(pyproject)
 
 
 def test_lefthook_timeout_stops_hung_job(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### What

`test_runtime_configuration_validates_with_pinned_lefthook` no longer carries the Lefthook version as a literal. It reads the pin from `pyproject.toml` instead, through a helper that fails closed.

### Why

`pyproject.toml` and this test held the same version twice. PR #5554 (Renovate, automerged at 13:05:59Z, commit `ae4b3687b`) bumped `lefthook==2.1.11` to `2.1.12` in `pyproject.toml`, and the literal in the test it never opened stayed at `2.1.11`:

```
FAILED tests/test_lefthook_integration.py::test_runtime_configuration_validates_with_pinned_lefthook
AssertionError: assert '2.1.12' == '2.1.11'
```

Reproduced at the time in a clean worktree at `origin/main` `19a103eb0` with no local changes, so it was the base branch's failure rather than any one PR's.

**Main is green again, and not because of this PR.** PR #5547 landed at 15:18:23Z (commit `ca415d8e3`) carrying a literal bump to `"2.1.12"`, which repaired the symptom. This PR is no longer the thing unblocking main, and it is not urgent. What it still does is remove the second source of truth, so the next Renovate bump cannot repeat this. Bumping the literal fixes today; deriving it fixes the class.

That coupling is the mechanism #4503 catalogs: a PR breaks an invariant in a file it never opened, and no per-PR check sees it.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4503 | Same coupling class: a global invariant split across two files that no per-PR check evaluates together |

These references do not close their linked items: #4503 is about the class across the whole repository. This PR removes one instance of it.

## Changes

- `tests/test_lefthook_integration.py`: add `_pinned_lefthook_version()`, which parses the single `lefthook==` pin from the `dev` extra and raises on a missing, duplicated, or non-exact requirement. The runtime assertion now compares against it.

## Acceptance criteria

- [x] `test_runtime_configuration_validates_with_pinned_lefthook` passes on current main plus this change
- [x] The assertion still fails when the runtime version genuinely disagrees with the pin
- [x] The helper cannot return a default, so the assertion cannot pass vacuously
- [x] A future Renovate bump of the pin does not require a matching edit here

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no longer urgent now that #5547 has main green.

**Focus areas**: the risk in a test that derives its expectation from a file is that it reads the same source twice and asserts nothing. The mutation control below is the evidence it does not. Worth your check that `_pinned_lefthook_version` reading the `dev` extra specifically is the right list, given `lefthook==` also appears in a second extra and `tests/test_pyproject_dev_deps_parity.py` is what keeps the two in agreement.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Four new tests, one positive and three negative controls:

| Test | Role |
|---|---|
| `test_pinned_lefthook_version_reads_the_declared_pin` | positive, helper returns exactly what pyproject declares |
| `test_pinned_lefthook_version_fails_closed_when_the_pin_is_absent` | negative control, no default fallback |
| `test_pinned_lefthook_version_fails_closed_on_duplicate_pins` | negative control, ambiguity refuses rather than picks |
| `test_pinned_lefthook_version_ignores_a_non_exact_requirement` | edge, `lefthook>=` is not a pin |

Evidence, re-run after merging `origin/main` `e076cfcdf` into this branch:

- `tests/test_lefthook_integration.py` gives **866 passed, 1 skipped** on the merge result (`2981d524b`).
- Mutation control, because a file-derived expectation can pass vacuously: setting the pin to `9.9.9` while the runtime holds `2.1.12` **fails** the assertion (`- 9.9.9 / + 2.1.12`); restoring the pin **passes** it. Re-run on the merge result, not only the pre-merge commit.
- Historical, on clean `origin/main` `19a103eb0` before #5547 landed: the runtime test **failed**, `assert '2.1.12' == '2.1.11'`.
- `ruff check` clean. `import tomllib` sits in the third-party block, which is where ruff's `target-version = "py310"` puts it and where `tests/validation/test_pytest_parallelism_policy.py:36-37` already has it.
- Full pre-push gate chain green on the push of `2981d524b`, including `count-ratchets`, `security-scan`, `python-tests`, `zero-collection-tests`, and `pre-pr-validation`.

### Merge conflict resolution

#5547's literal bump and this PR's helper both rewrite the same assertion line, so `origin/main` conflicted here. Resolved in `2981d524b` by keeping the derived call, which is what this PR exists to introduce. `git diff 19a103eb0 origin/main -- tests/test_lefthook_integration.py` confirms main's only change to this file was that one literal, so taking this side loses nothing from main.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (runs as the `pre-pr-validation` pre-push gate)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

Two other `2.1.11` strings are deliberately left alone: a docstring in this same file and a comment in `scripts/validation/check_git_hook_health.py:118`. Both read "Measured against/on ... Lefthook 2.1.11", and rewriting a recorded measurement to a version it was not measured against would make the comment false.

Worth flagging separately, and not fixed here: #5554 automerged despite `pyproject.toml` being a runtime-read pattern that forces the full suite, so the full suite either did not run or did not gate the merge. That gap can land a red main again regardless of this fix, and it is the same failure class as #4503. I have not investigated why the gate did not hold; that needs its own issue and its own evidence.

No GPT-5.6 Sol diff review: this environment has no transport for it (no `codex` CLI, no OpenAI credential, and the `benchmark-models` skill requires `codex exec`). An independent adversarial Claude review stood in. This PR claims no Sol verdict.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQevHtjhW9gdPToc6DKrKJ)_