### PR TITLE
fix(security): exclude the python3x compat rules by full id, and record the set

### DIFF
--- a/.semgrepconfig.yml
+++ b/.semgrepconfig.yml
@@ -1,0 +1,42 @@
+# Semgrep project configuration for rjmurillo/ai-agents.
+#
+# WHAT READS THIS FILE: `semgrep ci`, the entry point behind the
+# `semgrep-cloud-platform/scan` check. It loads the file through
+# semgrep.app.project_config.ProjectConfig.load_all() and ships the result in
+# the scan request as `project_config`.
+#
+# WHAT THIS FILE CANNOT DO: exclude a rule. The schema is closed. ProjectConfig
+# declares exactly `version` and `tags` and constructs itself with
+# `cls(**loaded)`, so any other key raises SemgrepError with exit code 5 and
+# fails the entire scan rather than being ignored. Measured against the pinned
+# semgrep 1.175.0: adding `exclude_rules:` produced
+#   SemgrepError code=5: ProjectConfig.__init__() got an unexpected keyword
+#   argument 'exclude_rules'
+# Rules travel the other direction, arriving from the Platform as
+# scan_response.config.rules. Do not add a rule key here; it will not be
+# ignored, it will break the scan.
+#
+# WHY THE TAG EXISTS: pyproject.toml sets `requires-python = ">=3.14"`, so every
+# finding from the python36 and python37 compatibility families is a guaranteed
+# false positive in this repository. Those four rules are:
+#
+#   python.lang.compatibility.python36.python36-compatibility-Popen1
+#   python.lang.compatibility.python36.python36-compatibility-Popen2
+#   python.lang.compatibility.python37.python37-compatibility-Popen1
+#   python.lang.compatibility.python37.python37-compatibility-Popen2
+#
+# Full ids are required wherever they are excluded. `--exclude-rule` matches an
+# id exactly, not by prefix. Measured on semgrep 1.175.0 against a local
+# ruleset: excluding the full id removed the finding; excluding the family
+# prefix `python.lang.compatibility.python36` left every finding in place.
+#
+# WHAT THIS FILE DOES NOT DO: it does not turn `semgrep-cloud-platform/scan`
+# green. No repository file can. The exclusion is Platform state, set once in
+# the Semgrep AppSec Platform detection policy and scoped to this project or to
+# the tag below. This file is the git-tracked, reviewable record of which rules
+# that exception must cover and why, so the scope lives in version control
+# rather than only as dashboard state. Refs #4725.
+
+version: v1
+tags:
+  - python-314-floor

--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -148,9 +148,7 @@ def _semgrep_pinned_version(repo_root: Path) -> str:
     try:
         text = pyproject.read_text(encoding="utf-8")
     except OSError as exc:
-        raise _SemgrepExecutableError(
-            f"cannot read semgrep pin from {pyproject}: {exc}"
-        ) from exc
+        raise _SemgrepExecutableError(f"cannot read semgrep pin from {pyproject}: {exc}") from exc
     matches: list[str] = re.findall(
         r'^\s*"semgrep==([^"]+)",\s*$',
         text,
@@ -159,8 +157,7 @@ def _semgrep_pinned_version(repo_root: Path) -> str:
     versions = set(matches)
     if len(versions) != 1:
         raise _SemgrepExecutableError(
-            f"pyproject.toml must declare exactly one semgrep pin, "
-            f"found: {sorted(versions)!r}"
+            f"pyproject.toml must declare exactly one semgrep pin, found: {sorted(versions)!r}"
         )
     return versions.pop()
 
@@ -187,9 +184,7 @@ def _probe_semgrep_version(executable: str) -> str:
         )
     version = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
     if not version:
-        raise _SemgrepExecutableError(
-            f"semgrep version probe returned no output for {executable}"
-        )
+        raise _SemgrepExecutableError(f"semgrep version probe returned no output for {executable}")
     return version
 
 
@@ -374,13 +369,27 @@ class SemgrepScanner:
             # before those versions, which are eight and seven minor versions
             # below the project floor. Every finding they produce is a
             # guaranteed false positive here, and their own metadata classifies
