### PR TITLE
test(worktree): pin the ref-update split that desynchronizes a linked worktree

### DIFF
--- a/tests/test_worktree_ref_update_split.py
+++ b/tests/test_worktree_ref_update_split.py
@@ -1,0 +1,135 @@
+"""Real git regression tests for the ref-update split issue #4498 reported.
+
+A linked worktree holds its own HEAD, index, and files, but the branch it has
+checked out is an ordinary ref in the shared ref store. `git update-ref` is
+plumbing and refuses nothing, so a writer in another worktree can move that ref
+forward while the linked worktree's index and files stay on the old commit.
+Git then answers `rev-parse HEAD` with the new commit and `write-tree` with the
+old tree, and `git status` presents the whole difference as if the worktree's
+owner had staged it.
+
+Whether git actually behaves that way is a fact about git, not about this
+repository's code, so these tests move a real ref in a real worktree and then
+ask real git. Each positive assertion is paired with a control that fails when
+the split is absent, so an assertion that stops detecting is caught rather than
+passing silently.
+
+Scope: issue #4498's acceptance criteria ask the correction queue to refuse or
+repair this state. No correction queue exists in this repository, so these
+tests pin the hazard rather than any queue behavior. They give a future
+assignment preflight a falsifiable target: the third test shows the comparison
+such a preflight cannot rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.gc_real_git import GitSandbox, git, write_and_commit
+
+
+def _feature_worktree(sandbox: GitSandbox) -> tuple[Path, str]:
+    """Check `feature` out in a linked worktree and return it with its commit."""
+    commit_a = git(sandbox.main, "rev-parse", "HEAD").stdout.strip()
+    git(sandbox.main, "branch", "feature", commit_a)
+    worktree = sandbox.root / "feature-worktree"
+    git(sandbox.main, "worktree", "add", str(worktree), "feature")
+    return worktree, commit_a
+
+
+def _tree_of(cwd: Path, commit: str) -> str:
+    return git(cwd, "rev-parse", f"{commit}^{{tree}}").stdout.strip()
+
+
+def test_update_ref_splits_a_linked_worktree_head_from_its_index(
+    git_sandbox: GitSandbox,
+) -> None:
+    """Moving the checked-out branch ref leaves HEAD ahead of the index.
+
+    This is issue #4498's minimal reproduction. `update-ref` is plumbing, so
+    unlike `git branch -f` it does not refuse a branch checked out elsewhere.
+    """
+    worktree, commit_a = _feature_worktree(git_sandbox)
+    commit_b = write_and_commit(git_sandbox.main, "b.txt", "b\n", "commit B")
+    assert commit_b != commit_a
+
+    git(git_sandbox.main, "update-ref", "refs/heads/feature", commit_b)
+
+    assert git(worktree, "rev-parse", "HEAD").stdout.strip() == commit_b
+    index_tree = git(worktree, "write-tree").stdout.strip()
+    assert index_tree == _tree_of(worktree, commit_a), (
+        "the index should still hold commit A's tree, which is the split"
+    )
+    assert index_tree != _tree_of(worktree, commit_b)
+    assert git(worktree, "status", "--porcelain").stdout.strip() != "", (
+        "git should present the A-to-B difference as pending work"
+    )
+
+
+def test_control_a_worktree_left_alone_keeps_head_and_index_agreeing(
+    git_sandbox: GitSandbox,
+) -> None:
+    """Without the ref move, HEAD's tree and the index tree are the same object.
+
+    The control for the test above. A worktree that reported a split here would
+    mean the assertions are measuring ordinary worktree state rather than the
+    damage `update-ref` does, and the positive case would prove nothing.
+    """
+    worktree, commit_a = _feature_worktree(git_sandbox)
+    write_and_commit(git_sandbox.main, "b.txt", "b\n", "commit B")
+
+    assert git(worktree, "rev-parse", "HEAD").stdout.strip() == commit_a
+    assert git(worktree, "write-tree").stdout.strip() == _tree_of(worktree, commit_a)
+    assert git(worktree, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_comparing_head_to_the_branch_ref_cannot_detect_the_split(
+    git_sandbox: GitSandbox,
+) -> None:
+    """A preflight keyed on HEAD alone reports the split worktree as healthy.
+
+    Issue #4498's second acceptance criterion asks an assignment preflight to
+    compare the branch commit tree, the index tree, and the worktree state. This
+    test is why all three are named: after the ref move, the linked worktree's
+    HEAD and the branch ref agree exactly, so the cheapest check passes on the
+    damaged worktree. Only the tree comparison separates them.
+    """
+    worktree, _ = _feature_worktree(git_sandbox)
+    commit_b = write_and_commit(git_sandbox.main, "b.txt", "b\n", "commit B")
+    git(git_sandbox.main, "update-ref", "refs/heads/feature", commit_b)
+
+    worktree_head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    branch_ref = git(git_sandbox.main, "rev-parse", "refs/heads/feature").stdout.strip()
+    assert worktree_head == branch_ref, "the HEAD-only comparison agrees, and is therefore blind"
+    assert git(worktree, "write-tree").stdout.strip() != _tree_of(worktree, branch_ref), (
+        "the tree comparison is the one that separates them"
+    )
+
+
+def test_the_split_worktree_still_holds_content_a_reset_would_discard(
+    git_sandbox: GitSandbox,
+) -> None:
+    """Files on disk stay on the old commit, so `reset --hard` is a data loss.
+
+    Issue #4498's impact section: a reset or checkout used as routine recovery
+    discards work the worktree still owns. The edge case is a path the newer
+    commit deleted, because the file is present on disk while HEAD says it
+    should not exist, and no ordinary reachability query names its content.
+    """
+    worktree, commit_a = _feature_worktree(git_sandbox)
+    doomed = worktree / "only-in-a.txt"
+    doomed.write_text("work that predates the ref move\n", encoding="utf-8")
+    git(worktree, "add", "only-in-a.txt")
+    git(worktree, "commit", "-m", "commit A-prime with a file B will not have")
+    commit_a_prime = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    assert commit_a_prime != commit_a
+
+    commit_b = write_and_commit(git_sandbox.main, "b.txt", "b\n", "commit B")
+    git(git_sandbox.main, "update-ref", "refs/heads/feature", commit_b)
+
+    assert doomed.read_text(encoding="utf-8") == "work that predates the ref move\n"
+    assert git(worktree, "rev-parse", "HEAD").stdout.strip() == commit_b
+    listed = git(worktree, "ls-tree", "--name-only", commit_b).stdout.split()
+    assert "only-in-a.txt" not in listed, (
+        "HEAD no longer lists the file, so a hard reset would remove it from disk"
+    )


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds `tests/test_worktree_ref_update_split.py`: four real-git regression tests
that pin the hazard issue #4498 reports, where `git update-ref` moves a branch
ref that a linked worktree has checked out, leaving that worktree's HEAD ahead
of its index and its files.

### Why

Issue #4498 documents a minimal reproduction, but nothing in the repository
exercises it. The hazard rests on a single 2026-08-03 incident report, so
nothing fails if git's behavior changes or if a future guard stops detecting
it. These tests make the claim reproducible.

**This does not close #4498.** Its five acceptance criteria ask the correction
queue to refuse or repair the split. No correction queue exists in this
repository: a repo-wide search for `correction queue` / `correction_queue` and
for `assignment preflight` returns only session records and retrospectives,
nothing under `scripts/`, `.claude/`, or `.github/`. So four of the five
criteria have no implementation surface here, and this PR delivers the half of
AC-5 that is buildable, the reproduction, without the queue behavior it asks
the queue to prove.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4498 | bug(orchestration): branch ref updates desynchronize linked worktrees. Not closing; see Acceptance criteria |

## Changes

- `tests/test_worktree_ref_update_split.py`. New. Four cases on the shared
  `git_sandbox` fixture, because whether git behaves this way is a fact about
  git rather than about this repository's code:
  - `test_update_ref_splits_a_linked_worktree_head_from_its_index`. The
    reproduction. HEAD reports commit B while `write-tree` returns commit A's
    tree and `status --porcelain` presents the difference as pending work.
    `update-ref` is plumbing, so unlike `git branch -f` it does not refuse a
    branch checked out elsewhere.
  - `test_control_a_worktree_left_alone_keeps_head_and_index_agreeing`. The
    control. Without the ref move the two trees are the same object and status
    is empty, so a split reported here would mean the assertions are measuring
    ordinary worktree state rather than the damage.
  - `test_comparing_head_to_the_branch_ref_cannot_detect_the_split`. After the
    move, the worktree's HEAD and the branch ref agree exactly, so the cheapest
    check passes on the damaged worktree. This is why AC-2 names the branch
    tree, the index tree, and the worktree state rather than HEAD alone.
  - `test_the_split_worktree_still_holds_content_a_reset_would_discard`. The
    data-loss edge: a file the newer commit does not list survives on disk, so
    a `reset --hard` used as routine recovery removes it.

## Acceptance criteria

- [x] A regression test reproduces the `update-ref` split (first half of #4498's AC-5)
- [x] Each positive case is paired with a control that fails when the split is absent
- [x] The reproduction covers the data-loss consequence, not only the tree mismatch
- [x] The tests name why a HEAD-only comparison is insufficient, so a future assignment preflight has a falsifiable target
- [ ] The queue refuses or repairs the split (second half of AC-5). Not met and not buildable here: no correction queue exists in this repository
- [ ] #4498's AC-1 through AC-4 (queue ref-update discipline, assignment preflight, safety refs, foreign-state isolation). Not met; same reason

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)
- [x] Test-only change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**:

1. Whether the control genuinely discriminates. It is the assertion that stops
   the three positive cases from measuring ordinary worktree state.
2. Whether `test_the_split_worktree_still_holds_content_a_reset_would_discard`
   proves data loss or merely restates the tree mismatch. It commits inside the
   linked worktree before the ref move, which is the only case that does.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

`uv run pytest tests/test_worktree_ref_update_split.py -q` reports
`4 passed in 0.48s`.

**Falsified rather than merely passing.** Replacing the
`git update-ref` call with a no-op in all three positive cases produced
`3 failed, 1 passed`: every positive case fails and the control still passes,
which is the required signature. A control that failed there would mean it
never discriminated. Restored and re-run green.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [x] No security-critical changes in this PR

Test-only. Adds no runtime code path and no new dependency.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

One independent diff review ran against this commit and returned
`APPROVE: no findings at 80+ confidence`, checking correctness of each
assertion, control discrimination, test isolation, and compliance with
`.claude/rules/testing.md` SHOULD 10, SHOULD 17, MUST 5, and MUST 12.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py` reported `RESULT: All validations passed`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

One process note worth recording, since it cost a push. The pre-push
`push-ref-policy` gate refused this branch because the container's clone was
shallow at 50 commits (`.git/shallow` pinned at `e54dab4213`). Cleared with the
gate's own documented fix, `git fetch --unshallow origin`, not by bypassing it.
Every pre-push job then ran green, including `count-ratchets` at 35.72s and
`pre-pr-validation` at 65.80s.

## Related Issues

These references do not close their linked items:

Refs #4498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7p7VAPNYQ42f9ukjR1VXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7p7VAPNYQ42f9ukjR1VXA)_