### PR TITLE
feat(eval): Codex runtime profile and behavioral capability probers for #5423

### DIFF
--- a/scripts/eval/_capability_probes.py
+++ b/scripts/eval/_capability_probes.py
@@ -1,0 +1,469 @@
+"""Behavioral capability probers for the #5422 orchestration experiment.
+
+Step 2 of issue #5423. `_harness_capability` classifies evidence a caller
+supplies and makes zero subprocess calls; this module is that caller. It runs a
+harness CLI through an injected runner, reads the runtime's own event stream,
+and hands what it found to the existing classifiers. The split is deliberate:
+gathering lives here, classification stays there, and neither file grows a copy
+of the other's job.
+
+Nothing in this module has been executed against a real Codex or Copilot CLI.
+Step 3 of the issue (live runs, paid spend) is not authorized in the
+environment this was written in, so every path here is exercised only by
+injected fake runners and recorded output shapes. That is also why no function
+here writes to `examples/harness-capability-matrix.json`: every cell in the
+checked-in matrix stays UNVERIFIED until a live run produces evidence.
+
+Fail-closed rules, each of which can only ever refuse a claim:
+
+* `VERIFIED` is reachable only from `EvidenceKind.BACKEND`, and only through
+  `_harness_capability.classify_override` or the two presence gates below.
+* An override plan whose child request does not differ from the parent value
+  cannot be constructed. `classify_override` returns `UNVERIFIED` for equal
+  values, so such a plan is a probe that can never verify anything; building
+  one silently would waste a live run and read as a failed capability.
+* A harness with no in-tree backend parser observes `EvidenceKind.NONE`, never
+  a guess.
+* A missing CLI, a non-zero exit, and a timeout all resolve to `UNVERIFIED`.
+  Malformed or truncated output raises `HarnessCapabilityError` instead,
+  because a half-read stream is a broken contract rather than a negative
+  result.
+* `Sol Ultra` is a literal control value. Nothing here folds it onto `high`,
+  `xhigh`, `max`, or any other tier, and `_discriminates` is the only
+  comparison any value passes through.
+
+Authority boundary: provider, model, and pricing tables stay in
+`scripts/eval/_providers.py` and `scripts/eval/_eval_common.py`. This module
+reads runtime output and records what it observed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from _harness_capability import (
+    Capability,
+    CapabilityStatus,
+    EvidenceKind,
+    HarnessCapabilityError,
+    classify_override,
+)
+from _runtime_output import (
+    RuntimeOutputError,
+    copilot_result,
+    parse_events,
+    structured_tool_model,
+    traces,
+)
+
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+#: Capabilities this module can probe through `classify_override`.
+OVERRIDE_CAPABILITIES: tuple[str, ...] = ("model_override", "effort_override")
+
+#: The event type Copilot attaches a backend answer to. `copilot_result`
+#: reads the same type, and the model on it is attributable to the turn that
+#: produced the text.
+ASSISTANT_EVENT = "assistant.message"
+
+#: Session-state events the CLI emits about its own configuration. A value
+#: read from one of these is the client reporting what it set, not the backend
+#: reporting what it ran, so it is `CLIENT_ECHO` and can never verify.
+#: `session.model_change` with `data.newModel` and `data.reasoningEffort` is
+#: the shape recorded in `tests/eval/test_providers.py`, whose comment states
+#: it is modeled on a real log.
+SESSION_STATE_EVENTS: frozenset[str] = frozenset({"session.model_change", "session.start"})
+
+#: Keys an assistant turn might carry a resolved reasoning effort or tier on.
+#: Only `reasoningEffort` is attested in-tree, and only on a session-state
+#: event. The rest are candidates. A key that never matches yields
+#: `EvidenceKind.NONE`, so a wrong guess here withholds a claim rather than
+#: inventing one. A live run should replace this with the observed key.
+DEFAULT_EFFORT_KEYS: tuple[str, ...] = ("reasoningEffort", "reasoning_effort", "effort")
+
+#: Harnesses with an in-tree parser that attributes a model to a backend turn.
+#: Claude is absent on purpose: `_runtime_output.claude_result` reads the model
+#: off the `system`/`init` event, which the CLI emits before the backend has
+#: replied, so it cannot be told apart from the request echoed back. Codex is
+#: absent because no Codex output parser exists in this repository at all.
+BACKEND_MODEL_HARNESSES: frozenset[str] = frozenset({"copilot"})
+
+_START_HINTS: tuple[str, ...] = ("start", "begin", "launch", "spawn")
+_END_HINTS: tuple[str, ...] = ("complete", "end", "stop", "finish", "exit", "result")
+
+
+class ProbeError(HarnessCapabilityError):
+    """A probe could not be constructed or its output could not be trusted.
+
+    Subclasses `HarnessCapabilityError` so callers that already fail closed on
+    the capability-matrix contract keep doing so without a second except arm.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class OverridePlan:
+    """A model or effort override probe that can discriminate a real override.
+
+    `child_value` is guaranteed to differ from `parent_value`, so an observed
+    match means the override mechanism ran rather than the child inheriting.
+    Both values are the caller's verbatim strings; nothing normalizes them.
+    """
+
+    capability: str
+    harness: str
+    parent_value: str
+    child_value: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeCommand:
+    """One CLI invocation, built by the caller.
+
+    `argv` is supplied rather than built here because no Codex flag surface is
+    verified in this repository, and inventing one would put an unverified
+    contract in the tree. `eval_runtime_parity.build_argv` holds the Copilot
+    flag set that is attested.
+    """
+
+    harness: str
+    argv: tuple[str, ...]
+    cwd: Path | None = None
+    env: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeObservation:
+    """What the runtime's own output said, and how much that is worth."""
+
+    observed: str | None
+    evidence: EvidenceKind
+    detail: str
+
+
+def _discriminates(candidate: str, parent: str) -> bool:
+    """Report whether `candidate` can tell an honored override from an inherit.
+
+    Stricter than `classify_override`, which compares with `==`: a candidate
+    differing from the parent only by case or surrounding whitespace is
+    rejected here, because a harness that case-folds its own values would
+    report the parent's value back and look like a successful override.
+    Rejecting is the fail-closed direction; it withholds a probe rather than
+    accepting a weaker one.
+
+    This is not normalization of the values themselves. Neither string is
+    rewritten, mapped, or aliased, and `Sol Ultra` reaches `OverridePlan`
+    exactly as it was passed in.
+    """
+    return candidate.strip().casefold() != parent.strip().casefold()
+
+
+def build_override_plan(
+    *,
+    capability: str,
+    harness: str,
+    parent_value: str,
+    candidates: Sequence[str],
+) -> OverridePlan:
+    """Select a child request that differs from the parent, or fail closed.
+
+    Raises `ProbeError` when no candidate discriminates. That is the point of
+    the function: `classify_override` returns `UNVERIFIED` when the requested
+    value equals the parent's, so a plan built from an equal value is a probe
+    that spends a live run and can never verify anything. PR #5547 focus area 1
+    and the reopen comment on issue #5423 both name this trap, so it is made
+    unconstructible rather than merely documented.
+    """
+    if capability not in OVERRIDE_CAPABILITIES:
+        raise ProbeError(f"capability must be one of {OVERRIDE_CAPABILITIES}, got {capability!r}")
+    if not harness:
+        raise ProbeError("harness must be a non-empty string")
+    if not parent_value:
+        raise ProbeError(
+            "parent_value must be a non-empty string; an unknown parent cannot discriminate"
+        )
+    usable = [value for value in candidates if value and _discriminates(value, parent_value)]
+    if not usable:
+        raise ProbeError(
+            f"no candidate for {harness} {capability} differs from the parent value "
+            f"{parent_value!r}; an equal-value request cannot tell an honored override "
+            "from a silent inherit"
+        )
+    return OverridePlan(
+        capability=capability,
+        harness=harness,
+        parent_value=parent_value,
+        child_value=usable[0],
+    )
+
+
+def _capture_events(
+    command: ProbeCommand,
+    *,
+    runner: Runner,
+    timeout: float,
+) -> tuple[list[dict[str, object]] | None, str]:
+    """Run one probe and return its events, or a reason it produced none.
+
+    A missing CLI, a failed launch, a timeout, and a non-zero exit return
+    `(None, reason)` so the caller records `UNVERIFIED`. Malformed or empty
+    output raises, because output that cannot be parsed says nothing about the
+    capability and must not be read as a negative result either.
+    """
+    try:
+        run = runner(
+            list(command.argv),
+            cwd=command.cwd,
+            env=dict(command.env) if command.env is not None else None,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return None, f"{command.argv[0]} is not on PATH: {exc}"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"{command.harness} probe did not complete: {exc}"
+    if run.returncode != 0:
+        stderr = (run.stderr or "").strip()
+        return None, stderr or f"{command.harness} probe exited with code {run.returncode}"
+    try:
+        events = parse_events(run.stdout or "")
+    except RuntimeOutputError as exc:
+        raise ProbeError(f"{command.harness} probe output is malformed: {exc}") from exc
+    if not events:
+        raise ProbeError(
+            f"{command.harness} probe exited 0 with no events; the output is empty or truncated"
+        )
+    return events, ""
+
+
+def _assistant_values(
+    events: Sequence[Mapping[str, object]],
+    keys: Sequence[str],
+) -> str | None:
+    """Return the single value `keys` carries on a backend answer turn.
+
+    Requires non-empty text content on the same event, which is what makes the
+    turn an answer the backend produced rather than a status line. Two turns
+    disagreeing return `None`, mirroring `copilot_result`: a blended answer has
+    no single author, so no value earns the claim.
+    """
+    found: set[str] = set()
+    for event in events:
+        if event.get("type") != ASSISTANT_EVENT:
+            continue
+        data = event.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        content = data.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                found.add(value)
+                break
+    return found.pop() if len(found) == 1 else None
+
+
+def _session_state_value(
+    events: Sequence[Mapping[str, object]],
+    keys: Sequence[str],
+) -> str | None:
+    """Return a value the CLI reported about its own session configuration."""
+    for event in events:
+        kind = event.get("type")
+        if not isinstance(kind, str) or kind not in SESSION_STATE_EVENTS:
+            continue
+        data = event.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def observe_model(
+    harness: str,
+    events: Sequence[Mapping[str, object]],
+) -> ProbeObservation:
+    """Read the model the backend attributed to its own answer."""
+    if harness not in BACKEND_MODEL_HARNESSES:
+        return ProbeObservation(
+            None,
+            EvidenceKind.NONE,
+            f"no in-tree parser attributes a model to a backend turn for {harness}",
+        )
+    _, model = copilot_result(events)
+    if not model:
+        model = structured_tool_model(events)
+    if model:
+        return ProbeObservation(model, EvidenceKind.BACKEND, "model attributed to an answer turn")
+    echoed = _session_state_value(events, ("newModel", "selectedModel", "model"))
+    if echoed:
+        return ProbeObservation(
+            echoed,
+            EvidenceKind.CLIENT_ECHO,
+            "model came from a session-state event, which is the request echoed back",
+        )
+    return ProbeObservation(None, EvidenceKind.NONE, "no answer turn carried a model attribution")
+
+
+def observe_effort(
+    harness: str,
+    events: Sequence[Mapping[str, object]],
+    *,
+    effort_keys: Sequence[str] = DEFAULT_EFFORT_KEYS,
+) -> ProbeObservation:
+    """Read the reasoning effort or tier the backend attributed to its answer."""
+    observed = _assistant_values(events, effort_keys)
+    if observed:
+        return ProbeObservation(
+            observed, EvidenceKind.BACKEND, f"{harness} answer turn carried a resolved effort"
+        )
+    echoed = _session_state_value(events, effort_keys)
+    if echoed:
+        return ProbeObservation(
+            echoed,
+            EvidenceKind.CLIENT_ECHO,
+            "effort came from a session-state event, which is the request echoed back",
+        )
+    return ProbeObservation(None, EvidenceKind.NONE, f"no {harness} answer turn carried an effort")
+
+
+def probe_override(
+    plan: OverridePlan,
+    command: ProbeCommand,
+    *,
+    runner: Runner,
+    timeout: float,
+    effort_keys: Sequence[str] = DEFAULT_EFFORT_KEYS,
+) -> Capability:
+    """Run one override probe and classify it with the existing classifier.
+
+    Classification is not reimplemented here: the observed value, its evidence
+    kind, and the plan's parent value go straight to
+    `_harness_capability.classify_override`, which owns every rule that can
+    withhold `VERIFIED`.
+    """
+    events, failure = _capture_events(command, runner=runner, timeout=timeout)
+    if events is None:
+        return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
+    observation = (
+        observe_model(plan.harness, events)
+        if plan.capability == "model_override"
+        else observe_effort(plan.harness, events, effort_keys=effort_keys)
+    )
+    status = classify_override(
+        plan.child_value,
+        observation.observed,
+        observation.evidence,
+        parent_value=plan.parent_value,
+    )
+    return Capability(
+        status=status,
+        evidence=observation.evidence,
+        detail=(
+            f"requested {plan.child_value!r} against parent {plan.parent_value!r}; "
+            f"observed {observation.observed!r} ({observation.detail})"
+        ),
+    )
+
+
+def probe_subagent_support(
+    command: ProbeCommand,
+    *,
+    runner: Runner,
+    timeout: float,
+) -> Capability:
+    """Verify the harness actually launched a child, from its own event stream.
+
+    Presence, not a requested count: a run that asked for children and shows
+    none in its output is `UNVERIFIED`, which is the config-echo rule applied
+    to a different observable.
+    """
+    events, failure = _capture_events(command, runner=runner, timeout=timeout)
+    if events is None:
+        return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
+    _, subagents = traces(events)
+    if not subagents:
+        return Capability(
+            CapabilityStatus.UNVERIFIED,
+            EvidenceKind.NONE,
+            f"{command.harness} output carried no subagent events",
+        )
+    return Capability(
+        CapabilityStatus.VERIFIED,
+        EvidenceKind.BACKEND,
+        f"{command.harness} output carried {len(subagents)} subagent events",
+    )
+
+
+def max_concurrent_children(events: Sequence[Mapping[str, object]]) -> int | None:
+    """Return the peak number of children in flight at once, or `None`.
+
+    Derived by walking subagent start and completion boundaries in order, so
+    the result is what the runtime reported running, never what the probe
+    asked for. Returns `None` when no completion boundary appears: without
+    one, a run of N starts is indistinguishable from N sequential children,
+    and assuming they overlapped would report the requested number wearing the
+    observed number's label. Claude's `tool_use` blocks for `Agent` and `Task`
+    carry no boundary of either kind, so they resolve to `None` here.
+    """
+    depth = 0
+    peak = 0
+    saw_end = False
+    for event in events:
+        kind = event.get("type")
+        if not isinstance(kind, str) or "subagent" not in kind.lower():
+            continue
+        lowered = kind.lower()
+        if any(hint in lowered for hint in _END_HINTS):
+            depth = max(0, depth - 1)
+            saw_end = True
+        elif any(hint in lowered for hint in _START_HINTS):
+            depth += 1
+            peak = max(peak, depth)
+    if not saw_end or peak == 0:
+        return None
+    return peak
+
+
+def probe_concurrency(
+    command: ProbeCommand,
+    *,
+    requested: int,
+    runner: Runner,
+    timeout: float,
+) -> Capability:
+    """Measure the maximum children actually running at once.
+
+    `requested` is recorded in the detail text and never becomes the value.
+    A harness that was asked for four children and ran two records two.
+    """
+    if requested < 1:
+        raise ProbeError("requested concurrency must be at least 1")
+    events, failure = _capture_events(command, runner=runner, timeout=timeout)
+    if events is None:
+        return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
+    peak = max_concurrent_children(events)
+    if peak is None:
+        return Capability(
+            CapabilityStatus.UNVERIFIED,
+            EvidenceKind.NONE,
+            f"{command.harness} output has no paired subagent start and completion boundaries, "
+            f"so concurrency cannot be derived (requested {requested})",
+        )
+    return Capability(
+        CapabilityStatus.VERIFIED,
+        EvidenceKind.BACKEND,
+        f"{command.harness} ran at most {peak} children at once while {requested} were requested",
+        value=peak,
+    )

--- a/scripts/eval/_harness_capability.py
+++ b/scripts/eval/_harness_capability.py
@@ -232,19 +232,32 @@ def classify_override(
 ) -> CapabilityStatus:
     """Verify a requested model or effort was honored by the backend.
 
-    Enforces three negative controls at once:
+    Enforces four negative controls at once:
       * control 2: non-`BACKEND` evidence (an echo of the request or config)
         never verifies;
+      * an equal-value request (`requested == parent_value`) never verifies,
+        even when the backend reports that same value. This closes a gap
+        identified after PR #5547 shipped (issue #5423, reopened comment
+        2026-09-04): when a child asks for the value it would already have
+        inherited, an observed match is indistinguishable from the override
+        mechanism never running at all. Only a child request that *differs*
+        from the parent can discriminate "honored" from "silently
+        inherited", so callers driving a real probe must always vary the
+        child request from the parent's value;
       * control 3/5: an observed value that silently inherited `parent_value`
         while a different value was requested never verifies;
       * a backend value that simply does not equal the request never verifies.
 
     Returns `VERIFIED` only when the backend reported exactly the requested
-    value and did not fall back to the parent. Returns `UNVERIFIED` otherwise.
-    Callers that know the harness rejects a control outright record
-    `UNSUPPORTED` directly; this helper never invents `UNSUPPORTED`.
+    value, that value differed from the parent's (or there was no parent to
+    compare against), and it did not fall back to the parent. Returns
+    `UNVERIFIED` otherwise. Callers that know the harness rejects a control
+    outright record `UNSUPPORTED` directly; this helper never invents
+    `UNSUPPORTED`.
     """
     if evidence is not EvidenceKind.BACKEND:
+        return CapabilityStatus.UNVERIFIED
+    if parent_value is not None and requested == parent_value:
         return CapabilityStatus.UNVERIFIED
     if not observed:
         return CapabilityStatus.UNVERIFIED

--- a/scripts/eval/_runtime_parity.py
+++ b/scripts/eval/_runtime_parity.py
@@ -394,16 +394,13 @@ def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
         "SSL_CERT_FILE",
         "REQUESTS_CA_BUNDLE",
     }
