### PR TITLE
fix(forgetful): remove the remaining live functional references to the retired MCP server

### DIFF
--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -1,6 +1,6 @@
 ---
 description: Research external topics, create comprehensive analysis, and incorporate learnings into memory systems
-allowed-tools: WebSearch, WebFetch, Read, Write, Glob, Grep, Bash(python3:*/skills/github/scripts/*), mcp__forgetful__*, mcp__serena__*, Skill
+allowed-tools: WebSearch, WebFetch, Read, Write, Glob, Grep, Bash(python3:*/skills/github/scripts/*), mcp__serena__*, Skill
 # Security Note: the single Bash entry is scoped to the github skill's script
 # directory so this command can reach GitHub discourse and file its Phase 5 issue
 # without raw shell. Wildcards are Claude Code tool patterns, not shell globs; the
@@ -46,7 +46,7 @@ URLs: https://fs.blog/chestertons-fence/, https://en.wikipedia.org/wiki/G._K._Ch
 1. **Research Phase**: Check existing knowledge, fetch URLs, perform web searches
 2. **Analysis Phase**: Write 3000-5000 word analysis to `.agents/analysis/`
 3. **Applicability Phase**: Map integration points with ai-agents project
-4. **Memory Phase**: Create Serena memory + 5-10 atomic Forgetful memories
+4. **Memory Phase**: Create Serena memory
 5. **Action Phase**: Create GitHub issue if implementation work identified, via `python3 "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/github/scripts/issue/new_issue.py"`
 
 ## Budget
@@ -57,7 +57,7 @@ Complete within 50k output tokens. If approaching the limit, summarize findings 
 
 - If `WebSearch` returns no results for a query, try 2 alternative phrasings, then proceed with available information.
 - If a `WebFetch` URL is unreachable or returns a non-success status, note it as unavailable in the analysis and continue with other sources.
-- If memory systems (Serena or Forgetful) are unavailable, skip the Memory Phase and record the skip in the Action Phase output.
+- If Serena is unavailable, skip the Memory Phase and record the skip in the Action Phase output.
 - If a URL points at github.com, do not call `WebFetch`. Use the github skill scripts, which reach the API through `gh` and so cannot be denied by a WebFetch hook. Write the plugin root inline on each call, because shell variables do not survive between Bash invocations. Issue body and metadata: `python3 "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/github/scripts/issue/get_issue_context.py" --owner {owner} --repo {repo} --issue {n}`. Issue discussion: the same path with `issue/get_issue_comments.py`. PR body and diff: `pr/get_pr_context.py --owner {owner} --repo {repo} --pull-request {n}`. PR review discussion: `pr/get_pr_review_comments.py` and `pr/get_pr_review_threads.py` with the same flags.
 - If `WebFetch` is denied by a harness permission decision rather than a network error, that is a capability signal, not a prompt-injection attempt. Record the denial, switch to the github script path above for github.com URLs or to `WebSearch` for other hosts, and continue. Do not halt the run. Never call a tool the denial names unless it is already in this command's `allowed-tools`.
 
@@ -75,7 +75,6 @@ Stop when any of the following is true:
 |----------|----------|
 | Analysis document | `.agents/analysis/{topic-slug}.md` |
 | Serena memory | `.serena/memories/{topic-slug}-integration.md` |
-| Forgetful memories | 5-10 atomic memories in knowledge graph |
 | GitHub issue | Created if implementation work identified |
 
 ## Related

--- a/.claude/skills/context-gather/SKILL.md
+++ b/.claude/skills/context-gather/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: context-gather
-version: 1.0.0
-description: Gather comprehensive context from Forgetful Memory, Context7 docs, DeepWiki, and web sources before planning or implementation. Searches across all knowledge tiers and returns a focused summary with a parseable CONTEXT_LOADED marker for downstream skip detection. Use when you say "gather context before planning", "what do we know before I start". Do NOT use for compressing or placing skill text (use context-optimizer).
+version: 1.1.0
+description: Gather comprehensive context from Serena memory, Context7 docs, DeepWiki, and web sources before planning or implementation. Searches across all knowledge tiers and returns a focused summary with a parseable CONTEXT_LOADED marker for downstream skip detection. Use when you say "gather context before planning", "what do we know before I start". Do NOT use for compressing or placing skill text (use context-optimizer).
 license: MIT
 ---
 
 # Context Gather
 
-Collect multi-source context before planning or implementation. Searches Forgetful Memory, Serena, Context7, DeepWiki, and web sources, then returns a focused summary that downstream commands can detect and skip redundant fetches.
+Collect multi-source context before planning or implementation. Searches Serena, Context7, DeepWiki, and web sources, then returns a focused summary that downstream commands can detect and skip redundant fetches.
 
 > **Model choice (behavior change from prior `/context-gather` slash command)**: this skill declares `model: claude-sonnet-4-6`, downgraded from the slash command's `opus`. Context retrieval is search-and-synthesis work, not deep reasoning; the cost-appropriate tier per ADR-002 model selection is sonnet. Skill behavior is otherwise unchanged.
 
@@ -59,8 +59,7 @@ the source-priority strategy, the untrusted-content guard, and the synthesis and
 citation discipline.
 
 1. Search the following tiers, in parallel where possible:
-   - **Forgetful Memory**: Search across ALL projects for relevant patterns, decisions, and code artifacts.
-   - **Serena Memory**: Read linked entities, observations, and relations for the topic.
+   - **Serena Memory**: Always first. Read this project's memories for prior decisions, patterns, and ADRs on the topic.
    - **Context7**: Query framework-specific documentation if the topic involves a known library or SDK.
    - **DeepWiki**: Read repository-level documentation for relevant GitHub repos.
    - **Web Search**: Fall back to web sources only when memory and docs are insufficient.
@@ -71,7 +70,7 @@ citation discipline.
 TIER_QUERIED: <tier>
 ```
 
-Where `<tier>` is one of: `forgetful`, `serena`, `context7`, `deepwiki`, `web`. Emit one `TIER_QUERIED:` line per tier actually queried.
+Where `<tier>` is one of: `serena`, `context7`, `deepwiki`, `web`. Emit one `TIER_QUERIED:` line per tier actually queried.
 
 ### Phase 3: Synthesize, Emit Marker, and Return
 
@@ -99,7 +98,6 @@ Where `<topic>` is a short, normalized label for the subject (e.g., `pytest-fixt
 
 This skill searches the knowledge tiers using:
 
-- `mcp__forgetful__execute_forgetful_tool`
 - `mcp__serena__read_memory`, `mcp__serena__list_memories`
 - `mcp__context7__resolve-library-id`, `mcp__context7__get-library-docs`
 - `mcp__deepwiki__read_wiki_structure`, `mcp__deepwiki__read_wiki_contents`, `mcp__deepwiki__ask_question`

--- a/.claude/skills/curating-memories/SKILL.md
+++ b/.claude/skills/curating-memories/SKILL.md
@@ -14,7 +14,7 @@ every search that touches it.
 
 This skill owns in-file supersession markers on `.serena/memories/**`. It never
 merges or deletes Serena files and never edits Serena index files. Use
-`memory-consolidate` for cross-file merges, deletions, and index cleanup, and
+`memory-consolidate` for cross-file Serena merges, deletions, and index cleanup, and
 `memory-maintenance` for health, token, and size checks.
 
 ## Triggers
@@ -35,7 +35,7 @@ rather than because a backend hides it.
 
 | In scope | Out of scope |
 |----------|--------------|
-| Strike-through and dated banners inside one memory file | Merging two memory files (`memory-consolidate`) |
+| Strike-through and dated banners inside one memory file | Merging two Serena memory files (`memory-consolidate`) |
 | Collapsing a resolved investigation to a changelog footer | Deleting a memory file (`memory-consolidate`) |
 | Adding a dated-snapshot banner to a point-in-time doc | Editing `memory-index.md` (`memory-consolidate`) |
 | Running and verifying the supersession sweep | Store health, token, and size checks (`memory-maintenance`) |

--- a/.claude/skills/curating-memories/SKILL.md
+++ b/.claude/skills/curating-memories/SKILL.md
@@ -1,181 +1,58 @@
 ---
 name: curating-memories
-description: Guidance for maintaining Forgetful record quality and in-file Serena supersession markers. Covers updating outdated records, marking obsolete content, and linking related knowledge. Use when you say "how do I update a memory", "how do I mark a memory obsolete", or "how do I deduplicate Forgetful memories". Do NOT use for merging or deleting Serena files or tidying Serena indexes; use memory-consolidate.
+description: Maintain Serena memory files in place. Mark superseded content, keep current truth visible inline, and run the supersession sweep that proposes a disposition per file without editing it. Use when you say "how do I mark a memory obsolete", "how do I supersede a memory", or "run the supersession sweep". Do NOT use for merging or deleting Serena files or tidying Serena indexes; use memory-consolidate.
 license: MIT
-version: 1.1.0
+version: 2.0.0
 ---
 
 # Curating Memories
 
-Active curation keeps the knowledge base accurate and connected. Outdated memories pollute search results and reduce effectiveness.
+Active curation keeps the knowledge base accurate. A memory that is fully
+resolved or historical but still reads as live guidance forces a fresh agent
+to read past archaeology to reach current truth, and outdated content pollutes
+every search that touches it.
 
-This skill owns Forgetful record curation and in-file Serena supersession
-markers. It never merges or deletes Serena files and never edits Serena index
-files. Use `memory-consolidate` for cross-file Serena merges, deletions, and
-index cleanup.
+This skill owns in-file supersession markers on `.serena/memories/**`. It never
+merges or deletes Serena files and never edits Serena index files. Use
+`memory-consolidate` for cross-file merges, deletions, and index cleanup, and
+`memory-maintenance` for health, token, and size checks.
 
 ## Triggers
 
 | Trigger Phrase | Operation |
 |----------------|-----------|
-| `how do I update a memory` | update_memory with PATCH semantics |
-| `how do I mark a memory obsolete` | mark_memory_obsolete with reason |
-| `how do I link related memories` | link_memories bidirectional linking |
-| `how do I deduplicate Forgetful memories` | Curation workflow: query, analyze, merge |
-| `how do I clean up stale memories` | Identify and mark obsolete outdated content |
+| `how do I mark a memory obsolete` | Strike the obsolete content, add a dated banner |
+| `how do I supersede a memory` | Apply the healthy-supersession shape below |
+| `how do I clean up stale memories` | Run the sweep, then verify each proposal |
+| `run the supersession sweep` | Scripts section below |
 
----
+## Scope
 
-## When to Update a Memory
+Serena memories are markdown files, not records in a store. There is no
+soft-delete, no obsolete flag, and no link table to write. Curation is an edit
+to the file's own text, and history survives because the file keeps it visible
+rather than because a backend hides it.
 
-Use `update_memory` when:
+| In scope | Out of scope |
+|----------|--------------|
+| Strike-through and dated banners inside one memory file | Merging two memory files (`memory-consolidate`) |
+| Collapsing a resolved investigation to a changelog footer | Deleting a memory file (`memory-consolidate`) |
+| Adding a dated-snapshot banner to a point-in-time doc | Editing `memory-index.md` (`memory-consolidate`) |
+| Running and verifying the supersession sweep | Store health, token, and size checks (`memory-maintenance`) |
 
-- Information needs correction or clarification
-- Importance level changes (more/less relevant than thought)
-- Content needs refinement
-- Links to projects/artifacts/documents change
+## When to Supersede
 
-```javascript
-execute_forgetful_tool("update_memory", {
-  "memory_id": <id>,
-  "content": "Updated content...",
-  "importance": 8
-})
-```
+Supersede content when:
 
-Only specified fields are changed (PATCH semantics).
+- Newer information contradicts it.
+- A decision has been reversed or replaced.
+- The code, script, workflow, or artifact it references no longer exists.
+- The file records a resolved investigation but still reads as an open one.
+- A dated point-in-time snapshot is framed as current state.
 
-## When to Mark Obsolete
-
-Use `mark_memory_obsolete` when:
-
-- Memory is outdated or contradicted by newer information
-- Decision has been reversed or superseded
-- Referenced code/feature no longer exists
-- Memory was created in error
-
-```javascript
-execute_forgetful_tool("mark_memory_obsolete", {
-  "memory_id": <id>,
-  "reason": "Superseded by new architecture decision",
-  "superseded_by": <new_memory_id>  // optional
-})
-```
-
-Obsolete memories are soft-deleted (preserved for audit, hidden from queries).
-
-## When to Link Memories
-
-Use `link_memories` when:
-
-- Concepts are related but not caught by auto-linking
-- Building explicit knowledge graph structure
-- Connecting decisions to their implementations
-- Relating patterns across projects
-
-```javascript
-execute_forgetful_tool("link_memories", {
-  "memory_id": <source_id>,
-  "related_ids": [<target_id_1>, <target_id_2>]
-})
-```
-
-Links are bidirectional (A↔B created automatically).
-
-## Curation Workflow
-
-When creating new memories, check impact on existing knowledge:
-
-### Step 1: Query Related Memories
-
-```javascript
-execute_forgetful_tool("query_memory", {
-  "query": "<topic of new memory>",
-  "query_context": "Checking for memories that may need curation",
-  "k": 5
-})
-```
-
-### Step 2: Analyze Each Result
-
-For each existing memory, determine action:
-
-| Situation | Action |
-|-----------|--------|
-| Existing memory is still accurate | Link to it |
-| Existing memory has minor gaps | Update it |
-| Existing memory is now wrong | Mark obsolete, create new |
-| Existing memory is partially valid | Create new, link both |
-
-### Step 3: Execute Curation Plan
-
-Present plan to user before executing:
-
-```text
-Curation plan:
-- Create: "New authentication approach" (importance: 8)
-- Mark obsolete: #42 "Old auth pattern" (superseded)
-- Link: New memory ↔ #38 "Security requirements"
-
-Proceed? (y/n)
-```
-
-### Step 4: Execute and Report
-
-After user confirms:
-
-1. Create new memory
-2. Mark obsolete memories
-3. Create links
-4. Report results with all changes made
-
-## Signs of Poor Curation
-
-Watch for these indicators:
-
-- Multiple similar memories on same topic (deduplicate)
-- Memories referencing deleted code (mark obsolete)
-- Contradictory memories (resolve conflict)
-- Low-importance memories (importance < 6) accumulating
-- Orphaned memories with no links (consider linking or removing)
-
-## Auto-Linking
-
-Forgetful auto-links semantically similar memories (similarity >= 0.7) during creation. Manual linking is for:
-
-- Explicit relationships auto-linking missed
-- Cross-project connections
-- Non-obvious conceptual links
-
-Check `similar_memories` in create response to see what was auto-linked.
-
----
-
-## When to Use
-
-Use this skill when:
-
-- Existing memories need correction or updated content
-- New information supersedes an older memory
-- Building explicit links between related knowledge
-- Duplicate memories need consolidation
-- Referenced code or features no longer exist
-
-Use [using-forgetful-memory](../using-forgetful-memory/SKILL.md) instead when:
-
-- Creating new memories from scratch
-- Learning Forgetful tool parameters and constraints
-
----
-
-## Process
-
-1. Search for the target memory using `query_memory`
-2. Evaluate whether the memory needs updating, linking, or marking obsolete
-3. Apply the appropriate curation operation
-4. Verify the change took effect
-
----
+Do not supersede on style, length, or strikethrough density. A file that
+already carries struck-through history with current truth visible is the
+target shape, not a rot signal.
 
 ## Scripts: Supersession Sweep
 
@@ -225,26 +102,43 @@ history preserved, nothing hidden. Strikethrough density alone is a
 healthy-supersession signal, never a rot signal; the sweep will not propose
 archiving a file on strikethrough count.
 
----
+## Process
+
+1. Run the sweep, or open the memory the user named.
+2. Read the file and classify it against the four buckets.
+3. Verify the proposal against the code: confirm the artifacts the file
+   references are actually gone before treating it as historical.
+4. Present the disposition to the user and wait for confirmation.
+5. Edit the file to the healthy-supersession shape, keeping history visible.
+6. Re-read the edited file and confirm current truth is reachable without
+   reading the struck-through content.
 
 ## Anti-Patterns
 
 | Avoid | Why | Instead |
 |-------|-----|---------|
-| Deleting memories instead of marking obsolete | Loses audit trail | Use mark_memory_obsolete with reason |
-| Creating duplicates of existing memories | Pollutes search results | Query first, update existing if found |
-| Linking everything to everything | Dilutes relationship signal | Link only semantically meaningful connections |
-| Skipping user confirmation on curation plans | May obsolete valuable content | Present plan and wait for approval |
-| Ignoring low-importance memory accumulation | Degrades search quality over time | Periodically review and cull sub-6 importance |
-
----
+| Deleting obsolete content outright | Loses the audit trail and the reason the position changed | Strike it through under a dated banner |
+| Treating a sweep bucket as a verdict | The sweep is a self-report; a mis-flag on a load-bearing memory is unrecoverable | Verify against the code, then confirm with the user |
+| Archiving on strikethrough density | That is the healthy shape, not rot | Check for removed-artifact references and a resolved status |
+| Editing `memory-index.md` from here | Index cleanup belongs to a different owner and the two passes conflict | Route to `memory-consolidate` |
+| Burying superseded content in a collapsed footer with no date | A future reader cannot tell what changed or when | Date the banner and say why the content was superseded |
 
 ## Verification
 
 After curation operations:
 
-- [ ] Reconciliation: paste the `update_memory` tool response showing the memory ID and updated fields (not a claim)
-- [ ] Obsolete memories have a non-empty `reason` field in the `mark_memory_obsolete` response (paste the response)
-- [ ] Reconciliation: paste the `link_memories` response confirming both directions created (A-to-B and B-to-A)
-- [ ] Reconciliation: `query_memory` on the consolidated topic returns exactly 1 active result (paste the result count)
-- [ ] Curation changes were confirmed by user before execution
+- [ ] Reconciliation: paste the sweep output line for each file you acted on, showing its bucket (not a claim about it)
+- [ ] Every artifact a superseded file references was confirmed gone by an actual lookup, quoted in the output
+- [ ] Each edited file still shows current truth inline without reading the struck-through content
+- [ ] Every supersession carries a date and a one-line reason
+- [ ] Curation changes were confirmed by the user before execution
+- [ ] No memory file was merged, deleted, or removed from `memory-index.md` by this skill
+
+## References
+
+| Artifact | Relationship |
+|----------|-------------|
+| `.claude/skills/memory-consolidate/SKILL.md` | Owns cross-file merges, deletions, and index cleanup |
+| `.claude/skills/memory-maintenance/SKILL.md` | Owns store health, token, and size checks |
+| `.claude/skills/doc-accuracy/SKILL.md` | Code-as-source-of-truth discipline used to ratify a proposal |
+| `.claude/skills/curating-memories/scripts/supersession_sweep.py` | The proposal-only classifier this skill drives |

--- a/scripts/mcp_cli/wrapper.py
+++ b/scripts/mcp_cli/wrapper.py
@@ -13,9 +13,6 @@ Usage::
     # Call with arguments
     result = mcp_call("serena", "read_memory", name="my-memory")
 
-    # Call a Forgetful tool
-    result = mcp_call("forgetful", "discover_forgetful_tools")
-
 See: Issue #1484
 """
 
@@ -89,7 +86,8 @@ def mcp_call(
     """Call an MCP tool via mcporter.
 
     Args:
-        server: MCP server name (e.g. "serena", "forgetful", "deepwiki").
+        server: MCP server name. `.mcp.json` configures "serena" and
+            "deepwiki"; mcporter resolves the name against that file.
         tool: Tool name on that server (e.g. "list_memories", "read_memory").
         timeout: Subprocess timeout in seconds.
         cwd: Working directory for mcporter (affects server config discovery).

--- a/scripts/skill_registry.py
+++ b/scripts/skill_registry.py
@@ -133,7 +133,7 @@ def categorize_skill(name: str, description: str) -> str:
 
     category_keywords = {
         "security": ["security", "threat", "owasp", "cwe", "codeql", "vulnerability"],
-        "memory": ["memory", "forgetful", "serena", "knowledge", "curating"],
+        "memory": ["memory", "serena", "knowledge", "curating"],
         "analysis": [
             "analy",
             "critic",

--- a/scripts/validation/skill_frontmatter.py
+++ b/scripts/validation/skill_frontmatter.py
@@ -108,7 +108,6 @@ VALID_TOOLS: frozenset[str] = frozenset(
         "github-mcp-server",
         "deepwiki",
         "serena",
-        "forgetful",
     }
 )
 

--- a/src/copilot-cli/skills/context-gather/SKILL.md
+++ b/src/copilot-cli/skills/context-gather/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: context-gather
-version: 1.0.0
-description: Gather comprehensive context from Forgetful Memory, Context7 docs, DeepWiki, and web sources before planning or implementation. Searches across all knowledge tiers and returns a focused summary with a parseable CONTEXT_LOADED marker for downstream skip detection. Use when you say "gather context before planning", "what do we know before I start". Do NOT use for compressing or placing skill text (use context-optimizer).
+version: 1.1.0
+description: Gather comprehensive context from Serena memory, Context7 docs, DeepWiki, and web sources before planning or implementation. Searches across all knowledge tiers and returns a focused summary with a parseable CONTEXT_LOADED marker for downstream skip detection. Use when you say "gather context before planning", "what do we know before I start". Do NOT use for compressing or placing skill text (use context-optimizer).
 license: MIT
 ---
 
 # Context Gather
 
-Collect multi-source context before planning or implementation. Searches Forgetful Memory, Serena, Context7, DeepWiki, and web sources, then returns a focused summary that downstream commands can detect and skip redundant fetches.
+Collect multi-source context before planning or implementation. Searches Serena, Context7, DeepWiki, and web sources, then returns a focused summary that downstream commands can detect and skip redundant fetches.
 
 > **Model choice (behavior change from prior `/context-gather` slash command)**: this skill declares `model: claude-sonnet-4-6`, downgraded from the slash command's `opus`. Context retrieval is search-and-synthesis work, not deep reasoning; the cost-appropriate tier per ADR-002 model selection is sonnet. Skill behavior is otherwise unchanged.
 
@@ -59,8 +59,7 @@ the source-priority strategy, the untrusted-content guard, and the synthesis and
 citation discipline.
 
 1. Search the following tiers, in parallel where possible:
-   - **Forgetful Memory**: Search across ALL projects for relevant patterns, decisions, and code artifacts.
-   - **Serena Memory**: Read linked entities, observations, and relations for the topic.
+   - **Serena Memory**: Always first. Read this project's memories for prior decisions, patterns, and ADRs on the topic.
    - **Context7**: Query framework-specific documentation if the topic involves a known library or SDK.
    - **DeepWiki**: Read repository-level documentation for relevant GitHub repos.
    - **Web Search**: Fall back to web sources only when memory and docs are insufficient.
@@ -71,7 +70,7 @@ citation discipline.
 TIER_QUERIED: <tier>
 ```
 
-Where `<tier>` is one of: `forgetful`, `serena`, `context7`, `deepwiki`, `web`. Emit one `TIER_QUERIED:` line per tier actually queried.
+Where `<tier>` is one of: `serena`, `context7`, `deepwiki`, `web`. Emit one `TIER_QUERIED:` line per tier actually queried.
 
 ### Phase 3: Synthesize, Emit Marker, and Return
 
@@ -99,7 +98,6 @@ Where `<topic>` is a short, normalized label for the subject (e.g., `pytest-fixt
 
 This skill searches the knowledge tiers using:
 
-- `mcp__forgetful__execute_forgetful_tool`
 - `mcp__serena__read_memory`, `mcp__serena__list_memories`
 - `mcp__context7__resolve-library-id`, `mcp__context7__get-library-docs`
 - `mcp__deepwiki__read_wiki_structure`, `mcp__deepwiki__read_wiki_contents`, `mcp__deepwiki__ask_question`

--- a/src/copilot-cli/skills/curating-memories/SKILL.md
+++ b/src/copilot-cli/skills/curating-memories/SKILL.md
@@ -14,7 +14,7 @@ every search that touches it.
 
 This skill owns in-file supersession markers on `.serena/memories/**`. It never
 merges or deletes Serena files and never edits Serena index files. Use
-`memory-consolidate` for cross-file merges, deletions, and index cleanup, and
+`memory-consolidate` for cross-file Serena merges, deletions, and index cleanup, and
 `memory-maintenance` for health, token, and size checks.
 
 ## Triggers
@@ -35,7 +35,7 @@ rather than because a backend hides it.
 
 | In scope | Out of scope |
 |----------|--------------|
-| Strike-through and dated banners inside one memory file | Merging two memory files (`memory-consolidate`) |
+| Strike-through and dated banners inside one memory file | Merging two Serena memory files (`memory-consolidate`) |
 | Collapsing a resolved investigation to a changelog footer | Deleting a memory file (`memory-consolidate`) |
 | Adding a dated-snapshot banner to a point-in-time doc | Editing `memory-index.md` (`memory-consolidate`) |
 | Running and verifying the supersession sweep | Store health, token, and size checks (`memory-maintenance`) |

--- a/src/copilot-cli/skills/curating-memories/SKILL.md
+++ b/src/copilot-cli/skills/curating-memories/SKILL.md
@@ -1,181 +1,58 @@
 ---
 name: curating-memories
-description: Guidance for maintaining Forgetful record quality and in-file Serena supersession markers. Covers updating outdated records, marking obsolete content, and linking related knowledge. Use when you say "how do I update a memory", "how do I mark a memory obsolete", or "how do I deduplicate Forgetful memories". Do NOT use for merging or deleting Serena files or tidying Serena indexes; use memory-consolidate.
+description: Maintain Serena memory files in place. Mark superseded content, keep current truth visible inline, and run the supersession sweep that proposes a disposition per file without editing it. Use when you say "how do I mark a memory obsolete", "how do I supersede a memory", or "run the supersession sweep". Do NOT use for merging or deleting Serena files or tidying Serena indexes; use memory-consolidate.
 license: MIT
-version: 1.1.0
+version: 2.0.0
 ---
 
 # Curating Memories
 
-Active curation keeps the knowledge base accurate and connected. Outdated memories pollute search results and reduce effectiveness.
+Active curation keeps the knowledge base accurate. A memory that is fully
+resolved or historical but still reads as live guidance forces a fresh agent
+to read past archaeology to reach current truth, and outdated content pollutes
+every search that touches it.
 
-This skill owns Forgetful record curation and in-file Serena supersession
-markers. It never merges or deletes Serena files and never edits Serena index
-files. Use `memory-consolidate` for cross-file Serena merges, deletions, and
-index cleanup.
+This skill owns in-file supersession markers on `.serena/memories/**`. It never
+merges or deletes Serena files and never edits Serena index files. Use
+`memory-consolidate` for cross-file merges, deletions, and index cleanup, and
+`memory-maintenance` for health, token, and size checks.
 
 ## Triggers
 
 | Trigger Phrase | Operation |
 |----------------|-----------|
-| `how do I update a memory` | update_memory with PATCH semantics |
-| `how do I mark a memory obsolete` | mark_memory_obsolete with reason |
-| `how do I link related memories` | link_memories bidirectional linking |
-| `how do I deduplicate Forgetful memories` | Curation workflow: query, analyze, merge |
-| `how do I clean up stale memories` | Identify and mark obsolete outdated content |
+| `how do I mark a memory obsolete` | Strike the obsolete content, add a dated banner |
+| `how do I supersede a memory` | Apply the healthy-supersession shape below |
+| `how do I clean up stale memories` | Run the sweep, then verify each proposal |
+| `run the supersession sweep` | Scripts section below |
 
----
+## Scope
 
-## When to Update a Memory
+Serena memories are markdown files, not records in a store. There is no
+soft-delete, no obsolete flag, and no link table to write. Curation is an edit
+to the file's own text, and history survives because the file keeps it visible
+rather than because a backend hides it.
 
-Use `update_memory` when:
+| In scope | Out of scope |
+|----------|--------------|
+| Strike-through and dated banners inside one memory file | Merging two memory files (`memory-consolidate`) |
+| Collapsing a resolved investigation to a changelog footer | Deleting a memory file (`memory-consolidate`) |
+| Adding a dated-snapshot banner to a point-in-time doc | Editing `memory-index.md` (`memory-consolidate`) |
+| Running and verifying the supersession sweep | Store health, token, and size checks (`memory-maintenance`) |
 
-- Information needs correction or clarification
-- Importance level changes (more/less relevant than thought)
-- Content needs refinement
-- Links to projects/artifacts/documents change
+## When to Supersede
 
-```javascript
-execute_forgetful_tool("update_memory", {
-  "memory_id": <id>,
-  "content": "Updated content...",
-  "importance": 8
-})
-```
+Supersede content when:
 
-Only specified fields are changed (PATCH semantics).
+- Newer information contradicts it.
+- A decision has been reversed or replaced.
+- The code, script, workflow, or artifact it references no longer exists.
+- The file records a resolved investigation but still reads as an open one.
+- A dated point-in-time snapshot is framed as current state.
 
-## When to Mark Obsolete
-
-Use `mark_memory_obsolete` when:
-
-- Memory is outdated or contradicted by newer information
-- Decision has been reversed or superseded
-- Referenced code/feature no longer exists
-- Memory was created in error
-
-```javascript
-execute_forgetful_tool("mark_memory_obsolete", {
-  "memory_id": <id>,
-  "reason": "Superseded by new architecture decision",
-  "superseded_by": <new_memory_id>  // optional
-})
-```
-
-Obsolete memories are soft-deleted (preserved for audit, hidden from queries).
-
-## When to Link Memories
-
-Use `link_memories` when:
-
-- Concepts are related but not caught by auto-linking
-- Building explicit knowledge graph structure
-- Connecting decisions to their implementations
-- Relating patterns across projects
-
-```javascript
-execute_forgetful_tool("link_memories", {
-  "memory_id": <source_id>,
-  "related_ids": [<target_id_1>, <target_id_2>]
-})
-```
-
-Links are bidirectional (A↔B created automatically).
-
-## Curation Workflow
-
-When creating new memories, check impact on existing knowledge:
-
-### Step 1: Query Related Memories
-
-```javascript
-execute_forgetful_tool("query_memory", {
-  "query": "<topic of new memory>",
-  "query_context": "Checking for memories that may need curation",
-  "k": 5
-})
-```
-
-### Step 2: Analyze Each Result
-
-For each existing memory, determine action:
-
-| Situation | Action |
-|-----------|--------|
-| Existing memory is still accurate | Link to it |
-| Existing memory has minor gaps | Update it |
-| Existing memory is now wrong | Mark obsolete, create new |
-| Existing memory is partially valid | Create new, link both |
-
-### Step 3: Execute Curation Plan
-
-Present plan to user before executing:
-
-```text
-Curation plan:
-- Create: "New authentication approach" (importance: 8)
-- Mark obsolete: #42 "Old auth pattern" (superseded)
-- Link: New memory ↔ #38 "Security requirements"
-
-Proceed? (y/n)
-```
-
-### Step 4: Execute and Report
-
-After user confirms:
-
-1. Create new memory
-2. Mark obsolete memories
-3. Create links
-4. Report results with all changes made
-
-## Signs of Poor Curation
-
-Watch for these indicators:
-
-- Multiple similar memories on same topic (deduplicate)
-- Memories referencing deleted code (mark obsolete)
-- Contradictory memories (resolve conflict)
-- Low-importance memories (importance < 6) accumulating
-- Orphaned memories with no links (consider linking or removing)
-
-## Auto-Linking
-
-Forgetful auto-links semantically similar memories (similarity >= 0.7) during creation. Manual linking is for:
-
-- Explicit relationships auto-linking missed
-- Cross-project connections
-- Non-obvious conceptual links
-
-Check `similar_memories` in create response to see what was auto-linked.
-
----
-
-## When to Use
-
-Use this skill when:
-
-- Existing memories need correction or updated content
-- New information supersedes an older memory
-- Building explicit links between related knowledge
-- Duplicate memories need consolidation
-- Referenced code or features no longer exist
-
-Use [using-forgetful-memory](../using-forgetful-memory/SKILL.md) instead when:
-
-- Creating new memories from scratch
-- Learning Forgetful tool parameters and constraints
-
----
-
-## Process
-
-1. Search for the target memory using `query_memory`
-2. Evaluate whether the memory needs updating, linking, or marking obsolete
-3. Apply the appropriate curation operation
-4. Verify the change took effect
-
----
+Do not supersede on style, length, or strikethrough density. A file that
+already carries struck-through history with current truth visible is the
+target shape, not a rot signal.
 
 ## Scripts: Supersession Sweep
 
@@ -225,26 +102,43 @@ history preserved, nothing hidden. Strikethrough density alone is a
 healthy-supersession signal, never a rot signal; the sweep will not propose
 archiving a file on strikethrough count.
 
----
+## Process
+
+1. Run the sweep, or open the memory the user named.
+2. Read the file and classify it against the four buckets.
+3. Verify the proposal against the code: confirm the artifacts the file
+   references are actually gone before treating it as historical.
+4. Present the disposition to the user and wait for confirmation.
+5. Edit the file to the healthy-supersession shape, keeping history visible.
+6. Re-read the edited file and confirm current truth is reachable without
+   reading the struck-through content.
 
 ## Anti-Patterns
 
 | Avoid | Why | Instead |
 |-------|-----|---------|
-| Deleting memories instead of marking obsolete | Loses audit trail | Use mark_memory_obsolete with reason |
-| Creating duplicates of existing memories | Pollutes search results | Query first, update existing if found |
-| Linking everything to everything | Dilutes relationship signal | Link only semantically meaningful connections |
-| Skipping user confirmation on curation plans | May obsolete valuable content | Present plan and wait for approval |
-| Ignoring low-importance memory accumulation | Degrades search quality over time | Periodically review and cull sub-6 importance |
-
----
+| Deleting obsolete content outright | Loses the audit trail and the reason the position changed | Strike it through under a dated banner |
+| Treating a sweep bucket as a verdict | The sweep is a self-report; a mis-flag on a load-bearing memory is unrecoverable | Verify against the code, then confirm with the user |
+| Archiving on strikethrough density | That is the healthy shape, not rot | Check for removed-artifact references and a resolved status |
+| Editing `memory-index.md` from here | Index cleanup belongs to a different owner and the two passes conflict | Route to `memory-consolidate` |
+| Burying superseded content in a collapsed footer with no date | A future reader cannot tell what changed or when | Date the banner and say why the content was superseded |
 
 ## Verification
 
 After curation operations:
 
-- [ ] Reconciliation: paste the `update_memory` tool response showing the memory ID and updated fields (not a claim)
-- [ ] Obsolete memories have a non-empty `reason` field in the `mark_memory_obsolete` response (paste the response)
-- [ ] Reconciliation: paste the `link_memories` response confirming both directions created (A-to-B and B-to-A)
-- [ ] Reconciliation: `query_memory` on the consolidated topic returns exactly 1 active result (paste the result count)
-- [ ] Curation changes were confirmed by user before execution
+- [ ] Reconciliation: paste the sweep output line for each file you acted on, showing its bucket (not a claim about it)
+- [ ] Every artifact a superseded file references was confirmed gone by an actual lookup, quoted in the output
+- [ ] Each edited file still shows current truth inline without reading the struck-through content
+- [ ] Every supersession carries a date and a one-line reason
+- [ ] Curation changes were confirmed by the user before execution
+- [ ] No memory file was merged, deleted, or removed from `memory-index.md` by this skill
+
+## References
+
+| Artifact | Relationship |
+|----------|-------------|
+| `.claude/skills/memory-consolidate/SKILL.md` | Owns cross-file merges, deletions, and index cleanup |
+| `.claude/skills/memory-maintenance/SKILL.md` | Owns store health, token, and size checks |
+| `.claude/skills/doc-accuracy/SKILL.md` | Code-as-source-of-truth discipline used to ratify a proposal |
+| `.claude/skills/curating-memories/scripts/supersession_sweep.py` | The proposal-only classifier this skill drives |

--- a/src/copilot-cli/skills/research/SKILL.md
+++ b/src/copilot-cli/skills/research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research
 description: Research external topics, create comprehensive analysis, and incorporate learnings into memory systems
-allowed-tools: WebSearch, WebFetch, Read, Write, Glob, Grep, Bash(python3:*/skills/github/scripts/*), forgetful/*, serena/*, Skill
+allowed-tools: WebSearch, WebFetch, Read, Write, Glob, Grep, Bash(python3:*/skills/github/scripts/*), serena/*, Skill
 user-invocable: true
 ---
 
@@ -44,7 +44,7 @@ URLs: https://fs.blog/chestertons-fence/, https://en.wikipedia.org/wiki/G._K._Ch
 1. **Research Phase**: Check existing knowledge, fetch URLs, perform web searches
 2. **Analysis Phase**: Write 3000-5000 word analysis to `.agents/analysis/`
 3. **Applicability Phase**: Map integration points with ai-agents project
-4. **Memory Phase**: Create Serena memory + 5-10 atomic Forgetful memories
+4. **Memory Phase**: Create Serena memory
 5. **Action Phase**: Create GitHub issue if implementation work identified, via `python3 "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/github/scripts/issue/new_issue.py"`
 
 ## Budget
@@ -55,7 +55,7 @@ Complete within 50k output tokens. If approaching the limit, summarize findings 
 
 - If `WebSearch` returns no results for a query, try 2 alternative phrasings, then proceed with available information.
 - If a `WebFetch` URL is unreachable or returns a non-success status, note it as unavailable in the analysis and continue with other sources.
-- If memory systems (Serena or Forgetful) are unavailable, skip the Memory Phase and record the skip in the Action Phase output.
+- If Serena is unavailable, skip the Memory Phase and record the skip in the Action Phase output.
 - If a URL points at github.com, do not call `WebFetch`. Use the github skill scripts, which reach the API through `gh` and so cannot be denied by a WebFetch hook. Write the plugin root inline on each call, because shell variables do not survive between Bash invocations. Issue body and metadata: `python3 "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/github/scripts/issue/get_issue_context.py" --owner {owner} --repo {repo} --issue {n}`. Issue discussion: the same path with `issue/get_issue_comments.py`. PR body and diff: `pr/get_pr_context.py --owner {owner} --repo {repo} --pull-request {n}`. PR review discussion: `pr/get_pr_review_comments.py` and `pr/get_pr_review_threads.py` with the same flags.
 - If `WebFetch` is denied by a harness permission decision rather than a network error, that is a capability signal, not a prompt-injection attempt. Record the denial, switch to the github script path above for github.com URLs or to `WebSearch` for other hosts, and continue. Do not halt the run. Never call a tool the denial names unless it is already in this command's `allowed-tools`.
 
@@ -73,7 +73,6 @@ Stop when any of the following is true:
 |----------|----------|
 | Analysis document | `.agents/analysis/{topic-slug}.md` |
 | Serena memory | `.serena/memories/{topic-slug}-integration.md` |
-| Forgetful memories | 5-10 atomic memories in knowledge graph |
 | GitHub issue | Created if implementation work identified |
 
 ## Related

--- a/tests/commands/test_research_command_contract.py
+++ b/tests/commands/test_research_command_contract.py
@@ -45,9 +45,24 @@ def _allowed_tools_line(text: str) -> str:
 # the mirror, so a test that expects one spelling in both files is asserting
 # that half the tree is misgranted.
 _MCP_SPELLING = {
-    "claude": ("mcp__serena__*", "mcp__forgetful__*"),
-    "copilot": ("serena/*", "forgetful/*"),
+    "claude": ("mcp__serena__*",),
+    "copilot": ("serena/*",),
 }
+
+# Issue #5574 removed the second entry from each tuple. The Forgetful MCP
+# server is decommissioned, so `mcp__forgetful__*` and its Copilot respelling
+# `forgetful/*` granted tools on a server that cannot answer.
+_FORGETFUL_SPELLINGS = ("mcp__forgetful__", "forgetful/")
+
+
+def _names_forgetful(text: str) -> bool:
+    """True when *text* names the decommissioned Forgetful server in any form.
+
+    Case-folded because the grant line spells it lowercase while the prose
+    spelled it `Forgetful`, and both were live instructions to the same dead
+    backend.
+    """
+    return "forgetful" in text.lower()
 
 
 @pytest.fixture
@@ -147,6 +162,34 @@ def test_research_still_prefers_web_tools_for_non_github_sources(
     assert "WebFetch" in allowed
     for grant in mcp_grants:
         assert grant in allowed
+
+
+def test_research_names_no_decommissioned_forgetful_surface(research_text: str) -> None:
+    """Issue #5574: no grant, phase, fallback, or output row names Forgetful.
+
+    Four references were live, not merely stale. `allowed-tools` granted
+    `mcp__forgetful__*`; the Memory Phase told the agent to write 5-10 atomic
+    memories into the knowledge graph; the fallback rule keyed degradation on a
+    backend that can no longer be reachable or unreachable; and the Output table
+    promised those memories as a deliverable. The server is gone, so each one
+    directed work at something that cannot answer.
+    """
+    assert not _names_forgetful(research_text)
+
+
+def test_the_forgetful_detector_catches_every_spelling_it_guards() -> None:
+    """Negative control: the detector above is not vacuous.
+
+    Fires on both harness grant spellings and on the prose capitalization,
+    stays quiet on the Serena grants that replaced them.
+    """
+    for spelling in _FORGETFUL_SPELLINGS:
+        assert _names_forgetful(f"allowed-tools: Read, {spelling}*, Skill"), spelling
+    assert _names_forgetful("4. **Memory Phase**: 5-10 atomic Forgetful memories")
+
+    assert not _names_forgetful("allowed-tools: Read, mcp__serena__*, Skill")
+    assert not _names_forgetful("allowed-tools: Read, serena/*, Skill")
+    assert not _names_forgetful("")
 
 
 def test_each_tree_carries_only_its_own_mcp_spelling(

--- a/tests/skills/context-gather/test_context_gather.py
+++ b/tests/skills/context-gather/test_context_gather.py
@@ -65,6 +65,33 @@ def frontmatter(skill_content: str) -> dict[str, str]:
     return fm
 
 
+def _names_forgetful(text: str) -> bool:
+    """True when *text* names the decommissioned Forgetful server in any form.
+
+    Case-folded because the surfaces spelled it four ways: `Forgetful Memory`
+    in the frontmatter description and body, `forgetful` as a `TIER_QUERIED`
+    token, and `mcp__forgetful__execute_forgetful_tool` in the Tools list.
+    """
+    return "forgetful" in text.lower()
+
+
+def test_the_forgetful_detector_catches_every_spelling_it_guards() -> None:
+    """Negative control: the guard below is not vacuous.
+
+    Fires on each of the four surfaces #5574 removed and stays quiet on the
+    Serena and Context7 names that remain.
+    """
+    assert _names_forgetful("description: Gather context from Forgetful Memory, Context7 docs")
+    assert _names_forgetful("TIER_QUERIED: forgetful")
+    assert _names_forgetful("- `mcp__forgetful__execute_forgetful_tool`")
+
+    assert not _names_forgetful("- `mcp__serena__read_memory`, `mcp__serena__list_memories`")
+    assert not _names_forgetful(
+        "Where `<tier>` is one of: `serena`, `context7`, `deepwiki`, `web`."
+    )
+    assert not _names_forgetful("")
+
+
 class TestFrontmatter:
     """Verify required frontmatter fields exist and have correct values."""
 
@@ -191,6 +218,21 @@ class TestStructure:
         assert "exploring-knowledge-graph" not in skill_content, (
             "SKILL.md must not reference the retired knowledge-graph skill"
         )
+
+    def test_skill_names_no_decommissioned_forgetful_tier(self, skill_content: str) -> None:
+        """Issue #5574: no tier, output token, or tool names Forgetful.
+
+        Five references were live instructions, not stale prose. The
+        frontmatter description routes skill selection; the body summary and
+        the Phase 2 bullet told the agent to query the tier; `TIER_QUERIED:
+        forgetful` was a machine-readable output token callers could emit; and
+        the Tools list named `mcp__forgetful__execute_forgetful_tool`. The MCP
+        server is decommissioned, so each pointed at a backend that cannot
+        answer. references/context-retrieval.md, which this skill points at,
+        already dropped Forgetful from its source table in #5612, so the skill
+        and its own reference disagreed until this change.
+        """
+        assert not _names_forgetful(skill_content)
 
     def test_context_retrieval_subagent_removed(self) -> None:
         """Issue #2103: the context-retrieval agent file was deleted after its

--- a/tests/skills/curating-memories/test_skill_contract.py
+++ b/tests/skills/curating-memories/test_skill_contract.py
@@ -1,0 +1,136 @@
+"""Contract tests for the curating-memories SKILL.md (issue #5574).
+
+The skill was written against the Forgetful MCP server: every operation it
+documented (`update_memory`, `mark_memory_obsolete`, `link_memories`,
+`query_memory`) was an `execute_forgetful_tool` call, and its "When to Use"
+section routed the reader to `using-forgetful-memory` for the rest. That skill
+was retired in #5575 and the server was decommissioned under #5574, so the
+pointer resolved to nothing and every code block instructed a call that cannot
+be made.
+
+`.claude/skills/orphan-ref-validator/scripts/filters.py` carries
+`using-forgetful-memory` in `KNOWN_RETIRED_KEBAB_SKILLS`, which suppresses the
+bare-name mention, and `tests/skills/test_skill_md_cross_reference_links.py`
+pins only `golden-principles` and `memory-enhancement`. Nothing gated the
+relative Markdown link, which is why it survived two cleanup passes.
+
+Parametrized over the canonical `.claude/` tree and the generated
+`src/copilot-cli/` mirror so both copies satisfy the same contract.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CANONICAL_SKILL_MD = REPO_ROOT / ".claude" / "skills" / "curating-memories" / "SKILL.md"
+MIRROR_SKILL_MD = (
+    REPO_ROOT / "src" / "copilot-cli" / "skills" / "curating-memories" / "SKILL.md"
+)
+
+SKILL_MD_PATHS = [
+    pytest.param(CANONICAL_SKILL_MD, id="canonical"),
+    pytest.param(MIRROR_SKILL_MD, id="copilot-cli-mirror"),
+]
+
+_MD_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)#]+)(?:#[^)]*)?\)")
+
+
+@pytest.fixture(params=SKILL_MD_PATHS)
+def skill_md_path(request: pytest.FixtureRequest) -> Path:
+    path: Path = request.param
+    return path
+
+
+@pytest.fixture
+def skill_content(skill_md_path: Path) -> str:
+    assert skill_md_path.is_file(), f"SKILL.md not found at {skill_md_path}"
+    return skill_md_path.read_text(encoding="utf-8")
+
+
+def _names_forgetful(text: str) -> bool:
+    """True when *text* names the decommissioned Forgetful server in any form.
+
+    Case-folded because the removed surfaces spelled it three ways: `Forgetful`
+    in the description and prose, `execute_forgetful_tool` in every code block,
+    and `using-forgetful-memory` in the link and the bare-name mention.
+    """
+    return "forgetful" in text.lower()
+
+
+def _unresolved_relative_links(source_file: Path, text: str) -> list[str]:
+    """Relative Markdown link targets that do not resolve from *source_file*.
+
+    Markdown resolves a relative link against the directory of the file that
+    contains it, never against the repo root, so this mirrors that rule. Absolute
+    URLs are skipped; they are not this test's concern.
+    """
+    unresolved: list[str] = []
+    for target in _MD_LINK_RE.findall(text):
+        if "://" in target or target.startswith("mailto:"):
+            continue
+        if not (source_file.parent / target).resolve().exists():
+            unresolved.append(target)
+    return unresolved
+
+
+def test_skill_names_no_decommissioned_forgetful_surface(skill_content: str) -> None:
+    """The skill documents no operation against the retired server."""
+    assert not _names_forgetful(skill_content)
+
+
+def test_the_forgetful_detector_catches_every_spelling_it_guards() -> None:
+    """Negative control: the guard above is not vacuous.
+
+    Fires on each of the three spellings the rewrite removed and stays quiet on
+    the Serena wording that replaced them.
+    """
+    assert _names_forgetful("description: Guidance for maintaining Forgetful record quality")
+    assert _names_forgetful('execute_forgetful_tool("mark_memory_obsolete", {')
+    assert _names_forgetful("Use [using-forgetful-memory](../using-forgetful-memory/SKILL.md)")
+
+    assert not _names_forgetful("Maintain Serena memory files in place.")
+    assert not _names_forgetful("Use `memory-consolidate` for cross-file merges.")
+    assert not _names_forgetful("")
+
+
+def test_every_relative_link_resolves(skill_md_path: Path, skill_content: str) -> None:
+    """No Markdown link points at a path that does not exist in this tree.
+
+    The retired-skill link is the case this closes, but the check is general:
+    the mirror nests skills at a different depth from the source, so a link that
+    resolves in one tree can still be dead in the other.
+    """
+    assert _unresolved_relative_links(skill_md_path, skill_content) == []
+
+
+def test_the_link_resolver_catches_a_dead_target() -> None:
+    """Negative control: the resolver flags the exact link that was dead here.
+
+    Uses the real SKILL.md location so the relative depth is the one the
+    renderer would apply, and pairs the dead target with a live sibling so a
+    resolver that flagged everything would fail this too.
+    """
+    dead = "[using-forgetful-memory](../using-forgetful-memory/SKILL.md)"
+    live = "[doc-accuracy](../doc-accuracy/SKILL.md)"
+
+    found = _unresolved_relative_links(CANONICAL_SKILL_MD, f"{dead}\n{live}\n")
+
+    assert found == ["../using-forgetful-memory/SKILL.md"]
+
+
+def test_skill_does_not_claim_ownership_of_memory_consolidate_work(
+    skill_content: str,
+) -> None:
+    """The scope split with `memory-consolidate` survives the rewrite.
+
+    `memory-consolidate` owns cross-file merges, deletions, and index cleanup.
+    Losing that hand-off would let two skills edit the same files with
+    different rules.
+    """
+    assert "memory-consolidate" in skill_content
+    assert "never edits Serena index files" in skill_content

--- a/tests/skills/memory-consolidate/test_skill_structure.py
+++ b/tests/skills/memory-consolidate/test_skill_structure.py
@@ -171,5 +171,12 @@ def test_discovery_index_and_output_contract() -> None:
         assert "never merges or deletes serena files" in curating
         assert "never edits serena index files" in curating
         assert "use `memory-consolidate` for cross-file serena merges" in curating
-        assert "`how do i deduplicate forgetful memories`" in curating
+        # Issue #5574 flipped the next assertion. It required the trigger
+        # `how do I deduplicate Forgetful memories`, which kept the two skills'
+        # dedup vocabularies apart by naming a separate store. That store is
+        # decommissioned, and deduplication across Serena files is a merge,
+        # which memory-consolidate owns. So curating-memories must now claim no
+        # dedup trigger in either spelling, and the boundary this block guards
+        # is preserved by both negatives rather than by one positive.
+        assert "`how do i deduplicate forgetful memories`" not in curating
         assert "`how do i deduplicate memories`" not in curating

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -114,6 +114,29 @@ class TestCategorizeSkill:
         """Falls back to other when no keywords match."""
         assert categorize_skill("xyzzy", "does unknown things") == "other"
 
+    def test_retired_forgetful_keyword_no_longer_routes_to_memory(self) -> None:
+        """Issue #5574: `forgetful` was a memory-category keyword.
+
+        The MCP server is decommissioned, so no skill name or description will
+        carry the word again. Measured before removal: dropping the keyword
+        changed the category of 0 of the 93 skills under `.claude/skills/`, so
+        it matched nothing that the surviving keywords do not already match.
+        """
+        assert categorize_skill("forgetful-client", "queries the graph") == "other"
+
+    def test_live_memory_keywords_still_route_to_memory(self) -> None:
+        """Control: the surviving keywords keep their routing.
+
+        Without this, deleting the whole memory category would also pass the
+        test above.
+        """
+        for name, description in (
+            ("memory-search", "search stored memories"),
+            ("encode-repo-serena", "populate the serena knowledge base"),
+            ("curating-memories", "maintain memory files"),
+        ):
+            assert categorize_skill(name, description) == "memory", name
+
 
 class TestScanSkill:
     """Tests for scan_skill function."""

--- a/tests/test_validation_skill_frontmatter.py
+++ b/tests/test_validation_skill_frontmatter.py
@@ -295,6 +295,37 @@ class TestValidateAllowedTools:
         all_tools = ",".join(VALID_TOOLS)
         assert validate_allowed_tools(all_tools) == []
 
+    def test_decommissioned_forgetful_server_root_rejected(self) -> None:
+        """Issue #5574: `forgetful` was an MCP server root in VALID_TOOLS.
+
+        The server is decommissioned, so a skill naming it as a tool root
+        declares a capability no harness can grant.
+        """
+        errors = validate_allowed_tools("Read,forgetful")
+
+        assert any("Unknown tools" in e for e in errors)
+        assert any("forgetful" in e for e in errors)
+
+    def test_live_mcp_server_roots_still_accepted(self) -> None:
+        """Control: the two roots `.mcp.json` still configures are untouched.
+
+        Without this, dropping every MCP root would also pass the test above.
+        """
+        assert validate_allowed_tools("Read,serena,deepwiki") == []
+
+    def test_wildcard_grants_bypass_the_root_allow_list_entirely(self) -> None:
+        """Documents the limit of the check above, measured not assumed.
+
+        `validate_allowed_tools` skips any entry containing `*` before the
+        VALID_TOOLS lookup, so `mcp__forgetful__*` and its Copilot respelling
+        `forgetful/*` are accepted no matter what VALID_TOOLS holds. Removing
+        the root closes the bare-name case only. The wildcard case is guarded
+        per file instead, by the contract tests on the research command and on
+        the context-gather and curating-memories skills.
+        """
+        assert validate_allowed_tools("Read,mcp__forgetful__*") == []
+        assert validate_allowed_tools("Read,forgetful/*") == []
+
 
 # ---------------------------------------------------------------------------
 # get_skill_files


### PR DESCRIPTION
# Pull Request

## Summary

### What

Removes the remaining live functional references to the decommissioned `forgetful` MCP server: one tool grant, one machine-readable output token, one validator allow-list entry, two script code paths, and a skill whose every documented operation was a call into that server. Adds guard tests so each removed surface fails loudly if it returns.

### Why

`forgetful` was removed under #5574 with Serena as the only replacement. A reference that names a tool, a tier, or a code path on a server that no longer exists is broken, not merely stale: the research command held a capability no harness can grant, `context-gather` told the agent to query a tier that cannot answer, and `curating-memories` documented four operations that cannot be performed and pointed at a skill deleted in #5575.

This is the functional half of the remaining cleanup. The prose half and Stage 3 (`.agents/architecture/**`) are separate work, so this PR uses `Refs`, not a closing keyword.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5574 | Decommission the `forgetful` MCP server |

These references do not close their linked items: #5574 tracks the whole decommission, and the prose half plus Stage 3 remain open.

## Changes

- `.claude/commands/research.md`: drop the `mcp__forgetful__*` tool grant, the Memory Phase instruction, the Output table row, and the dead half of the Fallback Rule trigger.
- `.claude/skills/context-gather/SKILL.md`: drop the Forgetful tier from the routing description, the Phase 2 list, the `TIER_QUERIED` vocabulary, and the Tools list.
- `.claude/skills/curating-memories/SKILL.md`: rewrite around Serena, the only remaining backend, and remove the link to a skill deleted in #5575.
- `scripts/validation/skill_frontmatter.py`, `scripts/mcp_cli/wrapper.py`, `scripts/skill_registry.py`: remove the three script-level references.
- Five test modules gain guard tests with negative controls; one stale assertion is flipped.
- Copilot mirrors regenerated by the repository build script.

### Functional references removed (a tool grant, a tier token, a code path)

| Surface | What it was |
|---------|-------------|
| `.claude/commands/research.md:3` | `allowed-tools` granted `mcp__forgetful__*`, respelled `forgetful/*` in the generated Copilot mirror. A grant on a server that cannot answer. |
| `.claude/commands/research.md:49` | Phase 4 instructed the agent to create "5-10 atomic Forgetful memories" in the knowledge graph. |
| `.claude/commands/research.md:78` | The Output table promised those memories as a deliverable of the run. |
| `.claude/commands/research.md:60` | The Fallback Rule keyed degradation on "Serena or Forgetful" being unavailable. The rule keeps its job with the trigger narrowed to Serena, which still goes down. |
| `.claude/skills/context-gather/SKILL.md:4` | The frontmatter `description` is the routing surface the harness reads to select a skill. It advertised Forgetful and omitted Serena. |
| `.claude/skills/context-gather/SKILL.md:62` | The Phase 2 tier the agent is told to query. |
| `.claude/skills/context-gather/SKILL.md:74` | `TIER_QUERIED: forgetful`, a token in the documented machine-readable output vocabulary. |
| `.claude/skills/context-gather/SKILL.md:102` | Tools list entry `mcp__forgetful__execute_forgetful_tool`. |
| `.claude/skills/curating-memories/SKILL.md` | Every documented operation (`update_memory`, `mark_memory_obsolete`, `link_memories`, `query_memory`) was an `execute_forgetful_tool` call, and the Verification checklist required pasting those responses, so the skill could not be completed as written. Its "When to Use" section linked the `using-forgetful-memory` skill, which #5575 deleted. |
| `scripts/validation/skill_frontmatter.py:111` | `forgetful` was an accepted MCP server root in `allowed-tools`. |
| `scripts/mcp_cli/wrapper.py:16` | A module docstring usage example, `mcp_call("forgetful", "discover_forgetful_tools")`, that an agent copying the pattern would run. The `server` arg doc listed the same name. |
| `scripts/skill_registry.py:136` | `forgetful` was a memory-category keyword matched against skill name plus description. |

### Prose touched only because it sat in the same file

- `.claude/skills/context-gather/SKILL.md:10`, the body sentence repeating the same source list as the description.
- The Serena bullet in context-gather Phase 2. It is not a Forgetful reference; it described an entity, observation, and relation graph Serena does not have, and deleting the tier above it would have left that as the list's opening claim. Respelled from the contract in the context-retrieval reference this skill already points at.
- The narrative sections of `curating-memories` ("Auto-Linking", "Signs of Poor Curation") removed alongside the API they described.

### Guard tests added

- `tests/commands/test_research_command_contract.py`: `_MCP_SPELLING` pinned `mcp__forgetful__*` and `forgetful/*` in both trees, so it asserted the dead grant was present. Both tuples drop to Serena alone, plus a file-wide guard and its negative control.
- `tests/skills/context-gather/test_context_gather.py`: guard plus negative control over both trees.
- `tests/skills/curating-memories/test_skill_contract.py` (new): forgetful guard, and a general check that every relative Markdown link in the SKILL.md resolves from the containing directory in both trees, with a negative control using the exact link that was dead.
- `tests/test_validation_skill_frontmatter.py`: the bare `forgetful` root is now rejected, live roots still accepted, and a third test documents the measured limit below.
- `tests/test_skill_registry.py`: the retired keyword no longer routes, surviving keywords still do.

### Contract test flipped, not weakened

`tests/skills/memory-consolidate/test_skill_structure.py` required the trigger `how do I deduplicate Forgetful memories` in `curating-memories`. That assertion pinned the old contract: it kept the two skills' dedup vocabularies apart by naming a separate store, paired with a negative control forbidding the generic spelling. With one file-based backend, deduplicating means merging files, which `memory-consolidate` already owns. The assertion flips from `in` to `not in`, so the boundary is held by both negatives. Its other pinned phrase, "use `memory-consolidate` for cross-file Serena merges", is restored verbatim in the rewrite.

## Measured limit, stated because the removal reads stronger than it is

`validate_allowed_tools` skips any entry containing `*` before the `VALID_TOOLS` lookup, so `mcp__forgetful__*` and `forgetful/*` were never checked against the allow-list at all. Removing the root closes the bare-name case only. The wildcard case is not guarded by that validator for any server; it is guarded per file by the contract tests listed above. A test pins this limit so the next reader does not mistake the change for a wildcard guard. Closing the wildcard hole would change behavior for every skill and is not attempted here.

## Deliberately left alone

| Surface | Why |
|---------|-----|
| `scripts/consolidate_skills.py:140` | `forgetful` is a category keyword applied to historical action strings from session logs. 66 files under `.agents/sessions/` still contain the word and still mean memory work. Removing the keyword would misclassify existing records; it is not a call into the server. |
| `scripts/restructure_memories.py:166` | A prefix map in a one-time migration script with no callers and no tests. It routes memory filenames, not MCP calls, and `.serena/memories/memory/forgetful-migration-plan.md` still exists at the destination. Removing it would make a completed migration non-reproducible. |
| `scripts/eval/README.md`, `scripts/eval/examples/*.json` | Historical `_comment` and expectation text describing the decommission itself. |
| `tests/evals/skill-scenarios/memory-consolidate.json` | Scenario S4 asserts `memory-consolidate` stays inactive on a Forgetful-curation request. It is driven by `memory-consolidate`'s own description, which this PR does not touch, so it still passes. |
| `tests/evals/skills/triage-prompts.json` | Stale eval expectations. `git grep -rn "triage-prompts"` finds no consumer, so nothing grades against them. |
| `scripts/validation/check_adr_links_baseline.txt` | Baseline entries for a `.agents/specs/` PRD. Stage 3. |
| `.claude/skills/orphan-ref-validator/scripts/filters.py` | Deliberate `KNOWN_RETIRED_KEBAB_SKILLS` entries. |
| `.agents/architecture/**` | Stage 3, and ADRs are Ask First. |
| The passive-prose skill set | Queued as the separate prose half. |

## Known remaining inconsistency

`.claude/skills/memory-consolidate/SKILL.md:11` and `:24` still route "Forgetful-store curation" to `curating-memories`, which no longer does that. That file is on the out-of-scope prose list and its eval scenario depends on the current wording, so it is left for the prose half rather than changed here.

## Acceptance criteria

- [x] No `allowed-tools` line in any tree grants the retired server (`git grep -in "^allowed-tools:.*forgetful" -- .claude src .github` returns nothing)
- [x] `.claude/commands/research.md` names no Forgetful surface, and its generated Copilot mirror matches
- [x] `.claude/skills/context-gather/SKILL.md` names no Forgetful tier, output token, or tool, and agrees with its own context-retrieval reference
- [x] `.claude/skills/curating-memories/SKILL.md` documents only operations Serena can perform, and every relative Markdown link in it resolves
- [x] The three script code paths named in the scope no longer reference the retired server
- [x] Each removed surface has a guard test with a negative control proving the guard is not vacuous
- [x] The `memory-consolidate` boundary contract still holds, with the stale assertion flipped rather than deleted

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush

**Focus areas**:

1. `.claude/skills/curating-memories/SKILL.md` is a rewrite, not a deletion. The judgment call is that the skill survives with a narrowed scope because `supersession_sweep.py` is live, Serena-only, and has no other owner. Retiring the skill outright (as #5612 did for `exploring-knowledge-graph`) is the alternative and was not taken because it touches the catalog, the orphan-ref filters, and eval prompts.
2. The flipped assertion in `tests/skills/memory-consolidate/test_skill_structure.py`. It is the only place a test changed direction.
3. Whether leaving `consolidate_skills.py` and `restructure_memories.py` untouched is the right call. Both classify historical text and filenames rather than calling the server.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [ ] Manual testing completed
- [ ] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The one security-adjacent file is `scripts/validation/skill_frontmatter.py`, an allow-list validator. The change removes a permitted MCP server root, which narrows what is accepted; it does not widen any surface. No authentication, authorization, secret, CI, or git-hook path is touched.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (repository build script, exit 0, clean working tree afterward)
- [x] Pre-PR validation passed (`uv run --frozen python scripts/validation/pre_pr.py`, exit 0, "RESULT: All validations passed"). Full suite green: `uv run --frozen pytest tests/ -q` reported 32841 passed, 117 skipped, exit 0.
- [x] Lint and formatting clean (`uv run --frozen ruff check .`, exit 0)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5574

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF