### PR TITLE
feat(validation): detect stray Serena memory writes across worktrees

### DIFF
--- a/scripts/validation/check_serena_memory_worktree_scope.py
+++ b/scripts/validation/check_serena_memory_worktree_scope.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -83,7 +84,6 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 sys.path.insert(0, str(_SCRIPT_DIR))
 
-from check_tmp_worktrees import parse_worktree_list  # noqa: E402
 from checks_common import _run_subprocess  # noqa: E402
 
 # Matches this repo's own glob for memory content, cited verbatim from
@@ -154,31 +154,74 @@ def parse_stray_memory_files(porcelain: str) -> list[str]:
     return findings
 
 
-def _bare_worktree_paths(porcelain: str) -> set[str]:
-    """Return the worktree paths in ``porcelain`` whose block carries ``bare``.
+def _git_environment() -> dict[str, str]:
+    """Environment for this scan's git calls, with every ambient ``GIT_*`` removed.
 
-    ``git worktree list --porcelain`` emits one blank-line-separated block per
-    worktree, each opening with ``worktree <path>``. A bare repository's block
-    carries a lone ``bare`` line. A bare repo has no working tree, so it can
-    never hold a stray memory file and ``git status`` there exits 128. Counting
-    it unreadable would print a permanent scan-failure line on exactly the
-    bare-clone-plus-worktrees layout this gate exists to serve, which trains the
-    reader to ignore the line that signals a real failure.
+    ``git push`` from a linked worktree exports ``GIT_DIR`` into the pre-push
+    hook, and this gate runs inside ``pre_pr.py``, which the pre-push hook runs.
+    An exported ``GIT_DIR``, ``GIT_WORK_TREE`` or ``GIT_INDEX_FILE`` outranks
+    ``cwd=``, so a sibling scan would read the pushing worktree rather than the
+    sibling it was pointed at.
 
-    ``parse_worktree_list`` keys on the ``worktree `` prefix alone and cannot
-    see the marker, so the block structure is re-read here rather than changing
-    shared code that other gates depend on.
+    Measured on git 2.43.0, a sibling holding a file the scan should see:
+
+        clean env,   cwd=sibling            ' M .serena/memories/git/stray.md'
+        GIT_DIR,     cwd=sibling            ' M .serena/memories/git/stray.md'
+        GIT_DIR + GIT_WORK_TREE             ''
+
+    The third row is the defect: every sibling reads clean, so the gate reports
+    a scan it never performed. Issue #4914 is the same class in the count
+    ratchets, and ``scripts/ci/count_ratchet.py`` records the same measurement.
+
+    Mirrors the ``GIT_*`` half of the rule that file quotes verbatim, including
+    its ``name.upper()`` so a lowercased ``git_dir`` folded by a
+    case-insensitive platform is stripped too. ``HOME`` and the config
+    variables are deliberately kept: this scans real checkouts, where a global
+    ``safe.directory`` entry is load-bearing.
     """
-    bare: set[str] = set()
-    current_path: str | None = None
-    for line in porcelain.splitlines():
-        if line.startswith("worktree "):
-            current_path = line[len("worktree ") :].strip()
-        elif line.strip() == "bare" and current_path is not None:
-            bare.add(current_path)
-        elif not line.strip():
-            current_path = None
-    return bare
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.upper().startswith("GIT_"):
+            env.pop(name)
+    return env
+
+
+def parse_worktree_records(porcelain: str) -> list[tuple[str, bool]]:
+    """Return ``(path, is_bare)`` per record of ``git worktree list --porcelain -z``.
+
+    ``-z`` is required rather than preferred. Without it git delimits attributes
+    with newlines, so a worktree path that itself contains a newline is split
+    across lines and a line-based parser keeps only the first fragment. The scan
+    then skips a real worktree and never reports the stray memory inside it.
+    Under ``-z`` every attribute is NUL-terminated and a record ends at an empty
+    attribute, so a newline in a path is ordinary data.
+
+    A bare repository is flagged rather than returned as scannable: it has no
+    working tree, so ``git status`` there exits 128 and it can never hold a
+    stray memory file. Counting it unreadable would print a permanent
+    scan-failure line on the bare-clone-plus-worktrees layout this gate serves,
+    which trains the reader to ignore the line that flags a real failure.
+
+    ``check_tmp_worktrees.parse_worktree_list`` is deliberately left alone
+    rather than widened: it is line-based, serves a different gate, and changing
+    its contract to suit this one would put that gate's behavior in scope here.
+    """
+    records: list[tuple[str, bool]] = []
+    path: str | None = None
+    bare = False
+    for attribute in porcelain.split("\0"):
+        if attribute == "":
+            if path is not None:
+                records.append((path, bare))
+            path, bare = None, False
+            continue
+        if attribute.startswith("worktree "):
+            path = attribute[len("worktree ") :]
+        elif attribute == "bare":
+            bare = True
+    if path is not None:
+        records.append((path, bare))
+    return records
 
 
 def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], bool]:
@@ -190,9 +233,10 @@ def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], boo
     """
     try:
         exit_code, stdout, _stderr = _run_subprocess(
-            ["git", "worktree", "list", "--porcelain"],
+            ["git", "worktree", "list", "--porcelain", "-z"],
             cwd=repo_root,
             timeout=_GIT_TIMEOUT_SECONDS,
+            env=_git_environment(),
         )
     except OSError:
         # ``_run_subprocess`` absorbs FileNotFoundError and TimeoutExpired but
@@ -203,11 +247,10 @@ def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], boo
     if exit_code != 0:
         return [], True
 
-    bare = _bare_worktree_paths(stdout)
     others: list[str] = []
     seen: set[str] = {current}
-    for raw in parse_worktree_list(stdout):
-        if raw in bare:
+    for raw, is_bare in parse_worktree_records(stdout):
+        if is_bare:
             continue
         try:
             resolved = str(Path(raw).resolve())
@@ -246,6 +289,7 @@ def _stray_files_in(worktree_path: str) -> tuple[list[str], bool]:
             ["git", "status", "--porcelain", "--untracked-files=all", "--", ".serena/memories"],
             cwd=worktree_path,
             timeout=_GIT_TIMEOUT_SECONDS,
+            env=_git_environment(),
         )
     except OSError:
         return [], True

