### PR TITLE
fix(pr-autofix): drop the unrecognized --output-format from the disarm gate

### DIFF
--- a/.claude/commands/pr-autofix.md
+++ b/.claude/commands/pr-autofix.md
@@ -783,14 +783,29 @@ if [ "$AUTO_MERGE" != "null" ] && [ "$TIER_TRUSTED_T1" != "yes" ]; then
     else
         echo "Auto-merge armed on non-T1 PR #$PR (method: $AUTO_MERGE); disabling before acting."
     fi
+    # No --output-format here. set_pr_auto_merge.py registers no such option,
+    # so argparse exited 2 before the mutation ran and this gate took its
+    # failure branch on every armed non-T1 PR, leaving auto-merge armed (issue
+    # #5551). The script already prints the AutoMergeEnabled object the
+    # verification checklist asks for, with no flag needed.
     if run_pr_mutation_if_live \
         python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" \
-        --pull-request "$PR" --disable --output-format json; then
-        :
+        --pull-request "$PR" --disable; then
+        MUTATION_RC=0
     else
         MUTATION_RC=$?
+    fi
+    # Captured in both arms rather than read from $? inside the else. The
+    # single-arm form holds the right value today only because nothing sits
+    # between the `if` and the read; this form does not depend on that.
+    if [ "$MUTATION_RC" -ne 0 ]; then
         if [ "$MUTATION_RC" -ne 75 ]; then
-            echo "Failed to disable auto-merge on #$PR; skipping to avoid unguarded merge."
+            # 75 is the wrapper's own skip and it already printed the reason.
+            # Any other status means the disable was attempted and did not
+            # land, so auto-merge is still armed on a PR whose readiness this
+            # session never verified. Say that. The old wording, "skipping to
+            # avoid unguarded merge", named the opposite of the state it left.
+            echo "Failed to disable auto-merge on #$PR (rc=$MUTATION_RC); auto-merge is still armed and GitHub can land the PR unattended. Skipping; this one needs a human."
         fi
         cleanup_pr_autofix
         continue

--- a/src/copilot-cli/skills/pr-autofix/SKILL.md
+++ b/src/copilot-cli/skills/pr-autofix/SKILL.md
@@ -785,14 +785,29 @@ if [ "$AUTO_MERGE" != "null" ] && [ "$TIER_TRUSTED_T1" != "yes" ]; then
     else
         echo "Auto-merge armed on non-T1 PR #$PR (method: $AUTO_MERGE); disabling before acting."
     fi
+    # No --output-format here. set_pr_auto_merge.py registers no such option,
+    # so argparse exited 2 before the mutation ran and this gate took its
+    # failure branch on every armed non-T1 PR, leaving auto-merge armed (issue
+    # #5551). The script already prints the AutoMergeEnabled object the
+    # verification checklist asks for, with no flag needed.
     if run_pr_mutation_if_live \
         python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" \
-        --pull-request "$PR" --disable --output-format json; then
-        :
+        --pull-request "$PR" --disable; then
+        MUTATION_RC=0
     else
         MUTATION_RC=$?
+    fi
+    # Captured in both arms rather than read from $? inside the else. The
+    # single-arm form holds the right value today only because nothing sits
+    # between the `if` and the read; this form does not depend on that.
+    if [ "$MUTATION_RC" -ne 0 ]; then
         if [ "$MUTATION_RC" -ne 75 ]; then
-            echo "Failed to disable auto-merge on #$PR; skipping to avoid unguarded merge."
+            # 75 is the wrapper's own skip and it already printed the reason.
+            # Any other status means the disable was attempted and did not
+            # land, so auto-merge is still armed on a PR whose readiness this
+            # session never verified. Say that. The old wording, "skipping to
+            # avoid unguarded merge", named the opposite of the state it left.
+            echo "Failed to disable auto-merge on #$PR (rc=$MUTATION_RC); auto-merge is still armed and GitHub can land the PR unattended. Skipping; this one needs a human."
         fi
         cleanup_pr_autofix
         continue

