### PR TITLE
docs(audit): correct findings 3 and 19 and sharpen finding 5

### DIFF
--- a/.agents/audit/2026-09-04-ponytail-audit-over-engineering.md
+++ b/.agents/audit/2026-09-04-ponytail-audit-over-engineering.md
@@ -131,14 +131,22 @@ extra (`mypy`, `semgrep`, `bandit`, `pip-audit`, `ruff`, `pytest*`, `lefthook`,
    docstring reads "This is a FORENSIC TOOL, not a regression gate. Do NOT add
    it to CI") and is excluded from the count.
 5. `.claude/rules/session-logs.md:9`: "Session log creation is discontinued: do
-   not create a new `.agents/sessions/*.json` file." The 1,538 existing logs are
-   frozen history. `scripts/measure_context_retrieval_metrics.py` parses that
+   not create a new `.agents/sessions/*.json` file." The 1,467 existing logs are
+   frozen history. An earlier draft said 1,538, which is every tracked file under
+   `.agents/sessions/`: it counts the 15 files in `handoffs/` and the non-JSON
+   entries the quoted rule does not describe.
+   `scripts/measure_context_retrieval_metrics.py` parses that
    frozen corpus and is imported only by `tests/test_context_retrieval_decision.py`.
    `scripts/validate_session_json.py` and its 5,258-line test are NOT part of this
-   cut: `new_pr_validations.py:192-206` sets `validate_script` to that path
+   cut. It has three live callers, not the zero the first draft claimed:
+   `new_pr_validations.py:192-206` sets `validate_script` to that path
    (`.claude/skills/github/scripts/pr/`) and runs it under `subprocess.run` as
-   the "Session End" PR validation, and
-   `git_hook_policy.py session` is a validate-if-present pre-commit gate. Both fire
+   the "Session End" PR validation;
+   `git_hook_policy.py session` is a validate-if-present pre-commit gate that
+   `lefthook.yml` runs as `session-policy`; and
+   `scripts/validation/pre_pr_sequence.py:257` registers it as the
+   "Session End Validation" gate.
+   All three fire
    whenever a legacy log is staged or cherry-picked, so the validator stays.
 6. `scripts/workflow/coordinator.py:29` defines `CoordinationStrategy(ABC)` with
    `CentralizedStrategy`, `HierarchicalStrategy`, and `MeshStrategy`. Searching

--- a/.agents/audit/2026-09-04-ponytail-audit-over-engineering.md
+++ b/.agents/audit/2026-09-04-ponytail-audit-over-engineering.md
@@ -20,7 +20,8 @@ working tree.
    plugin payload. Migrate the 14,883 authored lines to `tests/skills/<name>/`,
    which deletes the 14,656-line generated mirror.
    [`.claude/skills/*/tests/`, `src/copilot-cli/skills/*/tests/`]
-3. `delete:` 9.2 MB claude-mem export blob with no code reader. Nothing.
+3. `delete:` 9.2 MB claude-mem export blob whose only reader is a manual
+   importer. Retire the documented import procedure, then the blob.
    [`.claude-mem/memories/direct-backup-2026-01-03-1434-ai-agents.json`]
 4. `yagni:` 33 `scripts/` modules, 11,405 lines, reachable only from their own
    tests. Delete the module and its test together. [`scripts/`, see Evidence 4]
@@ -69,12 +70,15 @@ working tree.
     singular and plural pair holding 360 and 344 files, forcing
     `extract_session_episode.py:1614` to search both. One directory, one lookup.
     [`.agents/archive/`]
-19. `shrink:` 1.0 MB JSON fixture loaded whole by one import test. A trimmed
-    fixture with the same shape.
-    [`2026-01-19-full-backup.json` at `tests/test_import_forgetful_memories.py:232`]
+19. `delete:` 1.0 MB committed export corpus that one test reaches out of
+    `tests/` to read whole. Superseded by the forgetful decommission, which
+    removes the corpus and the test together.
+    [`.forgetful/exports/2026-01-19-full-backup.json`, read at
+    `tests/test_import_forgetful_memories.py:228-232`]
 
-net: -34,700 lines, -35 MB, -0 deps possible, plus 14,883 lines relocated
-from the plugin roots to `tests/skills/`.
+net: -34,700 lines, -26.8 MB, -0 deps possible, plus 14,883 lines relocated
+from the plugin roots to `tests/skills/`. A further 9.2 MB (finding 3) is
+recoverable only if the manual claude-mem import procedure is retired first.
 
 Zero deps: every entry in `pyproject.toml` (`anthropic`, `jsonschema`,
 `markdown-it-py`, `python-frontmatter`, `PyYAML`, `tiktoken`) and every dev
@@ -99,10 +103,19 @@ extra (`mypy`, `semgrep`, `bandit`, `pip-audit`, `ruff`, `pytest*`, `lefthook`,
    legacy colocated suites until migrated". Nobody migrated them. Counts:
    `git ls-files '.claude/skills/*/tests/*.py' | xargs wc -l` gives 14,883 and the
    `src/copilot-cli` mirror gives 14,656, over 121 files.
-3. Search for `direct-backup-2026-01-03` outside `.agents/` and the file itself
-   returns only a directory listing in `.claude-mem/memories/README.md`. The
-   one analysis that mined it (`.agents/analysis/906-skill-learning-heuristic-enhancement.md`)
-   finished in the past.
+3. Corrected. The original claim, "no code reader", came from searching for
+   `direct-backup-2026-01-03` and finding only a directory listing in
+   `.claude-mem/memories/README.md`. That search could not have found the
+   reader, because the reader never names the file:
+   `.claude-mem/scripts/import_claude_mem_memories.py:86` sets `_MEMORIES_DIR`
+   to the sibling `memories` directory, and line 428 globs it. The blob is the
+   only top-level `.json` there, so it is the importer's sole input.
+   What is actually absent is an automated caller. Six suites under
+   `tests/claude_mem/` load the importer.
+   `.agents/governance/MEMORY-MANAGEMENT.md:168` runs
+   `python3 .claude-mem/scripts/import_claude_mem_memories.py` by hand.
+   Deleting the blob without retiring that documented procedure leaves the
+   procedure pointing at nothing.
 4. Each of the 33 has an importer only in its own test module. Roughly ten also
    carry a documented manual invocation in `scripts/README.md`,
    `scripts/eval/README.md`, or a `SKILL.md`, so triage before cutting:
@@ -198,8 +211,10 @@ rewrite, which is ocean, not lake.
 
 ## Method note: indirect runners
 
-Two findings in an earlier draft of this report were wrong the same way, and the
-error is worth naming because it is cheap to repeat. Grepping `.github/workflows/`
+Three findings in this report were wrong about who uses a thing, and the errors
+are worth naming because they are cheap to repeat.
+
+The first two failed the same way. Grepping `.github/workflows/`
 and `lefthook.yml` for an invocation is NOT sufficient to prove nothing runs a
 thing. A caller can sit inside an ordinary Python file that CI collects for other
 reasons:
@@ -214,6 +229,18 @@ Before asserting that nothing invokes a path, grep the whole repository for the
 path string itself, not only for import statements, and read every hit. Both
 misses were caught by searching the issue tracker (#3593, #4838) rather than the
 tree, which is a second source worth checking on any "nothing uses this" claim.
+
+The third failed differently, and grepping harder would not have caught it.
+Finding 3 claimed a data file had no reader. Its reader resolves the path by
+directory glob, so the file name appears nowhere in the source, and no search
+for that name can succeed. When the subject is a data file rather than a module,
+search for readers of its DIRECTORY, not for its name.
+
+All three errors share one shape: absence was inferred from a single search
+whose scope could not have covered the thing being denied. That is the failure
+mode `.claude/rules/universal.md` MUST NOT item 9 names. Two corrections in this
+report were themselves wrong on first attempt, so a correction earns no
+discount: it needs the same evidence as the claim it replaces.
 
 Also not flagged: `scripts/memory/memory_health.py` is documented as a runnable
 command in `.serena/memories/README.md:112` and


### PR DESCRIPTION
## Summary

### What

Corrects two more findings in the audit artifact merged in #5566, and sharpens a
third that the first correction pass (#5569) fixed incompletely. One file changes.

Net removable drops from 35 MB to 26.8 MB, because finding 3's 9.2 MB is no
longer unconditionally recoverable.

### Why

Finding 3 said the claude-mem export blob has no code reader. It has one. The
importer resolves its input directory as a sibling of its own script and globs
it, and the blob is the only top-level JSON there, so the blob is that
importer's sole input. The original search looked for the file name, which the
reader never writes, so the search could not have found it. What is genuinely
absent is an automated caller: the importer runs from a documented manual
procedure in the governance docs and is otherwise exercised only by its own
suites. Deleting the blob without retiring that procedure leaves the procedure
pointing at nothing, so the cut becomes conditional rather than free.

Finding 19 called the file a test fixture and proposed trimming it. It is a
committed export corpus, and the test reaches out of the test tree to read it.
Trimming was the wrong remedy for the wrong classification: the forgetful
decommission tracked in #5574 removes the corpus and the test together, which
supersedes this finding.

Finding 5 was corrected once already and was still wrong twice over. It said
1,538 existing session logs; that number counts every tracked file under the
sessions directory, including a handoffs subdirectory and non-JSON entries the
quoted rule does not describe. The count the rule's own glob describes is 1,467.
It also named two callers of the session-log validator after the first
correction. There are three: the pre-PR gate registration was missed both times.

The method note grows a second failure mode. The first two misses were indirect
runners, and grepping harder would have caught them. Finding 3 was different: a
reader that resolves its path by directory glob never names the file, so no
search for that name can succeed. All three share one shape, which is inferring
absence from a single search whose scope could not have covered the denial.
That is what universal rule MUST NOT item 9 names, and two corrections in this
report have now been wrong on first attempt, so a correction earns no discount.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5397 | Apply code-quality principles to executable natural-language artifacts and ratchet structural debt |
| **Issue** | Refs #5566 | The merged pull request whose audit artifact this corrects |
| **Spec** | None | Correction to an audit artifact; no specification change |

## Changes

- `.agents/audit/2026-09-04-ponytail-audit-over-engineering.md`

The diff is one file. Every other path named in this description is a finding
target or a piece of cited evidence, not a changed file.

## Acceptance criteria

- [x] Each corrected finding states what is actually true, with the verifying command
- [x] The net total is recomputed from the corrected numbers, not carried over
- [x] The conditional cut is labelled conditional rather than folded into a flat total
- [x] The method note names the new failure mode concretely enough to prevent a repeat

## Type of Change

- [x] Documentation update

## Reviewer Expectations

Three corrections are the review surface, each checkable in one command.

Finding 3: read the importer's directory constant and its glob, then list the
top-level JSON in that directory. If more than the one blob is there, the
"sole input" claim is wrong.

Finding 5: count tracked JSON matching the sessions glob, then count every
tracked file under that directory. The two numbers are 1,467 and 1,538, and the
quoted rule describes the first.

Finding 19: confirm the corpus lives under the export tree rather than the test
tree, and that the decommission branch deletes both it and the test.

If any check fails, that correction is wrong and should be rejected.

## Testing

- [x] No testing required (documentation only)

## Validation

Pre-PR validation on the head commit: exit 0, 142 passed, 0 failed. Citation
Freshness examined 4 citations across the changed file with 0 stale, after one
anchor was retargeted because the gate harvests anchors from wrapped-sentence
neighbours and was reading a neighbouring path instead of the cited one.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed (read the diff as if you did not write it)
- [x] No new warnings introduced

## Notes for Reviewers

The corrections in this pass came from two independent sources that agreed.
Verifying the report's own claims surfaced findings 3 and 19, and a separate
drafting run over the same findings independently returned "no longer holds" for
both, plus the session-log count. Agreement is not proof, so each claim here was
re-derived against the tree before being written.

This lands on a new branch for the same reason #5569 did: the previous branch
was squash-merged, so pushing to it would orphan the commit.

## Related Issues

These references do not close their linked items:

Refs #5397
Refs #5566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF

---
_Generated by [Claude Code](https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF)_