--- a/scripts/validation/check_serena_memory_worktree_scope.py
+++ b/scripts/validation/check_serena_memory_worktree_scope.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Detect a Serena memory file that landed in the wrong git worktree (issue #5061).
+
+Issue #5061 reported that ``mcp__serena__write_memory``, called from a
+subagent whose cwd was a linked git worktree, wrote its new memory file into
+the MAIN checkout's ``.serena/memories/`` tree instead of the worktree's own.
+The file arrived untracked in a checkout the calling agent never touched
+directly, invisible to the agent's own branch and commits.
+
+ROOT CAUSE, confirmed from upstream and this repo's own launch config
+(issue #5061 comment, 2026-09-04): the Serena MCP server resolves its project
+root once, at server startup, from ``--project`` (see ``.mcp.json``, which
+passes ``${workspaceFolder:-.}``) or a later ``activate_project`` call. It is
+never resolved per tool call. One server serves the whole session, subagents
+included, so a worktree-scoped subagent has no server of its own to point
+elsewhere; every ``write_memory`` call in that session lands under whichever
+checkout was active when the server started. This is a defect in a
+third-party MCP server (github.com/oraios/serena), not in this repository's
+own code, and no value of this repo's own configuration changes it: neither
+``--project <worktree>`` nor ``--project-from-cwd`` re-resolve after launch,
+and calling ``activate_project`` from the subagent redirects the *whole
+server's* root, corrupting the parent session's writes instead.
+
+A ``PreToolUse`` hook, ``invoke_serena_memory_scope_guard.py``, blocked this
+before it landed (PR #5152) by denying the write outright when the calling
+worktree and the activated project root disagreed. ADR-097 retired every
+tool-call hook, this one included, for an unrelated reason (Windows spawn
+cost) and named the loss explicitly: "A Serena write can again land in the
+wrong worktree's checkout ... Nothing replaces this." This module is the
+replacement class of guard ADR-097 anticipated could exist outside the
+tool-call-hook surface it retired: a Lefthook/pre-PR check that observes
+committed *and untracked* state after the fact, rather than a hook that
+intercepts the MCP call itself. It cannot prevent the stray write (only a
+per-call fix in Serena's own activation model, or the retired hook, could do
+that); it can make the stray file visible before it either gets lost as
+clutter or gets accidentally committed to the wrong branch.
+
+DETECTION. From the worktree running this check, list every other linked
+worktree of the same repository (``git worktree list --porcelain``) and look
+for untracked ``.serena/memories/**/*.md`` files in each one. An untracked
+memory file sitting in a worktree nobody is actively drafting a memory in is
+exactly the symptom issue #5061 described. The check never inspects its own
+worktree's untracked memory files: those are ordinary in-progress work, not
+evidence of a misdirected write.
+
+ADVISORY, NOT BLOCKING, when wired into the pre-PR sequence.
+``check_tmp_worktrees.validate_tmp_worktrees`` states the reasoning this
+module follows verbatim: "The subject is machine state, not repository
+state ... so a blocking verdict would refuse every push on that machine for
+a condition the current diff did not create and the pushing agent may not
+own." A sibling worktree with a stray memory file is exactly that class of
+state: it was not created by the diff this check runs against, and the agent
+running it does not own the sibling worktree. The standalone CLI below exits
+1 on the same findings for a caller that wants the blocking form.
+
+EXIT CODES (ADR-035):
+  0 - no findings (prints the count of worktrees examined)
+  1 - at least one untracked ``.serena/memories/**/*.md`` file in another
+      worktree
+  2 - configuration error (``--repo-root`` does not exist)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent.parent
+
+# checks_common imports subprocess_runner, which imports scripts.cli_exec
+# (absolute), so the repo root must be importable even when this file runs as
+# a plain script, not only via python -m or a caller that already set up
+# scripts/validation on sys.path. Mirrors check_model_pins.py's block for the
+# same reason (issue #3073).
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_SCRIPT_DIR))
+
+from check_tmp_worktrees import parse_worktree_list  # noqa: E402
+from checks_common import _run_subprocess  # noqa: E402
+
+# Matches this repo's own glob for memory content, cited verbatim from
+# lefthook.yml (the memory-token-update, memory-size, memory-index,
+# memory-token-counts, memory-tier, memory-cross-reference, and
+# memory-skill-format jobs all key on it): ".serena/memories/**/*.md"
+_MEMORY_PATH_PREFIX = ".serena/memories/"
+_MEMORY_FILE_SUFFIX = ".md"
+_GIT_TIMEOUT_SECONDS = 10
+
+ISSUE_CITATION = "issue #5061 (Serena write_memory can land in the wrong git worktree)"
+
+
+@dataclass(frozen=True, slots=True)
+class StrayMemoryFinding:
+    """One untracked memory file found in a worktree other than the caller's."""
+
+    worktree: str
+    relpath: str
+
+
+@dataclass
+class ScopeReport:
+    """What one scan found. ``other_worktrees_examined`` distinguishes a clean
+    run (checked N sibling worktrees, found nothing) from a single-worktree
+    repository (nothing to check at all).
+    """
+
+    current_worktree: str
+    other_worktrees_examined: int = 0
+    findings: list[StrayMemoryFinding] = field(default_factory=list)
+    worktree_listing_failed: bool = False
+    stale_worktree_entries: int = 0
+    unreadable_worktrees: int = 0
+
+    @property
+    def has_findings(self) -> bool:
+        """True when at least one sibling worktree carries a stray memory file."""
+        return bool(self.findings)
+
+
+def parse_stray_memory_files(porcelain: str) -> list[str]:
+    """Return the untracked ``.serena/memories/**/*.md`` paths in ``git status`` output.
+
+    Expects ``git status --porcelain --untracked-files=all -- .serena/memories``
+    output. Only ``??`` (untracked) entries count: a *modified* tracked memory
+    file is ordinary working-tree editing, not evidence of a misdirected write
+    landing somewhere new. ``--untracked-files=all`` is required so a brand new
+    ``.serena/memories/<tier>/`` directory is reported file by file rather than
+    collapsed to one directory line, matching the file-level suffix filter
+    below.
+
+    Empty or whitespace-only input returns an empty list: a worktree with no
+    stray memory files is the expected, common case, not an error.
+    """
+    findings: list[str] = []
+    for line in porcelain.splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[len("?? ") :].strip()
+        # git quotes a path containing unusual characters in double quotes;
+        # memory filenames in this repo are ASCII kebab-case, so a bare strip
+        # of a wrapping quote covers the realistic case without a full
+        # C-style unquote implementation.
+        path = path.strip('"')
+        if path.startswith(_MEMORY_PATH_PREFIX) and path.endswith(_MEMORY_FILE_SUFFIX):
+            findings.append(path)
+    return findings
+
+
+def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], bool]:
+    """Return (sibling worktree paths, listing_failed).
+
+    ``current`` is excluded by resolved-path comparison so the caller's own
+    worktree is never scanned. Deduplicates in case ``git worktree list``
+    ever reports the same admin path twice.
+    """
+    exit_code, stdout, _stderr = _run_subprocess(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo_root,
+        timeout=_GIT_TIMEOUT_SECONDS,
+    )
+    if exit_code != 0:
+        return [], True
+
+    others: list[str] = []
+    seen: set[str] = {current}
+    for raw in parse_worktree_list(stdout):
+        try:
+            resolved = str(Path(raw).resolve())
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        others.append(resolved)
+    return others, False
+
+
+def _stray_files_in(worktree_path: str) -> tuple[list[str], bool]:
+    """Return (stray memory relpaths, unreadable) for one sibling worktree.
+
+    A git command failure is reported as unreadable, never raised: this is a
+    read-only advisory scan, and one unreadable sibling must not stop the
+    rest of the report (fail-open, mirroring
+    ``check_tmp_worktrees._list_registered``).
+    """
+    exit_code, stdout, _stderr = _run_subprocess(
+        ["git", "status", "--porcelain", "--untracked-files=all", "--", ".serena/memories"],
+        cwd=worktree_path,
+        timeout=_GIT_TIMEOUT_SECONDS,
+    )
+    if exit_code != 0:
+        return [], True
+    return parse_stray_memory_files(stdout), False
+
+
+def build_scope_report(repo_root: Path) -> ScopeReport:
+    """Scan every other worktree of ``repo_root``'s repository for stray memory files."""
+    current = str(repo_root.resolve())
+    report = ScopeReport(current_worktree=current)
+
+    others, listing_failed = _list_other_worktrees(repo_root, current)
+    report.worktree_listing_failed = listing_failed
+    if listing_failed:
+        return report
+
+    for worktree in others:
+        if not Path(worktree).is_dir():
+            # Registered but gone (merged and removed, or not yet created on
+            # this machine). Not a failure: skip silently, same as a
+            # single-worktree repository skips nothing to check.
+            report.stale_worktree_entries += 1
+            continue
+
+        report.other_worktrees_examined += 1
+        stray, unreadable = _stray_files_in(worktree)
+        if unreadable:
+            report.unreadable_worktrees += 1
+            continue
+        for relpath in stray:
+            report.findings.append(StrayMemoryFinding(worktree=worktree, relpath=relpath))
+
+    return report
+
+
+def format_report(report: ScopeReport) -> str:
+    """Render the human-readable report. Always names the examined count."""
+    lines: list[str] = []
+
+    if report.worktree_listing_failed:
+        return (
+            "serena-memory-worktree-scope: git worktree list failed; "
+            "nothing was examined"
+        )
+
+    for finding in report.findings:
+        lines.append(f"  {finding.worktree}: {finding.relpath}")
+
+    if report.findings:
+        lines.insert(
+            0,
+            f"serena-memory-worktree-scope: {len(report.findings)} untracked memory "
+            f"file(s) found in a sibling worktree, against {ISSUE_CITATION}:",
+        )
+        lines.append(
+            "  Likely cause: Serena's MCP server resolved its project root to that "
+            "worktree when this session's write_memory call landed there instead of "
+            f"here ({report.current_worktree}). Verify by hand: move the file into "
+            "the worktree that should own it, or delete it if it duplicates a memory "
+            "already written correctly."
+        )
+
+    if report.unreadable_worktrees:
+        lines.append(
+            f"serena-memory-worktree-scope: {report.unreadable_worktrees} sibling "
+            "worktree(s) could not be read and were skipped."
+        )
+
+    lines.append(
+        f"serena-memory-worktree-scope: {len(report.findings)} finding(s) across "
+        f"{report.other_worktrees_examined} sibling worktree(s) examined "
+        f"({report.stale_worktree_entries} stale entr(y/ies) skipped)."
+    )
+    return "\n".join(lines)
+
+
+def validate_serena_memory_worktree_scope(repo_root: Path) -> bool:
+    """Advisory pre-PR gate. Prints findings and always returns True.
+
+    Advisory for the same reason ``validate_tmp_worktrees`` is: the subject is
+    another worktree's uncommitted state, not this diff's own repository
+    state, so a blocking verdict would refuse this push for a condition it did
+    not create and this agent does not own. The standalone CLI below exits 1
+    on the same findings for a caller that wants the blocking form.
+    """
+    report = build_scope_report(repo_root)
+    print(format_report(report))
+    return True
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report untracked Serena memory files sitting in a sibling git "
+            "worktree (issue #5061)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root to scan from (default: this script's own repo root).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of human-readable text.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    args = parse_args(argv)
+
+    repo_root = args.repo_root if args.repo_root is not None else _REPO_ROOT
+    if not repo_root.is_dir():
+        print(f"error: --repo-root is not a directory: {repo_root}", file=sys.stderr)
+        return 2
+
+    report = build_scope_report(repo_root)
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(format_report(report))
+    return 1 if report.has_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_serena_memory_worktree_scope.py
+++ b/scripts/validation/check_serena_memory_worktree_scope.py
@@ -57,7 +57,10 @@ EXIT CODES (ADR-035):
   0 - no findings (prints the count of worktrees examined)
   1 - at least one untracked ``.serena/memories/**/*.md`` file in another
       worktree
-  2 - configuration error (``--repo-root`` does not exist)
+  2 - configuration or environment error: ``--repo-root`` does not exist, or
+      ``git worktree list`` itself failed so nothing could be examined. A scan
+      that could not look never reports 0: a scripted caller reads the exit
+      code, not the text.
 """
 
 from __future__ import annotations
@@ -151,6 +154,33 @@ def parse_stray_memory_files(porcelain: str) -> list[str]:
     return findings
 
 
+def _bare_worktree_paths(porcelain: str) -> set[str]:
+    """Return the worktree paths in ``porcelain`` whose block carries ``bare``.
+
+    ``git worktree list --porcelain`` emits one blank-line-separated block per
+    worktree, each opening with ``worktree <path>``. A bare repository's block
+    carries a lone ``bare`` line. A bare repo has no working tree, so it can
+    never hold a stray memory file and ``git status`` there exits 128. Counting
+    it unreadable would print a permanent scan-failure line on exactly the
+    bare-clone-plus-worktrees layout this gate exists to serve, which trains the
+    reader to ignore the line that signals a real failure.
+
+    ``parse_worktree_list`` keys on the ``worktree `` prefix alone and cannot
+    see the marker, so the block structure is re-read here rather than changing
+    shared code that other gates depend on.
+    """
+    bare: set[str] = set()
+    current_path: str | None = None
+    for line in porcelain.splitlines():
+        if line.startswith("worktree "):
+            current_path = line[len("worktree ") :].strip()
+        elif line.strip() == "bare" and current_path is not None:
+            bare.add(current_path)
+        elif not line.strip():
+            current_path = None
+    return bare
+
+
 def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], bool]:
     """Return (sibling worktree paths, listing_failed).
 
@@ -158,17 +188,27 @@ def _list_other_worktrees(repo_root: Path, current: str) -> tuple[list[str], boo
     worktree is never scanned. Deduplicates in case ``git worktree list``
     ever reports the same admin path twice.
     """
-    exit_code, stdout, _stderr = _run_subprocess(
-        ["git", "worktree", "list", "--porcelain"],
-        cwd=repo_root,
-        timeout=_GIT_TIMEOUT_SECONDS,
-    )
+    try:
+        exit_code, stdout, _stderr = _run_subprocess(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except OSError:
+        # ``_run_subprocess`` absorbs FileNotFoundError and TimeoutExpired but
+        # lets every other OSError through, and ``pre_pr.run_validation`` turns
+        # any exception into a FAIL. An advisory gate that fails the push is not
+        # advisory, so a listing that cannot run reports itself failed instead.
+        return [], True
     if exit_code != 0:
         return [], True
 
+    bare = _bare_worktree_paths(stdout)
     others: list[str] = []
     seen: set[str] = {current}
     for raw in parse_worktree_list(stdout):
+        if raw in bare:
+            continue
         try:
             resolved = str(Path(raw).resolve())
         except OSError:
@@ -187,12 +227,28 @@ def _stray_files_in(worktree_path: str) -> tuple[list[str], bool]:
     read-only advisory scan, and one unreadable sibling must not stop the
     rest of the report (fail-open, mirroring
     ``check_tmp_worktrees._list_registered``).
+
+    That promise covers two distinct failures. A git process that runs and exits
+    non-zero returns through ``exit_code``. A failure BEFORE git starts raises:
+    ``_run_subprocess`` catches only FileNotFoundError and TimeoutExpired, so a
+    sibling directory that stats but cannot be entered (mode 600, or a locked
+    Windows handle) raises PermissionError out of ``subprocess.run(cwd=...)``.
+    ``pre_pr.run_validation`` converts any exception into a FAIL, which would
+    make this advisory gate block the push. Both are caught here.
+
+    ``--untracked-files=all`` is load-bearing, not cosmetic: without it git
+    collapses a brand-new ``.serena/memories/<tier>/`` directory to a single
+    directory line, which fails the ``.md`` suffix filter. A write into a tier
+    the sibling's branch does not carry is precisely the issue #5061 symptom.
     """
-    exit_code, stdout, _stderr = _run_subprocess(
-        ["git", "status", "--porcelain", "--untracked-files=all", "--", ".serena/memories"],
-        cwd=worktree_path,
-        timeout=_GIT_TIMEOUT_SECONDS,
-    )
+    try:
+        exit_code, stdout, _stderr = _run_subprocess(
+            ["git", "status", "--porcelain", "--untracked-files=all", "--", ".serena/memories"],
+            cwd=worktree_path,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except OSError:
+        return [], True
     if exit_code != 0:
         return [], True
     return parse_stray_memory_files(stdout), False
@@ -216,11 +272,16 @@ def build_scope_report(repo_root: Path) -> ScopeReport:
             report.stale_worktree_entries += 1
             continue
 
-        report.other_worktrees_examined += 1
         stray, unreadable = _stray_files_in(worktree)
         if unreadable:
+            # Counted as unreadable, NOT as examined. Collapsing the two would
+            # let the summary line report a clean scan of a worktree nothing
+            # could read, contradicting the "could not be read" line above it.
+            # ``check_tmp_worktrees.scan_temp_root`` orders these the same way.
             report.unreadable_worktrees += 1
             continue
+
+        report.other_worktrees_examined += 1
         for relpath in stray:
             report.findings.append(StrayMemoryFinding(worktree=worktree, relpath=relpath))
 
@@ -232,10 +293,7 @@ def format_report(report: ScopeReport) -> str:
     lines: list[str] = []
 
     if report.worktree_listing_failed:
-        return (
-            "serena-memory-worktree-scope: git worktree list failed; "
-            "nothing was examined"
-        )
+        return "serena-memory-worktree-scope: git worktree list failed; nothing was examined"
 
     for finding in report.findings:
         lines.append(f"  {finding.worktree}: {finding.relpath}")
@@ -286,8 +344,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Report untracked Serena memory files sitting in a sibling git "
-            "worktree (issue #5061)."
+            "Report untracked Serena memory files sitting in a sibling git worktree (issue #5061)."
         ),
     )
     parser.add_argument(
@@ -319,6 +376,11 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(asdict(report), indent=2))
     else:
         print(format_report(report))