--- a/tests/commands/pr_autofix_flag_parser.py
+++ b/tests/commands/pr_autofix_flag_parser.py
@@ -1,0 +1,252 @@
+"""Contract between `pr-autofix.md`'s script calls and its producers' parsers.
+
+Refs #5551. `tests/commands/pr_autofix_field_contract.py` guards the read side:
+every `jq` path in the command body has to name a field its producer emits. The
+write side had no such guard, and it drifted the same way. The auto-merge disarm
+gate passed `--output-format json` to `set_pr_auto_merge.py`, which registers no
+such option, so `argparse` exited 2 with `unrecognized arguments` before the
+mutation ran.
+
+An unrecognized flag is worse than a missing field, because it fails the call
+outright rather than returning a sentinel. The disarm gate's failure branch then
+skipped the pull request and printed "skipping to avoid unguarded merge" while
+auto-merge stayed armed, which is the state the gate exists to remove.
+
+The extractor binds each long option to the script it was passed to, then checks
+it against the options that script's `add_argument` calls register. Deriving the
+accepted set statically keeps the check honest without importing a producer,
+which would run its `sys.path` bootstrap and its authentication preflight.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+
+from tests.commands.pr_autofix_field_parser import (
+    COMMAND_PATH,
+    MIRROR_PATH,
+    logical_lines,
+)
+
+__all__ = [
+    "COMMAND_PATH",
+    "MIRROR_PATH",
+    "FlagUse",
+    "derive_accepted_flags",
+    "extract_flag_uses",
+    "extract_invocations",
+    "flag_violations",
+    "script_reference_lines",
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# `SCRIPTS_DIR` is rebound inside the command body: line 62 points it at the
+# shared `utils` directory for the transport preflight, and every later block
+# re-resolves it to the `pr` directory. Both are searched, in that resolution
+# order, so a script name is looked up where the body would find it.
+SCRIPT_DIRS = (
+    REPO_ROOT / ".claude" / "skills" / "github" / "scripts" / "pr",
+    REPO_ROOT / ".claude" / "skills" / "github" / "scripts" / "utils",
+)
+# Shared library the producers import. `add_output_format_arg` lives here and
+# registers `--output-format` on nine of the thirteen producers the command body
+# calls, so a derivation that read only `add_argument` calls in the script would
+# report every one of those nine as a violation.
+SHARED_LIB_DIR = REPO_ROOT / ".claude" / "lib" / "github_core"
+
+_INVOKE = re.compile(r"\$SCRIPTS_DIR/([A-Za-z0-9_]+)\.py")
+# Pipeline and list separators. `||` is listed before `|` so the two-character
+# operator wins at a position where both could match.
+_SEGMENT = re.compile(r"\|\||&&|[|;)]")
+# A long option. The lookbehind rejects the `--` inside a word or a path, and
+# requiring an alphanumeric after the dashes rejects the bare `--` terminator.
+_LONG_FLAG = re.compile(r"(?<![A-Za-z0-9_./-])--([A-Za-z0-9][A-Za-z0-9-]*)")
+
+
+@dataclass(frozen=True)
+class FlagUse:
+    """One long option passed to a producer script in the command body.
+
+    Attributes:
+        line: 1-indexed line where the use's logical line starts.
+        script: Producer the option was passed to, without the `.py` suffix.
+        flag: The option as written, including its leading dashes.
+    """
+
+    line: int
+    script: str
+    flag: str
+
+
+def extract_invocations(text: str) -> list[tuple[int, str]]:
+    """Every `$SCRIPTS_DIR/<script>.py` call in `text`, as (line, script).
+
+    Comment lines are skipped: the body documents alternatives it does not run,
+    and a commented call cannot fail at runtime.
+    """
+    found: list[tuple[int, str]] = []
+    for lineno, line in logical_lines(text):
+        if line.lstrip().startswith("#"):
+            continue
+        for segment in _SEGMENT.split(line):
+            match = _INVOKE.search(segment)
+            if match is not None:
+                found.append((lineno, match.group(1)))
+    return found
+
+
+def extract_flag_uses(text: str) -> list[FlagUse]:
+    """Extract every long option in `text`, bound to the script it was given to.
+
+    The logical line is split on shell separators first so a `jq` or a second
+    producer downstream of a pipe does not donate its options to the producer
+    upstream of it. Within a segment only the text after the script token is
+    scanned, which keeps an interpreter option such as `python3 -X dev` from
+    being read as a producer option.
+    """
+    uses: list[FlagUse] = []
+    for lineno, line in logical_lines(text):
+        if line.lstrip().startswith("#"):
+            continue
+        for segment in _SEGMENT.split(line):
+            match = _INVOKE.search(segment)
+            if match is None:
+                continue
+            for flag in _LONG_FLAG.findall(segment[match.end() :]):
+                uses.append(FlagUse(line=lineno, script=match.group(1), flag=f"--{flag}"))
+    return uses
+
+
+def _script_path(script: str) -> Path | None:
+    for directory in SCRIPT_DIRS:
+        candidate = directory / f"{script}.py"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _literal_flags(node: ast.Call) -> set[str]:
+    """Long options registered by one `add_argument` call."""
+    return {
+        arg.value
+        for arg in node.args
+        if isinstance(arg, ast.Constant)
+        and isinstance(arg.value, str)
+        and arg.value.startswith("--")
+    }
+
+
+def _is_add_argument(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Attribute) and node.func.attr == "add_argument"
+
+
+def _helper_flags(tree: ast.Module) -> dict[str, frozenset[str]]:
+    """Map each function in `tree` to the long options its body registers.
+
+    A producer does not always call `add_argument` itself. `get_pr_context.py`
+    and eight of its siblings register `--output-format` by handing their parser
+    to `add_output_format_arg`, so a derivation that stopped at direct calls
+    would judge those options unregistered and report every use of them.
+    """
+    helpers: dict[str, frozenset[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        flags: set[str] = set()
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call) and _is_add_argument(inner):
+                flags |= _literal_flags(inner)
+        if flags:
+            helpers[node.name] = frozenset(flags)
+    return helpers
+
+
+@cache
+def _shared_helper_flags() -> dict[str, frozenset[str]]:
+    """Argument-adding helpers exported by the shared `github_core` library."""
+    helpers: dict[str, frozenset[str]] = {}
+    for module in sorted(SHARED_LIB_DIR.glob("*.py")):
+        helpers.update(_helper_flags(ast.parse(module.read_text(encoding="utf-8"))))
+    return helpers
+
+
+@cache
+def derive_accepted_flags(script: str) -> frozenset[str] | None:
+    """Statically derive the long options `script` registers.
+
+    Returns None when the script is not on disk, which is itself a finding. An
+    empty set means the source parsed but registered no long option, so there is
+    nothing to compare against and the caller reports nothing.
+
+    Three shapes contribute. A literal `add_argument` call anywhere in the
+    module, including one on a mutually exclusive group, which is how
+    `set_pr_auto_merge.py` registers `--enable` and `--disable`. A call to a
+    helper the script defines itself. A call to a helper the shared library
+    defines, which is where `--output-format` comes from.
+    """
+    path = _script_path(script)
+    if path is None:
+        return None
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    helpers = dict(_shared_helper_flags())
+    helpers.update(_helper_flags(tree))
+    flags: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_add_argument(node):
+            flags |= _literal_flags(node)
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name is not None and name in helpers:
+            flags |= helpers[name]
+    return frozenset(flags)
+
+
+def script_reference_lines(text: str) -> list[tuple[int, str]]:
+    """Logical lines that name a script under `SCRIPTS_DIR`.
+
+    Exists so a test can assert the extractor reached every one of them. It
+    deliberately does not reuse `_INVOKE`: a guard built on the regex it guards
+    goes blind in lockstep with it, passes vacuously, and certifies the
+    blindness it exists to catch. Matching the two substrings `SCRIPTS_DIR` and
+    `.py` is a much weaker claim than parsing the invocation, and that
+    independence is the point.
+
+    The five `SCRIPTS_DIR=` assignments in the body carry no `.py`, so they do
+    not appear here.
+    """
+    return [
+        (lineno, line)
+        for lineno, line in logical_lines(text)
+        if not line.lstrip().startswith("#") and "SCRIPTS_DIR" in line and ".py" in line
+    ]
+
+
+def flag_violations(text: str) -> list[str]:
+    """Every long option in `text` that its producer's parser would reject."""
+    problems: list[str] = []
+    for use in extract_flag_uses(text):
+        accepted = derive_accepted_flags(use.script)
+        if accepted is None:
+            problems.append(
+                f"line {use.line}: invokes {use.script}.py, which is not in "
+                f"{' or '.join(str(d.relative_to(REPO_ROOT)) for d in SCRIPT_DIRS)}. "
+                "The call cannot run and its options cannot be checked."
+            )
+            continue
+        if not accepted:
+            continue
+        if use.flag not in accepted:
+            problems.append(
+                f"line {use.line}: passes `{use.flag}` to {use.script}.py, which "
+                "registers no such option. argparse exits 2 with `unrecognized "
+                "arguments`, so the call fails before doing any work. Registered "
+                f"options: {', '.join(sorted(accepted))}."
+            )
+    return problems

--- a/tests/commands/test_pr_autofix_bot_tier_forwarding.py
+++ b/tests/commands/test_pr_autofix_bot_tier_forwarding.py
@@ -314,9 +314,15 @@ def test_every_dispatch_call_targets_its_current_pr(tmp_path: Path, doc: str) ->
         ["--pull-request", "5177", "--field", "author_is_bot", "--output-format", "json"],
         ["--pull-request", "5177", "--field", "auto_merge_method", "--output-format", "json"],
     ]
+    # No --output-format: the real set_pr_auto_merge.py registers no such option
+    # and exits 2 on it (issue #5551). This expectation carried the flag until
+    # the fix, because the fake here records its argv and accepts anything, so
+    # the harness cannot tell a rejected flag from an accepted one.
+    # `test_pr_autofix_flag_contract.py` checks each option against the real
+    # parser and is what closes that gap.
     assert run.disarm_calls == [
-        ["--pull-request", "5176", "--disable", "--output-format", "json"],
-        ["--pull-request", "5177", "--disable", "--output-format", "json"],
+        ["--pull-request", "5176", "--disable"],
+        ["--pull-request", "5177", "--disable"],
     ]
 
 

--- a/tests/commands/test_pr_autofix_flag_contract.py
+++ b/tests/commands/test_pr_autofix_flag_contract.py
@@ -1,0 +1,264 @@
+"""Contract test between `pr-autofix.md`'s script calls and producer parsers.
+
+Refs #5551. `test_pr_autofix_field_contract.py` closed the read side: a `jq`
+path naming a field its producer never emits. This closes the write side, which
+drifted the same way and is louder when it does. A field read that misses yields
+`null` and lets the `//` default fire. A flag the producer never registered
+makes `argparse` exit 2 with `unrecognized arguments`, so the call does no work
+at all.
+
+The instance was the auto-merge disarm gate (issue #3913, CWE-284). It passed
+`--output-format json` to `set_pr_auto_merge.py`, which registers no such
+option, so every armed non-T1 pull request took the gate's failure branch. The
+branch skips the pull request, which is the safe half, and leaves auto-merge
+armed on a pull request whose readiness the session never verified, which is the
+outcome the gate exists to prevent. The log line said the opposite: it claimed
+the pull request was skipped "to avoid unguarded merge" while the merge stayed
+unguarded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.commands.pr_autofix_flag_parser import (
+    COMMAND_PATH,
+    MIRROR_PATH,
+    derive_accepted_flags,
+    extract_flag_uses,
+    extract_invocations,
+    flag_violations,
+    script_reference_lines,
+)
+
+
+@pytest.fixture(scope="module")
+def command_body() -> str:
+    return COMMAND_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def mirror_body() -> str:
+    return MIRROR_PATH.read_text(encoding="utf-8")
+
+
+# Positive: the shipped command and its generated mirror pass every parser.
+
+
+def test_source_command_has_no_flag_violations(command_body: str) -> None:
+    violations = flag_violations(command_body)
+
+    assert violations == [], "pr-autofix.md passes options its producers reject:\n" + "\n".join(
+        violations
+    )
+
+
+def test_copilot_mirror_has_no_flag_violations(mirror_body: str) -> None:
+    violations = flag_violations(mirror_body)
+
+    assert violations == [], (
+        "The shipped Copilot mirror passes options its producers reject:\n" + "\n".join(violations)
+    )
+
+
+def test_disarm_gate_passes_only_options_the_script_registers(command_body: str) -> None:
+    """The reported defect, asserted on the shipped body rather than a fixture.
+
+    A general violation sweep would also go green if the disarm gate were
+    deleted. This names the gate's own invocation and the two options it is
+    supposed to carry.
+    """
+    by_call: dict[int, set[str]] = {}
+    for use in extract_flag_uses(command_body):
+        if use.script == "set_pr_auto_merge":
+            by_call.setdefault(use.line, set()).add(use.flag)
+    disarm = [flags for flags in by_call.values() if "--disable" in flags]
+
+    assert len(disarm) == 1, (
+        "expected exactly one set_pr_auto_merge.py --disable call in pr-autofix.md; "
+        f"found {len(disarm)}"
+    )
+    assert disarm[0] == {"--pull-request", "--disable"}, (
+        "the disarm gate carries an option set_pr_auto_merge.py does not register; "
+        f"found {sorted(disarm[0])}"
+    )
+
+
+# Negative: the defect this test exists to catch, and its neighbors.
+
+
+def test_the_reported_regression_is_reported() -> None:
+    body = (
+        'if run_pr_mutation_if_live python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" '
+        '--pull-request "$PR" --disable --output-format json; then'
+    )
+
+    violations = flag_violations(body)
+
+    assert len(violations) == 1
+    assert "--output-format" in violations[0]
+    assert "set_pr_auto_merge.py" in violations[0]
+    assert "line 1" in violations[0]
+
+
+def test_unregistered_flag_on_any_producer_is_reported() -> None:
+    body = 'python3 "$SCRIPTS_DIR/get_pr_context.py" --pull-request "$PR" --nonesuch'
+
+    violations = flag_violations(body)
+
+    assert len(violations) == 1
+    assert "--nonesuch" in violations[0]
+
+
+def test_invocation_of_a_missing_script_is_reported() -> None:
+    body = 'python3 "$SCRIPTS_DIR/no_such_producer.py" --pull-request "$PR"'
+
+    violations = flag_violations(body)
+
+    assert len(violations) == 1
+    assert "no_such_producer.py" in violations[0]
+    assert "not in" in violations[0]
+
+
+def test_registered_flag_is_not_reported() -> None:
+    body = 'python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" --pull-request "$PR" --disable'
+
+    assert flag_violations(body) == []
+
+
+# Edge: the shapes the command body actually uses.
+
+
+def test_backslash_continued_invocation_is_bound_to_its_script() -> None:
+    body = (
+        "if run_pr_mutation_if_live \\\n"
+        '    python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" \\\n'
+        '    --pull-request "$PR" --disable --output-format json; then'
+    )
+
+    violations = flag_violations(body)
+
+    assert len(violations) == 1, "a continued invocation must be joined before scanning"
+    assert "line 1" in violations[0], "the finding must point at the first physical line"
+
+
+def test_downstream_options_do_not_attach_to_the_upstream_producer() -> None:
+    body = (
+        'python3 "$SCRIPTS_DIR/get_pr_checks.py" --pull-request "$PR" | '
+        'python3 "$SCRIPTS_DIR/get_pr_check_logs.py" --pull-request "$PR" --checks-input -'
+    )
+
+    uses = extract_flag_uses(body)
+
+    assert {(u.script, u.flag) for u in uses} == {
+        ("get_pr_checks", "--pull-request"),
+        ("get_pr_check_logs", "--pull-request"),
+        ("get_pr_check_logs", "--checks-input"),
+    }
+    assert flag_violations(body) == []
+
+
+def test_jq_program_after_a_pipe_donates_no_options() -> None:
+    body = (
+        'python3 "$SCRIPTS_DIR/get_pr_context.py" --pull-request "$PR" | '
+        "jq -r '.Data.auto_merge_method // \"--nonesuch\"'"
+    )
+
+    assert flag_violations(body) == []
+
+
+def test_option_in_equals_form_is_extracted() -> None:
+    body = 'python3 "$SCRIPTS_DIR/get_pr_context.py" --pull-request="$PR" --nonesuch=1'
+
+    violations = flag_violations(body)
+
+    assert len(violations) == 1
+    assert "--nonesuch" in violations[0]
+
+
+def test_interpreter_option_before_the_script_is_not_attributed_to_it() -> None:
+    body = 'python3 -X dev --check-hash-based-pycs never "$SCRIPTS_DIR/get_pr_context.py" --field x'
+
+    uses = extract_flag_uses(body)
+
+    assert {u.flag for u in uses} == {"--field"}
+    assert flag_violations(body) == []
+
+
+def test_bare_double_dash_terminator_is_not_read_as_an_option() -> None:
+    body = 'python3 "$SCRIPTS_DIR/get_pr_context.py" --pull-request "$PR" -- rest'
+
+    assert extract_flag_uses(body) == [
+        use for use in extract_flag_uses(body) if use.flag == "--pull-request"
+    ]
+    assert flag_violations(body) == []
+
+
+def test_commented_invocation_is_skipped() -> None:
+    body = '# python3 "$SCRIPTS_DIR/set_pr_auto_merge.py" --pull-request 1 --output-format json'
+
+    assert extract_invocations(body) == []
+    assert flag_violations(body) == []
+
+
+def test_short_option_is_ignored() -> None:
+    body = 'python3 "$SCRIPTS_DIR/get_pr_context.py" -q --field x'
+
+    assert {u.flag for u in extract_flag_uses(body)} == {"--field"}
+
+
+# Producer-side derivation.
+
+
+def test_shared_helper_options_count_as_registered() -> None:
+    """`--output-format` reaches nine producers through `add_output_format_arg`.
+
+    Without following the helper call, the derivation would judge the option
+    unregistered and report every legitimate use of it as a violation.
+    """
+    accepted = derive_accepted_flags("get_pr_context")
+
+    assert accepted is not None
+    assert "--output-format" in accepted
+
+
+def test_mutually_exclusive_group_options_count_as_registered() -> None:
+    accepted = derive_accepted_flags("set_pr_auto_merge")
+
+    assert accepted is not None
+    assert {"--enable", "--disable"} <= accepted
+    assert "--output-format" not in accepted, (
+        "set_pr_auto_merge.py grew an --output-format flag; the disarm gate can "
+        "pass it again and this contract should be re-derived, not deleted"
+    )
+
+
+def test_missing_script_derives_no_flag_set() -> None:
+    assert derive_accepted_flags("no_such_producer") is None
+
+
+# Reach: the extractor must see every invocation the body contains.
+
+
+@pytest.mark.parametrize("which", ["source", "mirror"])
+def test_every_script_reference_line_yields_an_invocation(
+    which: str, command_body: str, mirror_body: str
+) -> None:
+    """A guard against a silently narrowing extractor.
+
+    `flag_violations` can only judge an invocation it found. One it never saw
+    (an unusual quoting style, a separator the splitter does not know) leaves
+    this suite green while checking nothing. `script_reference_lines` spots the
+    two substrings `SCRIPTS_DIR` and `.py` without reusing the invocation regex,
+    so it cannot go blind in lockstep with the thing it guards.
+    """
+    body = command_body if which == "source" else mirror_body
+    seen = {lineno for lineno, _ in extract_invocations(body)}
+
+    missed = [
+        f"line {lineno}: {line.strip()[:120]}"
+        for lineno, line in script_reference_lines(body)
+        if lineno not in seen
+    ]
+
+    assert missed == [], "the invocation extractor did not reach every call:\n" + "\n".join(missed)


### PR DESCRIPTION
# Pull Request

## Summary

### What

The auto-merge disarm gate in `.claude/commands/pr-autofix.md` passed `--output-format json` to `set_pr_auto_merge.py`, which registers no such option. The flag is dropped, the mutation status is captured in both arms of the `if` instead of read from `$?` inside the `else`, and the failure message now names the state it leaves behind. A new contract test checks every long option in the command body against the options its producer's parser actually registers.

### Why

`argparse` exits 2 with `unrecognized arguments`, so the call did no work and the gate took its failure branch on every armed non-T1 PR. The branch skips the PR, which is the safe half. The unsafe half is that auto-merge stayed armed on a PR whose readiness the session never verified, and GitHub can land it unattended. That is the outcome the gate was added to prevent (issue #3913, CWE-284), and the log line claimed the opposite: it said the PR was skipped "to avoid unguarded merge" while the merge stayed unguarded.

Nothing caught it. `test_pr_autofix_field_contract.py` guards the read side (a `jq` path naming a field the producer never emits) but there was no equivalent on the write side, and the runtime dispatch harness fakes the producer with a script that records its argv and accepts anything, so it cannot tell a rejected flag from an accepted one.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5551 | fix(pr-autofix): disarm gate passes --output-format to set_pr_auto_merge.py, which rejects it, so auto-merge is never disabled |

## Changes

- `.claude/commands/pr-autofix.md`: drop `--output-format json` from the disarm invocation. The script already prints the `AutoMergeEnabled` object the verification checklist at line 1256 reads, with no flag needed.
- Same file: capture `MUTATION_RC` in both arms of the `if` rather than reading `$?` inside the `else`, matching the `MERGE_READY_RC` idiom at line 607. The old form held the right value only because nothing sat between the condition and the read.
- Same file: reword the failure message to say auto-merge is still armed and the PR needs a human, instead of claiming the merge was guarded.
- `src/copilot-cli/skills/pr-autofix/SKILL.md`: regenerated mirror (`uv run python build/scripts/generate_commands.py`).
- `tests/commands/pr_autofix_flag_parser.py` (new): binds every long option in the command body to the script it was passed to, and derives each producer's registered options from its `add_argument` calls. Follows `add_output_format_arg`, so the nine producers that take `--output-format` through the shared `github_core` helper are not misread as rejecting it.
- `tests/commands/test_pr_autofix_flag_contract.py` (new): 20 tests. Positive on the shipped body and its mirror, negative on the reported regression and on an unknown script, edge cases for continuation lines, pipelines, `--flag=value`, interpreter options ahead of the script, the bare `--` terminator, and commented calls, plus a reach guard that does not reuse the invocation regex it guards.
- `tests/commands/test_pr_autofix_bot_tier_forwarding.py`: update the disarm argv expectation, which encoded the bad flag.

## Acceptance criteria

- [x] The disarm gate passes only options `set_pr_auto_merge.py` registers (`--pull-request`, `--disable`).
- [x] A test fails when a long option in the command body names an option its producer does not register.
- [x] The Copilot mirror carries the same fix and is regenerated rather than hand edited.
- [x] The disarm gate's failure message describes the state it leaves (auto-merge still armed) rather than the opposite.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny (the gate is a CWE-284 control), no rush.

**Focus areas**: the reworded failure message, and whether the flag contract's producer derivation should also follow helpers outside `github_core`. Today it walks `.claude/lib/github_core/*.py` plus functions the script defines itself; a helper imported from anywhere else would be missed and its options reported as unregistered.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence:

- `uv run pytest tests/commands/ tests/skills/pr-autofix`: 636 passed, 1 skipped.
- `uv run python scripts/validation/pre_pr.py`: all validations passed.
- `uv run ruff check tests/commands/`: clean.
- Negative control on the real file: `flag_violations` run against `git show HEAD~1:.claude/commands/pr-autofix.md` reports exactly one violation, the reported defect, and zero on the fixed body.
- One pre-push flake seen and re-run: `tests/e2e/test_plugin_load_smoke.py::test_claude_analyst_runtime_uses_exact_allowlist_with_executor_control` hit the 120s pytest timeout under the parallel pre-push group, then passed in 24.21s on the same commit run alone and passed on the re-run of the full hook.

## Agent Review

### Security Review

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes

The gate is the CWE-284 control from issue #3913. This change restores it to working order; it does not widen it. The T1 exemption, the `fetched_pages_complete` completeness requirement, and the ordering ahead of the round-cap breaker are all unchanged.

**Files requiring security review:**

- `.claude/commands/pr-autofix.md` (auto-merge disarm gate, Step 2.6)
- `src/copilot-cli/skills/pr-autofix/SKILL.md` (generated mirror of the same block)

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5551
Refs #3913

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018G3Pg1rrKNKw7eCvLjdAe5

---
_Generated by [Claude Code](https://claude.ai/code/session_018G3Pg1rrKNKw7eCvLjdAe5)_