### PR TITLE
fix(build): publish generated agents atomically, closing the xdist truncation race

### DIFF
--- a/build/generate_agents.py
+++ b/build/generate_agents.py
@@ -26,6 +26,7 @@ import argparse
 import os
 import re
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -489,7 +490,7 @@ def generate_agents(
                     )
                     continue
                 output_dir.mkdir(parents=True, exist_ok=True)
-                output_file.write_bytes(output_content.encode("utf-8"))
+                _atomic_write_bytes(output_file, output_content.encode("utf-8"))
                 print(f"  Generated: {platform_name}")
                 generated += 1
 
@@ -512,6 +513,90 @@ def generate_agents(
 
     print()
     return 0
+
+
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Publish ``content`` at ``path`` atomically via a temp file plus ``os.replace``.
+
+    Follows ``build/scripts/generate_adr_index.py``, function
+    ``_atomic_write_text`` (lines 876 to 957 as of this commit; the name is the
+    durable handle). Its docstring reads verbatim:
+
+        Write ``content`` to ``path`` atomically via a temp file plus ``os.replace``.
+
+        ``Path.write_text`` opens ``path`` for writing, which follows a symlink and
+        writes through to whatever it targets. A contributor who committed
+        ``path`` as a symlink (or a CI runner checking out such a commit) would
+        then have this generator overwrite an arbitrary file the process can
+        write, not the intended destination (CWE-59/CWE-22; Copilot review,
+        originally found on the standalone extraction PR #5285). ``os.replace``
+        does not follow a symlink destination: it replaces the directory entry
+        itself, so a symlink at ``path`` is unlinked and swapped for a regular
+        file rather than written through. Verified empirically: replacing a
+        symlink this way leaves its former target byte-for-byte unchanged and
+        leaves ``path`` a regular file.
+
+    That is the security half. This generator needs the concurrency half of the
+    same property, which issue #5502 measured. ``Path.write_bytes`` opens the
+    destination ``"wb"``, so the file is 0 bytes from the truncate until the
+    buffer flushes, and every intermediate flush size is observable in between.
+    Polling ``src/copilot-cli/agents/analyst.agent.md`` on this branch while
+    running ``build/scripts/build_all.py --check`` recorded
+    ``13110 -> 0 -> 8192 -> 12288 -> 13110`` with 376 zero-size samples. A
+    reader in another process inside that window gets an empty file that passes
+    ``Path.is_file()``, which is how ``tests/test_pr_identity_gate.py`` failed
+    on ``assert ('merge' in '')`` against a file git reported as clean.
+    ``os.replace`` swaps one directory entry, so a concurrent reader opens
+    either the old inode or the new one and never a partial destination.
+
+    Stricter/looser/different than canonical:
+
+    - Different: writes bytes (``"wb"``, no ``encoding``) because the caller
+      has already encoded to UTF-8 and normalized line endings. The canonical
+      writes text. The defensive ``os.close`` below is kept anyway: the
+      canonical documents it as required for an ``os.fdopen`` that fails
+      argument validation before touching the descriptor, and that half does
+      not depend on the mode string.
+    - Same as canonical, deliberately: a symlink destination and a
+      first-ever generation are both left at ``mkstemp``'s own 0600 rather
+      than given a world-readable literal, per the canonical comment naming
+      CodeQL ``py/overly-permissive-mask`` (PR #5321). Every destination this
+      generator writes in the committed tree already exists as a regular file,
+      so the preserve branch is the one that runs in practice.
+    """
+    existing_mode: int | None
+    if path.is_symlink() or not path.is_file():
+        existing_mode = None
+    else:
+        try:
+            existing_mode = path.stat().st_mode & 0o777
+        except OSError:
+            existing_mode = None
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        try:
+            handle = os.fdopen(fd, "wb")
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        with handle:
+            handle.write(content)
+            # Widened only after the write, so the file spends its writable
+            # life at mkstemp's restrictive default.
+            if existing_mode is not None:
+                os.chmod(tmp_name, existing_mode)
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _handle_validate(

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -1308,6 +1308,74 @@ def _write_bytes_no_redirect(
         os.close(fd)
 
 
+def _publish_bytes_atomically(
+    path: Path, content: bytes, *, mode: int | None = None
+) -> None:
+    """Put ``content`` at ``path`` in one step, via a sibling temp file.
+
+    Only :func:`_restore_owned_prefixes` calls this. It replaces that
+    function's former remove-then-recreate sequence, which left the
+    destination observably absent and then observably empty while
+    ``--check`` was still running. Measured on this branch by polling
+    ``src/copilot-cli/agents/analyst.agent.md`` during
+    ``build/scripts/build_all.py --check`` against a stale tree:
+    ``13147 -> 13110 -> -1 -> 0 -> 8192 -> 12288 -> 13147``, where ``-1`` is
+    the file missing entirely. 74 missing samples and 28 zero-size samples.
+    A reader in another process inside that window gets ``FileNotFoundError``
+    or an empty file that still passes ``Path.is_file()``, which is issue
+    #5502. ``os.replace`` swaps one directory entry, so a concurrent reader
+    opens either the old inode or the new one and never a partial state.
+
+    Follows ``build/generate_agents.py``, function ``_atomic_write_bytes``,
+    which in turn follows ``build/scripts/generate_adr_index.py``, function
+    ``_atomic_write_text``. That chain's load-bearing property, quoted
+    verbatim from the latter:
+
+        ``os.replace``
+        does not follow a symlink destination: it replaces the directory entry
+        itself, so a symlink at ``path`` is unlinked and swapped for a regular
+        file rather than written through.
+
+    Stricter/looser/different than canonical:
+
+    - Different: the temp file is created by :func:`_write_bytes_no_redirect`
+      rather than ``tempfile.mkstemp``. That helper opens with
+      ``O_CREAT | O_EXCL | O_NOFOLLOW`` at ``0o600`` and then ``fchmod``s to
+      ``mode``, which is what ``mkstemp`` does plus the mode handling this
+      caller already needed, so reusing it keeps that helper's contract and
+      its three direct unit tests untouched. The random name supplies the
+      uniqueness ``mkstemp`` would; a collision raises ``FileExistsError``,
+      an ``OSError`` the caller already turns into a ``WARN``.
+    - Looser than the sequence it replaces, deliberately, and this is the one
+      behavior change a reviewer must weigh. Before, a redirect raced in
+      between the removal and the write made ``O_EXCL`` refuse, printing a
+      ``WARN`` and returning ``False``. Now the raced entry is replaced.
+      Nothing is ever opened at ``path``, so the CWE-367 exposure the refusal
+      existed to close (PR #5343 review thread ``PRRT_kwDOQoWRls6epgus``,
+      build_all.py:1843) is closed here by construction instead: the
+      snapshot's bytes cannot travel through a planted link because no
+      descriptor is ever obtained on the destination path.
+      ``test_restore_owned_prefixes_replaces_a_raced_symlink_without_writing_through_it``
+      pins that. The restore contract also strictly improves: the old
+      sequence unlinked first, so a refused write left the file DELETED and
+      the tree further from its pre-run state than when the run started,
+      while a failed ``os.replace`` leaves the destination exactly as it
+      was. ``WARN`` and the ``False`` return survive for every ``OSError``
+      ``os.replace`` can still raise, so
+      :func:`run`'s exit-2 escalation is unchanged.
+    """
+    temporary = path.parent / f".{path.name}.{os.urandom(8).hex()}.tmp"
+    try:
+        _write_bytes_no_redirect(temporary, content, mode=mode)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def _reject_redirecting_ancestors(repo_root: Path, path: Path) -> None:
     """Fail the strict snapshot when a component above ``path`` redirects.
 
@@ -1756,10 +1824,9 @@ def _restore_owned_prefixes(
     printed for each one as it happens). :func:`run` uses this to escalate
     ``--check``'s exit code: this function has always been best-effort
     internally (one failed path must not abort the rest of the restore),
-    but the caller silently ignored the outcome, so a raced redirect that
-    :func:`_write_bytes_no_redirect` correctly refused to write through
-    still let ``--check`` exit 0 with the rollback incomplete (PR #5343
-    review, build_all.py:1724). A directory left over after
+    but the caller silently ignored the outcome, so a restore write that
+    failed still let ``--check`` exit 0 with the rollback incomplete
+    (PR #5343 review, build_all.py:1724). A directory left over after
     :func:`_prune_empty_dirs` fails is not counted: pruning is cosmetic
     (an empty directory carries no content to diverge from the snapshot),
     not a break in the read-only content-restoration contract this return
@@ -1797,15 +1864,19 @@ def _restore_owned_prefixes(
 
     # Cases 1 & 2: restore every file that was in the snapshot.
     #
-    # Both the "already matches" read and the write below go through
-    # _read_bytes_no_redirect / _write_bytes_no_redirect rather than
-    # Path.read_bytes() / Path.write_bytes(), so a symlink or junction raced
-    # in after the is_symlink() checks here and before the actual I/O is
-    # refused instead of written through (CWE-367, PR #5343 review thread at
-    # build_all.py:1843). The write also passes the path's captured mode, so
-    # a restored file keeps its pre-run permissions instead of always coming
-    # back at the write helper's restrictive create default (PR #5343
-    # review, build_all.py:1261).
+    # The "already matches" read goes through _read_bytes_no_redirect rather
+    # than Path.read_bytes(), so a symlink or junction raced in after the
+    # is_symlink() check here and before the read is refused instead of
+    # followed (CWE-367, PR #5343 review thread at build_all.py:1843). The
+    # write goes through _publish_bytes_atomically, which never opens the
+    # destination at all: it fills a fresh sibling temp file and swaps the
+    # directory entry, so the same raced redirect cannot receive the
+    # snapshot's bytes either. Read that helper's divergence section before
+    # changing this; it is the one place the refuse-and-WARN behavior of the
+    # old remove-then-recreate sequence changed. The write also passes the
+    # path's captured mode, so a restored file keeps its pre-run permissions
+    # instead of always coming back at the write helper's restrictive create
+    # default (PR #5343 review, build_all.py:1261).
     for path, content in snapshot.items():
         try:
             if (
@@ -1815,11 +1886,14 @@ def _restore_owned_prefixes(
             ):
                 continue  # already matches snapshot
             if path.is_dir() and not path.is_symlink():
+                # os.replace cannot put a file over a directory, so this one
+                # case still needs an explicit removal first.
                 shutil.rmtree(path)
-            elif path.exists() or path.is_symlink():
-                path.unlink()
             path.parent.mkdir(parents=True, exist_ok=True)
-            _write_bytes_no_redirect(path, content, mode=modes.get(path))
+            # A file or symlink destination is NOT removed first: publishing
+            # over it in one step is what keeps a concurrent reader from ever
+            # seeing it absent or empty (issue #5502).
+            _publish_bytes_atomically(path, content, mode=modes.get(path))
         except OSError as exc:
             # Best-effort restore; surface so CI logs show what was missed,
             # and tell the caller so --check does not report success over an
@@ -2129,9 +2203,9 @@ def run(
                 snapshot,
                 preexisting_boundaries=boundaries,
             )
-            # A raced redirect _write_bytes_no_redirect correctly refused to
-            # write through only prints a WARN, so without this, --check
-            # could still exit 0 over an incomplete rollback (PR #5343
+            # A restore write that failed only prints a WARN, so without
+            # this, --check could still exit 0 over an incomplete
+            # rollback (PR #5343
             # review, build_all.py:1724). Only escalate when generation
             # itself did not already report a failure: a genuine generator
             # error keeps its own, more specific exit code.

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -1565,9 +1565,8 @@ def test_run_check_escalates_to_2_when_restore_reports_failure(
     Unit-level test of the wiring in ``run()``: stubs ``_run_generators`` to
     a clean ``0`` (so the escalation is the only thing that can produce a
     nonzero result) and ``_restore_owned_prefixes`` to ``False`` (what it
-    now returns when :func:`_write_bytes_no_redirect` correctly refuses to
-    write through a path raced back into existence, per
-    ``test_restore_owned_prefixes_refuses_a_symlink_raced_in_before_the_write``
+    now returns when a restore write fails, per
+    ``test_restore_owned_prefixes_warns_and_keeps_the_file_when_the_swap_fails``
     on the underlying primitive). Deliberately does not run the real
     generator pipeline: that pipeline has its own unrelated failure modes in
     a minimal fixture repo (a missing ADR directory, an absent skills
@@ -3490,20 +3489,26 @@ def test_write_bytes_no_redirect_creates_with_no_group_or_world_access(
     assert stat.S_IMODE(dest.stat().st_mode) == 0o600
 
 
-def test_restore_owned_prefixes_refuses_a_symlink_raced_in_before_the_write(
+def test_restore_owned_prefixes_replaces_a_raced_symlink_without_writing_through_it(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """End-to-end: a redirect planted between removal and write is refused.
+    """A redirect planted just before the swap gets replaced, never followed.
 
-    Monkeypatches ``Path.unlink`` so the moment ``_restore_owned_prefixes``
-    removes the pre-existing file at ``owned/frozen.py``, this test plants a
-    symlink to an external file at that exact path before the function's
-    own write runs, reproducing review thread ``PRRT_kwDOQoWRls6epgus``
-    (build_all.py:1843) without needing real concurrency. Restore must
-    refuse the write (WARN, keep going) rather than send the snapshot's
-    original bytes through the link to the external target.
+    Successor to ``..._refuses_a_symlink_raced_in_before_the_write``, which
+    hooked ``Path.unlink`` because restore removed the destination before
+    recreating it. Issue #5502 replaced that sequence with
+    ``_publish_bytes_atomically``, so there is no removal to hook and the only
+    remaining window is the instant before ``os.replace``. This plants the
+    symlink there, which is the same review thread ``PRRT_kwDOQoWRls6epgus``
+    (build_all.py:1843) scenario without real concurrency.
+
+    The security assertion is unchanged and is the first one below: the
+    snapshot's bytes must not reach the external target. What changed is the
+    outcome for the destination. The old sequence refused and left the file
+    DELETED, further from its pre-run state than when the run started; the
+    swap restores it, because ``os.replace`` exchanges the directory entry
+    rather than opening the path.
     """
     repo = tmp_path / "repo"
     owned = repo / "owned"
@@ -3516,25 +3521,109 @@ def test_restore_owned_prefixes_refuses_a_symlink_raced_in_before_the_write(
     external = tmp_path / "external.py"
     external.write_text("do not touch\n", encoding="utf-8")
 
-    real_unlink = Path.unlink
+    real_replace = os.replace
     raced = False
 
-    def racing_unlink(self: Path, missing_ok: bool = False) -> None:
+    def racing_replace(source: Any, destination: Any) -> None:
         nonlocal raced
-        real_unlink(self, missing_ok=missing_ok)
-        if self == protected and not raced:
+        target = Path(destination)
+        if target == protected and not raced:
             raced = True
-            self.symlink_to(external)
+            target.unlink()
+            target.symlink_to(external)
+        real_replace(source, destination)
 
     # The generator "changed" the file so restore's already-matches
-    # shortcut does not skip straight past the removal-and-write path.
+    # shortcut does not skip straight past the write path.
     protected.write_text("generator output\n", encoding="utf-8")
-    monkeypatch.setattr(Path, "unlink", racing_unlink)
+    monkeypatch.setattr(build_all.os, "replace", racing_replace)
 
-    build_all._restore_owned_prefixes(repo, ("owned/",), snapshot)
+    assert build_all._restore_owned_prefixes(repo, ("owned/",), snapshot) is True
 
+    assert raced, "precondition: the redirect was planted"
     assert external.read_text(encoding="utf-8") == "do not touch\n"
+    assert not protected.is_symlink()
+    assert protected.read_bytes() == b"x = 1\n"
+
+
+def test_restore_owned_prefixes_never_empties_the_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #5502: a concurrent reader must never see absent or empty bytes.
+
+    Fails against the previous remove-then-recreate sequence two ways:
+    ``os.replace`` was never called, so ``observed`` stays empty and the first
+    assertion goes red; and by the time the write ran the destination had
+    already been unlinked, so the observation would have been ``<absent>``.
+
+    Measured before the fix by polling
+    ``src/copilot-cli/agents/analyst.agent.md`` during
+    ``build/scripts/build_all.py --check`` against a stale tree:
+    ``13147 -> 13110 -> -1 -> 0 -> 8192 -> 12288 -> 13147``, 74 missing samples
+    and 28 zero-size samples.
+    """
+    repo = tmp_path / "repo"
+    owned = repo / "owned"
+    owned.mkdir(parents=True)
+    tracked = owned / "frozen.py"
+    tracked.write_bytes(b"x = 1\n")
+    snapshot = build_all._snapshot_owned_prefixes(repo, ("owned/",))
+
+    generated = b"generator output that is longer than the snapshot\n"
+    tracked.write_bytes(generated)
+
+    observed: list[bytes] = []
+    real_replace = os.replace
+
+    def observing_replace(source: Any, destination: Any) -> None:
+        target = Path(destination)
+        # One instruction before the swap. A remove-then-recreate sequence
+        # would already have deleted or truncated the destination by now.
+        observed.append(target.read_bytes() if target.is_file() else b"<absent>")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(build_all.os, "replace", observing_replace)
+
+    assert build_all._restore_owned_prefixes(repo, ("owned/",), snapshot) is True
+
+    assert observed, "restore did not publish through os.replace"
+    assert observed == [generated], (
+        "destination was not intact at the swap: a reader in another process "
+        "would have seen it absent or empty"
+    )
+    assert tracked.read_bytes() == b"x = 1\n"
+    assert list(owned.glob(".frozen.py.*")) == []
+
+
+def test_restore_owned_prefixes_warns_and_keeps_the_file_when_the_swap_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The WARN and False return that run()'s exit-2 escalation depends on.
+
+    Also the inverse of the old sequence's worst case: a failed publish must
+    leave the destination on disk, not deleted.
+    """
+    repo = tmp_path / "repo"
+    owned = repo / "owned"
+    owned.mkdir(parents=True)
+    tracked = owned / "frozen.py"
+    tracked.write_bytes(b"x = 1\n")
+    snapshot = build_all._snapshot_owned_prefixes(repo, ("owned/",))
+    tracked.write_bytes(b"generator output\n")
+
+    def failing_replace(source: Any, destination: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(build_all.os, "replace", failing_replace)
+
+    assert build_all._restore_owned_prefixes(repo, ("owned/",), snapshot) is False
+
     assert "WARN: failed to restore" in capsys.readouterr().err
+    assert tracked.read_bytes() == b"generator output\n"
+    assert list(owned.glob(".frozen.py.*")) == []
 
 
 def test_snapshot_non_strict_still_skips_an_owned_directory_symlink(

--- a/tests/build_scripts/test_generate_agents.py
+++ b/tests/build_scripts/test_generate_agents.py
@@ -10,9 +10,11 @@ inspect a few load-bearing fields per platform.
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -117,3 +119,152 @@ def test_validate_mode_passes_against_committed_state() -> None:
     preserve byte-equality with what's checked in."""
     rc = generate_agents.main(["--validate"])
     assert rc == 0
+
+
+# Atomic-write tests (issue #5502) ------------------------------------------
+#
+# `Path.write_bytes` opens the destination "wb", so the file is 0 bytes from
+# the truncate until the buffer flushes. `build_all.py --check` runs this
+# generator against the real working tree, so a reader in another process
+# (an xdist sibling worker) inside that window gets an empty file that still
+# passes `Path.is_file()`. Measured on this branch before the fix, polling
+# `src/copilot-cli/agents/analyst.agent.md` during
+# `build/scripts/build_all.py --check`: 13110 -> 0 -> 8192 -> 12288 -> 13110,
+# 376 zero-size samples.
+#
+# Concurrency is flaky to assert directly, so these test the property that
+# removes the window instead: the destination is published by swapping a
+# directory entry, so it is never observed empty or partial.
+
+
+def _temp_leftovers(destination: Path) -> list[Path]:
+    """Temp files this helper would leave behind, by its own naming scheme."""
+    return sorted(destination.parent.glob(f".{destination.name}.*"))
+
+
+def test_generate_publishes_without_ever_emptying_the_destination(
+    staging: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The old destination must be intact at the instant of the swap.
+
+    Fails against the previous `output_file.write_bytes(...)` line two ways:
+    `os.replace` is never called, so `swaps` stays empty and the first
+    assertion goes red; and the destination is observably truncated mid-write.
+    """
+    first = generate_agents.generate_agents(
+        templates_path=staging / "templates",
+        output_root=staging / "src",
+        repo_root=staging,
+    )
+    assert first == 0
+    watched = staging / "src" / "copilot-cli" / "agents" / "analyst.agent.md"
+    before = watched.read_bytes()
+    assert before, "fixture must produce a non-empty destination to protect"
+
+    swaps: list[tuple[Path, bytes]] = []
+    real_replace = os.replace
+
+    def _observing_replace(source: Any, destination: Any) -> None:
+        target = Path(destination)
+        # Read the destination as it stands one instruction before the swap.
+        # Any in-place write would already have truncated it by now.
+        swaps.append((target, target.read_bytes() if target.is_file() else b"<absent>"))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(generate_agents.os, "replace", _observing_replace)
+
+    second = generate_agents.generate_agents(
+        templates_path=staging / "templates",
+        output_root=staging / "src",
+        repo_root=staging,
+    )
+    assert second == 0
+
+    assert swaps, "generator did not publish through os.replace"
+    observed = [content for target, content in swaps if target == watched]
+    assert observed == [before], (
+        "destination was not intact at the swap: the old bytes must still be "
+        "there until the directory entry is replaced"
+    )
+    assert b"" not in {content for _, content in swaps}
+    assert _temp_leftovers(watched) == []
+
+
+def test_generate_swaps_from_a_temp_file_in_the_same_directory(
+    staging: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cross-directory rename can cross a filesystem, where it is not atomic."""
+    sources: list[tuple[Path, Path]] = []
+    real_replace = os.replace
+
+    def _recording_replace(source: Any, destination: Any) -> None:
+        sources.append((Path(source), Path(destination)))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(generate_agents.os, "replace", _recording_replace)
+
+    rc = generate_agents.generate_agents(
+        templates_path=staging / "templates",
+        output_root=staging / "src",
+        repo_root=staging,
+    )
+    assert rc == 0
+    assert sources
+    for source, destination in sources:
+        assert source.parent == destination.parent
+
+
+def test_atomic_write_creates_a_destination_that_does_not_exist(
+    tmp_path: Path,
+) -> None:
+    """First generation: nothing to replace, and no temp file left behind."""
+    destination = tmp_path / "fresh.md"
+
+    generate_agents._atomic_write_bytes(destination, b"first generation\n")
+
+    assert destination.read_bytes() == b"first generation\n"
+    assert _temp_leftovers(destination) == []
+
+
+def test_atomic_write_replaces_longer_content_with_no_tail(tmp_path: Path) -> None:
+    """The case an in-place write leaves a truncated tail behind."""
+    destination = tmp_path / "shrinking.md"
+    destination.write_bytes(b"x" * 4096)
+
+    generate_agents._atomic_write_bytes(destination, b"short\n")
+
+    assert destination.read_bytes() == b"short\n"
+    assert destination.stat().st_size == 6
+    assert _temp_leftovers(destination) == []
+
+
+def test_atomic_write_preserves_an_existing_destination_mode(tmp_path: Path) -> None:
+    """mkstemp creates at 0600 and os.replace publishes that mode verbatim."""
+    destination = tmp_path / "moded.md"
+    destination.write_bytes(b"old\n")
+    destination.chmod(0o644)
+
+    generate_agents._atomic_write_bytes(destination, b"new\n")
+
+    assert destination.read_bytes() == b"new\n"
+    if os.name == "posix":
+        assert destination.stat().st_mode & 0o777 == 0o644
+
+
+def test_atomic_write_failure_leaves_the_destination_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed publish must not truncate, half-write, or strand a temp file."""
+    destination = tmp_path / "kept.md"
+    destination.write_bytes(b"original\n")
+
+    def _explode(source: Any, target: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(generate_agents.os, "replace", _explode)
+
+    with pytest.raises(OSError, match="disk full"):
+        generate_agents._atomic_write_bytes(destination, b"replacement\n")
+
+    assert destination.read_bytes() == b"original\n"
+    assert _temp_leftovers(destination) == []

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -67,6 +67,22 @@ def _sequence_with_passing_corpus_gates() -> tuple[Any, ...]:
         # restated here, and the gate's registration is covered in
         # tests/validation/test_pre_pr_index_line_endings_wiring.py.
         "Index Line Endings",
+        # Spawns `build/scripts/build_all.py --check` against the real
+        # repository root. That child is not mocked: the gate reaches it
+        # through `subprocess.Popen`
+        # (scripts/validation/check_generated_staleness.py:239) and
+        # TestMain patches `subprocess.run` only. So this gate is not merely
+        # real-corpus-dependent like the ones above, it MUTATES the real
+        # corpus: build_all regenerates every generator-owned file and then
+        # restores its snapshot, and a sibling xdist worker reading one of
+        # those files mid-write sees it truncated. Issue #5502 recorded that
+        # as `src/vs-code-agents/skillbook.agent.md` read empty; the same
+        # window turned `tests/test_pr_identity_gate.py` red on
+        # `src/copilot-cli/agents/analyst.agent.md`. The gate's own behavior
+        # is covered by tests/validation/test_check_generated_staleness.py,
+        # and its registration by
+        # tests/validation/test_pre_pr_sequence_registry.py.
+        "Generated Artifact Staleness",
     }
     return tuple(
         replace(gate, run=lambda _repo_root, _args: True)


### PR DESCRIPTION
# Pull Request

## Summary

### What

Closes issue #5502. Generated agent files are published through a temp file plus `os.replace` instead of a truncating write, and the pre-PR runner's `TestMain` no longer spawns the build orchestrator against the real working tree.

### Why

`main` is red at `19f257b5b`, `pytest (bulk)` job 101363994986's sibling run 101352438699:

```
test_merge_commit_reconciliation_required[agent_path4]
E   AssertionError: the generated Copilot analyst agent must require reconciling a claimed merge commit ...
E   assert ('merge' in '')
```

The empty string is the whole finding. The helper asserts the path is a file before reading, so the file existed and read as empty. Not a missing file, a truncation window.

`TestMain` calls the pre-PR runner's `main(["--quick"])`, whose Generated Artifact Staleness gate spawns the real build orchestrator with `--check` against the repository root. That regenerates every generator-owned file, and a sibling xdist worker read the analyst agent inside the window. In the CI log, on `gw3`, the passing sibling assertion and the failing one are 34 ms apart on the same file, while `gw1` sat inside `TestMain` across that instant. The `subprocess.run` patch in that test does not cover the spawn.

Not caused by any recent merge. Issue #5502 filed the same mechanism on 2026-09-02 against a different generated agent, and the two governing files last changed in PR #5573 and PR #4787.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5502 | Generator writes race readers in sibling xdist workers |

## Changes

- `build/generate_agents.py`. The `write_bytes` call became a temp file in the same directory plus `os.replace`. `write_bytes` opens `wb`, so the destination is 0 bytes until the buffer flushes; a rename is atomic, so a concurrent reader sees the old bytes or the new bytes and never zero.
- `build/scripts/build_all.py`. The owned-prefix restore publishes the same way. Its window was wider than a truncate, not narrower: it unlinked the destination first, so a reader could also get `FileNotFoundError`, measured at 74 missing samples against 28 zero samples.
- `tests/test_validation_pre_pr.py`. Generated Artifact Staleness added to the corpus-gate exclusion, so `TestMain` stops mutating the real tree. The gate's own behavior stays covered by its dedicated suite under the validation tests directory.
- `tests/build_scripts/test_generate_agents.py` and `tests/build_scripts/test_build_all.py`. Positive, negative, and edge coverage for the atomic publish.

## The evidence that matters

A poller on the generated Copilot analyst agent during a `--check` run of the build orchestrator:

| Scenario | Size transitions | zero obs | missing obs |
|---|---|---|---|
| Before, clean tree | `13110 -> 0 -> 8192 -> 12288 -> 13110` | 376 | 0 |
| Before, stale tree | `13147 -> 13110 -> -1 -> 0 -> 8192 -> 12288 -> 13147` | 28 | 74 |
| After, clean tree | `13110` | 0 | 0 |
| After, stale tree | `13147 -> 13110 -> 13147` | 0 | 0 |

Under `pytest tests/test_validation_pre_pr.py::TestMain`: 137 zero observations before, 0 after. Working tree clean and the file's sha256 unchanged in every run, which is why no after-the-fact check ever caught this.

Reproduced independently after the fix: one stable state `[13110]`, `zero: 0`, `missing: 0`, across a full `--check` run.

Negative controls, each restored byte-identically by sha256: reverting the test exclusion brings the 137 zero observations back; reverting the generator call site fails 2 tests with `generator did not publish through os.replace`; reverting the restore call site fails 3.

## Please decide: a reviewed security posture changes here

The owned-prefix restore carried a deliberate CWE-367 posture from PR #5343, review thread `PRRT_kwDOQoWRls6epgus`: a redirect raced onto the destination made `O_EXCL` **refuse**, print WARN, and return `False`. This PR **replaces** instead.

The argument that the exposure stays closed: nothing is ever opened at the destination path, so the snapshot's bytes cannot travel through a planted link. `os.replace` swaps the link itself, not its target. The existing test keeps its original assertion, that the external target is byte-unchanged, and gains two the refusing version could not make: the destination is not a symlink afterwards, and it holds the snapshot bytes.

The restore contract also improves. The old sequence unlinked first, so a refused write left the file **deleted**, further from its pre-run state than when the run started. A failed `os.replace` leaves the destination untouched. WARN and the `False` return survive every `OSError` `os.replace` raises, so the runner's exit-2 escalation is unchanged.

`AGENTS.md` puts Security behind "Ask First", so this is not being self-merged. It is the last commit, `6eaff3fca`, and reverts alone if you want the refusing posture back; the first two commits fix the observed failure without it. The no-redirect writer itself is untouched, along with its three direct unit tests.

## Acceptance criteria

- [x] A `--check` run never exposes a zero-byte or missing generated file to a concurrent reader. Poller: one state, 0 zero, 0 missing.
- [x] `TestMain` no longer writes the real tree. 137 zero observations to 0.
- [x] Every new test has a negative control that goes red against the old write, with the file restored byte-identically.
- [x] The pre-PR runner reports `RESULT: All validations passed`.
- [x] The build-scripts suite passes: 1945 passed, 2 skipped.
- [x] `tests/test_validation_pre_pr.py` with the identity-gate suite under `-n 4` passes three consecutive times.
- [x] The taste count ratchet is unchanged at 566.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny on the security commit, `main` is red until this lands

**Focus areas**:

1. The posture change in `6eaff3fca`, above. That is the call this PR is asking for.
2. Whether the new exclusion belongs in the corpus-gate set. Its rationale differs in kind from the existing entries: those are there because a real-git gate returns a nonsense verdict under the mock, this one is there because the gate **mutates** the corpus. It reaches the real corpus either way, so the set is right, but the comment states the mutation reason rather than borrowing the noise framing.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Positive, negative, and edge: the generator writes the expected bytes and leaves no temp file; the implementation is asserted to publish through `os.replace` rather than in place; first generation with no destination; and a destination longer than the new content, which is the case that leaves a truncated tail without a rename.

## Agent Review

### Security Review

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `build/scripts/build_all.py`, the owned-prefix restore. See the section above. This is the reviewed CWE-367 posture from PR #5343.
- `build/generate_agents.py`. The new write follows the ADR index generator's atomic-write helper, quoted verbatim in the code comment per the canonical-source-mirror rule. That canonical deliberately does not preserve a mode for a symlink destination or a first generation, leaving both at mkstemp's 0600, citing CodeQL `py/overly-permissive-mask` from PR #5321. This change follows that rather than inventing a world-readable fallback.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Noticed on the path, not fixed here

- `main` is also red on the lefthook count-ratchet timing test, 87.7s against an 85s deadline. Separate cause, separate fix, filed as #5610: the test pins wall clock inside a contended xdist shard while its own docstring says it needs a controlled runner, and the corpus shrank over the merges that preceded it, so there is no added work to attribute the time to.
- The mutation harness creates git worktrees under the clone, which the universal rules forbid. Filed as #5611.
- `build/generate_agents.py` is over the 500-line taste ceiling and one of its functions has complexity 13. Both pre-existing and advisory; the count ratchet is unchanged.

## Related Issues

Fixes #5502
Refs #5610, #5611

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YBXz6oCDPsiFZTQEYnAi7