-    # Codex's environment-variables reference documents `CODEX_API_KEY`
-    # ("Supplies an API key to non-interactive processes") and
-    # `CODEX_ACCESS_TOKEN` ("Furnishes access tokens for trusted automation")
-    # as its two non-interactive auth variables. Fetched and quoted directly
-    # from https://developers.openai.com/codex/environment-variables
-    # (redirects to https://learn.chatgpt.com/docs/config-file/environment-variables)
-    # on 2026-09-06. `OPENAI_API_KEY` is documented elsewhere only as a value
-    # piped into the interactive `codex login --with-api-key` command, not as
-    # an ambient variable Codex reads during a run, so it is deliberately
-    # excluded here.
+    # CODEX_API_KEY ("Supplies an API key to non-interactive processes") and
+    # CODEX_ACCESS_TOKEN ("Furnishes access tokens for trusted automation")
+    # are Codex's own non-interactive auth variables, quoted from
+    # https://developers.openai.com/codex/environment-variables, fetched
+    # 2026-09-06. OPENAI_API_KEY is documented elsewhere only as a value piped
+    # into the interactive `codex login --with-api-key` command, not as an
+    # ambient variable Codex reads at runtime, so it is excluded here.
     authentication = {
         "claude": {"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
         "copilot": {"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"},
@@ -430,12 +427,9 @@ def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
     else:
         # CODEX_HOME "Sets the root for Codex state, including config, auth,
         # logs, sessions, skills, and standalone package metadata," default
-        # ~/.codex. Quoted from
-        # https://developers.openai.com/codex/environment-variables
-        # (redirects to
-        # https://learn.chatgpt.com/docs/config-file/environment-variables),
-        # fetched 2026-09-06. Pointing it at the workspace profile isolates
-        # state the same way CLAUDE_CONFIG_DIR and COPILOT_HOME do.
+        # ~/.codex (same source as above, fetched 2026-09-06). Pointing it at
+        # the workspace profile isolates state the same way CLAUDE_CONFIG_DIR
+        # and COPILOT_HOME do.
         env["CODEX_HOME"] = str(profile)
     return env
 
@@ -452,12 +446,11 @@ def probe_version(
     argv = [executable, "--version"]
     if harness == "copilot":
         argv.insert(1, "--no-auto-update")
-    # Codex needs no equivalent flag here. Third-party CLI references describe
-    # `codex --version` as printing a single `codex-cli x.y.z` line with no
-    # login required, but the official reference page for that flag 404s as
-    # of 2026-09-06, so this is web-search evidence, not a fetched primary
-    # source; it is also the existing default for every harness other than
-    # copilot, so no behavior changes here regardless.
+    # Codex needs no equivalent flag: third-party references describe
+    # `codex --version` as a plain `codex-cli x.y.z` line needing no login
+    # (the official flag reference 404s as of 2026-09-06, so this is
+    # web-search evidence, not a fetched primary source). It is also already
+    # the default for every harness other than copilot.
     run = runner(
         argv,
         env=runtime_env(workspace, harness),

--- a/scripts/eval/_runtime_parity.py
+++ b/scripts/eval/_runtime_parity.py
@@ -362,7 +362,7 @@ def _profile_roots(profile: Path) -> dict[str, str]:
     Copilot's bootstrap reads LOCALAPPDATA, XDG_CACHE_HOME, and
     COPILOT_CACHE_HOME before COPILOT_HOME, so leaving the operator's values in
     place lets a run read or write cached packages and profile state outside
-    the workspace. Both harnesses get the same treatment.
+    the workspace. All harnesses get the same treatment.
     """
     home = profile / "home"
     roots = {
@@ -394,10 +394,24 @@ def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
         "SSL_CERT_FILE",
         "REQUESTS_CA_BUNDLE",
     }
+    # Codex's environment-variables reference documents `CODEX_API_KEY`
+    # ("Supplies an API key to non-interactive processes") and
+    # `CODEX_ACCESS_TOKEN` ("Furnishes access tokens for trusted automation")
+    # as its two non-interactive auth variables. Fetched and quoted directly
+    # from https://developers.openai.com/codex/environment-variables
+    # (redirects to https://learn.chatgpt.com/docs/config-file/environment-variables)
+    # on 2026-09-06. `OPENAI_API_KEY` is documented elsewhere only as a value
+    # piped into the interactive `codex login --with-api-key` command, not as
+    # an ambient variable Codex reads during a run, so it is deliberately
+    # excluded here.
     authentication = {
         "claude": {"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
         "copilot": {"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"},
+        "codex": {"CODEX_API_KEY", "CODEX_ACCESS_TOKEN"},
     }
+    # A harness outside this mapping raises KeyError here rather than falling
+    # through to the profile branch below, so that branch's final `else` is
+    # reachable only for "codex".
     allow.update(authentication[harness])
     env = {key: value for key, value in os.environ.items() if key in allow}
     runtime = workspace / ".runtime"
@@ -408,11 +422,21 @@ def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
     env.update(_profile_roots(profile))
     if harness == "claude":
         env["CLAUDE_CONFIG_DIR"] = str(profile)
-    else:
+    elif harness == "copilot":
         session_state = profile / "session-state"
         session_state.mkdir(exist_ok=True)
         env["COPILOT_HOME"] = str(profile)
         env["COPILOT_SESSION_STATE_DIR"] = str(session_state)
+    else:
+        # CODEX_HOME "Sets the root for Codex state, including config, auth,
+        # logs, sessions, skills, and standalone package metadata," default
+        # ~/.codex. Quoted from
+        # https://developers.openai.com/codex/environment-variables
+        # (redirects to
+        # https://learn.chatgpt.com/docs/config-file/environment-variables),
+        # fetched 2026-09-06. Pointing it at the workspace profile isolates
+        # state the same way CLAUDE_CONFIG_DIR and COPILOT_HOME do.
+        env["CODEX_HOME"] = str(profile)
     return env
 
 
@@ -428,6 +452,12 @@ def probe_version(
     argv = [executable, "--version"]
     if harness == "copilot":
         argv.insert(1, "--no-auto-update")
+    # Codex needs no equivalent flag here. Third-party CLI references describe
+    # `codex --version` as printing a single `codex-cli x.y.z` line with no
+    # login required, but the official reference page for that flag 404s as
+    # of 2026-09-06, so this is web-search evidence, not a fetched primary
+    # source; it is also the existing default for every harness other than
+    # copilot, so no behavior changes here regardless.
     run = runner(
         argv,
         env=runtime_env(workspace, harness),

--- a/scripts/eval/eval_harness_capability.py
+++ b/scripts/eval/eval_harness_capability.py
@@ -43,10 +43,13 @@ DEFAULT_MATRIX = Path(__file__).parent / "examples" / "harness-capability-matrix
 DEFAULT_TIMEOUT = 60.0
 
 # Only harnesses whose isolated profile `_runtime_parity.runtime_env` knows how
-# to build are probe-capable through the existing prober. Codex has no in-tree
-# runtime support (issue #5423 confirms the gap), so its version stays
-# UNVERIFIED rather than being fabricated here.
-PROBE_HARNESS: dict[str, str] = {"copilot": "copilot"}
+# to build are probe-capable through the existing prober. `_runtime_parity`
+# now has a codex branch (profile root, isolated env, version-probe argv), so
+# codex is wired in alongside copilot. Neither harness's *behavioral*
+# capabilities (model/effort override, subagent support, and so on) are
+# probed anywhere in this module: only the version string can move off
+# UNVERIFIED here, and only when the CLI is actually on PATH.
+PROBE_HARNESS: dict[str, str] = {"copilot": "copilot", "codex": "codex"}
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 

--- a/tests/eval/_capability_probe_fixtures.py
+++ b/tests/eval/_capability_probe_fixtures.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for the capability-probe tests (issue #5423 step 2).
+
+Recorded runtime output shapes and an injected fake runner. Nothing here
+reaches the network, PATH, or a real CLI. The runner dispatches on argv rather
+than call order, so a probe that stops issuing a command fails loudly instead
+of silently consuming the next entry in a positional list.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from tests.eval._harness_capability_test_support import capability, probes
+
+CapabilityStatus = capability.CapabilityStatus
+EvidenceKind = capability.EvidenceKind
+HarnessCapabilityError = capability.HarnessCapabilityError
+ProbeError = probes.ProbeError
+ProbeCommand = probes.ProbeCommand
+
+TIMEOUT = 5.0
+
+
+def _jsonl(events: Sequence[Mapping[str, object]]) -> str:
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
+def _answer(text: str, **data: object) -> dict[str, object]:
+    """One Copilot answer turn, the shape `copilot_result` already reads."""
+    return {"type": "assistant.message", "data": {"content": text, **data}}
+
+
+def _session_change(**data: object) -> dict[str, object]:
+    """A session-state event: the CLI reporting its own configuration."""
+    return {"type": "session.model_change", "data": dict(data)}
+
+
+def _runner(
+    stdout: str = "",
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+    raises: BaseException | None = None,
+    seen: list[list[str]] | None = None,
+):
+    """Build a fake runner that dispatches on argv rather than call order."""
+
+    def run(argv: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if seen is not None:
+            seen.append(list(argv))
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(list(argv), returncode, stdout, stderr)
+
+    return run
+
+
+def _command(harness: str = "copilot") -> probes.ProbeCommand:
+    return ProbeCommand(harness=harness, argv=(harness, "--prompt", "probe"))
+
+
+def _plan(
+    *,
+    capability_key: str = "model_override",
+    harness: str = "copilot",
+    parent: str = "claude-opus-5",
+    candidates: Sequence[str] = ("gpt-5.6-sol",),
+) -> probes.OverridePlan:
+    return probes.build_override_plan(
+        capability=capability_key,
+        harness=harness,
+        parent_value=parent,
+        candidates=candidates,
+    )
+
+

--- a/tests/eval/_harness_capability_test_support.py
+++ b/tests/eval/_harness_capability_test_support.py
@@ -15,6 +15,7 @@ _path_added = str(EVAL_DIR) not in sys.path
 if _path_added:
     sys.path.insert(0, str(EVAL_DIR))
 try:
+    import _capability_probes as probes
     import _harness_capability as capability
 
     _spec = importlib.util.spec_from_file_location("eval_harness_capability", CLI_SCRIPT)
@@ -26,4 +27,4 @@ finally:
     if _path_added:
         sys.path.remove(str(EVAL_DIR))
 
-__all__ = ["MATRIX", "capability", "cli"]
+__all__ = ["MATRIX", "capability", "cli", "probes"]

--- a/tests/eval/test_capability_probe_plans.py
+++ b/tests/eval/test_capability_probe_plans.py
@@ -1,0 +1,89 @@
+"""Tests for override probe-plan construction, issue #5423 step 2.
+
+A plan whose child request cannot differ from the parent value is a probe
+that spends a live run and can never verify anything: `classify_override`
+returns UNVERIFIED for equal values. These cases pin that such a plan is
+unconstructible, and that `Sol Ultra` survives construction unaliased.
+
+Discrimination. Twenty-one mutations were run against `_capability_probes.py`,
+each removing or weakening one guard, with `__pycache__` cleared between every
+mutation and its rerun. All twenty-one were killed, a behavior-preserving
+inverted control survived, and the restored file was byte-compared against the
+original. Every case marked NEGATIVE CONTROL below failed under at least one of
+those mutations and is named by it. Cases marked CONFIRMATORY survived all
+twenty-one, or failed only as collateral of a mutation aimed at a different
+case; they are labeled because they are not evidence that any guard works.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.eval._capability_probe_fixtures import (
+    HarnessCapabilityError,
+    ProbeError,
+    _plan,
+)
+
+
+def test_a_plan_selects_the_first_candidate_that_differs_from_the_parent() -> None:
+    """NEGATIVE CONTROL: an undiscriminating candidate must never be selected."""
+    plan = _plan(candidates=("claude-opus-5", "gpt-5.6-sol"))
+
+    assert plan.parent_value == "claude-opus-5"
+    assert plan.child_value == "gpt-5.6-sol"
+
+
+def test_an_equal_parent_and_child_value_cannot_produce_a_plan() -> None:
+    """NEGATIVE CONTROL: the equal-value probe that can never verify anything."""
+    with pytest.raises(ProbeError, match="cannot tell an honored override"):
+        _plan(candidates=("claude-opus-5",))
+
+
+def test_a_case_only_difference_cannot_produce_a_plan() -> None:
+    """NEGATIVE CONTROL: a case-folding harness would echo the parent back."""
+    with pytest.raises(ProbeError, match="cannot tell an honored override"):
+        _plan(parent="Sol Ultra", candidates=("sol ultra", "  SOL ULTRA  "))
+
+
+def test_sol_ultra_survives_plan_construction_unaliased() -> None:
+    """NEGATIVE CONTROL: Sol Ultra is a literal, never folded onto a tier."""
+    plan = _plan(
+        capability_key="effort_override",
+        parent="high",
+        candidates=("Sol Ultra",),
+    )
+
+    assert plan.child_value == "Sol Ultra"
+    assert plan.child_value not in {"high", "xhigh", "max"}
+
+
+def test_sol_ultra_as_the_parent_still_admits_a_genuinely_different_child() -> None:
+    """CONFIRMATORY: the guard rejects sameness, not the literal itself."""
+    plan = _plan(capability_key="effort_override", parent="Sol Ultra", candidates=("high",))
+
+    assert plan.parent_value == "Sol Ultra"
+    assert plan.child_value == "high"
+
+
+def test_a_plan_rejects_an_unknown_capability() -> None:
+    """NEGATIVE CONTROL: only capabilities classify_override covers are probeable."""
+    with pytest.raises(ProbeError, match="capability must be one of"):
+        _plan(capability_key="concurrency_limit")
+
+
+def test_a_plan_rejects_an_empty_parent_value() -> None:
+    """NEGATIVE CONTROL: an unknown parent cannot discriminate."""
+    with pytest.raises(ProbeError, match="parent_value must be"):
+        _plan(parent="")
+
+
+def test_a_plan_rejects_an_empty_harness() -> None:
+    """NEGATIVE CONTROL: an unnamed harness cannot be recorded against."""
+    with pytest.raises(ProbeError, match="harness must be"):
+        _plan(harness="")
+
+
+def test_a_plan_error_is_a_harness_capability_error() -> None:
+    """CONFIRMATORY: callers keep one fail-closed except arm."""
+    assert issubclass(ProbeError, HarnessCapabilityError)

--- a/tests/eval/test_capability_probes.py
+++ b/tests/eval/test_capability_probes.py
@@ -1,0 +1,531 @@
+"""Tests for the behavioral capability probers, issue #5423 step 2.
+
+Every case here is deterministic: an injected fake runner returns recorded
+runtime output, and no test touches the network, PATH, or a real CLI. No test
+writes to `scripts/eval/examples/harness-capability-matrix.json`; the honesty
+of that file is pinned by `test_harness_capability.py`.
+
+Discrimination. Twenty-one mutations were run against `_capability_probes.py`,
+each removing or weakening one guard, with `__pycache__` cleared between every
+mutation and its rerun. All twenty-one were killed, a behavior-preserving
+inverted control survived, and the restored file was byte-compared against the
+original. Every case marked NEGATIVE CONTROL below failed under at least one of
+those mutations and is named by it.
+
+The nine cases marked CONFIRMATORY survived all twenty-one, or failed only as
+collateral of a mutation aimed at a different case. They exercise a happy path,
+or a path whose behavior belongs entirely to `_runtime_output`. They are here
+because a reachable VERIFIED path is what gives the negative controls something
+to be negative about, and they are labeled because they are not evidence that
+any guard in this module works.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pytest
+
+from tests.eval._harness_capability_test_support import capability, probes
+
+CapabilityStatus = capability.CapabilityStatus
+EvidenceKind = capability.EvidenceKind
+HarnessCapabilityError = capability.HarnessCapabilityError
+ProbeError = probes.ProbeError
+ProbeCommand = probes.ProbeCommand
+
+TIMEOUT = 5.0
+
+
+def _jsonl(events: Sequence[Mapping[str, object]]) -> str:
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
+def _answer(text: str, **data: object) -> dict[str, object]:
+    """One Copilot answer turn, the shape `copilot_result` already reads."""
+    return {"type": "assistant.message", "data": {"content": text, **data}}
+
+
+def _session_change(**data: object) -> dict[str, object]:
+    """A session-state event: the CLI reporting its own configuration."""
+    return {"type": "session.model_change", "data": dict(data)}
+
+
+def _runner(
+    stdout: str = "",
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+    raises: BaseException | None = None,
+    seen: list[list[str]] | None = None,
+):
+    """Build a fake runner that dispatches on argv rather than call order."""
+
+    def run(argv: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if seen is not None:
+            seen.append(list(argv))
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(list(argv), returncode, stdout, stderr)
+
+    return run
+
+
+def _command(harness: str = "copilot") -> probes.ProbeCommand:
+    return ProbeCommand(harness=harness, argv=(harness, "--prompt", "probe"))
+
+
+def _plan(
+    *,
+    capability_key: str = "model_override",
+    harness: str = "copilot",
+    parent: str = "claude-opus-5",
+    candidates: Sequence[str] = ("gpt-5.6-sol",),
+) -> probes.OverridePlan:
+    return probes.build_override_plan(
+        capability=capability_key,
+        harness=harness,
+        parent_value=parent,
+        candidates=candidates,
+    )
+
+
+# --- Plan construction ---------------------------------------------------------
+
+
+def test_a_plan_selects_the_first_candidate_that_differs_from_the_parent() -> None:
+    """NEGATIVE CONTROL: an undiscriminating candidate must never be selected."""
+    plan = _plan(candidates=("claude-opus-5", "gpt-5.6-sol"))
+
+    assert plan.parent_value == "claude-opus-5"
+    assert plan.child_value == "gpt-5.6-sol"
+
+
+def test_an_equal_parent_and_child_value_cannot_produce_a_plan() -> None:
+    """NEGATIVE CONTROL: the equal-value probe that can never verify anything."""
+    with pytest.raises(ProbeError, match="cannot tell an honored override"):
+        _plan(candidates=("claude-opus-5",))
+
+
+def test_a_case_only_difference_cannot_produce_a_plan() -> None:
+    """NEGATIVE CONTROL: a case-folding harness would echo the parent back."""
+    with pytest.raises(ProbeError, match="cannot tell an honored override"):
+        _plan(parent="Sol Ultra", candidates=("sol ultra", "  SOL ULTRA  "))
+
+
+def test_sol_ultra_survives_plan_construction_unaliased() -> None:
+    """NEGATIVE CONTROL: Sol Ultra is a literal, never folded onto a tier."""
+    plan = _plan(
+        capability_key="effort_override",
+        parent="high",
+        candidates=("Sol Ultra",),
+    )
+
+    assert plan.child_value == "Sol Ultra"
+    assert plan.child_value not in {"high", "xhigh", "max"}
+
+
+def test_sol_ultra_as_the_parent_still_admits_a_genuinely_different_child() -> None:
+    """CONFIRMATORY: the guard rejects sameness, not the literal itself."""
+    plan = _plan(capability_key="effort_override", parent="Sol Ultra", candidates=("high",))
+
+    assert plan.parent_value == "Sol Ultra"
+    assert plan.child_value == "high"
+
+
+def test_a_plan_rejects_an_unknown_capability() -> None:
+    """NEGATIVE CONTROL: only capabilities classify_override covers are probeable."""
+    with pytest.raises(ProbeError, match="capability must be one of"):
+        _plan(capability_key="concurrency_limit")
+
+
+def test_a_plan_rejects_an_empty_parent_value() -> None:
+    """NEGATIVE CONTROL: an unknown parent cannot discriminate."""
+    with pytest.raises(ProbeError, match="parent_value must be"):
+        _plan(parent="")
+
+
+def test_a_plan_rejects_an_empty_harness() -> None:
+    """NEGATIVE CONTROL: an unnamed harness cannot be recorded against."""
+    with pytest.raises(ProbeError, match="harness must be"):
+        _plan(harness="")
+
+
+def test_a_plan_error_is_a_harness_capability_error() -> None:
+    """CONFIRMATORY: callers keep one fail-closed except arm."""
+    assert issubclass(ProbeError, HarnessCapabilityError)
+
+
+# --- Model override probe ------------------------------------------------------
+
+
+def test_a_backend_attributed_model_verifies_the_override() -> None:
+    """CONFIRMATORY: the only path that may reach VERIFIED."""
+    stdout = _jsonl([_session_change(newModel="gpt-5.6-sol"), _answer("hi", model="gpt-5.6-sol")])
+
+    result = probes.probe_override(
+        _plan(), _command(), runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+    assert result.evidence is EvidenceKind.BACKEND
+
+
+def test_an_echo_only_output_never_verifies_the_override() -> None:
+    """NEGATIVE CONTROL: client and schema echo is not backend evidence."""
+    stdout = _jsonl([_session_change(newModel="gpt-5.6-sol"), _answer("hi")])
+
+    result = probes.probe_override(
+        _plan(), _command(), runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.CLIENT_ECHO
+
+
+def test_a_child_that_silently_inherits_the_parent_never_verifies() -> None:
+    """NEGATIVE CONTROL: an inherit is not an honored override."""
+    stdout = _jsonl([_answer("hi", model="claude-opus-5")])
+
+    result = probes.probe_override(
+        _plan(), _command(), runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert "claude-opus-5" in result.detail
+
+
+def test_a_hand_built_plan_with_an_equal_child_value_still_cannot_verify() -> None:
+    """NEGATIVE CONTROL: the parent value reaches classify_override, not only the builder.
+
+    `OverridePlan` is a public dataclass, so a caller can skip
+    `build_override_plan`. Without the parent value forwarded, an equal-value
+    plan whose backend echoes that value would read as a verified override.
+    """
+    plan = probes.OverridePlan(
+        capability="model_override",
+        harness="copilot",
+        parent_value="gpt-5.6-sol",
+        child_value="gpt-5.6-sol",
+    )
+    stdout = _jsonl([_answer("hi", model="gpt-5.6-sol")])
+
+    result = probes.probe_override(plan, _command(), runner=_runner(stdout), timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+
+
+def test_two_answer_turns_naming_different_models_verify_nothing() -> None:
+    """NEGATIVE CONTROL: a blended answer has no single author."""
+    stdout = _jsonl(
+        [_answer("first", model="gpt-5.6-sol"), _answer("second", model="claude-opus-5")]
+    )
+
+    result = probes.probe_override(
+        _plan(), _command(), runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+
+
+def test_a_harness_with_no_backend_model_parser_verifies_nothing() -> None:
+    """NEGATIVE CONTROL: codex has no in-tree output parser, so it observes nothing."""
+    stdout = _jsonl([_answer("hi", model="sol-medium")])
+
+    result = probes.probe_override(
+        _plan(harness="codex", parent="sol-low", candidates=("sol-medium",)),
+        _command("codex"),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+    assert "no in-tree parser" in result.detail
+
+
+def test_claude_init_model_is_not_treated_as_backend_evidence() -> None:
+    """NEGATIVE CONTROL: the init event precedes any backend turn."""
+    stdout = _jsonl(
+        [
+            {"type": "system", "subtype": "init", "model": "claude-opus-5"},
+            {"type": "result", "result": "hi"},
+        ]
+    )
+
+    result = probes.probe_override(
+        _plan(harness="claude", parent="claude-sonnet-5", candidates=("claude-opus-5",)),
+        _command("claude"),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+
+
+def test_the_probe_passes_the_command_argv_through_verbatim() -> None:
+    """CONFIRMATORY: pins the injected-runner seam."""
+    seen: list[list[str]] = []
+    stdout = _jsonl([_answer("hi", model="gpt-5.6-sol")])
+
+    probes.probe_override(
+        _plan(), _command(), runner=_runner(stdout, seen=seen), timeout=TIMEOUT
+    )
+
+    assert seen == [["copilot", "--prompt", "probe"]]
+
+
+# --- Effort override probe -----------------------------------------------------
+
+
+def test_an_effort_on_an_answer_turn_verifies_the_override() -> None:
+    """CONFIRMATORY: happy path for the effort observable."""
+    stdout = _jsonl([_answer("hi", reasoningEffort="Sol Ultra")])
+
+    result = probes.probe_override(
+        _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
+        _command(),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+    assert result.evidence is EvidenceKind.BACKEND
+    assert "'Sol Ultra'" in result.detail
+
+
+def test_an_effort_read_from_session_state_never_verifies() -> None:
+    """NEGATIVE CONTROL: session state is the request echoed back."""
+    stdout = _jsonl([_session_change(reasoningEffort="Sol Ultra"), _answer("hi")])
+
+    result = probes.probe_override(
+        _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
+        _command(),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.CLIENT_ECHO
+
+
+def test_an_effort_on_a_contentless_turn_is_not_backend_evidence() -> None:
+    """NEGATIVE CONTROL: a status line is not an answer the backend produced."""
+    stdout = _jsonl([{"type": "assistant.message", "data": {"reasoningEffort": "Sol Ultra"}}])
+
+    result = probes.probe_override(
+        _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
+        _command(),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+
+
+def test_an_effort_key_outside_the_configured_set_observes_nothing() -> None:
+    """NEGATIVE CONTROL: the key set is a bounded allowlist, not a scan."""
+    stdout = _jsonl([_answer("hi", tier="Sol Ultra")])
+
+    result = probes.probe_override(
+        _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
+        _command(),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+    )
+
+    assert result.evidence is EvidenceKind.NONE
+
+
+def test_a_caller_supplied_effort_key_is_honored() -> None:
+    """CONFIRMATORY: a live run can name the real key without a code change."""
+    stdout = _jsonl([_answer("hi", tier="Sol Ultra")])
+
+    result = probes.probe_override(
+        _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
+        _command(),
+        runner=_runner(stdout),
+        timeout=TIMEOUT,
+        effort_keys=("tier",),
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+
+
+# --- Process-level failures ----------------------------------------------------
+
+
+def test_a_missing_cli_yields_unverified_without_crashing() -> None:
+    """NEGATIVE CONTROL: an absent PATH entry is a withheld claim, not a traceback."""
+    runner = _runner(raises=FileNotFoundError(2, "No such file or directory", "copilot"))
+
+    result = probes.probe_override(_plan(), _command(), runner=runner, timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert "is not on PATH" in result.detail
+
+
+def test_a_timed_out_probe_yields_unverified() -> None:
+    """NEGATIVE CONTROL: a killed run proves nothing about the capability."""
+    runner = _runner(raises=subprocess.TimeoutExpired(cmd="copilot", timeout=TIMEOUT))
+
+    result = probes.probe_override(_plan(), _command(), runner=runner, timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert "did not complete" in result.detail
+
+
+def test_a_nonzero_exit_yields_unverified_and_records_stderr() -> None:
+    """NEGATIVE CONTROL: a failed run is not a negative capability result."""
+    runner = _runner("", returncode=1, stderr="not logged in")
+
+    result = probes.probe_override(_plan(), _command(), runner=runner, timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.detail == "not logged in"
+
+
+def test_malformed_runtime_output_fails_closed_rather_than_degrading() -> None:
+    """NEGATIVE CONTROL: unparseable output raises, it does not become UNVERIFIED."""
+    runner = _runner('{"type": "assistant.message"\n')
+
+    with pytest.raises(HarnessCapabilityError, match="output is malformed"):
+        probes.probe_override(_plan(), _command(), runner=runner, timeout=TIMEOUT)
+
+
+def test_truncated_runtime_output_fails_closed() -> None:
+    """NEGATIVE CONTROL: exit 0 with no events is a broken contract."""
+    runner = _runner("   \n")
+
+    with pytest.raises(HarnessCapabilityError, match="empty or truncated"):
+        probes.probe_override(_plan(), _command(), runner=runner, timeout=TIMEOUT)
+
+
+# --- Subagent support ----------------------------------------------------------
+
+
+def test_subagent_events_in_the_stream_verify_support() -> None:
+    """CONFIRMATORY: happy path; the observable comes from `traces`."""
+    stdout = _jsonl(
+        [{"type": "subagent.start", "data": {}}, {"type": "subagent.complete", "data": {}}]
+    )
+
+    result = probes.probe_subagent_support(_command(), runner=_runner(stdout), timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.VERIFIED
+    assert result.evidence is EvidenceKind.BACKEND
+
+
+def test_a_run_with_no_subagent_events_does_not_verify_support() -> None:
+    """NEGATIVE CONTROL: asking for children is not observing them."""
+    stdout = _jsonl([_answer("hi", model="gpt-5.6-sol")])
+
+    result = probes.probe_subagent_support(_command(), runner=_runner(stdout), timeout=TIMEOUT)
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+
+
+def test_a_missing_cli_does_not_crash_the_subagent_probe() -> None:
+    """NEGATIVE CONTROL: same fail-closed path on a different prober."""
+    runner = _runner(raises=FileNotFoundError(2, "No such file or directory", "codex"))
+
+    result = probes.probe_subagent_support(
+        _command("codex"), runner=runner, timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+
+
+# --- Concurrency ---------------------------------------------------------------
+
+
+def test_concurrency_records_the_observed_peak_not_the_requested_count() -> None:
+    """NEGATIVE CONTROL: the config-echo failure applied to a count."""
+    stdout = _jsonl(
+        [
+            {"type": "subagent.start", "data": {"id": "a"}},
+            {"type": "subagent.start", "data": {"id": "b"}},
+            {"type": "subagent.complete", "data": {"id": "a"}},
+            {"type": "subagent.complete", "data": {"id": "b"}},
+            {"type": "subagent.start", "data": {"id": "c"}},
+            {"type": "subagent.complete", "data": {"id": "c"}},
+        ]
+    )
+
+    result = probes.probe_concurrency(
+        _command(), requested=4, runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+    assert result.value == 2
+    assert result.value != 4
+
+
+def test_starts_with_no_completion_boundary_cannot_derive_concurrency() -> None:
+    """NEGATIVE CONTROL: N starts without ends is N sequential children too."""
+    stdout = _jsonl(
+        [{"type": "subagent.start", "data": {"id": str(index)}} for index in range(4)]
+    )
+
+    result = probes.probe_concurrency(
+        _command(), requested=4, runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.value is None
+
+
+def test_claude_agent_tool_blocks_carry_no_concurrency_boundary() -> None:
+    """CONFIRMATORY: no mutation of this module changes the result; `traces` owns it."""
+    events = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Task", "input": {}},
+                    {"type": "tool_use", "name": "Task", "input": {}},
+                ]
+            },
+        }
+    ]
+
+    assert probes.max_concurrent_children(events) is None
+
+
+def test_a_sequential_run_records_a_peak_of_one() -> None:
+    """CONFIRMATORY: pins the walk, which is arithmetic over the boundaries."""
+    events = [
+        {"type": "subagent.start"},
+        {"type": "subagent.complete"},
+        {"type": "subagent.start"},
+        {"type": "subagent.complete"},
+    ]
+
+    assert probes.max_concurrent_children(events) == 1
+
+
+def test_concurrency_rejects_a_requested_count_below_one() -> None:
+    """NEGATIVE CONTROL: a probe that asks for no children measures nothing."""
+    with pytest.raises(ProbeError, match="at least 1"):
+        probes.probe_concurrency(
+            _command(), requested=0, runner=_runner(""), timeout=TIMEOUT
+        )
+
+
+def test_a_missing_cli_does_not_crash_the_concurrency_probe() -> None:
+    """NEGATIVE CONTROL: same fail-closed path on the third prober."""
+    runner = _runner(raises=FileNotFoundError(2, "No such file or directory", "copilot"))
+
+    result = probes.probe_concurrency(
+        _command(), requested=2, runner=runner, timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.value is None

--- a/tests/eval/test_capability_probes.py
+++ b/tests/eval/test_capability_probes.py
@@ -1,163 +1,41 @@
-"""Tests for the behavioral capability probers, issue #5423 step 2.
+"""Tests for capability probe execution, issue #5423 step 2.
 
-Every case here is deterministic: an injected fake runner returns recorded
-runtime output, and no test touches the network, PATH, or a real CLI. No test
-writes to `scripts/eval/examples/harness-capability-matrix.json`; the honesty
-of that file is pinned by `test_harness_capability.py`.
+Deterministic cases over an injected fake runner and recorded runtime
+output. No network, no PATH lookup, no real CLI. No test writes to
+`scripts/eval/examples/harness-capability-matrix.json`; the honesty of that
+file is pinned by `test_harness_capability.py`. Plan construction is
+covered by `test_capability_probe_plans.py`.
 
 Discrimination. Twenty-one mutations were run against `_capability_probes.py`,
 each removing or weakening one guard, with `__pycache__` cleared between every
 mutation and its rerun. All twenty-one were killed, a behavior-preserving
 inverted control survived, and the restored file was byte-compared against the
 original. Every case marked NEGATIVE CONTROL below failed under at least one of
-those mutations and is named by it.
-
-The nine cases marked CONFIRMATORY survived all twenty-one, or failed only as
-collateral of a mutation aimed at a different case. They exercise a happy path,
-or a path whose behavior belongs entirely to `_runtime_output`. They are here
-because a reachable VERIFIED path is what gives the negative controls something
-to be negative about, and they are labeled because they are not evidence that
-any guard in this module works.
+those mutations and is named by it. Cases marked CONFIRMATORY survived all
+twenty-one, or failed only as collateral of a mutation aimed at a different
+case; they are labeled because they are not evidence that any guard works.
 """
 
 from __future__ import annotations
 
-import json
 import subprocess
-from collections.abc import Mapping, Sequence
-from typing import Any
 
 import pytest
 
-from tests.eval._harness_capability_test_support import capability, probes
-
-CapabilityStatus = capability.CapabilityStatus
-EvidenceKind = capability.EvidenceKind
-HarnessCapabilityError = capability.HarnessCapabilityError
-ProbeError = probes.ProbeError
-ProbeCommand = probes.ProbeCommand
-
-TIMEOUT = 5.0
-
-
-def _jsonl(events: Sequence[Mapping[str, object]]) -> str:
-    return "\n".join(json.dumps(event) for event in events) + "\n"
-
-
-def _answer(text: str, **data: object) -> dict[str, object]:
-    """One Copilot answer turn, the shape `copilot_result` already reads."""
-    return {"type": "assistant.message", "data": {"content": text, **data}}
-
-
-def _session_change(**data: object) -> dict[str, object]:
-    """A session-state event: the CLI reporting its own configuration."""
-    return {"type": "session.model_change", "data": dict(data)}
-
-
-def _runner(
-    stdout: str = "",
-    *,
-    returncode: int = 0,
-    stderr: str = "",
-    raises: BaseException | None = None,
-    seen: list[list[str]] | None = None,
-):
-    """Build a fake runner that dispatches on argv rather than call order."""
-
-    def run(argv: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        if seen is not None:
-            seen.append(list(argv))
-        if raises is not None:
-            raise raises
-        return subprocess.CompletedProcess(list(argv), returncode, stdout, stderr)
-
-    return run
-
-
-def _command(harness: str = "copilot") -> probes.ProbeCommand:
-    return ProbeCommand(harness=harness, argv=(harness, "--prompt", "probe"))
-
-
-def _plan(
-    *,
-    capability_key: str = "model_override",
-    harness: str = "copilot",
-    parent: str = "claude-opus-5",
-    candidates: Sequence[str] = ("gpt-5.6-sol",),
-) -> probes.OverridePlan:
-    return probes.build_override_plan(
-        capability=capability_key,
-        harness=harness,
-        parent_value=parent,
-        candidates=candidates,
-    )
-
-
-# --- Plan construction ---------------------------------------------------------
-
-
-def test_a_plan_selects_the_first_candidate_that_differs_from_the_parent() -> None:
-    """NEGATIVE CONTROL: an undiscriminating candidate must never be selected."""
-    plan = _plan(candidates=("claude-opus-5", "gpt-5.6-sol"))
-
-    assert plan.parent_value == "claude-opus-5"
-    assert plan.child_value == "gpt-5.6-sol"
-
-
-def test_an_equal_parent_and_child_value_cannot_produce_a_plan() -> None:
-    """NEGATIVE CONTROL: the equal-value probe that can never verify anything."""
-    with pytest.raises(ProbeError, match="cannot tell an honored override"):
-        _plan(candidates=("claude-opus-5",))
-
-
-def test_a_case_only_difference_cannot_produce_a_plan() -> None:
-    """NEGATIVE CONTROL: a case-folding harness would echo the parent back."""
-    with pytest.raises(ProbeError, match="cannot tell an honored override"):
-        _plan(parent="Sol Ultra", candidates=("sol ultra", "  SOL ULTRA  "))
-
-
-def test_sol_ultra_survives_plan_construction_unaliased() -> None:
-    """NEGATIVE CONTROL: Sol Ultra is a literal, never folded onto a tier."""
-    plan = _plan(
-        capability_key="effort_override",
-        parent="high",
-        candidates=("Sol Ultra",),
-    )
-
-    assert plan.child_value == "Sol Ultra"
-    assert plan.child_value not in {"high", "xhigh", "max"}
-
-
-def test_sol_ultra_as_the_parent_still_admits_a_genuinely_different_child() -> None:
-    """CONFIRMATORY: the guard rejects sameness, not the literal itself."""
-    plan = _plan(capability_key="effort_override", parent="Sol Ultra", candidates=("high",))
-
-    assert plan.parent_value == "Sol Ultra"
-    assert plan.child_value == "high"
-
-
-def test_a_plan_rejects_an_unknown_capability() -> None:
-    """NEGATIVE CONTROL: only capabilities classify_override covers are probeable."""
-    with pytest.raises(ProbeError, match="capability must be one of"):
-        _plan(capability_key="concurrency_limit")
-
-
-def test_a_plan_rejects_an_empty_parent_value() -> None:
-    """NEGATIVE CONTROL: an unknown parent cannot discriminate."""
-    with pytest.raises(ProbeError, match="parent_value must be"):
-        _plan(parent="")
-
-
-def test_a_plan_rejects_an_empty_harness() -> None:
-    """NEGATIVE CONTROL: an unnamed harness cannot be recorded against."""
-    with pytest.raises(ProbeError, match="harness must be"):
-        _plan(harness="")
-
-
-def test_a_plan_error_is_a_harness_capability_error() -> None:
-    """CONFIRMATORY: callers keep one fail-closed except arm."""
-    assert issubclass(ProbeError, HarnessCapabilityError)
-
+from tests.eval._capability_probe_fixtures import (
+    TIMEOUT,
+    CapabilityStatus,
+    EvidenceKind,
+    HarnessCapabilityError,
+    ProbeError,
+    _answer,
+    _command,
+    _jsonl,
+    _plan,
+    _runner,
+    _session_change,
+)
+from tests.eval._harness_capability_test_support import probes
 
 # --- Model override probe ------------------------------------------------------
 

--- a/tests/eval/test_harness_capability.py
+++ b/tests/eval/test_harness_capability.py
@@ -369,7 +369,8 @@ def test_cli_live_probe_fills_copilot_version(tmp_path: Path, monkeypatch) -> No
     by_harness = {row["harness"]: row for row in report["harnesses"]}
     assert by_harness["copilot"]["version"] == "copilot 9.9.9"
     assert by_harness["copilot"]["version_evidence"] == "backend"
-    # Codex is not probe-capable and stays UNVERIFIED.
+    # Codex is probe-capable (see PROBE_HARNESS) but absent from PATH in this
+    # fake, so it stays UNVERIFIED rather than being fabricated.
     assert by_harness["codex"]["version"] == ""
     assert by_harness["codex"]["version_evidence"] == "none"
 

--- a/tests/eval/test_harness_capability_codex_probe.py
+++ b/tests/eval/test_harness_capability_codex_probe.py
@@ -1,0 +1,127 @@
+"""Codex wiring coverage for the capability-matrix CLI (issue #5423 reopen).
+
+Before this change `PROBE_HARNESS` had no "codex" key, so `_augment_versions`
+never attempted a codex probe at all, regardless of whether the CLI was on
+PATH or what `shutil.which` returned. `test_cli_live_probe_fills_codex_version`
+and `test_cli_probe_failure_still_attempts_codex` assert on `runner.calls` to
+prove a probe was actually attempted; both failed on pre-fix code because that
+list never contained a codex call. The other two tests describe required
+behavior (never crash, never a silent pass) that already held before this
+change by omission, so they pass on both pre-fix and post-fix code; they guard
+against a future regression rather than proving this one.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from tests.eval._harness_capability_test_support import capability, cli
+
+
+class _MultiHarnessRunner:
+    """Dispatch fake `--version` output keyed by the invoked executable."""
+
+    def __init__(
+        self,
+        *,
+        versions: dict[str, str] | None = None,
+        fail: frozenset[str] = frozenset(),
+    ) -> None:
+        self.versions = versions or {}
+        self.fail = fail
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, argv: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        args = [str(value) for value in argv]
+        self.calls.append(args)
+        executable = args[0]
+        if executable in self.fail:
+            return subprocess.CompletedProcess(args, 1, "", "boom")
+        return subprocess.CompletedProcess(args, 0, self.versions.get(executable, ""), "")
+
+
+def _which_only(*names: str):
+    allowed = set(names)
+    return lambda name: f"/bin/{name}" if name in allowed else None
+
+
+# --- Positive: codex is probed and its version filled when on PATH -------------
+
+
+def test_cli_live_probe_fills_codex_version(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(cli.shutil, "which", _which_only("codex", "copilot"))
+    runner = _MultiHarnessRunner(
+        versions={"codex": "codex-cli 0.34.0", "copilot": "copilot 9.9.9"}
+    )
+
+    code = cli.main(["--output", str(output)], runner=runner)
+
+    assert code == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    by_harness = {row["harness"]: row for row in report["harnesses"]}
+    assert by_harness["codex"]["version"] == "codex-cli 0.34.0"
+    assert by_harness["codex"]["version_evidence"] == "backend"
+    assert ["codex", "--version"] in runner.calls
+
+
+# --- Negative: a probe failure still attempts codex and stays UNVERIFIED -------
+
+
+def test_cli_probe_failure_still_attempts_codex(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(cli.shutil, "which", _which_only("codex", "copilot"))
+    runner = _MultiHarnessRunner(fail=frozenset({"codex"}), versions={"copilot": "copilot 9.9.9"})
+
+    code = cli.main(["--output", str(output)], runner=runner)
+
+    assert code == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    by_harness = {row["harness"]: row for row in report["harnesses"]}
+    assert by_harness["codex"]["version_evidence"] == "none"
+    # A probe was actually attempted and failed closed, rather than never
+    # being attempted at all.
+    assert ["codex", "--version"] in runner.calls
+
+
+# --- Edge: missing Codex CLI on PATH stays UNVERIFIED, never a crash -----------
+
+
+def test_cli_missing_codex_binary_stays_unverified_not_crash(
+    tmp_path: Path, monkeypatch
+) -> None:
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(cli.shutil, "which", _which_only("copilot"))
+    runner = _MultiHarnessRunner(versions={"copilot": "copilot 9.9.9"})
+
+    code = cli.main(["--output", str(output)], runner=runner)
+
+    assert code == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    by_harness = {row["harness"]: row for row in report["harnesses"]}
+    assert by_harness["codex"]["version"] == ""
+    assert by_harness["codex"]["version_evidence"] == "none"
+    assert not any(call[0] == "codex" for call in runner.calls)
+
+
+def test_cli_missing_codex_binary_verifies_no_capability_silently(
+    tmp_path: Path, monkeypatch
+) -> None:
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(cli.shutil, "which", _which_only("copilot"))
+    runner = _MultiHarnessRunner(versions={"copilot": "copilot 9.9.9"})
+
+    cli.main(["--output", str(output)], runner=runner)
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    codex_capabilities = next(
+        row for row in report["harnesses"] if row["harness"] == "codex"
+    )["capabilities"]
+    # A missing version probe must never be read as license to mark a
+    # behavioral capability VERIFIED by default (no silent pass).
+    for key in capability.CAPABILITY_KEYS:
+        assert codex_capabilities[key]["status"] == "UNVERIFIED", key

--- a/tests/eval/test_harness_capability_override_parity.py
+++ b/tests/eval/test_harness_capability_override_parity.py
@@ -1,0 +1,61 @@
+"""classify_override equal-value negative control (issue #5423 reopen).
+
+PR #5547 shipped `classify_override` without a guard for the case where a
+child requests the same value the parent already has. Run against
+pre-fix code, `classify_override("sol-medium", "sol-medium",
+EvidenceKind.BACKEND, parent_value="sol-medium")` returned `VERIFIED`: a
+backend value equal to both the request and the parent is indistinguishable
+from the override mechanism never running and the value simply passing
+through unchanged. `test_equal_parent_and_child_value_is_never_verified`
+is the negative control that closes this gap; it failed on pre-fix code
+(returned VERIFIED, not UNVERIFIED) and passes after the fix. The other two
+tests are regression guards proving the fix does not overreach: a genuinely
+differing, honored override must still verify, and a request made with no
+parent context at all (issue #5423 Arm E, single-agent) must be unaffected.
+Both already passed before this change and continue to pass after it.
+"""
+
+from __future__ import annotations
+
+from tests.eval._harness_capability_test_support import capability
+
+CapabilityStatus = capability.CapabilityStatus
+EvidenceKind = capability.EvidenceKind
+
+
+# --- Negative control: the equal-value trap ------------------------------------
+
+
+def test_equal_parent_and_child_value_is_never_verified() -> None:
+    status = capability.classify_override(
+        "sol-medium", "sol-medium", EvidenceKind.BACKEND, parent_value="sol-medium"
+    )
+    assert status is CapabilityStatus.UNVERIFIED
+
+
+def test_equal_value_trap_applies_to_effort_too() -> None:
+    # The same undecidable case can arise on effort_override, not only
+    # model_override; classify_override backs both.
+    status = capability.classify_override(
+        "high", "high", EvidenceKind.BACKEND, parent_value="high"
+    )
+    assert status is CapabilityStatus.UNVERIFIED
+
+
+# --- Regression guards: the fix must not overreach -----------------------------
+
+
+def test_genuinely_differing_honored_override_still_verifies() -> None:
+    status = capability.classify_override(
+        "luna-high", "luna-high", EvidenceKind.BACKEND, parent_value="sol-medium"
+    )
+    assert status is CapabilityStatus.VERIFIED
+
+
+def test_no_parent_context_still_verifies_on_matching_backend_value() -> None:
+    # Arm E (single-agent, issue #5423) has no parent to compare against.
+    # The equal-value guard only fires when parent_value is given; without
+    # one, a matching backend observation is still the best available
+    # evidence and must keep verifying.
+    status = capability.classify_override("sol-medium", "sol-medium", EvidenceKind.BACKEND)
+    assert status is CapabilityStatus.VERIFIED

--- a/tests/eval/test_runtime_parity_codex.py
+++ b/tests/eval/test_runtime_parity_codex.py
@@ -1,0 +1,110 @@
+"""Codex coverage for the runtime-parity evaluator (issue #5423 reopen).
+
+`_runtime_parity.runtime_env` and `probe_version` branched only on "claude"
+and "copilot" before this change, so `runtime_env(workspace, "codex")` raised
+`KeyError: 'codex'` from the `authentication[harness]` lookup, and any call to
+`probe_version` for codex failed the same way (it builds its env through
+`runtime_env`). Every test here was run against that pre-fix code and failed
+with `KeyError`; each now passes. See the session report for the exact
+pre-fix output.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from tests.eval._runtime_parity_test_support import parity
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _version_runner(stdout: str = "codex-cli 0.34.0\n", *, returncode: int = 0) -> Runner:
+    def runner(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        args = [str(value) for value in argv]
+        return subprocess.CompletedProcess(args, returncode, stdout, "")
+
+    return runner
+
+
+# --- Positive: the codex profile builds ---------------------------------------
+
+
+def test_runtime_env_builds_isolated_codex_profile(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", "/operator/home")
+    workspace = tmp_path / "codex"
+    workspace.mkdir()
+
+    env = parity.runtime_env(workspace, "codex")
+
+    assert env["HOME"].startswith(str(workspace))
+    assert env["CODEX_HOME"].startswith(str(workspace))
+    assert Path(env["CODEX_HOME"]).is_dir()
+    assert "/operator/home" not in env.values()
+
+
+def test_codex_receives_only_its_own_credentials(tmp_path: Path, monkeypatch) -> None:
+    credentials = {
+        "ANTHROPIC_API_KEY": "anthropic",
+        "COPILOT_GITHUB_TOKEN": "copilot",
+        "CODEX_API_KEY": "codex-key",
+        "CODEX_ACCESS_TOKEN": "codex-token",
+    }
+    for key, value in credentials.items():
+        monkeypatch.setenv(key, value)
+    workspace = tmp_path / "codex"
+    workspace.mkdir()
+
+    env = parity.runtime_env(workspace, "codex")
+
+    assert env["CODEX_API_KEY"] == "codex-key"
+    assert env["CODEX_ACCESS_TOKEN"] == "codex-token"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "COPILOT_GITHUB_TOKEN" not in env
+
+
+def test_probe_version_parses_well_formed_codex_version(tmp_path: Path) -> None:
+    runner = _version_runner("codex-cli 0.34.0\n")
+
+    version = parity.probe_version(
+        "codex", "codex", tmp_path / "probe", runner, 30
+    )
+
+    assert version == "codex-cli 0.34.0"
+
+
+def test_probe_version_argv_for_codex_has_no_extra_flag(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def recording_runner(argv: list[str], **_kwargs: object):
+        args = [str(value) for value in argv]
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, "codex-cli 0.34.0\n", "")
+
+    parity.probe_version("codex", "codex", tmp_path / "probe", recording_runner, 30)
+
+    # Unlike copilot, which inserts "--no-auto-update", codex takes the bare
+    # [executable, "--version"] argv.
+    assert calls == [["codex", "--version"]]
+
+
+# --- Edge: malformed codex version output fails closed -------------------------
+
+
+def test_empty_codex_version_output_fails_closed(tmp_path: Path) -> None:
+    runner = _version_runner("")
+
+    with pytest.raises(RuntimeError, match="returned no version"):
+        parity.probe_version("codex", "codex", tmp_path / "probe", runner, 30)
+
+
+def test_nonzero_exit_codex_version_probe_fails_closed(tmp_path: Path) -> None:
+    runner = _version_runner("", returncode=1)
+
+    with pytest.raises(RuntimeError, match="--version failed"):
+        parity.probe_version("codex", "codex", tmp_path / "probe", runner, 30)


### PR DESCRIPTION
## Summary

### What

Steps 1 and 2 of the four-step list in #5423's reopen comment (5545927372). Step 1 adds a `codex` branch to the eval runtime-parity harness and wires Codex into the capability probe. Step 2 adds the behavioral probers for model override, effort/tier override, subagent support, and concurrency. Also tightens `classify_override` so a request equal to the parent value can never classify as `VERIFIED`.

### Why

#5423 was reopened because PR #5547 shipped the classification layer under a `Closes` keyword that the work did not satisfy. The reopen comment separates the remainder into an environment gap and a code gap, and says of steps 1 and 2: "Say the word and I will do 1 and 2 behind tests, leaving 3 for an environment that has the runtimes." This is that work.

The code gap was real. `_harness_capability.py` makes zero subprocess calls: every function classifies evidence a caller supplies, and no caller gathered any. `_runtime_parity.runtime_env` had no Codex branch, so `PROBE_HARNESS` could only ever name `copilot`. Separately, `classify_override` returned `VERIFIED` when the child requested the value it would have inherited anyway, which is the one case where an observed match cannot distinguish "the override was honored" from "the override never ran".

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5423 | eval(harness): prove Codex/Copilot model, effort, and topology controls |

These references do not close their linked items: steps 3 and 4 (live probe runs with paid-spend authorization, then ticking the criteria the recorded evidence supports) remain open and cannot be performed in this environment.

## Changes

- **Step 1, Codex runtime support.**
  - `scripts/eval/_runtime_parity.py`: `codex` branch in `runtime_env` with a `CODEX_API_KEY` / `CODEX_ACCESS_TOKEN` auth allowlist and a `CODEX_HOME` profile root, mirroring the Copilot shape.
  - `scripts/eval/eval_harness_capability.py`: `PROBE_HARNESS` extended to include `codex`.
  - `scripts/eval/_harness_capability.py`: `classify_override` returns `UNVERIFIED` when `requested == parent_value`.
- **Step 2, the behavioral probers.**
  - `scripts/eval/_capability_probes.py` (new, 469 lines): probe-plan builder that refuses to construct a plan whose child value equals the parent, override probes for model and effort/tier, subagent-support and concurrency probes.
  - Evidence gathering only. Classification stays in `_harness_capability.py`, which still makes zero subprocess calls. That separation is the design: this module gathers, that module classifies, and `VERIFIED` is reachable only from `EvidenceKind.BACKEND` through the existing `classify_override`.

## What this PR deliberately does NOT do

Stated up front because it is the part that matters for review. #5423 was reopened once over a completion claim that outran its evidence, and `.agents/retrospective/2026-09-04-issue-5423-not-run-carried-forward-as-pass.md` is about a `NOT RUN` on this very issue being carried forward until it read as a pass.

- **No capability matrix cell is flipped.** `git diff origin/main..HEAD -- scripts/eval/examples/harness-capability-matrix.json` is empty. Every cell stays `UNVERIFIED` with its per-field reason.
- **No acceptance criterion on #5423 is ticked.** None of them are satisfiable without step 3.
- **Nothing here has run against a real Codex or Copilot CLI.** Every path is exercised by injected fakes.
- **The probers are not wired into `eval_harness_capability.py`.** A call path that cannot be executed here is the unrun artifact `AGENTS.md` forbids. Step 3 supplies the caller.

## How a value earns `BACKEND`

The issue's negative control 2 says client or schema echo is not backend evidence, so:

- A model or effort parsed from an **answer turn** in the runtime's own event stream is `BACKEND`.
- The same value read from **session state** (for example a `session.model_change` event) is `CLIENT_ECHO`, and can never verify.
- A harness with **no in-tree backend parser** observes `EvidenceKind.NONE`, never a default.
- Concurrency records the **peak children actually observed running**, derived from paired start and completion boundaries. The requested count appears in the detail text and never becomes the value. A harness asked for four children that ran two records two.

`Sol Ultra` is never normalized, aliased, or mapped onto `high` / `xhigh` / `max` anywhere in the module.

## Acceptance criteria

These are this PR's criteria, not #5423's.

- [x] Codex has a runtime profile with isolated credentials, mirroring the existing Copilot shape
- [x] Codex is reachable from the capability probe via `PROBE_HARNESS`
- [x] `classify_override` cannot return `VERIFIED` when the child request equals the parent value
- [x] Behavioral probers exist for model override, effort/tier override, subagent support, and concurrency
- [x] Every prober fails closed to `UNVERIFIED` when the CLI is absent, the output is malformed, or the evidence is not backend
- [x] Concurrency records the observed peak, never the requested count
- [x] No checked-in capability matrix cell is flipped, and no #5423 acceptance criterion is ticked

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny on the evidence-tagging boundary, no rush

**Focus areas**:

1. **The `BACKEND` versus `CLIENT_ECHO` boundary in `_capability_probes.py`.** If any path tags a value `BACKEND` that a harness could produce without actually honoring the request, the whole probe is a config reader wearing a probe's name. This is the hunk to attack.
2. **`DEFAULT_EFFORT_KEYS` is a guess and is labeled as one in-code.** Only `reasoningEffort` is attested anywhere in-tree (`tests/eval/test_providers.py:2615`), and it appears on a session-state event, which classifies `CLIENT_ECHO`. A wrong key can only fail to find evidence, never invent it, and the key set is a caller parameter so a live run can name the real one without a code change.
3. **The Codex credential names** rest on web-search evidence; the official Codex CLI reference page 404s as of 2026-09-06.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

`uv run pytest tests/eval/ -q` reports `2355 passed, 20 skipped in 15.96s` (2319 before step 2). `uv run ruff check .` reports `All checks passed!`. `uv run python scripts/validation/pre_pr.py` reports `RESULT: All validations passed`.

**Discrimination proven by mutation, not asserted.** 21 single-guard mutations of `_capability_probes.py`, `__pycache__` cleared between each mutation and its rerun, restore byte-compared: all 21 killed. An inverted control (a behavior-preserving edit, required to survive) survived, confirming the harness was not in a silent nothing-ran state.

Independently re-verified before push: mutating `value=peak` to `value=requested` in the concurrency probe fails exactly one test, `test_concurrency_records_the_observed_peak_not_the_requested_count`, and no others.

**Nine tests are confirmatory only, not negative controls**, and are labeled as such in both test module docstrings rather than counted toward the control tally.

One control was corrected during implementation rather than left mislabeled: `test_a_child_that_silently_inherits_the_parent_never_verifies` was first presented as the inherit control, but a mutation proved it non-discriminating for that guard, because `observed != requested` catches the same input. A hand-built-plan test that does discriminate was added.

`pre_pr.py` initially FAILED with `taste count ratchet: REGRESSION. 567 violations > baseline 566 (+1)`, from a 531-line test file. Fixed by splitting the file, not by raising the baseline. No hook was bypassed at any point.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The credential allowlist narrows what reaches a subprocess rather than widening it. A review traced that no Claude or Copilot credential can reach a Codex subprocess env.

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Pre-PR validation passed (full sequence, `RESULT: All validations passed`)
- [x] Lint and formatting clean
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

**Known process gap, stated rather than hidden.** The campaign that produced this PR requires one independent GPT-5.6 Sol diff review before a fix ships. Sol was **NOT RUN**. No Codex CLI is installed and no OpenAI credential exists in this environment; `which codex`, `npx @openai/codex`, and a filesystem credential sweep all came back empty. An independent Claude reviewer was substituted on the step 1 diff and returned approve with no findings. Treat the cross-model check as missing, not satisfied.

**Not built, and why:** no Codex argv builder and no Codex output parser. No Codex flag surface is verified anywhere in this repo, so `ProbeCommand.argv` is caller-supplied and `observe_model` returns `EvidenceKind.NONE` for codex. Inventing either would put an unverified contract in the tree, which is the failure mode this issue exists to prevent.

**Adjacent defects noticed, not fixed:**

- `scripts/eval/_harness_capability.py:283`: the `observed == parent_value and requested != parent_value` branch in `classify_override` is unreachable-distinct. Any input reaching it also fails the `observed != requested` check two lines below, so no input distinguishes the branch's presence from its absence. It predates this PR (it arrived with #5547) and is documented there as negative control 3/5. Harmless, but it is a documented control with no discriminating test.
- `scripts/eval/_runtime_parity.py` `prepare_workspace()` still branches only on `claude` and `copilot`, with no Codex agent-install path. It serves the fixture-execution flow, not the version-probe flow this issue targets.
- `pre_pr.py` emits `[WARN] base-ref: gh pr view did not give an authoritative answer (exit 1): HTTP 403`, so ratchets measured against a possibly stale base ref in this environment. Advisory, and the run passed.

## Related Issues

Refs #5423

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Fy5QhStgRK17mGDErqXQE