+
+    if report.worktree_listing_failed:
+        # Nothing was examined. Returning 0 here would hand a scripted caller a
+        # machine-readable "clean" for a run that never looked.
+        return 2
     return 1 if report.has_findings else 0
 
 

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -53,6 +53,9 @@ from check_git_hook_health import validate_git_hook_health
 from check_index_line_endings import validate_index_line_endings
 from check_nested_tests import validate_no_nested_tests
 from check_push_lock_paths import validate_push_lock_paths
+from check_serena_memory_worktree_scope import (
+    validate_serena_memory_worktree_scope,
+)
 from check_subprocess_encoding import validate_subprocess_encoding
 from check_test_tree_writes import validate_test_tree_writes
 from check_tmp_worktrees import validate_tmp_worktrees
@@ -254,6 +257,17 @@ _SEQUENCE: tuple[_Gate, ...] = (
     # Never fails; see the validator's docstring for why machine state does not
     # get to block a push. Issue #5111.
     _Gate("Temp-filesystem Worktrees (advisory)", _root_only(validate_tmp_worktrees)),
+    # Advisory sibling of the gate above, same reasoning, different subject:
+    # an untracked .serena/memories/**/*.md file in another linked worktree,
+    # the symptom of issue #5061 (Serena's MCP server resolves its project
+    # root at activation time, not per call, so a worktree-scoped subagent's
+    # write_memory can land in a different checkout entirely). Never fails;
+    # see the validator's docstring for why another worktree's uncommitted
+    # state does not get to block this push.
+    _Gate(
+        "Serena Memory Worktree Scope (advisory)",
+        _root_only(validate_serena_memory_worktree_scope),
+    ),
     _Gate("Session End Validation", _root_only(validate_session_end)),
     # Type-check changed Python files with ratchet semantics (issue #4674).
     # Surfaces regressions at pre-PR time rather than waiting for push CI.

--- a/tests/validation/test_check_serena_memory_worktree_scope.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope.py
@@ -11,11 +11,18 @@ Coverage:
   (registered but deleted) sibling worktree, and a git command failure on
   either the listing or one sibling's status call.
 
-Every test is hermetic: the git-status and git-worktree-list boundary is
-mocked (``checker._run_subprocess``) for the unit-level tests, and the two
-``main()`` tests that exercise real git use only directories under
-``tmp_path``. Nothing here reads or writes this repository's own
-``.serena/memories/`` tree.
+Isolation: the git-status and git-worktree-list boundary is mocked
+(``checker._run_subprocess``) for the unit-level tests, and the ``main()``
+tests that exercise real git use only directories under ``tmp_path``.
+
+One test is deliberately NOT hermetic.
+``test_the_sequence_runs_the_gate_and_it_stays_advisory_on_the_real_tree``
+drives the real pre-PR sequence against this repository, so it runs real
+``git status`` in this machine's sibling worktrees. That is the point of the
+test: it proves the gate stays advisory on a real tree. It is read-only and
+writes nothing, but calling it hermetic would be false.
+
+Nothing here writes this repository's own ``.serena/memories/`` tree.
 """
 
 from __future__ import annotations
@@ -77,10 +84,22 @@ def test_blank_input_reports_nothing(porcelain: str) -> None:
     assert checker.parse_stray_memory_files(porcelain) == []
 
 
-def test_a_quoted_path_with_a_space_is_unquoted_and_reported() -> None:
-    porcelain = '?? ".serena/memories/git/a b.md"\n'
+def test_a_git_quoted_path_is_still_detected_though_its_escapes_survive() -> None:
+    """Git wraps a path in double quotes only when it holds a character needing
+    an escape, so it C-escapes the same path. ``.strip('"')`` removes the
+    wrapper but not the escapes, so the reported name is mangled while the file
+    is still DETECTED, which is what an advisory report needs. A space alone
+    does not trigger quoting, so the old fixture asserted on input git never
+    emits.
+    """
+    porcelain = '?? ".serena/memories/git/caf\\303\\251.md"\n'
 
-    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/git/a b.md"]
+    found = checker.parse_stray_memory_files(porcelain)
+
+    assert len(found) == 1
+    assert found[0].startswith(".serena/memories/")
+    assert found[0].endswith(".md")
+    assert '"' not in found[0]
 
 
 def test_multiple_lines_are_filtered_independently() -> None:
@@ -102,13 +121,22 @@ def _make_fake_run_subprocess(
     status_by_worktree: dict[str, str],
     listing_exit_code: int = 0,
     status_exit_codes: dict[str, int] | None = None,
+    record: list[tuple[list[str], object, object]] | None = None,
 ) -> _SubprocessFake:
-    """Build a ``_run_subprocess`` stand-in keyed on the git subcommand and cwd."""
+    """Build a ``_run_subprocess`` stand-in keyed on the git subcommand and cwd.
+
+    ``record``, when given, receives ``(args, cwd, timeout)`` for every call, so
+    a test can assert on the argv rather than only on the parsed result. Without
+    that, dropping ``--untracked-files=all`` or the pathspec leaves every test
+    green while the gate silently stops detecting new memory tiers.
+    """
     status_exit_codes = status_exit_codes or {}
 
     def _fake(
         args: list[str], cwd: object = None, timeout: int | None = None
     ) -> tuple[int, str, str]:
+        if record is not None:
+            record.append((list(args), cwd, timeout))
         if args[:3] == ["git", "worktree", "list"]:
             return listing_exit_code, worktree_listing, ""
         if args[:2] == ["git", "status"]:
@@ -130,9 +158,7 @@ def test_a_stray_file_in_a_sibling_worktree_is_found(
     sibling_key = str(sibling.resolve())
 
     listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
-    fake = _make_fake_run_subprocess(
-        listing, {sibling_key: "?? .serena/memories/git/stray.md\n"}
-    )
+    fake = _make_fake_run_subprocess(listing, {sibling_key: "?? .serena/memories/git/stray.md\n"})
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
     report = checker.build_scope_report(current)
@@ -264,9 +290,7 @@ def test_one_unreadable_sibling_does_not_stop_the_rest_of_the_scan(
     broken_key = str(broken.resolve())
 
     listing = (
-        f"worktree {current.resolve()}\n"
-        f"worktree {broken.resolve()}\n"
-        f"worktree {healthy.resolve()}\n"
+        f"worktree {current.resolve()}\nworktree {broken.resolve()}\nworktree {healthy.resolve()}\n"
     )
     fake = _make_fake_run_subprocess(
         listing,
@@ -278,7 +302,10 @@ def test_one_unreadable_sibling_does_not_stop_the_rest_of_the_scan(
     report = checker.build_scope_report(current)
 
     assert report.unreadable_worktrees == 1
-    assert report.other_worktrees_examined == 2
+    # The unreadable sibling is NOT counted as examined: a summary line saying
+    # two worktrees were scanned clean, next to a line saying one could not be
+    # read, contradicts itself and hides the failure.
+    assert report.other_worktrees_examined == 1
     assert report.findings == [
         checker.StrayMemoryFinding(worktree=healthy_key, relpath=".serena/memories/git/stray.md")
     ]
@@ -358,9 +385,7 @@ def test_the_advisory_gate_always_returns_true_even_with_findings(
 
 def _init_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q", str(path)], check=True, cwd=path)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"], check=True, cwd=path
-    )
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=path)
     subprocess.run(["git", "config", "user.name", "Test"], check=True, cwd=path)
 
 
@@ -458,3 +483,161 @@ def test_the_sequence_runs_the_gate_and_it_stays_advisory_on_the_real_tree(
     verdicts = _run_gate_alone(monkeypatch)
 
     assert verdicts == {GATE_NAME: True}
+
+
+# --- argv contract, bare repos, and fail-open (review findings) --------------
+
+
+def test_the_status_call_asks_for_all_untracked_files_under_the_memories_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--untracked-files=all`` and the pathspec are load-bearing, so pin them.
+
+    Without the flag git collapses a brand-new ``.serena/memories/<tier>/``
+    directory to one directory line, which fails the ``.md`` suffix filter, and
+    a write into a tier the sibling's branch does not carry is exactly the
+    issue #5061 symptom. Every other test parses the fake's output and so stays
+    green when the flag is dropped.
+    """
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    calls: list[tuple[list[str], object, object]] = []
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _make_fake_run_subprocess(listing, {}, record=calls)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    checker.build_scope_report(current)
+
+    status_calls = [c for c in calls if c[0][:2] == ["git", "status"]]
+    assert len(status_calls) == 1
+    args, _cwd, timeout = status_calls[0]
+    assert "--untracked-files=all" in args
+    assert "--porcelain" in args
+    assert args[-2:] == ["--", ".serena/memories"]
+    assert timeout == checker._GIT_TIMEOUT_SECONDS
+
+
+def test_a_bare_repository_is_skipped_rather_than_reported_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare repo has no working tree, so ``git status`` there exits 128.
+
+    Reporting it "could not be read" on every run of a bare-clone-plus-worktrees
+    layout trains the reader to ignore the line that flags a real scan failure.
+    """
+    current = tmp_path / "current"
+    current.mkdir()
+    bare = tmp_path / "bare"
+    bare.mkdir()
+
+    listing = (
+        f"worktree {bare.resolve()}\nbare\n\nworktree {current.resolve()}\nbranch refs/heads/main\n"
+    )
+    fake = _make_fake_run_subprocess(listing, {}, status_exit_codes={str(bare.resolve()): 128})
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.unreadable_worktrees == 0
+    assert report.other_worktrees_examined == 0
+    assert report.findings == []
+
+
+def test_bare_worktree_paths_reads_the_marker_per_block() -> None:
+    porcelain = "worktree /repo/bare\nbare\n\nworktree /repo/wt\nbranch refs/heads/x\n\n"
+
+    assert checker._bare_worktree_paths(porcelain) == {"/repo/bare"}
+
+
+def test_an_unenterable_sibling_is_unreadable_rather_than_an_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory that stats but cannot be entered raises PermissionError out of
+    ``subprocess.run(cwd=...)``. ``_run_subprocess`` catches only
+    FileNotFoundError and TimeoutExpired, and ``pre_pr.run_validation`` turns any
+    exception into a FAIL, so an uncaught raise makes this advisory gate block
+    the push."""
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    sibling_key = str(sibling.resolve())
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return 0, listing, ""
+        if str(cwd) == sibling_key:
+            raise PermissionError(13, "Permission denied")
+        return 0, "", ""
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.unreadable_worktrees == 1
+    assert report.other_worktrees_examined == 0
+    assert report.findings == []
+
+
+def test_an_unrunnable_worktree_listing_is_reported_rather_than_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    report = checker.build_scope_report(tmp_path)
+
+    assert report.worktree_listing_failed is True
+    assert report.findings == []
+
+
+def test_the_advisory_gate_still_returns_true_when_the_scan_cannot_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of finding 1: advisory must survive an unrunnable scan."""
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    assert checker.validate_serena_memory_worktree_scope(tmp_path) is True
+
+
+def test_main_exits_two_when_the_listing_failed_so_nothing_was_examined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exit 0 here would hand a scripted caller a clean verdict from a run that
+    never looked at anything."""
+    fake = _make_fake_run_subprocess("", {}, listing_exit_code=128)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    assert checker.main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_an_adjacent_prefix_directory_is_not_reported() -> None:
+    """``.serena/memories-old/`` must not match ``.serena/memories/``.
+
+    The trailing slash in the prefix is what stops it. Nothing else pins that,
+    so removing the slash otherwise leaves the suite green.
+    """
+    porcelain = (
+        "?? .serena/memories-old/decoy.md\n"
+        "?? .serena/memoriesX/decoy.md\n"
+        "?? .serena/memories/real.md\n"
+    )
+
+    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/real.md"]

--- a/tests/validation/test_check_serena_memory_worktree_scope.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope.py
@@ -1,0 +1,460 @@
+"""Tests for the Serena memory worktree-scope advisory gate (issue #5061).
+
+Coverage:
+
+- positive: an untracked ``.serena/memories/**/*.md`` file in a sibling
+  worktree is parsed, found, and reported.
+- negative: a modified tracked memory file, a non-markdown untracked file, an
+  untracked file outside ``.serena/memories/``, and the CALLING worktree's own
+  untracked memory files are never reported (no over-fire).
+- edge: blank input, a quoted path, a single-worktree repository, a stale
+  (registered but deleted) sibling worktree, and a git command failure on
+  either the listing or one sibling's status call.
+
+Every test is hermetic: the git-status and git-worktree-list boundary is
+mocked (``checker._run_subprocess``) for the unit-level tests, and the two
+``main()`` tests that exercise real git use only directories under
+``tmp_path``. Nothing here reads or writes this repository's own
+``.serena/memories/`` tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Import the way pre_pr_sequence does (see that test file's header): prepend
+# scripts/validation to sys.path and import by bare name. Never restored.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_serena_memory_worktree_scope as checker
+import pre_pr_sequence
+
+GATE_NAME = "Serena Memory Worktree Scope (advisory)"
+
+_SubprocessFake = Callable[..., tuple[int, str, str]]
+
+
+# --- parse_stray_memory_files ---------------------------------------------
+
+
+def test_an_untracked_memory_markdown_file_is_reported() -> None:
+    porcelain = "?? .serena/memories/git/foo.md\n"
+
+    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/git/foo.md"]
+
+
+def test_a_modified_tracked_memory_file_is_not_reported() -> None:
+    """Only ``??`` (untracked) counts; a normal edit is not a stray write."""
+    porcelain = " M .serena/memories/git/foo.md\n"
+
+    assert checker.parse_stray_memory_files(porcelain) == []
+
+
+def test_an_untracked_non_markdown_file_is_not_reported() -> None:
+    porcelain = "?? .serena/memories/cache/tmp.bin\n"
+
+    assert checker.parse_stray_memory_files(porcelain) == []
+
+
+def test_an_untracked_file_outside_the_memories_prefix_is_not_reported() -> None:
+    porcelain = "?? scratch/foo.md\n"
+
+    assert checker.parse_stray_memory_files(porcelain) == []
+
+
+@pytest.mark.parametrize("porcelain", ["", "   ", "\n\n"])
+def test_blank_input_reports_nothing(porcelain: str) -> None:
+    assert checker.parse_stray_memory_files(porcelain) == []
+
+
+def test_a_quoted_path_with_a_space_is_unquoted_and_reported() -> None:
+    porcelain = '?? ".serena/memories/git/a b.md"\n'
+
+    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/git/a b.md"]
+
+
+def test_multiple_lines_are_filtered_independently() -> None:
+    porcelain = (
+        "?? .serena/memories/git/stray.md\n"
+        " M .serena/memories/git/tracked.md\n"
+        "?? .serena/memories/cache/tmp.bin\n"
+        "?? other/path/note.md\n"
+    )
+
+    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/git/stray.md"]
+
+
+# --- build_scope_report ----------------------------------------------------
+
+
+def _make_fake_run_subprocess(
+    worktree_listing: str,
+    status_by_worktree: dict[str, str],
+    listing_exit_code: int = 0,
+    status_exit_codes: dict[str, int] | None = None,
+) -> _SubprocessFake:
+    """Build a ``_run_subprocess`` stand-in keyed on the git subcommand and cwd."""
+    status_exit_codes = status_exit_codes or {}
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return listing_exit_code, worktree_listing, ""
+        if args[:2] == ["git", "status"]:
+            key = str(cwd)
+            exit_code = status_exit_codes.get(key, 0)
+            return exit_code, status_by_worktree.get(key, ""), ""
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    return _fake
+
+
+def test_a_stray_file_in_a_sibling_worktree_is_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    sibling_key = str(sibling.resolve())
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _make_fake_run_subprocess(
+        listing, {sibling_key: "?? .serena/memories/git/stray.md\n"}
+    )
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.has_findings is True
+    assert report.findings == [
+        checker.StrayMemoryFinding(worktree=sibling_key, relpath=".serena/memories/git/stray.md")
+    ]
+    assert report.other_worktrees_examined == 1
+
+
+def test_the_current_worktrees_own_untracked_memory_file_is_never_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No over-fire: the caller's own in-progress memory drafts are not a finding.
+
+    ``git status`` is never even invoked against the current worktree's own
+    path: the fake raises if it is, so this also proves the exclusion happens
+    before any status call, not merely that its result is discarded.
+    """
+    current = tmp_path / "current"
+    current.mkdir()
+    current_key = str(current.resolve())
+
+    listing = f"worktree {current.resolve()}\n"
+
+    def fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return 0, listing, ""
+        raise AssertionError(f"git status must not be called against the current worktree: {cwd}")
+
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.has_findings is False
+    assert report.other_worktrees_examined == 0
+    assert current_key == str(Path(report.current_worktree))
+
+
+def test_no_findings_when_every_sibling_is_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _make_fake_run_subprocess(listing, {str(sibling.resolve()): ""})
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.has_findings is False
+    assert report.other_worktrees_examined == 1
+    assert report.findings == []
+
+
+def test_a_single_worktree_repository_examines_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    listing = f"worktree {current.resolve()}\n"
+    fake = _make_fake_run_subprocess(listing, {})
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.other_worktrees_examined == 0
+    assert report.has_findings is False
+
+
+def test_a_stale_registered_worktree_is_skipped_without_a_status_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worktree git still lists but whose directory is gone is not a failure."""
+    current = tmp_path / "current"
+    current.mkdir()
+    gone = tmp_path / "gone"  # never created on disk
+
+    listing = f"worktree {current.resolve()}\nworktree {gone}\n"
+
+    def fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return 0, listing, ""
+        raise AssertionError(f"git status must not be called for a stale worktree: {cwd}")
+
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.stale_worktree_entries == 1
+    assert report.other_worktrees_examined == 0
+    assert report.has_findings is False
+
+
+def test_worktree_listing_failure_reports_no_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    fake = _make_fake_run_subprocess("", {}, listing_exit_code=1)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.worktree_listing_failed is True
+    assert report.has_findings is False
+
+
+def test_one_unreadable_sibling_does_not_stop_the_rest_of_the_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail-open per sibling: a broken git status on one worktree must not hide
+    a real finding in another."""
+    current = tmp_path / "current"
+    current.mkdir()
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    healthy = tmp_path / "healthy"
+    healthy.mkdir()
+    healthy_key = str(healthy.resolve())
+    broken_key = str(broken.resolve())
+
+    listing = (
+        f"worktree {current.resolve()}\n"
+        f"worktree {broken.resolve()}\n"
+        f"worktree {healthy.resolve()}\n"
+    )
+    fake = _make_fake_run_subprocess(
+        listing,
+        {healthy_key: "?? .serena/memories/git/stray.md\n", broken_key: ""},
+        status_exit_codes={broken_key: 128},
+    )
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.unreadable_worktrees == 1
+    assert report.other_worktrees_examined == 2
+    assert report.findings == [
+        checker.StrayMemoryFinding(worktree=healthy_key, relpath=".serena/memories/git/stray.md")
+    ]
+
+
+# --- format_report -----------------------------------------------------------
+
+
+def test_format_report_names_the_finding_and_the_issue() -> None:
+    report = checker.ScopeReport(
+        current_worktree="/repo/current",
+        other_worktrees_examined=1,
+        findings=[
+            checker.StrayMemoryFinding(worktree="/repo/sibling", relpath=".serena/memories/x.md")
+        ],
+    )
+
+    text = checker.format_report(report)
+
+    assert "#5061" in text
+    assert "/repo/sibling" in text
+    assert ".serena/memories/x.md" in text
+
+
+def test_format_report_on_a_clean_scan_names_the_examined_count() -> None:
+    report = checker.ScopeReport(current_worktree="/repo/current", other_worktrees_examined=3)
+
+    text = checker.format_report(report)
+
+    assert "0 finding(s)" in text
+    assert "3 sibling worktree(s) examined" in text
+
+
+def test_format_report_on_a_listing_failure_is_a_short_distinct_message() -> None:
+    report = checker.ScopeReport(current_worktree="/repo/current", worktree_listing_failed=True)
+
+    text = checker.format_report(report)
+
+    assert "git worktree list failed" in text
+
+
+def test_format_report_names_unreadable_siblings() -> None:
+    report = checker.ScopeReport(
+        current_worktree="/repo/current", other_worktrees_examined=1, unreadable_worktrees=1
+    )
+
+    text = checker.format_report(report)
+
+    assert "1 sibling" in text
+    assert "could not be read" in text
+
+
+# --- validate_serena_memory_worktree_scope (advisory gate) ------------------
+
+
+def test_the_advisory_gate_always_returns_true_even_with_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _make_fake_run_subprocess(
+        listing, {str(sibling.resolve()): "?? .serena/memories/git/stray.md\n"}
+    )
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    result = checker.validate_serena_memory_worktree_scope(current)
+
+    assert result is True
+    assert "stray.md" in capsys.readouterr().out
+
+
+# --- main() / CLI ------------------------------------------------------------
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(path)], check=True, cwd=path)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], check=True, cwd=path
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], check=True, cwd=path)
+
+
+def test_main_exits_zero_on_a_real_single_worktree_repo(tmp_path: Path) -> None:
+    """End-to-end with real git, hermetic under tmp_path: no linked worktrees,
+    nothing under .serena/memories/, so nothing to find."""
+    repo = tmp_path / "solo-repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    exit_code = checker.main(["--repo-root", str(repo)])
+
+    assert exit_code == 0
+
+
+def test_main_exits_two_when_repo_root_does_not_exist(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+
+    exit_code = checker.main(["--repo-root", str(missing)])
+
+    assert exit_code == 2
+
+
+def test_main_exits_one_and_prints_json_when_a_sibling_has_a_stray_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _make_fake_run_subprocess(
+        listing, {str(sibling.resolve()): "?? .serena/memories/git/stray.md\n"}
+    )
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    exit_code = checker.main(["--repo-root", str(current), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert len(payload["findings"]) == 1
+    assert payload["findings"][0]["relpath"] == ".serena/memories/git/stray.md"
+
+
+# --- pre_pr_sequence wiring (testing.md SHOULD 6) ---------------------------
+
+
+class _State:
+    """Minimal stand-in for pre_pr.ValidationState."""
+
+    def __init__(self) -> None:
+        self.total = 0
+        self.skipped = 0
+
+
+def _run_gate_alone(monkeypatch: pytest.MonkeyPatch) -> dict[str, bool]:
+    verdicts: dict[str, bool] = {}
+
+    def record(
+        name: str,
+        state: _State,
+        callback: Callable[[], bool],
+        skip: bool = False,
+    ) -> bool:
+        state.total += 1
+        if skip:
+            state.skipped += 1
+            return True
+        result = bool(callback())
+        verdicts[name] = result
+        return result
+
+    wanted = [gate for gate in pre_pr_sequence._SEQUENCE if gate.name == GATE_NAME]
+    monkeypatch.setattr(pre_pr_sequence, "_SEQUENCE", tuple(wanted))
+    args = argparse.Namespace(quick=False)
+    pre_pr_sequence.run_all_validations(REPO_ROOT, args, _State(), record)
+    return verdicts
+
+
+def test_the_gate_is_registered_in_the_sequence() -> None:
+    names = [gate.name for gate in pre_pr_sequence._SEQUENCE]
+
+    assert GATE_NAME in names
+
+
+def test_the_sequence_runs_the_gate_and_it_stays_advisory_on_the_real_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drives the real sequence (real git, this repository's own worktrees).
+
+    Read-only (``git worktree list`` / ``git status``), and the assertion is
+    on the always-True advisory contract, not on what it happens to find, so
+    this cannot flake on another concurrent session's worktree state.
+    """
+    verdicts = _run_gate_alone(monkeypatch)
+
+    assert verdicts == {GATE_NAME: True}

--- a/tests/validation/test_check_serena_memory_worktree_scope.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope.py
@@ -23,6 +23,12 @@ test: it proves the gate stays advisory on a real tree. It is read-only and
 writes nothing, but calling it hermetic would be false.
 
 Nothing here writes this repository's own ``.serena/memories/`` tree.
+
+Failure-mode coverage (unrunnable git, bare repositories, the argv contract,
+and the exit code of a scan that examined nothing) lives in the sibling module
+``test_check_serena_memory_worktree_scope_failure_modes.py``. The split keeps
+each file under the 500-line taste ceiling; it is not a topical boundary worth
+reading into.
 """
 
 from __future__ import annotations
@@ -121,22 +127,13 @@ def _make_fake_run_subprocess(
     status_by_worktree: dict[str, str],
     listing_exit_code: int = 0,
     status_exit_codes: dict[str, int] | None = None,
-    record: list[tuple[list[str], object, object]] | None = None,
 ) -> _SubprocessFake:
-    """Build a ``_run_subprocess`` stand-in keyed on the git subcommand and cwd.
-
-    ``record``, when given, receives ``(args, cwd, timeout)`` for every call, so
-    a test can assert on the argv rather than only on the parsed result. Without
-    that, dropping ``--untracked-files=all`` or the pathspec leaves every test
-    green while the gate silently stops detecting new memory tiers.
-    """
+    """Build a ``_run_subprocess`` stand-in keyed on the git subcommand and cwd."""
     status_exit_codes = status_exit_codes or {}
 
     def _fake(
         args: list[str], cwd: object = None, timeout: int | None = None
     ) -> tuple[int, str, str]:
-        if record is not None:
-            record.append((list(args), cwd, timeout))
         if args[:3] == ["git", "worktree", "list"]:
             return listing_exit_code, worktree_listing, ""
         if args[:2] == ["git", "status"]:
@@ -483,161 +480,3 @@ def test_the_sequence_runs_the_gate_and_it_stays_advisory_on_the_real_tree(
     verdicts = _run_gate_alone(monkeypatch)
 
     assert verdicts == {GATE_NAME: True}
-
-
-# --- argv contract, bare repos, and fail-open (review findings) --------------
-
-
-def test_the_status_call_asks_for_all_untracked_files_under_the_memories_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``--untracked-files=all`` and the pathspec are load-bearing, so pin them.
-
-    Without the flag git collapses a brand-new ``.serena/memories/<tier>/``
-    directory to one directory line, which fails the ``.md`` suffix filter, and
-    a write into a tier the sibling's branch does not carry is exactly the
-    issue #5061 symptom. Every other test parses the fake's output and so stays
-    green when the flag is dropped.
-    """
-    current = tmp_path / "current"
-    current.mkdir()
-    sibling = tmp_path / "sibling"
-    sibling.mkdir()
-    calls: list[tuple[list[str], object, object]] = []
-
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
-    fake = _make_fake_run_subprocess(listing, {}, record=calls)
-    monkeypatch.setattr(checker, "_run_subprocess", fake)
-
-    checker.build_scope_report(current)
-
-    status_calls = [c for c in calls if c[0][:2] == ["git", "status"]]
-    assert len(status_calls) == 1
-    args, _cwd, timeout = status_calls[0]
-    assert "--untracked-files=all" in args
-    assert "--porcelain" in args
-    assert args[-2:] == ["--", ".serena/memories"]
-    assert timeout == checker._GIT_TIMEOUT_SECONDS
-
-
-def test_a_bare_repository_is_skipped_rather_than_reported_unreadable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A bare repo has no working tree, so ``git status`` there exits 128.
-
-    Reporting it "could not be read" on every run of a bare-clone-plus-worktrees
-    layout trains the reader to ignore the line that flags a real scan failure.
-    """
-    current = tmp_path / "current"
-    current.mkdir()
-    bare = tmp_path / "bare"
-    bare.mkdir()
-
-    listing = (
-        f"worktree {bare.resolve()}\nbare\n\nworktree {current.resolve()}\nbranch refs/heads/main\n"
-    )
-    fake = _make_fake_run_subprocess(listing, {}, status_exit_codes={str(bare.resolve()): 128})
-    monkeypatch.setattr(checker, "_run_subprocess", fake)
-
-    report = checker.build_scope_report(current)
-
-    assert report.unreadable_worktrees == 0
-    assert report.other_worktrees_examined == 0
-    assert report.findings == []
-
-
-def test_bare_worktree_paths_reads_the_marker_per_block() -> None:
-    porcelain = "worktree /repo/bare\nbare\n\nworktree /repo/wt\nbranch refs/heads/x\n\n"
-
-    assert checker._bare_worktree_paths(porcelain) == {"/repo/bare"}
-
-
-def test_an_unenterable_sibling_is_unreadable_rather_than_an_exception(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A directory that stats but cannot be entered raises PermissionError out of
-    ``subprocess.run(cwd=...)``. ``_run_subprocess`` catches only
-    FileNotFoundError and TimeoutExpired, and ``pre_pr.run_validation`` turns any
-    exception into a FAIL, so an uncaught raise makes this advisory gate block
-    the push."""
-    current = tmp_path / "current"
-    current.mkdir()
-    sibling = tmp_path / "sibling"
-    sibling.mkdir()
-    sibling_key = str(sibling.resolve())
-
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
-
-    def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
-    ) -> tuple[int, str, str]:
-        if args[:3] == ["git", "worktree", "list"]:
-            return 0, listing, ""
-        if str(cwd) == sibling_key:
-            raise PermissionError(13, "Permission denied")
-        return 0, "", ""
-
-    monkeypatch.setattr(checker, "_run_subprocess", _fake)
-
-    report = checker.build_scope_report(current)
-
-    assert report.unreadable_worktrees == 1
-    assert report.other_worktrees_examined == 0
-    assert report.findings == []
-
-
-def test_an_unrunnable_worktree_listing_is_reported_rather_than_raised(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
-    ) -> tuple[int, str, str]:
-        raise PermissionError(13, "Permission denied")
-
-    monkeypatch.setattr(checker, "_run_subprocess", _fake)
-
-    report = checker.build_scope_report(tmp_path)
-
-    assert report.worktree_listing_failed is True
-    assert report.findings == []
-
-
-def test_the_advisory_gate_still_returns_true_when_the_scan_cannot_run(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The whole point of finding 1: advisory must survive an unrunnable scan."""
-
-    def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
-    ) -> tuple[int, str, str]:
-        raise PermissionError(13, "Permission denied")
-
-    monkeypatch.setattr(checker, "_run_subprocess", _fake)
-
-    assert checker.validate_serena_memory_worktree_scope(tmp_path) is True
-
-
-def test_main_exits_two_when_the_listing_failed_so_nothing_was_examined(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Exit 0 here would hand a scripted caller a clean verdict from a run that
-    never looked at anything."""
-    fake = _make_fake_run_subprocess("", {}, listing_exit_code=128)
-    monkeypatch.setattr(checker, "_run_subprocess", fake)
-
-    assert checker.main(["--repo-root", str(tmp_path)]) == 2
-
-
-def test_an_adjacent_prefix_directory_is_not_reported() -> None:
-    """``.serena/memories-old/`` must not match ``.serena/memories/``.
-
-    The trailing slash in the prefix is what stops it. Nothing else pins that,
-    so removing the slash otherwise leaves the suite green.
-    """
-    porcelain = (
-        "?? .serena/memories-old/decoy.md\n"
-        "?? .serena/memoriesX/decoy.md\n"
-        "?? .serena/memories/real.md\n"
-    )
-
-    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/real.md"]

--- a/tests/validation/test_check_serena_memory_worktree_scope.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope.py
@@ -34,8 +34,6 @@ reading into.
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -122,6 +120,24 @@ def test_multiple_lines_are_filtered_independently() -> None:
 # --- build_scope_report ----------------------------------------------------
 
 
+def _z(*records: object) -> str:
+    """Build ``git worktree list --porcelain -z`` output.
+
+    Each record is a path, or a ``(path, "bare")`` pair. The production parser
+    reads NUL-terminated attributes precisely so a newline inside a worktree
+    path stays data instead of splitting the record, so the fixtures have to
+    speak the same format the real command emits under ``-z``.
+    """
+    parts: list[str] = []
+    for record in records:
+        if isinstance(record, tuple):
+            path, marker = record
+            parts.append(f"worktree {path}\0{marker}\0\0")
+        else:
+            parts.append(f"worktree {record}\0\0")
+    return "".join(parts)
+
+
 def _make_fake_run_subprocess(
     worktree_listing: str,
     status_by_worktree: dict[str, str],
@@ -132,7 +148,10 @@ def _make_fake_run_subprocess(
     status_exit_codes = status_exit_codes or {}
 
     def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if args[:3] == ["git", "worktree", "list"]:
             return listing_exit_code, worktree_listing, ""
@@ -154,7 +173,7 @@ def test_a_stray_file_in_a_sibling_worktree_is_found(
     sibling.mkdir()
     sibling_key = str(sibling.resolve())
 
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    listing = _z(current.resolve(), sibling.resolve())
     fake = _make_fake_run_subprocess(listing, {sibling_key: "?? .serena/memories/git/stray.md\n"})
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
@@ -180,10 +199,13 @@ def test_the_current_worktrees_own_untracked_memory_file_is_never_reported(
     current.mkdir()
     current_key = str(current.resolve())
 
-    listing = f"worktree {current.resolve()}\n"
+    listing = _z(current.resolve())
 
     def fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if args[:3] == ["git", "worktree", "list"]:
             return 0, listing, ""
@@ -206,7 +228,7 @@ def test_no_findings_when_every_sibling_is_clean(
     sibling = tmp_path / "sibling"
     sibling.mkdir()
 
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    listing = _z(current.resolve(), sibling.resolve())
     fake = _make_fake_run_subprocess(listing, {str(sibling.resolve()): ""})
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
@@ -222,7 +244,7 @@ def test_a_single_worktree_repository_examines_nothing(
 ) -> None:
     current = tmp_path / "current"
     current.mkdir()
-    listing = f"worktree {current.resolve()}\n"
+    listing = _z(current.resolve())
     fake = _make_fake_run_subprocess(listing, {})
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
@@ -240,10 +262,13 @@ def test_a_stale_registered_worktree_is_skipped_without_a_status_call(
     current.mkdir()
     gone = tmp_path / "gone"  # never created on disk
 
-    listing = f"worktree {current.resolve()}\nworktree {gone}\n"
+    listing = _z(current.resolve(), gone)
 
     def fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if args[:3] == ["git", "worktree", "list"]:
             return 0, listing, ""
@@ -286,9 +311,7 @@ def test_one_unreadable_sibling_does_not_stop_the_rest_of_the_scan(
     healthy_key = str(healthy.resolve())
     broken_key = str(broken.resolve())
 
-    listing = (
-        f"worktree {current.resolve()}\nworktree {broken.resolve()}\nworktree {healthy.resolve()}\n"
-    )
+    listing = _z(current.resolve(), broken.resolve(), healthy.resolve())
     fake = _make_fake_run_subprocess(
         listing,
         {healthy_key: "?? .serena/memories/git/stray.md\n", broken_key: ""},
@@ -365,7 +388,7 @@ def test_the_advisory_gate_always_returns_true_even_with_findings(
     current.mkdir()
     sibling = tmp_path / "sibling"
     sibling.mkdir()
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    listing = _z(current.resolve(), sibling.resolve())
     fake = _make_fake_run_subprocess(
         listing, {str(sibling.resolve()): "?? .serena/memories/git/stray.md\n"}
     )
@@ -375,56 +398,6 @@ def test_the_advisory_gate_always_returns_true_even_with_findings(
 
     assert result is True
     assert "stray.md" in capsys.readouterr().out
-
-
-# --- main() / CLI ------------------------------------------------------------
-
-
-def _init_repo(path: Path) -> None:
-    subprocess.run(["git", "init", "-q", str(path)], check=True, cwd=path)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=path)
-    subprocess.run(["git", "config", "user.name", "Test"], check=True, cwd=path)
-
-
-def test_main_exits_zero_on_a_real_single_worktree_repo(tmp_path: Path) -> None:
-    """End-to-end with real git, hermetic under tmp_path: no linked worktrees,
-    nothing under .serena/memories/, so nothing to find."""
-    repo = tmp_path / "solo-repo"
-    repo.mkdir()
-    _init_repo(repo)
-
-    exit_code = checker.main(["--repo-root", str(repo)])
-
-    assert exit_code == 0
-
-
-def test_main_exits_two_when_repo_root_does_not_exist(tmp_path: Path) -> None:
-    missing = tmp_path / "does-not-exist"
-
-    exit_code = checker.main(["--repo-root", str(missing)])
-
-    assert exit_code == 2
-
-
-def test_main_exits_one_and_prints_json_when_a_sibling_has_a_stray_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    current = tmp_path / "current"
-    current.mkdir()
-    sibling = tmp_path / "sibling"
-    sibling.mkdir()
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
-    fake = _make_fake_run_subprocess(
-        listing, {str(sibling.resolve()): "?? .serena/memories/git/stray.md\n"}
-    )
-    monkeypatch.setattr(checker, "_run_subprocess", fake)
-
-    exit_code = checker.main(["--repo-root", str(current), "--json"])
-
-    payload = json.loads(capsys.readouterr().out)
-    assert exit_code == 1
-    assert len(payload["findings"]) == 1
-    assert payload["findings"][0]["relpath"] == ".serena/memories/git/stray.md"
 
 
 # --- pre_pr_sequence wiring (testing.md SHOULD 6) ---------------------------

--- a/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
@@ -1,0 +1,213 @@
+"""Failure modes of the Serena memory worktree-scope gate (issue #5061).
+
+Split from ``test_check_serena_memory_worktree_scope.py`` to keep both files
+under the 500-line taste ceiling. Everything here came out of an adversarial
+review of the gate's first commit, and each test below fails against that
+commit unless its docstring says otherwise.
+
+Covers the cases where the scan cannot run rather than the cases where it
+finds something: git raising before it starts, a bare repository that has no
+working tree to scan, the argv flags the detection silently depends on, and
+the exit code of a run that examined nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Same import bootstrap as the sibling test module: prepend scripts/validation
+# to sys.path and import by bare name. Never restored.
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+import check_serena_memory_worktree_scope as checker
+
+_SubprocessFake = Callable[..., tuple[int, str, str]]
+
+
+def _recording_fake(
+    worktree_listing: str,
+    calls: list[tuple[list[str], object, object]],
+    listing_exit_code: int = 0,
+    status_exit_codes: dict[str, int] | None = None,
+) -> _SubprocessFake:
+    """A ``_run_subprocess`` stand-in that records every call's argv.
+
+    The sibling module's fake keys on ``args[:2]`` and ignores the rest of the
+    argv, so dropping ``--untracked-files=all`` or the pathspec leaves its whole
+    suite green while the gate stops detecting new memory tiers.
+    """
+    status_exit_codes = status_exit_codes or {}
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        calls.append((list(args), cwd, timeout))
+        if args[:3] == ["git", "worktree", "list"]:
+            return listing_exit_code, worktree_listing, ""
+        if args[:2] == ["git", "status"]:
+            return status_exit_codes.get(str(cwd), 0), "", ""
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    return _fake
+
+
+def test_the_status_call_asks_for_all_untracked_files_under_the_memories_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--untracked-files=all`` and the pathspec are load-bearing, so pin them.
+
+    Without the flag git collapses a brand-new ``.serena/memories/<tier>/``
+    directory to one directory line, which fails the ``.md`` suffix filter, and
+    a write into a tier the sibling's branch does not carry is exactly the
+    issue #5061 symptom. Every other test parses the fake's output and so stays
+    green when the flag is dropped.
+    """
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    calls: list[tuple[list[str], object, object]] = []
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    fake = _recording_fake(listing, calls)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    checker.build_scope_report(current)
+
+    status_calls = [c for c in calls if c[0][:2] == ["git", "status"]]
+    assert len(status_calls) == 1
+    args, _cwd, timeout = status_calls[0]
+    assert "--untracked-files=all" in args
+    assert "--porcelain" in args
+    assert args[-2:] == ["--", ".serena/memories"]
+    assert timeout == checker._GIT_TIMEOUT_SECONDS
+
+
+def test_a_bare_repository_is_skipped_rather_than_reported_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare repo has no working tree, so ``git status`` there exits 128.
+
+    Reporting it "could not be read" on every run of a bare-clone-plus-worktrees
+    layout trains the reader to ignore the line that flags a real scan failure.
+    """
+    current = tmp_path / "current"
+    current.mkdir()
+    bare = tmp_path / "bare"
+    bare.mkdir()
+
+    listing = (
+        f"worktree {bare.resolve()}\nbare\n\nworktree {current.resolve()}\nbranch refs/heads/main\n"
+    )
+    fake = _recording_fake(listing, [], status_exit_codes={str(bare.resolve()): 128})
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.unreadable_worktrees == 0
+    assert report.other_worktrees_examined == 0
+    assert report.findings == []
+
+
+def test_bare_worktree_paths_reads_the_marker_per_block() -> None:
+    porcelain = "worktree /repo/bare\nbare\n\nworktree /repo/wt\nbranch refs/heads/x\n\n"
+
+    assert checker._bare_worktree_paths(porcelain) == {"/repo/bare"}
+
+
+def test_an_unenterable_sibling_is_unreadable_rather_than_an_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory that stats but cannot be entered raises PermissionError out of
+    ``subprocess.run(cwd=...)``. ``_run_subprocess`` catches only
+    FileNotFoundError and TimeoutExpired, and ``pre_pr.run_validation`` turns any
+    exception into a FAIL, so an uncaught raise makes this advisory gate block
+    the push."""
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    sibling_key = str(sibling.resolve())
+
+    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        if args[:3] == ["git", "worktree", "list"]:
+            return 0, listing, ""
+        if str(cwd) == sibling_key:
+            raise PermissionError(13, "Permission denied")
+        return 0, "", ""
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    report = checker.build_scope_report(current)
+
+    assert report.unreadable_worktrees == 1
+    assert report.other_worktrees_examined == 0
+    assert report.findings == []
+
+
+def test_an_unrunnable_worktree_listing_is_reported_rather_than_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    report = checker.build_scope_report(tmp_path)
+
+    assert report.worktree_listing_failed is True
+    assert report.findings == []
+
+
+def test_the_advisory_gate_still_returns_true_when_the_scan_cannot_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of finding 1: advisory must survive an unrunnable scan."""
+
+    def _fake(
+        args: list[str], cwd: object = None, timeout: int | None = None
+    ) -> tuple[int, str, str]:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(checker, "_run_subprocess", _fake)
+
+    assert checker.validate_serena_memory_worktree_scope(tmp_path) is True
+
+
+def test_main_exits_two_when_the_listing_failed_so_nothing_was_examined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exit 0 here would hand a scripted caller a clean verdict from a run that
+    never looked at anything."""
+    fake = _recording_fake("", [], listing_exit_code=128)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    assert checker.main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_an_adjacent_prefix_directory_is_not_reported() -> None:
+    """``.serena/memories-old/`` must not match ``.serena/memories/``.
+
+    The trailing slash in the prefix is what stops it. Nothing else pins that,
+    so removing the slash otherwise leaves the suite green.
+    """
+    porcelain = (
+        "?? .serena/memories-old/decoy.md\n"
+        "?? .serena/memoriesX/decoy.md\n"
+        "?? .serena/memories/real.md\n"
+    )
+
+    assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/real.md"]

--- a/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
@@ -13,6 +13,8 @@ the exit code of a run that examined nothing.
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -31,11 +33,30 @@ import check_serena_memory_worktree_scope as checker
 _SubprocessFake = Callable[..., tuple[int, str, str]]
 
 
+def _z(*records: object) -> str:
+    """Build ``git worktree list --porcelain -z`` output.
+
+    Each record is a path, or a ``(path, "bare")`` pair. The production parser
+    reads NUL-terminated attributes precisely so a newline inside a worktree
+    path stays data instead of splitting the record, so the fixtures have to
+    speak the same format the real command emits under ``-z``.
+    """
+    parts: list[str] = []
+    for record in records:
+        if isinstance(record, tuple):
+            path, marker = record
+            parts.append(f"worktree {path}\0{marker}\0\0")
+        else:
+            parts.append(f"worktree {record}\0\0")
+    return "".join(parts)
+
+
 def _recording_fake(
     worktree_listing: str,
-    calls: list[tuple[list[str], object, object]],
+    calls: list[tuple[list[str], object, object, dict[str, str] | None]],
     listing_exit_code: int = 0,
     status_exit_codes: dict[str, int] | None = None,
+    status_by_worktree: dict[str, str] | None = None,
 ) -> _SubprocessFake:
     """A ``_run_subprocess`` stand-in that records every call's argv.
 
@@ -44,15 +65,19 @@ def _recording_fake(
     suite green while the gate stops detecting new memory tiers.
     """
     status_exit_codes = status_exit_codes or {}
+    status_by_worktree = status_by_worktree or {}
 
     def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        calls.append((list(args), cwd, timeout))
+        calls.append((list(args), cwd, timeout, env))
         if args[:3] == ["git", "worktree", "list"]:
             return listing_exit_code, worktree_listing, ""
         if args[:2] == ["git", "status"]:
-            return status_exit_codes.get(str(cwd), 0), "", ""
+            return status_exit_codes.get(str(cwd), 0), status_by_worktree.get(str(cwd), ""), ""
         raise AssertionError(f"unexpected subprocess call: {args}")
 
     return _fake
@@ -73,9 +98,9 @@ def test_the_status_call_asks_for_all_untracked_files_under_the_memories_path(
     current.mkdir()
     sibling = tmp_path / "sibling"
     sibling.mkdir()
-    calls: list[tuple[list[str], object, object]] = []
+    calls: list[tuple[list[str], object, object, dict[str, str] | None]] = []
 
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    listing = _z(current.resolve(), sibling.resolve())
     fake = _recording_fake(listing, calls)
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
@@ -83,7 +108,7 @@ def test_the_status_call_asks_for_all_untracked_files_under_the_memories_path(
 
     status_calls = [c for c in calls if c[0][:2] == ["git", "status"]]
     assert len(status_calls) == 1
-    args, _cwd, timeout = status_calls[0]
+    args, _cwd, timeout, _env = status_calls[0]
     assert "--untracked-files=all" in args
     assert "--porcelain" in args
     assert args[-2:] == ["--", ".serena/memories"]
@@ -103,9 +128,7 @@ def test_a_bare_repository_is_skipped_rather_than_reported_unreadable(
     bare = tmp_path / "bare"
     bare.mkdir()
 
-    listing = (
-        f"worktree {bare.resolve()}\nbare\n\nworktree {current.resolve()}\nbranch refs/heads/main\n"
-    )
+    listing = _z((bare.resolve(), "bare"), current.resolve())
     fake = _recording_fake(listing, [], status_exit_codes={str(bare.resolve()): 128})
     monkeypatch.setattr(checker, "_run_subprocess", fake)
 
@@ -116,10 +139,22 @@ def test_a_bare_repository_is_skipped_rather_than_reported_unreadable(
     assert report.findings == []
 
 
-def test_bare_worktree_paths_reads_the_marker_per_block() -> None:
-    porcelain = "worktree /repo/bare\nbare\n\nworktree /repo/wt\nbranch refs/heads/x\n\n"
+def test_parse_worktree_records_reads_the_bare_marker_per_record() -> None:
+    porcelain = _z(("/repo/bare", "bare"), "/repo/wt")
 
-    assert checker._bare_worktree_paths(porcelain) == {"/repo/bare"}
+    assert checker.parse_worktree_records(porcelain) == [("/repo/bare", True), ("/repo/wt", False)]
+
+
+def test_parse_worktree_records_keeps_a_path_containing_a_newline_whole() -> None:
+    """A line-based parser keeps only the first fragment of such a path, so the
+    scan skips a real worktree and never reports the stray memory inside it.
+    Under ``-z`` the newline is ordinary data."""
+    porcelain = _z("/repo/we\nird", "/repo/plain")
+
+    assert checker.parse_worktree_records(porcelain) == [
+        ("/repo/we\nird", False),
+        ("/repo/plain", False),
+    ]
 
 
 def test_an_unenterable_sibling_is_unreadable_rather_than_an_exception(
@@ -136,10 +171,13 @@ def test_an_unenterable_sibling_is_unreadable_rather_than_an_exception(
     sibling.mkdir()
     sibling_key = str(sibling.resolve())
 
-    listing = f"worktree {current.resolve()}\nworktree {sibling.resolve()}\n"
+    listing = _z(current.resolve(), sibling.resolve())
 
     def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if args[:3] == ["git", "worktree", "list"]:
             return 0, listing, ""
@@ -160,7 +198,10 @@ def test_an_unrunnable_worktree_listing_is_reported_rather_than_raised(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         raise PermissionError(13, "Permission denied")
 
@@ -178,7 +219,10 @@ def test_the_advisory_gate_still_returns_true_when_the_scan_cannot_run(
     """The whole point of finding 1: advisory must survive an unrunnable scan."""
 
     def _fake(
-        args: list[str], cwd: object = None, timeout: int | None = None
+        args: list[str],
+        cwd: object = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         raise PermissionError(13, "Permission denied")
 
@@ -211,3 +255,109 @@ def test_an_adjacent_prefix_directory_is_not_reported() -> None:
     )
 
     assert checker.parse_stray_memory_files(porcelain) == [".serena/memories/real.md"]
+
+
+def test_both_git_calls_run_with_ambient_git_variables_stripped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A push from a linked worktree exports GIT_DIR into the pre-push hook, and
+    this gate runs inside pre_pr.py which that hook runs. An exported GIT_DIR,
+    GIT_WORK_TREE or GIT_INDEX_FILE outranks cwd=, so an unsanitized scan reads
+    the pushing worktree rather than the sibling it was aimed at. Measured on
+    git 2.43.0, with GIT_DIR and GIT_WORK_TREE both set every sibling reports
+    empty, so the gate reports a scan it never performed."""
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    calls: list[tuple[list[str], object, object, dict[str, str] | None]] = []
+
+    monkeypatch.setenv("GIT_DIR", "/somewhere/else/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/somewhere/else")
+    monkeypatch.setenv("GIT_INDEX_FILE", "/somewhere/else/.git/index")
+    monkeypatch.setenv("git_dir", "/lowercased/too/.git")
+
+    fake = _recording_fake(_z(current.resolve(), sibling.resolve()), calls)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    checker.build_scope_report(current)
+
+    assert len(calls) == 2, "expected the worktree listing and one sibling status call"
+    for args, _cwd, _timeout, env in calls:
+        assert env is not None, f"{args[:3]} inherited the ambient environment"
+        leaked = sorted(name for name in env if name.upper().startswith("GIT_"))
+        assert leaked == [], f"{args[:3]} leaked {leaked}"
+    assert any("PATH" in (env or {}) for *_rest, env in calls), (
+        "stripping must be narrow: PATH and the config variables stay, since this "
+        "scans real checkouts where a global safe.directory entry is load-bearing"
+    )
+
+
+def test_the_worktree_listing_is_requested_nul_delimited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without -z a newline inside a worktree path splits the record."""
+    current = tmp_path / "current"
+    current.mkdir()
+    calls: list[tuple[list[str], object, object, dict[str, str] | None]] = []
+
+    fake = _recording_fake(_z(current.resolve()), calls)
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    checker.build_scope_report(current)
+
+    listing_calls = [c for c in calls if c[0][:3] == ["git", "worktree", "list"]]
+    assert len(listing_calls) == 1
+    assert "-z" in listing_calls[0][0]
+
+
+# --- main() / CLI ------------------------------------------------------------
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(path)], check=True, cwd=path)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=path)
+    subprocess.run(["git", "config", "user.name", "Test"], check=True, cwd=path)
+
+
+def test_main_exits_zero_on_a_real_single_worktree_repo(tmp_path: Path) -> None:
+    """End-to-end with real git, hermetic under tmp_path: no linked worktrees,
+    nothing under .serena/memories/, so nothing to find."""
+    repo = tmp_path / "solo-repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    exit_code = checker.main(["--repo-root", str(repo)])
+
+    assert exit_code == 0
+
+
+def test_main_exits_two_when_repo_root_does_not_exist(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+
+    exit_code = checker.main(["--repo-root", str(missing)])
+
+    assert exit_code == 2
+
+
+def test_main_exits_one_and_prints_json_when_a_sibling_has_a_stray_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = tmp_path / "current"
+    current.mkdir()
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    listing = _z(current.resolve(), sibling.resolve())
+    fake = _recording_fake(
+        listing,
+        [],
+        status_by_worktree={str(sibling.resolve()): "?? .serena/memories/git/stray.md\n"},
+    )
+    monkeypatch.setattr(checker, "_run_subprocess", fake)
+
+    exit_code = checker.main(["--repo-root", str(current), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert len(payload["findings"]) == 1
+    assert payload["findings"][0]["relpath"] == ".serena/memories/git/stray.md"

--- a/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
@@ -32,6 +32,9 @@ import check_serena_memory_worktree_scope as checker
 
 _SubprocessFake = Callable[..., tuple[int, str, str]]
 
+# Seconds. A wedged git in a throwaway repo should fail the test, not the job.
+_GIT_TEST_TIMEOUT = 30
+
 
 def _z(*records: object) -> str:
     """Build ``git worktree list --porcelain -z`` output.
@@ -315,9 +318,20 @@ def test_the_worktree_listing_is_requested_nul_delimited(
 
 
 def _init_repo(path: Path) -> None:
-    subprocess.run(["git", "init", "-q", str(path)], check=True, cwd=path)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=path)
-    subprocess.run(["git", "config", "user.name", "Test"], check=True, cwd=path)
+    """Create a throwaway repo for the CLI tests, with timeouts so a wedged git
+    fails this test instead of hanging the session until the job timeout."""
+    subprocess.run(
+        ["git", "init", "-q", str(path)], check=True, cwd=path, timeout=_GIT_TEST_TIMEOUT
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=path,
+        timeout=_GIT_TEST_TIMEOUT,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], check=True, cwd=path, timeout=_GIT_TEST_TIMEOUT
+    )
 
 
 def test_main_exits_zero_on_a_real_single_worktree_repo(tmp_path: Path) -> None:

--- a/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
+++ b/tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py
@@ -1,14 +1,25 @@
 """Failure modes of the Serena memory worktree-scope gate (issue #5061).
 
 Split from ``test_check_serena_memory_worktree_scope.py`` to keep both files
-under the 500-line taste ceiling. Everything here came out of an adversarial
-review of the gate's first commit, and each test below fails against that
-commit unless its docstring says otherwise.
+under the 500-line taste ceiling.
 
 Covers the cases where the scan cannot run rather than the cases where it
 finds something: git raising before it starts, a bare repository that has no
 working tree to scan, the argv flags the detection silently depends on, and
 the exit code of a run that examined nothing.
+
+Most of these came out of review rounds on the gate's first commits and fail
+against them. The ``main()`` CLI tests did not: they were moved here from the
+sibling module for size, and they pass against every commit on this branch.
+
+DELIBERATE REAL-GIT EXCEPTION. Most tests here stub ``checker._run_subprocess``.
+The ``main()`` CLI tests do not: they build throwaway repositories under
+``tmp_path`` and run real git against them, which is the point of those three.
+A mocked exit-code test asserts that the code returns what the mock was told to
+produce, which pins nothing about whether the real command sequence works.
+Every such call is bounded by ``_GIT_TEST_TIMEOUT``, so a wedged git fails the
+owning test rather than hanging the session, and none of them touch this
+repository: only directories the test just created.
 """
 
 from __future__ import annotations

--- a/tests/validation/test_pre_pr_sequence_registry.py
+++ b/tests/validation/test_pre_pr_sequence_registry.py
@@ -59,6 +59,7 @@ EXPECTED_ORDER: tuple[str, ...] = (
     'Index Line Endings',
     'Worktree Recipe Destinations',
     'Temp-filesystem Worktrees (advisory)',
+    'Serena Memory Worktree Scope (advisory)',
     'Session End Validation',
     'Mypy Changed Files (ratchet)',
     'Markdown Linting',


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds `scripts/validation/check_serena_memory_worktree_scope.py`, an advisory pre-PR gate that scans every linked worktree other than the caller's for untracked `.serena/memories/**/*.md` files, and wires it into `pre_pr_sequence.py`.

### Why

Issue #5061: Serena's MCP server resolves its project root once at server activation, never per tool call. `.mcp.json` launches it with `--project "${workspaceFolder:-.}"`, and one server serves the whole session including subagents. A subagent whose cwd is a linked worktree therefore has its `write_memory` call land in a different checkout, where the file is invisible to the agent's own branch and silently mutates a checkout the agent never touched.

PR #5152 previously blocked this with a `PreToolUse` hook. ADR-097 retired every tool-call hook for an unrelated reason (Windows spawn cost) and named this specific loss: "A Serena write can again land in the wrong worktree's checkout ... Nothing replaces this." This gate is the replacement class of guard that lives outside the retired hook surface.

**Scope limit, stated plainly:** this detects the stray file after the fact. It does not prevent the write. Only a per-call fix in Serena's own activation model, or the retired hook, could do that. The issue stays open for that reason.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5061 | mcp__serena__write_memory writes into the main checkout, not the calling agent's git worktree |
| **ADR** | see `.agents/architecture/ADR-097-zero-tool-use-hooks.md` | Retired the PreToolUse guard this replaces |

These references do not close their linked items: #5061 needs an upstream Serena fix or a binding convention, both owner-level calls.

## Changes

- `scripts/validation/check_serena_memory_worktree_scope.py` (new): lists sibling worktrees with `git worktree list --porcelain -z`, runs `git status --porcelain --untracked-files=all -- .serena/memories` in each, and reports untracked `.md` files under `.serena/memories/`. Both git calls run with ambient `GIT_*` stripped. Reuses `_run_subprocess`; the worktree records are parsed locally because the shared parser is line-based (see below).
- `scripts/validation/pre_pr_sequence.py`: registers the gate as `Serena Memory Worktree Scope (advisory)`.
- `tests/validation/test_check_serena_memory_worktree_scope.py` (new): parsing, reporting, and happy-path coverage.
- `tests/validation/test_check_serena_memory_worktree_scope_failure_modes.py` (new): the cases where the scan cannot run, plus the CLI exit-code tests, split out so both modules stay under the 500-line taste ceiling.
- `tests/validation/test_pre_pr_sequence_registry.py`: adds the gate name to the pinned `EXPECTED_ORDER` literal (issue #4285).

Six commits: `e480e39e0` adds the gate, `dd94ec3bb` fixes five defects from an adversarial review, `d0d1a5f84` splits the grown test module, `ac407871a` fixes two defects Devin Review found, `abccc9951` bounds the throwaway repo's git calls, `ed3bd472c` records the deliberate real-git exception.

## Review history

Three review rounds, all three found real defects. That is worth recording because the first version passed every gate in this repository.

**Round 1, adversarial review before the PR left draft.** Mutation harness, 10 injected mutations with 6 killed, plus probe repositories including a bare repo and a worktree path containing a space. Five fixes in `dd94ec3bb`:

1. **The advisory gate could fail the push.** `_run_subprocess` absorbs `FileNotFoundError` and `TimeoutExpired` and lets every other `OSError` through; `pre_pr.run_validation` converts any exception into a FAIL. A sibling that stats but cannot be entered raises `PermissionError` out of `subprocess.run(cwd=...)`, so a gate documented as advisory in four places blocked the push.
2. **`--untracked-files=all` was load-bearing but unpinned.** Deleting it left all 26 tests green, while removing the gate's ability to see a brand-new `.serena/memories/<tier>/` directory, which is exactly the issue #5061 symptom.
3. **The summary counted unreadable worktrees as examined**, so it could report a clean scan of a worktree nothing could read.
4. **A bare repository was reported unreadable on every run**, on precisely the bare-clone-plus-worktrees layout this gate serves.
5. **`main()` returned 0 when `git worktree list` failed**, giving a scripted caller a clean verdict from a run that examined nothing.

**Round 2, Devin Review.** Two more, fixed in `ac407871a`:

6. **The scan inherited ambient `GIT_*`.** A push from a linked worktree exports `GIT_DIR` into the pre-push hook, and this gate runs inside `pre_pr.py`, which that hook runs. An exported `GIT_DIR`, `GIT_WORK_TREE` or `GIT_INDEX_FILE` outranks `cwd=`. Measured on git 2.43.0 against a real linked worktree holding a file the scan should see:

   ```
   clean env,    cwd=sibling      ' M .serena/memories/git/stray.md'
   GIT_DIR,      cwd=sibling      ' M .serena/memories/git/stray.md'
   GIT_DIR + GIT_WORK_TREE        ''
   ```

   The third row is the defect: every sibling reads clean, so the gate reports a scan it never performed. That is the failure mode this gate exists to catch, turned on itself. Both calls now strip `GIT_*`, mirroring the rule `scripts/ci/count_ratchet.py` quotes verbatim for issue #4914, `name.upper()` included. `HOME` and the config variables are kept deliberately: this scans real checkouts where a global `safe.directory` entry is load-bearing.

   The report's stated mechanism, a tracked file reclassified as modified, did not reproduce. The finding was right about the class and wrong about the path, and the docstring records the measurement rather than the claim.

7. **The worktree listing was line-delimited**, so a path containing a newline split across lines and the parser kept only its first fragment, silently skipping a real worktree. The listing now uses `-z` with a local NUL record parser that also reads the bare marker, retiring the helper fix 4 added. `check_tmp_worktrees.parse_worktree_list` is left alone rather than widened: it is line-based, serves a different gate, and changing its contract would put that gate's behavior in scope here.

**Round 3, CodeRabbit.** One fix and one documented exception:

8. **`_init_repo`'s three git calls were unbounded**, so a wedged `git init` would hang the whole pytest session rather than failing the one test that owns the throwaway repo. Bounded at 30s in `abccc9951`. The finding cited a `**/*.py` repository guideline requiring timeouts; CodeRabbit has since confirmed that attribution was incorrect and that the accompanying CWE-78 results do not apply to these helpers. Applied on the merit rather than the cited authority, and scoped to this function rather than the other 280 untimed `subprocess.run` calls under `tests/validation/`.
9. **Two tests use live git.** Taking the documented-exception branch its own guidance offers rather than mocking: a mocked exit-code test asserts that the code returns what the mock was told to produce, which pins nothing about whether the real command sequence works. `ed3bd472c` records the exception in the module header. Both build throwaway repos under `tmp_path` or read only; neither mutates this repository. Live git in tests is established here: 25 of 151 modules under `tests/validation/` do it.

Four false claims of my own were corrected along the way: a test header calling every test hermetic when one deliberately drives real git; a fixture asserting on a space-containing path that git never quotes; a header claiming every test in a module fails against the gate's first commit, which stopped being true when the CLI tests moved in for size; and a `Changes` entry claiming this reuses `parse_worktree_list`, which stopped being true in `ac407871a`.

## Acceptance criteria

- [x] An untracked `.serena/memories/**/*.md` file in another worktree is reported
- [x] The caller's own worktree's untracked memory files are never reported
- [x] A modified tracked memory file is not reported, only untracked ones
- [x] A path outside the `.serena/memories/` prefix or without a `.md` suffix is not reported
- [x] The gate stays advisory even when the scan cannot run at all, including when git raises before it starts
- [x] A failed scan is distinguishable from a clean scan, and an unreadable worktree is never counted as examined
- [x] A bare repository is skipped rather than reported unreadable
- [x] Neither git call inherits ambient `GIT_*`, so a scan cannot silently read the wrong tree
- [x] A worktree path containing a newline is parsed whole rather than truncated
- [x] The standalone CLI exits 1 on findings, and 2 both on a nonexistent `--repo-root` and on a listing failure that examined nothing (ADR-035)

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether advisory is the right severity versus blocking, and the deliberately partial quoted-path handling in `parse_stray_memory_files` (a git-quoted path keeps its C-escapes, so the reported name is mangled while the file is still detected; documented and tested as such).

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

37 tests across the two modules, up from 26.

**Negative controls.** Every code fix is pinned by at least one test that fails against the commit preceding it, verified by loading the pre-fix module under the tests' import name rather than by mutating the working tree. Round 1: seven tests fail against `e480e39e0`. Round 2: four fail against `d0d1a5f84`, including `test_both_git_calls_run_with_ambient_git_variables_stripped`, `test_the_worktree_listing_is_requested_nul_delimited` and `test_parse_worktree_records_keeps_a_path_containing_a_newline_whole`.

Two tests deliberately pass against their pre-fix module and are mutation guards rather than fixes: the argv assertion and the adjacent-prefix case pin behavior that was already correct but unpinned.

**The original defect was not reproduced live.** The Serena MCP server failed to connect this session (`CONNECT_TIMEOUT`). The root cause was established by reading `.mcp.json`, ADR-097 and the prior hook in PR #5152. Recorded as unreproduced, not as verified.

**The gate itself was exercised against real data**, run from a worktree with three live siblings:

```
$ uv run python scripts/validation/check_serena_memory_worktree_scope.py
serena-memory-worktree-scope: 0 finding(s) across 3 sibling worktree(s) examined (0 stale entr(y/ies) skipped).
exit=0

$ uv run python scripts/validation/check_serena_memory_worktree_scope.py --repo-root /nonexistent-xyz
exit=2
```

The sibling count matched the machine's actual worktrees, so enumeration is confirmed against ground truth rather than a mock.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:** the new validator, which spawns git subprocesses.

Stated precisely rather than by checkbox: the repository's `security` agent was **not** run. An independent adversarial review with a security lens was, and it examined and cleared the following, so the absence of findings is auditable. `shell=False` throughout, list argv with every token a compile-time constant. The only path-derived value, the sibling worktree path, is passed as `cwd=` and never as an argv element, so a path beginning with `-` cannot become a flag. No file is opened and no path is joined, so there is no traversal surface. Both calls carry a 10s timeout and the pathspec bounds stdout. Both now also run with a sanitized environment, which closes the wrong-tree read described above.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage (mutation harness: 10 mutations injected, 6 killed; the survivors traced to one root cause, now fixed and pinned)

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

Re-run independently rather than taken from any agent's report:

```
uv run pytest <the two scope test modules> -q                 37 passed
uv run pytest tests/validation/ -q                            4367 passed, 10 skipped
uv run ruff check / ruff format                               clean
uv run mypy <the three changed files>                         Success: no issues found
uv run python scripts/validation/checks_ratchet.py            exit 0
uv run python scripts/validation/pre_pr.py                    64 validations, 0 failed
```

The full pre-push chain ran on every push, including `ac407871a` and `ed3bd472c`: `count-ratchets`, `security-scan`, `python-type-check`, `python-tests`, `zero-collection-tests` and `pre-pr-validation`, all green.

An em dash and en dash scan over every changed file reports 0 occurrences.

## Related Issues

Refs #5061

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aMNFbxxoMCxiFty1ZDGLc
