### PR TITLE
test(lefthook): resolve lefthook from the interpreter environment, not PATH

### DIFF
--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -12,6 +12,7 @@ import runpy
 import shutil
 import subprocess
 import sys
+import sysconfig
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from datetime import UTC, datetime, tzinfo
@@ -30,7 +31,29 @@ from scripts.validation import git_hook_policy as policy
 pytestmark = pytest.mark.windows_path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-LEFTHOOK = shutil.which("lefthook")
+
+
+def _resolve_lefthook(scripts: str | None = None) -> str | None:
+    """Locate lefthook, preferring the running interpreter's own environment.
+
+    lefthook is a pinned dev dependency (`lefthook==` in pyproject's dev extra),
+    so the binary that matches the pin sits in this interpreter's scripts
+    directory. A bare PATH lookup agrees only while that directory leads PATH,
+    which `uv run` arranges and a directly invoked `.venv/bin/pytest` does not.
+    Measured with a stub `lefthook` placed earlier on PATH: `uv run` resolved
+    `.venv/bin/lefthook` either way, while `.venv/bin/python` resolved the stub
+    under PATH and the pinned 2.1.12 under the scripts directory. Binary
+    identity is not incidental here, because the assertions below pin lefthook's
+    own scheduling, skip, and templating behavior, which moves between releases.
+
+    PATH remains the fallback so a host without the dev extra installed keeps
+    whatever lefthook it has instead of failing every test that needs one.
+    """
+    directory = scripts if scripts is not None else sysconfig.get_path("scripts")
+    return shutil.which("lefthook", path=directory) or shutil.which("lefthook")
+
+
+LEFTHOOK = _resolve_lefthook()
 SEMGREP = shutil.which("semgrep")
 # The Semgrep carve-out proves a `run:` body parses by shelling out to `bash -n`,
 # and fails closed when the host has no Bash. Windows runners put Git's `cmd`
@@ -1305,6 +1328,59 @@ def test_pinned_lefthook_version_ignores_a_non_exact_requirement(
 
     with pytest.raises(ValueError, match="exactly one 'lefthook==' pin"):
         _pinned_lefthook_version(pyproject)
+
+
+def _stub_lefthook(directory: Path) -> Path:
+    """Create an executable file named like lefthook inside ``directory``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    stub = directory / ("lefthook.bat" if os.name == "nt" else "lefthook")
+    stub.write_text("", encoding="utf-8")
+    stub.chmod(0o755)
+    return stub
+
+
+def test_resolve_lefthook_prefers_the_interpreter_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Positive and negative control: the scripts directory beats PATH.
+
+    Reverting the helper to a bare ``shutil.which("lefthook")`` returns the PATH
+    copy here and fails this assertion, which is the whole point: an IDE that
+    runs ``.venv/bin/pytest`` directly leaves PATH pointing at whatever global
+    lefthook the developer installed, and the behavioral assertions in this
+    module would then describe a release nobody pinned.
+    """
+    pinned = _stub_lefthook(tmp_path / "env")
+    monkeypatch.setenv("PATH", str(_stub_lefthook(tmp_path / "elsewhere").parent))
+
+    resolved = _resolve_lefthook(str(pinned.parent))
+
+    # samefile, not string equality: Windows resolution applies PATHEXT and can
+    # return an extension whose case does not match the file on disk.
+    assert resolved is not None
+    assert Path(resolved).samefile(pinned)
+
+
+def test_resolve_lefthook_falls_back_to_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative: an environment without the dev extra still finds a lefthook."""
+    on_path = _stub_lefthook(tmp_path / "elsewhere")
+    monkeypatch.setenv("PATH", str(on_path.parent))
+
+    resolved = _resolve_lefthook(str(tmp_path / "empty"))
+
+    assert resolved is not None
+    assert Path(resolved).samefile(on_path)
+
+
+def test_resolve_lefthook_returns_none_when_no_binary_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Edge: neither source has one, so callers see None and fail loudly."""
+    monkeypatch.setenv("PATH", str(tmp_path / "nothing"))
+
+    assert _resolve_lefthook(str(tmp_path / "empty")) is None
 
 
 def test_lefthook_timeout_stops_hung_job(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

`tests/test_lefthook_integration.py` resolved the binary under test with a bare `shutil.which("lefthook")`, which reads PATH. It now prefers the running interpreter's own scripts directory, with PATH as the fallback.

### Why

lefthook is a pinned dev dependency and `lefthook.yml` declares `lefthook: uv run --frozen lefthook`, so the binary that matches the pin lives in the interpreter's scripts directory. PATH agrees only while that directory leads PATH.

The roughly 30 assertions in this module drive the real binary and pin lefthook's own scheduling, skip, and templating behavior. `lefthook.yml` lines 415 and 556 even carry claims marked "verified empirically on lefthook 2.1.10". Assertions that describe a specific release describe nothing when run against an undeclared build.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5562 | The merged fix that derived the expected version from the pin |
| **Issue** | Refs #5554 | The pin bump that exposed the original literal |

These references do not close their linked items. Nothing here closes an open issue.

## Changes

- `tests/test_lefthook_integration.py`: `LEFTHOOK = shutil.which("lefthook")` becomes `LEFTHOOK = _resolve_lefthook()`, a two-line helper that checks `sysconfig.get_path("scripts")` first and falls back to PATH. Three tests and a stub helper cover it.

## Acceptance criteria

- [x] The module resolves the lefthook that matches the pin when one is installed in the interpreter's environment
- [x] A host without the dev extra still runs, using whatever lefthook is on PATH
- [x] A host with no lefthook at all still fails loudly rather than skipping
- [x] A negative control fails when the helper is reverted to a bare PATH lookup
- [x] No change to what CI or the documented local invocation resolve

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush. This closes a latent hazard, not a live failure.

**Focus areas**: whether PATH should stay as a fallback at all. Keeping it means a host without the dev extra tests an undeclared build rather than failing, which is the same hazard in a smaller form. It was kept so the module does not become unrunnable outside a synced environment; say if you would rather it failed closed.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- Probe with a stub `lefthook` printing `9.9.9 impostor` placed first on PATH. Under `uv run`, both routes resolved `.venv/bin/lefthook`. Under a direct `.venv/bin/python`, PATH resolved the stub while the scripts directory resolved the pinned `2.1.12`.
- `pytest tests/test_lefthook_integration.py -k "resolve_lefthook or pinned_lefthook"`: 8 passed.
- Whole changed module: 870 passed in 30.65s.
- Dependent modules including the mutation partition: 20 passed in 296.88s.
- Negative control: reverting the helper to a bare PATH lookup fails `test_resolve_lefthook_prefers_the_interpreter_environment` with `assert False`; restoring gives 3 passed.
- ruff and mypy clean. Taste count ratchet level at 575.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [x] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (ran as the `pre-pr-validation` pre-push job, green)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

**This is not the fix for the red CI.** That was the hardcoded `2.1.11` literal, already fixed and merged in #5562 by deriving the expected version from the pin. This addresses a separate question that came out of reviewing it: which binary the assertion, and the other thirty, are actually run against.

**CI and the documented local command are unaffected**, both measured. Both go through `uv run`, which prepends the project venv's bin directory to PATH, so the two resolution routes already agree there. The exposure is the invocation that does not activate the venv on PATH: a `.venv/bin/pytest` started straight from an IDE test runner.

**Two rejected alternatives, recorded because each looks right first.** Matching production's `uv run --frozen lefthook` cannot work here: `_run_lefthook` runs with `cwd` set to a temporary fixture repository, which is not a uv project, so `uv run` would fail or resolve against the wrong one. Hardcoding `.venv/bin` breaks `UV_PROJECT_ENVIRONMENT` and needs a `bin` versus `Scripts` branch. `sysconfig.get_path("scripts")` is stdlib, handles both platforms, and is correct for CI's `uv pip install --system` layout too.

**Found and deliberately not fixed here**, both filed separately: `tests/ci/test_lefthook_prepush_fast_fail_runtime.py:26` carries the identical `shutil.which` defect while pinning two scheduling facts, and `ruff format --check` fails on this module on `origin/main` before this change, including inside code #5562 added.

## Related Issues

Refs #5562, #5554