-            # them as "compatibility", not security. Excluding the family keeps
-            # them from blocking PRs that comply with the encoding convention
-            # that tests/test_subprocess_text_encoding.py mandates (issue #4223).
+            # them as "compatibility", not security. Excluding them keeps them
+            # from blocking PRs that comply with the encoding convention that
+            # tests/test_subprocess_text_encoding.py mandates (issue #4223).
+            #
+            # Full ids, not the family prefix. `--exclude-rule` matches an id
+            # exactly. This call site passed `python.lang.compatibility.python36`
+            # and suppressed nothing, so the comment above described an exclusion
+            # that was not happening. Measured on semgrep 1.175.0 against a local
+            # ruleset carrying these ids: the full id removed its finding, the
+            # family prefix left every finding in place.
+            # scripts/validation/git_hook_policy.py carries the same four ids for
+            # the pre-push scan; PR #5462 corrected that call site and missed
+            # this one. Refs #4725.
             "--exclude-rule",
-            "python.lang.compatibility.python36",
+            "python.lang.compatibility.python36.python36-compatibility-Popen1",
             "--exclude-rule",
-            "python.lang.compatibility.python37",
+            "python.lang.compatibility.python36.python36-compatibility-Popen2",
+            "--exclude-rule",
+            "python.lang.compatibility.python37.python37-compatibility-Popen1",
+            "--exclude-rule",
+            "python.lang.compatibility.python37.python37-compatibility-Popen2",
         ]
 
         if self.severity:
@@ -403,11 +412,7 @@ class SemgrepScanner:
             if result.returncode not in (0, 1):
                 context = _semgrep_failure_context(result.stdout, result.stderr)
                 logger.error("Semgrep execution error: %s", context)
-                return [
-                    _scan_failure_finding(
-                        f"Semgrep exited {result.returncode}: {context}"
-                    )
-                ]
+                return [_scan_failure_finding(f"Semgrep exited {result.returncode}: {context}")]
 
             if not result.stdout.strip():
                 logger.error("Semgrep produced no JSON output")
@@ -418,11 +423,7 @@ class SemgrepScanner:
             except json.JSONDecodeError as e:
                 context = _semgrep_failure_context(result.stdout, result.stderr)
                 logger.error("Semgrep JSON parse failed: %s; %s", e, context)
-                return [
-                    _scan_failure_finding(
-                        f"Semgrep JSON parse failed: {e}; {context}"
-                    )
-                ]
+                return [_scan_failure_finding(f"Semgrep JSON parse failed: {e}; {context}")]
             findings = []
 
             for finding in data.get("results", []):
@@ -456,9 +457,7 @@ class SemgrepScanner:
                 "Semgrep timed out after %ds; failing scan",
                 self.SCAN_TIMEOUT_SECONDS,
             )
-            raise SemgrepScanError(
-                f"Semgrep timed out after {self.SCAN_TIMEOUT_SECONDS}s"
-            ) from e
+            raise SemgrepScanError(f"Semgrep timed out after {self.SCAN_TIMEOUT_SECONDS}s") from e
         except (subprocess.SubprocessError, OSError) as e:
             # OSError is a sibling of subprocess.SubprocessError, not a
             # subclass, and it is what subprocess.run raises when the exec

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -105,6 +105,10 @@ ALLOWED_REPO_ROOT_ENTRIES = frozenset(
         ".mcp.json",
         ".python-version",
         ".qualityrc.json",
+        # semgrep discovers this by walking from the scan cwd up to the git
+        # root (ProjectConfig.load_all), so the repository root is the only
+        # place it is found for a scan rooted here. Refs #4725.
+        ".semgrepconfig.yml",
         ".serena",
         ".vscode",
         ".worktreeinclude",

--- a/tests/test_semgrepconfig.py
+++ b/tests/test_semgrepconfig.py
@@ -1,0 +1,194 @@
+"""The semgrep project config and the two in-repo rule-exclusion call sites (issue #4725).
+
+Hermetic: no network, no semgrep.dev, no SEMGREP_APP_TOKEN. The only semgrep
+code exercised is the config loader that ships in the pinned wheel, and the two
+argv builders, both of which are pure functions over their inputs once the
+executable resolution and the subprocess are stubbed.
+
+Two things are pinned here, and they are different in kind.
+
+The FILE is a record, not a control. `.semgrepconfig.yml` is read and uploaded
+by `semgrep ci`, but its schema cannot express a rule exclusion, so it can never
+turn the cloud check green. The tests below pin that ceiling so a later reader
+does not mistake the file for a rule-control surface and add a key that breaks
+the scan.
+
+The ARGV is a control, and it was broken. `--exclude-rule` matches an id
+exactly. `scripts/security/run_semgrep.py` passed the family prefix
+`python.lang.compatibility.python36` and suppressed nothing while its comment
+claimed otherwise. The argv tests below bond both call sites to the same four
+full ids so the two cannot drift again.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / ".semgrepconfig.yml"
+
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+
+# The four ids every in-repo exclusion must carry, in full. A family prefix
+# such as "python.lang.compatibility.python36" matches nothing.
+EXPECTED_RULE_IDS = frozenset(
+    {
+        "python.lang.compatibility.python36.python36-compatibility-Popen1",
+        "python.lang.compatibility.python36.python36-compatibility-Popen2",
+        "python.lang.compatibility.python37.python37-compatibility-Popen1",
+        "python.lang.compatibility.python37.python37-compatibility-Popen2",
+    }
+)
+
+
+def _exclude_rule_values(argv: list[str]) -> set[str]:
+    """Collect every value following an ``--exclude-rule`` flag in ``argv``."""
+    return {argv[i + 1] for i, token in enumerate(argv) if token == "--exclude-rule"}
+
+
+# --- the file is read by the loader the Platform path uses -------------------
+
+
+def test_the_config_parses_with_the_pinned_semgrep_loader() -> None:
+    """Valid YAML is not the bar. The bar is that ProjectConfig accepts it,
+    because that is the loader `semgrep ci` runs before uploading the file."""
+    project_config = pytest.importorskip("semgrep.app.project_config")
+
+    config = project_config.ProjectConfig.load_from_file(CONFIG_PATH)
+
+    assert config.version == "v1"
+    assert isinstance(config.tags, list)
+    assert config.tags, "the tag is the only thing this file can actually carry"
+
+
+def test_the_wire_payload_carries_version_and_tags_only() -> None:
+    """Pins the ceiling: this is everything the repository can ever send the
+    Platform, so the file cannot become a rule-control surface by accident."""
+    project_config = pytest.importorskip("semgrep.app.project_config")
+
+    config = project_config.ProjectConfig.load_from_file(CONFIG_PATH)
+
+    assert set(config.to_CiConfigFromRepo().to_json()) == {"version", "tags"}
+
+
+def test_an_unknown_key_is_fatal_rather_than_ignored(tmp_path: Path) -> None:
+    """Negative control for the two tests above, which would otherwise pass on
+    an empty file. An exclusion key does not degrade to a no-op: it fails the
+    whole scan, which is why the record lives in comments instead."""
+    project_config = pytest.importorskip("semgrep.app.project_config")
+    from semgrep.error import SemgrepError
+
+    stray = tmp_path / ".semgrepconfig.yml"
+    stray.write_text(
+        "version: v1\nexclude_rules:\n  - python.lang.compatibility.python36\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SemgrepError) as excinfo:
+        project_config.ProjectConfig.load_from_file(stray)
+
+    assert excinfo.value.code == 5
+
+
+def test_the_config_declares_no_key_beyond_the_supported_schema() -> None:
+    loaded = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    assert set(loaded) <= {"version", "tags"}
+
+
+def test_the_config_records_every_rule_id_the_platform_exception_must_cover() -> None:
+    """The file cannot exclude the rules, so its whole value is naming them."""
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+
+    missing = sorted(rule_id for rule_id in EXPECTED_RULE_IDS if rule_id not in text)
+
+    assert not missing, f"rule ids absent from the record: {missing}"
+
+
+# --- the argv exclusions, which are a real control ---------------------------
+
+
+def test_the_pre_push_hook_excludes_the_four_ids_in_full() -> None:
+    import git_hook_policy
+
+    excluded = _exclude_rule_values(git_hook_policy._semgrep_command("auto", []))
+
+    assert excluded == EXPECTED_RULE_IDS
+
+
+def test_the_security_scanner_excludes_the_four_ids_in_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression this branch fixes. This call site passed the family prefix
+    and suppressed nothing while its comment said it did."""
+    from scripts.security import run_semgrep
+
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        captured["cmd"] = list(cmd)
+        raise AssertionError("stop after argv capture")
+
+    # Build the scanner BEFORE patching: its constructor resolves the repo root
+    # through its own subprocess call, which the stub would otherwise swallow.
+    scanner = run_semgrep.SemgrepScanner()
+    monkeypatch.setattr(run_semgrep, "_resolve_semgrep_executable", lambda _root: "semgrep")
+    monkeypatch.setattr(run_semgrep.subprocess, "run", _fake_run)
+
+    with pytest.raises(AssertionError, match="stop after argv capture"):
+        scanner._run_semgrep([Path("scripts/validation/run_workflow_local_test.py")])
+
+    assert _exclude_rule_values(captured["cmd"]) == EXPECTED_RULE_IDS
+
+
+def test_neither_call_site_passes_a_bare_family_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prefix is the specific defect, so assert its absence directly rather
+    than relying on the equality checks above to imply it."""
+    import git_hook_policy
+
+    from scripts.security import run_semgrep
+
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        captured["cmd"] = list(cmd)
+        raise AssertionError("stop")
+
+    scanner = run_semgrep.SemgrepScanner()
+    monkeypatch.setattr(run_semgrep, "_resolve_semgrep_executable", lambda _root: "semgrep")
+    monkeypatch.setattr(run_semgrep.subprocess, "run", _fake_run)
+    with pytest.raises(AssertionError):
+        scanner._run_semgrep([Path("x.py")])
+
+    every_exclusion = _exclude_rule_values(captured["cmd"]) | _exclude_rule_values(
+        git_hook_policy._semgrep_command("auto", [])
+    )
+
+    prefixes = sorted(
+        value
+        for value in every_exclusion
+        if value.startswith("python.lang.compatibility.") and value not in EXPECTED_RULE_IDS
+    )
+
+    assert not prefixes, f"family prefixes suppress nothing: {prefixes}"
+
+
+# --- what deliberately does not exist ----------------------------------------
+
+
+@pytest.mark.parametrize("name", [".semgrepignore", ".semgrep.yml", ".semgrep.yaml", ".semgrep"])
+def test_no_blanket_exclusion_surface_is_introduced(name: str) -> None:
+    """A root `.semgrepignore` would silence every rule on whichever file it
+    lists, and it REPLACES semgrep's built-in default ignore list rather than
+    extending it, so it would newly pull tests/ and build/ into scan scope.
+    `.semgrep.yml` and `.semgrep/` make a bare `semgrep scan` abort since 1.38.0.
+    """
+    assert not (REPO_ROOT / name).exists()

--- a/tests/test_semgrepconfig.py
+++ b/tests/test_semgrepconfig.py
@@ -135,11 +135,13 @@ def test_the_security_scanner_excludes_the_four_ids_in_full(
         captured["cmd"] = list(cmd)
         raise AssertionError("stop after argv capture")
 
-    # Build the scanner BEFORE patching: its constructor resolves the repo root
-    # through its own subprocess call, which the stub would otherwise swallow.
-    scanner = run_semgrep.SemgrepScanner()
+    # The constructor resolves the repo root through a Git subprocess. Stub that
+    # lookup first so the test reads no live Git state and passes outside a
+    # worktree; then stub the executable resolution and the scan subprocess.
+    monkeypatch.setattr(run_semgrep, "get_repo_root", lambda: REPO_ROOT)
     monkeypatch.setattr(run_semgrep, "_resolve_semgrep_executable", lambda _root: "semgrep")
     monkeypatch.setattr(run_semgrep.subprocess, "run", _fake_run)
+    scanner = run_semgrep.SemgrepScanner()
 
     with pytest.raises(AssertionError, match="stop after argv capture"):
         scanner._run_semgrep([Path("scripts/validation/run_workflow_local_test.py")])
@@ -162,9 +164,10 @@ def test_neither_call_site_passes_a_bare_family_prefix(
         captured["cmd"] = list(cmd)
         raise AssertionError("stop")
 
-    scanner = run_semgrep.SemgrepScanner()
+    monkeypatch.setattr(run_semgrep, "get_repo_root", lambda: REPO_ROOT)
     monkeypatch.setattr(run_semgrep, "_resolve_semgrep_executable", lambda _root: "semgrep")
     monkeypatch.setattr(run_semgrep.subprocess, "run", _fake_run)
+    scanner = run_semgrep.SemgrepScanner()
     with pytest.raises(AssertionError):
         scanner._run_semgrep([Path("x.py")])
 

--- a/tests/test_semgrepconfig.py
+++ b/tests/test_semgrepconfig.py
@@ -97,6 +97,8 @@ def test_an_unknown_key_is_fatal_rather_than_ignored(tmp_path: Path) -> None:
 
 
 def test_the_config_declares_no_key_beyond_the_supported_schema() -> None:
+    """Guards the file itself rather than the loader: an added key is fatal at
+    scan time, so catch it here instead of on the next `semgrep ci` run."""
     loaded = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
 
     assert set(loaded) <= {"version", "tags"}
@@ -115,6 +117,8 @@ def test_the_config_records_every_rule_id_the_platform_exception_must_cover() ->
 
 
 def test_the_pre_push_hook_excludes_the_four_ids_in_full() -> None:
+    """The call site PR #5462 already corrected. Pinned here so the two sites
+    stay bonded to one id set rather than drifting apart again."""
     import git_hook_policy
 
     excluded = _exclude_rule_values(git_hook_policy._semgrep_command("auto", []))
@@ -132,6 +136,7 @@ def test_the_security_scanner_excludes_the_four_ids_in_full(
     captured: dict[str, list[str]] = {}
 
     def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        """Capture the argv and abort, so no semgrep process is ever spawned."""
         captured["cmd"] = list(cmd)
         raise AssertionError("stop after argv capture")
 
@@ -161,6 +166,7 @@ def test_neither_call_site_passes_a_bare_family_prefix(
     captured: dict[str, list[str]] = {}
 
     def _fake_run(cmd: list[str], **_kwargs: object) -> object:
+        """Capture the argv and abort, so no semgrep process is ever spawned."""
         captured["cmd"] = list(cmd)
         raise AssertionError("stop")
 


### PR DESCRIPTION
# Pull Request

## Summary

### What

Fixes an inert rule exclusion in `scripts/security/run_semgrep.py`, and adds `.semgrepconfig.yml` as the git-tracked record of which semgrep rules the Platform exception must cover.

### Why

Issue #4725: the python36 and python37 compatibility families fire on a repository whose `pyproject.toml` sets `requires-python = ">=3.14"`, so every one of their findings is a guaranteed false positive.

Two separate problems turned up, and this PR is explicit about which one it actually fixes.

**The defect it fixes.** `run_semgrep.py` passed the family prefixes `python.lang.compatibility.python36` and `.python37` to `--exclude-rule`. That flag matches an id exactly, so the exclusion suppressed nothing, while the comment directly above it claimed it kept those findings from blocking PRs. `git_hook_policy.py` carries the four full ids for the pre-push scan: PR #5462 corrected that call site and missed this one.

**The problem it does not fix.** `semgrep-cloud-platform/scan` stays red. No repository file can exclude a semgrep rule by id, so this cannot be closed from the tree. Detail below.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #4725 | semgrep python36 compatibility rules fire on a repository with a 3.14 floor |
| **Issue** | see #5462 | corrected the same prefix defect in the pre-push call site |

These references do not close their linked items: #4725 needs a Semgrep AppSec Platform dashboard action that no branch can perform.

## Changes

- `scripts/security/run_semgrep.py`: replaces the two family prefixes with the four full rule ids, and corrects the comment that described an exclusion which was not happening.
- `.semgrepconfig.yml` (new): the record of the four rule ids and the tag a Platform exception can be scoped to. Read and uploaded by `semgrep ci`; cannot exclude anything, and says so.
- `scripts/validation/git_hook_policy.py`: allowlists `.semgrepconfig.yml` as a repository-root entry.
- `tests/test_semgrepconfig.py` (new): 12 hermetic tests.

## Evidence

**The prefix suppresses nothing.** Measured on the pinned semgrep 1.175.0, against a local ruleset carrying those exact ids:

```
baseline                          Popen1, Popen2, control
--exclude-rule <full id>          Popen2, control          <- the finding is gone
--exclude-rule <family prefix>    Popen1, Popen2, control  <- nothing suppressed
```

**`.semgrepconfig.yml` is genuinely read, and genuinely cannot exclude a rule.** Both halves verified against the pinned wheel:

```
ProjectConfig.load_from_file(".semgrepconfig.yml")
  -> ProjectConfig(version='v1', tags=['python-314-floor'])
  -> wire payload {'version': 'v1', 'tags': ['python-314-floor']}

same loader, with an added exclude_rules key
  -> SemgrepError code=5: ProjectConfig.__init__() got an unexpected
     keyword argument 'exclude_rules'
```

`semgrep.app.project_config.ProjectConfig` declares exactly `version: str` and `tags: Optional[List[str]]` and builds itself with `cls(**loaded)`, so an unknown key is a fatal scan failure rather than a no-op. `semgrep ci` calls `load_all()` and uploads the result as `project_config`; rules travel the other direction, arriving as `scan_response.config.rules`. Nothing the repository uploads can subtract a rule.

## What this does not do, stated plainly

**It does not turn `semgrep-cloud-platform/scan` green.** Both python36 findings keep appearing on every PR whose diff touches `scripts/validation/run_workflow_local_test.py` until someone with Semgrep AppSec Platform access disables the four ids in the detection policy for `rjmurillo_personal_org`, or adds exceptions scoped to this project or to the `python-314-floor` tag. All four full ids must be enumerated; there is no glob or prefix form in the UI either. Semgrep documents that existing findings clear on the next scan rather than immediately.

The tag is optional indirection. Scoping the exception directly to the project works without it. What the tag buys is that the scope becomes reviewable in git instead of existing only as dashboard state.

**Deliberately not shipped: a root `.semgrepignore`.** It is the only repository file that could plausibly stop these findings, and it is a bad trade twice over. It is path-scoped, so it would blind the scan to every present and future rule on a 1,595-line validator that builds subprocess argv, injects env, and reads an `act` secrets file; `GOTCHAS.md:1252-1259` records that this same cloud check has already caught two genuine defects in this repository. And a root `.semgrepignore` replaces semgrep's built-in default ignore list rather than extending it, so it would newly pull `tests/` and `build/` into scan scope. Trading a visible red false positive for an invisible blind spot is worse than the status quo.

**Inline `# nosemgrep` was never an option.** `SECURITY_SUPPRESSION_RE` in `git_hook_policy.py` matches `nosem(?:grep)?\b` and is enforced at pre-commit and pre-push.

## Acceptance criteria

- [x] Both in-repo `--exclude-rule` call sites pass the four rule ids in full, never a family prefix
- [x] A test bonds the two call sites to the same id set so they cannot drift again
- [x] `.semgrepconfig.yml` parses with the loader `semgrep ci` actually uses
- [x] The wire payload is `version` and `tags` only, pinning the ceiling so the file cannot be mistaken for a rule-control surface
- [x] A negative control proves an exclusion key is fatal rather than ignored
- [x] No blanket path-exclusion surface is introduced

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether the `.semgrepconfig.yml` record earns its place given it changes no finding, and whether the `python-314-floor` tag is the scope you want the Platform exception keyed to.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

12 hermetic tests. No network, no `semgrep.dev`, no `SEMGREP_APP_TOKEN`.

**Negative controls.** The two argv tests fail against the pre-fix `run_semgrep.py`, naming the defect directly:

```
FAILED test_the_security_scanner_excludes_the_four_ids_in_full
FAILED test_neither_call_site_passes_a_bare_family_prefix
  AssertionError: family prefixes suppress nothing:
    ['python.lang.compatibility.python36', 'python.lang.compatibility.python37']
```

`test_an_unknown_key_is_fatal_rather_than_ignored` is the control for the two config-parsing tests, which would otherwise pass on an empty file.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

```
uv run pytest tests/test_semgrepconfig.py tests/test_run_semgrep.py \
              tests/test_run_semgrep_pinning.py -q     52 passed
uv run ruff check / ruff format                        clean
uv run mypy <changed files>                            Success: no issues found
uv run python scripts/validation/checks_ratchet.py     exit 0
uv run python scripts/validation/pre_pr.py             63 validations, 0 failed
```

`.semgrepconfig.yml` needs a root-hygiene allowlist entry because semgrep discovers it by walking from the scan cwd up to the git root. `test_root_hygiene_allowlist_matches_current_tracked_root` requires that entry and the file to land in the same commit, which they do.

An em dash and en dash scan over every changed file reports 0 occurrences.

## Related Issues

Refs #4725

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aMNFbxxoMCxiFty1ZDGLc


---
_Generated by [Claude Code](https://claude.ai/code/session_011aMNFbxxoMCxiFty1ZDGLc)_