### PR TITLE
fix(eval): address the Devin review that landed after PR #5623 merged

### DIFF
--- a/scripts/eval/_capability_evidence.py
+++ b/scripts/eval/_capability_evidence.py
@@ -1,0 +1,153 @@
+"""What a runtime's own output said, and how much that is worth.
+
+Split out of `_capability_probes` after PR #5623's review. That module runs a
+harness CLI and classifies the result; this one only reads an event stream and
+labels the evidence it found. The seam is the same one that keeps
+`_harness_capability` free of subprocess calls: reading, running, and
+classifying are three jobs, and a value earns `BACKEND` in exactly one of
+them.
+
+Nothing here has been executed against a real Codex or Copilot CLI. Every
+shape below is exercised by recorded output only.
+
+Authority boundary: provider, model, and pricing tables stay in
+`scripts/eval/_providers.py` and `scripts/eval/_eval_common.py`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from _harness_capability import EvidenceKind
+from _runtime_output import copilot_result, structured_tool_model
+
+#: reads the same type, and the model on it is attributable to the turn that
+#: produced the text.
+ASSISTANT_EVENT = "assistant.message"
+
+#: Session-state events the CLI emits about its own configuration. A value
+#: read from one of these is the client reporting what it set, not the backend
+#: reporting what it ran, so it is `CLIENT_ECHO` and can never verify.
+#: `session.model_change` with `data.newModel` and `data.reasoningEffort` is
+#: the shape recorded in `tests/eval/test_providers.py`, whose comment states
+#: it is modeled on a real log.
+SESSION_STATE_EVENTS: frozenset[str] = frozenset({"session.model_change", "session.start"})
+
+#: Keys an assistant turn might carry a resolved reasoning effort or tier on.
+#: Only `reasoningEffort` is attested in-tree, and only on a session-state
+#: event. The rest are candidates. A key that never matches yields
+#: `EvidenceKind.NONE`, so a wrong guess here withholds a claim rather than
+#: inventing one. A live run should replace this with the observed key.
+DEFAULT_EFFORT_KEYS: tuple[str, ...] = ("reasoningEffort", "reasoning_effort", "effort")
+
+#: Harnesses with an in-tree parser that attributes a model to a backend turn.
+#: Claude is absent on purpose: `_runtime_output.claude_result` reads the model
+#: off the `system`/`init` event, which the CLI emits before the backend has
+#: replied, so it cannot be told apart from the request echoed back. Codex is
+#: absent because no Codex output parser exists in this repository at all.
+BACKEND_MODEL_HARNESSES: frozenset[str] = frozenset({"copilot"})
+
+@dataclass(frozen=True, slots=True)
+class ProbeObservation:
+    """What the runtime's own output said, and how much that is worth."""
+
+    observed: str | None
+    evidence: EvidenceKind
+    detail: str
+
+
+def _assistant_values(
+    events: Sequence[Mapping[str, object]],
+    keys: Sequence[str],
+) -> str | None:
+    """Return the single value `keys` carries on a backend answer turn.
+
+    Requires non-empty text content on the same event, which is what makes the
+    turn an answer the backend produced rather than a status line. Two turns
+    disagreeing return `None`, mirroring `copilot_result`: a blended answer has
+    no single author, so no value earns the claim.
+    """
+    found: set[str] = set()
+    for event in events:
+        if event.get("type") != ASSISTANT_EVENT:
+            continue
+        data = event.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        content = data.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                found.add(value)
+                break
+    return found.pop() if len(found) == 1 else None
+
+
+def _session_state_value(
+    events: Sequence[Mapping[str, object]],
+    keys: Sequence[str],
+) -> str | None:
+    """Return a value the CLI reported about its own session configuration."""
+    for event in events:
+        kind = event.get("type")
+        if not isinstance(kind, str) or kind not in SESSION_STATE_EVENTS:
+            continue
+        data = event.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def observe_model(
+    harness: str,
+    events: Sequence[Mapping[str, object]],
+) -> ProbeObservation:
+    """Read the model the backend attributed to its own answer."""
+    if harness not in BACKEND_MODEL_HARNESSES:
+        return ProbeObservation(
+            None,
+            EvidenceKind.NONE,
+            f"no in-tree parser attributes a model to a backend turn for {harness}",
+        )
+    _, model = copilot_result(events)
+    if not model:
+        model = structured_tool_model(events)
+    if model:
+        return ProbeObservation(model, EvidenceKind.BACKEND, "model attributed to an answer turn")
+    echoed = _session_state_value(events, ("newModel", "selectedModel", "model"))
+    if echoed:
+        return ProbeObservation(
+            echoed,
+            EvidenceKind.CLIENT_ECHO,
+            "model came from a session-state event, which is the request echoed back",
+        )
+    return ProbeObservation(None, EvidenceKind.NONE, "no answer turn carried a model attribution")
+
+
+def observe_effort(
+    harness: str,
+    events: Sequence[Mapping[str, object]],
+    *,
+    effort_keys: Sequence[str] = DEFAULT_EFFORT_KEYS,
+) -> ProbeObservation:
+    """Read the reasoning effort or tier the backend attributed to its answer."""
+    observed = _assistant_values(events, effort_keys)
+    if observed:
+        return ProbeObservation(
+            observed, EvidenceKind.BACKEND, f"{harness} answer turn carried a resolved effort"
+        )
+    echoed = _session_state_value(events, effort_keys)
+    if echoed:
+        return ProbeObservation(
+            echoed,
+            EvidenceKind.CLIENT_ECHO,
+            "effort came from a session-state event, which is the request echoed back",
+        )
+    return ProbeObservation(None, EvidenceKind.NONE, f"no {harness} answer turn carried an effort")

--- a/scripts/eval/_capability_probes.py
+++ b/scripts/eval/_capability_probes.py
@@ -22,8 +22,19 @@ Fail-closed rules, each of which can only ever refuse a claim:
   cannot be constructed. `classify_override` returns `UNVERIFIED` for equal
   values, so such a plan is a probe that can never verify anything; building
   one silently would waste a live run and read as a failed capability.
+* An override probe whose command does not implement its plan is refused
+  before the CLI runs. The argv is caller-supplied and opaque here, so a
+  command that omits the override, or targets a different harness, would
+  otherwise have its harness default classified as an honored override.
+* A subagent tool request is not a launched child. `_runtime_output.traces`
+  merges Claude `tool_use` blocks for `Agent` and `Task` with the runtime's
+  own lifecycle events; only the latter can verify subagent support.
+* A concurrency peak counts a child only while the stream still holds enough
+  completion boundaries to close it, so a truncated run reports fewer
+  children rather than more.
 * A harness with no in-tree backend parser observes `EvidenceKind.NONE`, never
-  a guess.
+  a guess. `_capability_evidence` owns that rule and every other question of
+  what a value read from an event stream is worth.
 * A missing CLI, a non-zero exit, and a timeout all resolve to `UNVERIFIED`.
   Malformed or truncated output raises `HarnessCapabilityError` instead,
   because a half-read stream is a broken contract rather than a negative
@@ -31,6 +42,11 @@ Fail-closed rules, each of which can only ever refuse a claim:
 * `Sol Ultra` is a literal control value. Nothing here folds it onto `high`,
   `xhigh`, `max`, or any other tier, and `_discriminates` is the only
   comparison any value passes through.
+
+Reading the runtime's output lives in `_capability_evidence`; this module
+builds the probes, runs them, and hands what that module observed to the
+classifier. `observe_model`, `observe_effort`, `ProbeObservation`, and the
+evidence constants are re-exported below so a caller needs one import.
 
 Authority boundary: provider, model, and pricing tables stay in
 `scripts/eval/_providers.py` and `scripts/eval/_eval_common.py`. This module
@@ -44,6 +60,12 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from _capability_evidence import (
+    DEFAULT_EFFORT_KEYS,
+    ProbeObservation,
+    observe_effort,
+    observe_model,
+)
 from _harness_capability import (
     Capability,
     CapabilityStatus,
@@ -51,13 +73,7 @@ from _harness_capability import (
     HarnessCapabilityError,
     classify_override,
 )
-from _runtime_output import (
-    RuntimeOutputError,
-    copilot_result,
-    parse_events,
-    structured_tool_model,
-    traces,
-)
+from _runtime_output import RuntimeOutputError, parse_events, traces
 
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 
@@ -65,32 +81,6 @@ Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 OVERRIDE_CAPABILITIES: tuple[str, ...] = ("model_override", "effort_override")
 
 #: The event type Copilot attaches a backend answer to. `copilot_result`
-#: reads the same type, and the model on it is attributable to the turn that
-#: produced the text.
-ASSISTANT_EVENT = "assistant.message"
-
-#: Session-state events the CLI emits about its own configuration. A value
-#: read from one of these is the client reporting what it set, not the backend
-#: reporting what it ran, so it is `CLIENT_ECHO` and can never verify.
-#: `session.model_change` with `data.newModel` and `data.reasoningEffort` is
-#: the shape recorded in `tests/eval/test_providers.py`, whose comment states
-#: it is modeled on a real log.
-SESSION_STATE_EVENTS: frozenset[str] = frozenset({"session.model_change", "session.start"})
-
-#: Keys an assistant turn might carry a resolved reasoning effort or tier on.
-#: Only `reasoningEffort` is attested in-tree, and only on a session-state
-#: event. The rest are candidates. A key that never matches yields
-#: `EvidenceKind.NONE`, so a wrong guess here withholds a claim rather than
-#: inventing one. A live run should replace this with the observed key.
-DEFAULT_EFFORT_KEYS: tuple[str, ...] = ("reasoningEffort", "reasoning_effort", "effort")
-
-#: Harnesses with an in-tree parser that attributes a model to a backend turn.
-#: Claude is absent on purpose: `_runtime_output.claude_result` reads the model
-#: off the `system`/`init` event, which the CLI emits before the backend has
-#: replied, so it cannot be told apart from the request echoed back. Codex is
-#: absent because no Codex output parser exists in this repository at all.
-BACKEND_MODEL_HARNESSES: frozenset[str] = frozenset({"copilot"})
-
 _START_HINTS: tuple[str, ...] = ("start", "begin", "launch", "spawn")
 _END_HINTS: tuple[str, ...] = ("complete", "end", "stop", "finish", "exit", "result")
 
@@ -110,12 +100,34 @@ class OverridePlan:
     `child_value` is guaranteed to differ from `parent_value`, so an observed
     match means the override mechanism ran rather than the child inheriting.
     Both values are the caller's verbatim strings; nothing normalizes them.
+
+    The guarantee is enforced here rather than only in `build_override_plan`,
+    because this dataclass is public and `probe_override` accepts a hand-built
+    plan. `classify_override` compares with `==`, so a plan differing from the
+    parent only by case or surrounding whitespace passed that check while a
+    case-folding harness would echo the parent back and read as an honored
+    override.
     """
 
     capability: str
     harness: str
     parent_value: str
     child_value: str
+
+    def __post_init__(self) -> None:
+        """Refuse a plan whose child request cannot discriminate an override."""
+        if not self.harness:
+            raise ProbeError("harness must be a non-empty string")
+        if not self.parent_value:
+            raise ProbeError(
+                "parent_value must be a non-empty string; an unknown parent cannot discriminate"
+            )
+        if not _discriminates(self.child_value, self.parent_value):
+            raise ProbeError(
+                f"child value {self.child_value!r} does not differ from parent "
+                f"{self.parent_value!r}; an equal-value request cannot tell an honored "
+                "override from a silent inherit"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -126,6 +138,10 @@ class ProbeCommand:
     verified in this repository, and inventing one would put an unverified
     contract in the tree. `eval_runtime_parity.build_argv` holds the Copilot
     flag set that is attested.
+
+    Because the argv is opaque to this module, `probe_override` checks that it
+    carries the plan's child value before running it. A caller that delivers
+    the override some other way must put it in `env` or the probe is refused.
     """
 
     harness: str
@@ -134,13 +150,30 @@ class ProbeCommand:
     env: Mapping[str, str] | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class ProbeObservation:
-    """What the runtime's own output said, and how much that is worth."""
+def _carries_request(command: ProbeCommand, value: str) -> bool:
+    """Report whether this invocation actually asks for `value`.
 
-    observed: str | None
-    evidence: EvidenceKind
-    detail: str
+    `ProbeCommand.argv` is caller-supplied, so nothing else in this module can
+    tell a command that requests the override from one that does not. Without
+    this check `probe_override` executes an opaque argv and classifies it
+    against a plan it may not implement: a command that omits the override
+    runs the harness default, and if that default happens to equal the plan's
+    child value the probe reports `VERIFIED` for a mechanism that never ran.
+
+    A token carries the request when it is the value itself (`--model`,
+    `gpt-5.6-sol`) or ends in `=value` (`--model=gpt-5.6-sol`). An environment
+    variable carries it on an exact value match. A request delivered any other
+    way (a config file, a profile setting) is not visible here and is refused
+    rather than assumed, which withholds a probe instead of accepting an
+    unbound one.
+    """
+    suffix = f"={value}"
+    for token in command.argv:
+        if token == value or token.endswith(suffix):
+            return True
+    if command.env is not None:
+        return any(entry == value for entry in command.env.values())
+    return False
 
 
 def _discriminates(candidate: str, parent: str) -> bool:
@@ -242,102 +275,6 @@ def _capture_events(
     return events, ""
 
 
-def _assistant_values(
-    events: Sequence[Mapping[str, object]],
-    keys: Sequence[str],
-) -> str | None:
-    """Return the single value `keys` carries on a backend answer turn.
-
-    Requires non-empty text content on the same event, which is what makes the
-    turn an answer the backend produced rather than a status line. Two turns
-    disagreeing return `None`, mirroring `copilot_result`: a blended answer has
-    no single author, so no value earns the claim.
-    """
-    found: set[str] = set()
-    for event in events:
-        if event.get("type") != ASSISTANT_EVENT:
-            continue
-        data = event.get("data")
-        if not isinstance(data, Mapping):
-            continue
-        content = data.get("content")
-        if not isinstance(content, str) or not content.strip():
-            continue
-        for key in keys:
-            value = data.get(key)
-            if isinstance(value, str) and value:
-                found.add(value)
-                break
-    return found.pop() if len(found) == 1 else None
-
-
-def _session_state_value(
-    events: Sequence[Mapping[str, object]],
-    keys: Sequence[str],
-) -> str | None:
-    """Return a value the CLI reported about its own session configuration."""
-    for event in events:
-        kind = event.get("type")
-        if not isinstance(kind, str) or kind not in SESSION_STATE_EVENTS:
-            continue
-        data = event.get("data")
-        if not isinstance(data, Mapping):
-            continue
-        for key in keys:
-            value = data.get(key)
-            if isinstance(value, str) and value:
-                return value
-    return None
-
-
-def observe_model(
-    harness: str,
-    events: Sequence[Mapping[str, object]],
-) -> ProbeObservation:
-    """Read the model the backend attributed to its own answer."""
-    if harness not in BACKEND_MODEL_HARNESSES:
-        return ProbeObservation(
-            None,
-            EvidenceKind.NONE,
-            f"no in-tree parser attributes a model to a backend turn for {harness}",
-        )
-    _, model = copilot_result(events)
-    if not model:
-        model = structured_tool_model(events)
-    if model:
-        return ProbeObservation(model, EvidenceKind.BACKEND, "model attributed to an answer turn")
-    echoed = _session_state_value(events, ("newModel", "selectedModel", "model"))
-    if echoed:
-        return ProbeObservation(
-            echoed,
-            EvidenceKind.CLIENT_ECHO,
-            "model came from a session-state event, which is the request echoed back",
-        )
-    return ProbeObservation(None, EvidenceKind.NONE, "no answer turn carried a model attribution")
-
-
-def observe_effort(
-    harness: str,
-    events: Sequence[Mapping[str, object]],
-    *,
-    effort_keys: Sequence[str] = DEFAULT_EFFORT_KEYS,
-) -> ProbeObservation:
-    """Read the reasoning effort or tier the backend attributed to its answer."""
-    observed = _assistant_values(events, effort_keys)
-    if observed:
-        return ProbeObservation(
-            observed, EvidenceKind.BACKEND, f"{harness} answer turn carried a resolved effort"
-        )
-    echoed = _session_state_value(events, effort_keys)
-    if echoed:
-        return ProbeObservation(
-            echoed,
-            EvidenceKind.CLIENT_ECHO,
-            "effort came from a session-state event, which is the request echoed back",
-        )
-    return ProbeObservation(None, EvidenceKind.NONE, f"no {harness} answer turn carried an effort")
-
-
 def probe_override(
     plan: OverridePlan,
     command: ProbeCommand,
@@ -352,7 +289,24 @@ def probe_override(
     kind, and the plan's parent value go straight to
     `_harness_capability.classify_override`, which owns every rule that can
     withhold `VERIFIED`.
+
+    Raises `ProbeError` when `command` does not implement `plan`: a different
+    harness, or an invocation that does not carry the plan's child value. Both
+    are refused before the CLI runs, because a probe whose command and plan
+    describe different invocations cannot attribute what it observes to the
+    override it claims to be testing.
     """
+    if command.harness != plan.harness:
+        raise ProbeError(
+            f"command targets {command.harness!r} but the plan probes {plan.harness!r}; "
+            "a run against one harness cannot verify an override on another"
+        )
+    if not _carries_request(command, plan.child_value):
+        raise ProbeError(
+            f"command does not request {plan.child_value!r} in its argv or env, so an "
+            f"observed {plan.child_value!r} would be the harness default rather than an "
+            "honored override"
+        )
     events, failure = _capture_events(command, runner=runner, timeout=timeout)
     if events is None:
         return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
@@ -377,6 +331,33 @@ def probe_override(
     )
 
 
+def _subagent_lifecycle_events(
+    events: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Return the runtime's own subagent lifecycle events.
+
+    Split out from `_runtime_output.traces`, which merges these with Claude
+    `tool_use` blocks named `Agent` or `Task`. That merge is right for a
+    parity report, which wants everything the run touched, and wrong here: a
+    `tool_use` block is the model asking for a child, emitted before anything
+    runs and present even when the launch fails. Counting one as a launch is
+    the config-echo failure wearing a different observable, so only events the
+    runtime itself emitted about a child's lifecycle are counted.
+    """
+    lifecycle: list[Mapping[str, object]] = []
+    for event in events:
+        kind = event.get("type")
+        if isinstance(kind, str) and "subagent" in kind.lower():
+            lifecycle.append(event)
+    return lifecycle
+
+
+def _requested_subagent_tools(events: Sequence[Mapping[str, object]]) -> int:
+    """Count subagent tool requests, which are asks rather than launches."""
+    _, subagents = traces(events)
+    return len(subagents) - len(_subagent_lifecycle_events(events))
+
+
 def probe_subagent_support(
     command: ProbeCommand,
     *,
@@ -387,22 +368,26 @@ def probe_subagent_support(
 
     Presence, not a requested count: a run that asked for children and shows
     none in its output is `UNVERIFIED`, which is the config-echo rule applied
-    to a different observable.
+    to a different observable. A `tool_use` block requesting `Agent` or `Task`
+    is such an ask, so it is reported and never verifies on its own.
     """
     events, failure = _capture_events(command, runner=runner, timeout=timeout)
     if events is None:
         return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
-    _, subagents = traces(events)
-    if not subagents:
-        return Capability(
-            CapabilityStatus.UNVERIFIED,
-            EvidenceKind.NONE,
-            f"{command.harness} output carried no subagent events",
+    launched = _subagent_lifecycle_events(events)
+    if not launched:
+        requested = _requested_subagent_tools(events)
+        detail = (
+            f"{command.harness} output carried {requested} subagent tool requests and no "
+            "lifecycle event, so no child is known to have run"
+            if requested
+            else f"{command.harness} output carried no subagent events"
         )
+        return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, detail)
     return Capability(
         CapabilityStatus.VERIFIED,
         EvidenceKind.BACKEND,
-        f"{command.harness} output carried {len(subagents)} subagent events",
+        f"{command.harness} output carried {len(launched)} subagent lifecycle events",
     )
 
 
@@ -411,27 +396,48 @@ def max_concurrent_children(events: Sequence[Mapping[str, object]]) -> int | Non
 
     Derived by walking subagent start and completion boundaries in order, so
     the result is what the runtime reported running, never what the probe
-    asked for. Returns `None` when no completion boundary appears: without
-    one, a run of N starts is indistinguishable from N sequential children,
-    and assuming they overlapped would report the requested number wearing the
-    observed number's label. Claude's `tool_use` blocks for `Agent` and `Task`
-    carry no boundary of either kind, so they resolve to `None` here.
+    asked for. A start counts toward the peak only while enough completion
+    boundaries remain in the stream to close it and every child already open
+    beside it. Without that, a run of N starts is indistinguishable from N
+    sequential children whose completions were never emitted, and assuming
+    they overlapped would report the requested number wearing the observed
+    number's label.
+
+    One global "a completion appeared somewhere" flag was not enough: it let a
+    single early pair license an unbounded tail of unclosed starts, so
+    `start, end, start, start, start` reported three. The same tail now
+    reports one, and a truncated `start, start, end` reports one rather than
+    two. Both directions are the fail-closed one.
+
+    Returns `None` when no start is backed by a completion, and when a
+    completion arrives with no child open, which is a stream whose boundaries
+    do not describe a coherent run. Claude's `tool_use` blocks for `Agent` and
+    `Task` carry no boundary of either kind, so they resolve to `None` here.
     """
-    depth = 0
-    peak = 0
-    saw_end = False
+    boundaries: list[bool] = []
     for event in events:
         kind = event.get("type")
         if not isinstance(kind, str) or "subagent" not in kind.lower():
             continue
         lowered = kind.lower()
         if any(hint in lowered for hint in _END_HINTS):
-            depth = max(0, depth - 1)
-            saw_end = True
+            boundaries.append(False)
         elif any(hint in lowered for hint in _START_HINTS):
-            depth += 1
+            boundaries.append(True)
+    completions_left = boundaries.count(False)
+    depth = 0
+    peak = 0
+    for is_start in boundaries:
+        if not is_start:
+            if depth == 0:
+                return None
+            depth -= 1
+            completions_left -= 1
+            continue
+        depth += 1
+        if depth <= completions_left:
             peak = max(peak, depth)
-    if not saw_end or peak == 0:
+    if peak == 0:
         return None
     return peak
 
@@ -467,3 +473,21 @@ def probe_concurrency(
         f"{command.harness} ran at most {peak} children at once while {requested} were requested",
         value=peak,
     )
+
+
+#: Re-exported from `_capability_evidence` so a probe caller needs one import.
+__all__ = [
+    "DEFAULT_EFFORT_KEYS",
+    "OVERRIDE_CAPABILITIES",
+    "OverridePlan",
+    "ProbeCommand",
+    "ProbeError",
+    "ProbeObservation",
+    "build_override_plan",
+    "max_concurrent_children",
+    "observe_effort",
+    "observe_model",
+    "probe_concurrency",
+    "probe_override",
+    "probe_subagent_support",
+]

--- a/scripts/eval/_capability_probes.py
+++ b/scripts/eval/_capability_probes.py
@@ -26,12 +26,10 @@ Fail-closed rules, each of which can only ever refuse a claim:
   before the CLI runs. The argv is caller-supplied and opaque here, so a
   command that omits the override, or targets a different harness, would
   otherwise have its harness default classified as an honored override.
-* A subagent tool request is not a launched child. `_runtime_output.traces`
-  merges Claude `tool_use` blocks for `Agent` and `Task` with the runtime's
-  own lifecycle events; only the latter can verify subagent support.
-* A concurrency peak counts a child only while the stream still holds enough
-  completion boundaries to close it, so a truncated run reports fewer
-  children rather than more.
+* A subagent tool request is not a launched child, and a concurrency peak
+  counts a child only while the stream still holds enough completion
+  boundaries to close it. `_capability_topology` owns both rules and the
+  event vocabulary they share.
 * A harness with no in-tree backend parser observes `EvidenceKind.NONE`, never
   a guess. `_capability_evidence` owns that rule and every other question of
   what a value read from an event stream is worth.
@@ -62,9 +60,13 @@ from pathlib import Path
 
 from _capability_evidence import (
     DEFAULT_EFFORT_KEYS,
-    ProbeObservation,
     observe_effort,
     observe_model,
+)
+from _capability_topology import (
+    max_concurrent_children,
+    requested_subagent_tools,
+    subagent_lifecycle_events,
 )
 from _harness_capability import (
     Capability,
@@ -73,16 +75,13 @@ from _harness_capability import (
     HarnessCapabilityError,
     classify_override,
 )
-from _runtime_output import RuntimeOutputError, parse_events, traces
+from _runtime_output import RuntimeOutputError, parse_events
 
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 
 #: Capabilities this module can probe through `classify_override`.
 OVERRIDE_CAPABILITIES: tuple[str, ...] = ("model_override", "effort_override")
 
-#: The event type Copilot attaches a backend answer to. `copilot_result`
-_START_HINTS: tuple[str, ...] = ("start", "begin", "launch", "spawn")
-_END_HINTS: tuple[str, ...] = ("complete", "end", "stop", "finish", "exit", "result")
 
 
 class ProbeError(HarnessCapabilityError):
@@ -331,33 +330,6 @@ def probe_override(
     )
 
 
-def _subagent_lifecycle_events(
-    events: Sequence[Mapping[str, object]],
-) -> list[Mapping[str, object]]:
-    """Return the runtime's own subagent lifecycle events.
-
-    Split out from `_runtime_output.traces`, which merges these with Claude
-    `tool_use` blocks named `Agent` or `Task`. That merge is right for a
-    parity report, which wants everything the run touched, and wrong here: a
-    `tool_use` block is the model asking for a child, emitted before anything
-    runs and present even when the launch fails. Counting one as a launch is
-    the config-echo failure wearing a different observable, so only events the
-    runtime itself emitted about a child's lifecycle are counted.
-    """
-    lifecycle: list[Mapping[str, object]] = []
-    for event in events:
-        kind = event.get("type")
-        if isinstance(kind, str) and "subagent" in kind.lower():
-            lifecycle.append(event)
-    return lifecycle
-
-
-def _requested_subagent_tools(events: Sequence[Mapping[str, object]]) -> int:
-    """Count subagent tool requests, which are asks rather than launches."""
-    _, subagents = traces(events)
-    return len(subagents) - len(_subagent_lifecycle_events(events))
-
-
 def probe_subagent_support(
     command: ProbeCommand,
     *,
@@ -374,9 +346,9 @@ def probe_subagent_support(
     events, failure = _capture_events(command, runner=runner, timeout=timeout)
     if events is None:
         return Capability(CapabilityStatus.UNVERIFIED, EvidenceKind.NONE, failure)
-    launched = _subagent_lifecycle_events(events)
+    launched = subagent_lifecycle_events(events)
     if not launched:
-        requested = _requested_subagent_tools(events)
+        requested = requested_subagent_tools(events)
         detail = (
             f"{command.harness} output carried {requested} subagent tool requests and no "
             "lifecycle event, so no child is known to have run"
@@ -389,57 +361,6 @@ def probe_subagent_support(
         EvidenceKind.BACKEND,
         f"{command.harness} output carried {len(launched)} subagent lifecycle events",
     )
-
-
-def max_concurrent_children(events: Sequence[Mapping[str, object]]) -> int | None:
-    """Return the peak number of children in flight at once, or `None`.
-
-    Derived by walking subagent start and completion boundaries in order, so
-    the result is what the runtime reported running, never what the probe
-    asked for. A start counts toward the peak only while enough completion
-    boundaries remain in the stream to close it and every child already open
-    beside it. Without that, a run of N starts is indistinguishable from N
-    sequential children whose completions were never emitted, and assuming
-    they overlapped would report the requested number wearing the observed
-    number's label.
-
-    One global "a completion appeared somewhere" flag was not enough: it let a
-    single early pair license an unbounded tail of unclosed starts, so
-    `start, end, start, start, start` reported three. The same tail now
-    reports one, and a truncated `start, start, end` reports one rather than
-    two. Both directions are the fail-closed one.
-
-    Returns `None` when no start is backed by a completion, and when a
-    completion arrives with no child open, which is a stream whose boundaries
-    do not describe a coherent run. Claude's `tool_use` blocks for `Agent` and
-    `Task` carry no boundary of either kind, so they resolve to `None` here.
-    """
-    boundaries: list[bool] = []
-    for event in events:
-        kind = event.get("type")
-        if not isinstance(kind, str) or "subagent" not in kind.lower():
-            continue
-        lowered = kind.lower()
-        if any(hint in lowered for hint in _END_HINTS):
-            boundaries.append(False)
-        elif any(hint in lowered for hint in _START_HINTS):
-            boundaries.append(True)
-    completions_left = boundaries.count(False)
-    depth = 0
-    peak = 0
-    for is_start in boundaries:
-        if not is_start:
-            if depth == 0:
-                return None
-            depth -= 1
-            completions_left -= 1
-            continue
-        depth += 1
-        if depth <= completions_left:
-            peak = max(peak, depth)
-    if peak == 0:
-        return None
-    return peak
 
 
 def probe_concurrency(
@@ -473,21 +394,3 @@ def probe_concurrency(
         f"{command.harness} ran at most {peak} children at once while {requested} were requested",
         value=peak,
     )
-
-
-#: Re-exported from `_capability_evidence` so a probe caller needs one import.
-__all__ = [
-    "DEFAULT_EFFORT_KEYS",
-    "OVERRIDE_CAPABILITIES",
-    "OverridePlan",
-    "ProbeCommand",
-    "ProbeError",
-    "ProbeObservation",
-    "build_override_plan",
-    "max_concurrent_children",
-    "observe_effort",
-    "observe_model",
-    "probe_concurrency",
-    "probe_override",
-    "probe_subagent_support",
-]

--- a/scripts/eval/_capability_probes.py
+++ b/scripts/eval/_capability_probes.py
@@ -41,10 +41,12 @@ Fail-closed rules, each of which can only ever refuse a claim:
   `xhigh`, `max`, or any other tier, and `_discriminates` is the only
   comparison any value passes through.
 
-Reading the runtime's output lives in `_capability_evidence`; this module
-builds the probes, runs them, and hands what that module observed to the
-classifier. `observe_model`, `observe_effort`, `ProbeObservation`, and the
-evidence constants are re-exported below so a caller needs one import.
+Reading the runtime's output lives in `_capability_evidence` and reading child
+lifecycles in `_capability_topology`; this module builds the probes, runs them,
+and hands what those modules observed to the classifier. It imports what it
+calls and re-exports nothing: a caller wanting `observe_model` or
+`max_concurrent_children` imports the module that owns it, so the boundary is
+visible at the import site.
 
 Authority boundary: provider, model, and pricing tables stay in
 `scripts/eval/_providers.py` and `scripts/eval/_eval_common.py`. This module
@@ -114,7 +116,18 @@ class OverridePlan:
     child_value: str
 
     def __post_init__(self) -> None:
-        """Refuse a plan whose child request cannot discriminate an override."""
+        """Refuse a plan this module cannot probe or that cannot discriminate.
+
+        `capability` is checked here rather than only in `build_override_plan`
+        for the same reason the rest of these checks moved: `probe_override`
+        routes every capability that is not `model_override` through
+        `observe_effort`, so a hand-built plan naming anything else would have
+        had effort evidence classified as that capability.
+        """
+        if self.capability not in OVERRIDE_CAPABILITIES:
+            raise ProbeError(
+                f"capability must be one of {OVERRIDE_CAPABILITIES}, got {self.capability!r}"
+            )
         if not self.harness:
             raise ProbeError("harness must be a non-empty string")
         if not self.parent_value:
@@ -150,7 +163,7 @@ class ProbeCommand:
 
 
 def _carries_request(command: ProbeCommand, value: str) -> bool:
-    """Report whether this invocation actually asks for `value`.
+    """Report whether this invocation actually asks for `value` in its argv.
 
     `ProbeCommand.argv` is caller-supplied, so nothing else in this module can
     tell a command that requests the override from one that does not. Without
@@ -160,19 +173,24 @@ def _carries_request(command: ProbeCommand, value: str) -> bool:
     child value the probe reports `VERIFIED` for a mechanism that never ran.
 
     A token carries the request when it is the value itself (`--model`,
-    `gpt-5.6-sol`) or ends in `=value` (`--model=gpt-5.6-sol`). An environment
-    variable carries it on an exact value match. A request delivered any other
-    way (a config file, a profile setting) is not visible here and is refused
-    rather than assumed, which withholds a probe instead of accepting an
-    unbound one.
+    `gpt-5.6-sol`) or ends in `=value` (`--model=gpt-5.6-sol`). A token that
+    merely contains the value, such as a prompt mentioning the model name,
+    does not.
+
+    Environment variables were accepted here and no longer are: any variable
+    whose value happened to equal the request counted as the request, and
+    naming the variables that really carry it would mean writing down a Codex
+    and Copilot contract this repository has not verified. Argv is the one
+    surface a caller can be required to make explicit, so a request delivered
+    any other way is refused rather than assumed.
+
+    Known residual gap: this proves the value appears as an argument, not that
+    it appears as the *model* or *effort* option, because no verified flag
+    surface for either harness exists in this repository. Closing that needs
+    step 3 of issue #5423, which is where a real flag set gets observed.
     """
     suffix = f"={value}"
-    for token in command.argv:
-        if token == value or token.endswith(suffix):
-            return True
-    if command.env is not None:
-        return any(entry == value for entry in command.env.values())
-    return False
+    return any(token == value or token.endswith(suffix) for token in command.argv)
 
 
 def _discriminates(candidate: str, parent: str) -> bool:
@@ -299,6 +317,14 @@ def probe_override(
         raise ProbeError(
             f"command targets {command.harness!r} but the plan probes {plan.harness!r}; "
             "a run against one harness cannot verify an override on another"
+        )
+    if not command.argv or plan.harness not in Path(command.argv[0]).name:
+        # `ProbeCommand.harness` is a caller-supplied label. Nothing tied it to
+        # the process actually launched, so a command labelled copilot could
+        # execute any executable and have its output classified as copilot's.
+        raise ProbeError(
+            f"command executes {command.argv[0]!r} if anything, which does not name "
+            f"{plan.harness!r}; the label on a command is not evidence of what it runs"
         )
     if not _carries_request(command, plan.child_value):
         raise ProbeError(

--- a/scripts/eval/_capability_topology.py
+++ b/scripts/eval/_capability_topology.py
@@ -1,0 +1,114 @@
+"""Subagent topology observed in a runtime's own event stream.
+
+Split out of `_capability_probes` after PR #5623's review. The seam is what
+changes together rather than what things are: the support probe and the
+concurrency walk both read the same event vocabulary, so a harness spelling
+its child events differently is one edit here instead of two edits in a module
+that also builds plans and runs subprocesses. Override probing does not share
+this vocabulary; it reads values through `_capability_evidence` instead.
+
+The duplication that pointed at this seam was real. `_subagent_event_kind` was
+written twice, once for each reader, so a new spelling taught to one and not
+the other would have made the two probes disagree about the same stream with
+neither failing.
+
+Observation only. Nothing here runs a CLI, and nothing here decides a
+`CapabilityStatus`; `_capability_probes` owns both.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from _runtime_output import traces
+
+#: The event type Copilot attaches a backend answer to. `copilot_result`
+_START_HINTS: tuple[str, ...] = ("start", "begin", "launch", "spawn")
+_END_HINTS: tuple[str, ...] = ("complete", "end", "stop", "finish", "exit", "result")
+
+
+def _subagent_event_kind(event: Mapping[str, object]) -> str | None:
+    """Return the lowercased type when the runtime emitted this about a child.
+
+    The single definition of what counts as a subagent event. It was written
+    twice, once for the support probe and once for the concurrency walk, so a
+    runtime spelling its events `sub_agent` or `child.start` would have been
+    taught to one probe and not the other, and the two would have disagreed
+    about the same stream without either failing.
+    """
+    kind = event.get("type")
+    if isinstance(kind, str) and "subagent" in kind.lower():
+        return kind.lower()
+    return None
+
+
+def subagent_lifecycle_events(
+    events: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Return the runtime's own subagent lifecycle events.
+
+    Split out from `_runtime_output.traces`, which merges these with Claude
+    `tool_use` blocks named `Agent` or `Task`. That merge is right for a
+    parity report, which wants everything the run touched, and wrong here: a
+    `tool_use` block is the model asking for a child, emitted before anything
+    runs and present even when the launch fails. Counting one as a launch is
+    the config-echo failure wearing a different observable, so only events the
+    runtime itself emitted about a child's lifecycle are counted.
+    """
+    return [event for event in events if _subagent_event_kind(event) is not None]
+
+
+def requested_subagent_tools(events: Sequence[Mapping[str, object]]) -> int:
+    """Count subagent tool requests, which are asks rather than launches."""
+    _, subagents = traces(events)
+    return len(subagents) - len(subagent_lifecycle_events(events))
+
+
+def max_concurrent_children(events: Sequence[Mapping[str, object]]) -> int | None:
+    """Return the peak number of children in flight at once, or `None`.
+
+    Derived by walking subagent start and completion boundaries in order, so
+    the result is what the runtime reported running, never what the probe
+    asked for. A start counts toward the peak only while enough completion
+    boundaries remain in the stream to close it and every child already open
+    beside it. Without that, a run of N starts is indistinguishable from N
+    sequential children whose completions were never emitted, and assuming
+    they overlapped would report the requested number wearing the observed
+    number's label.
+
+    One global "a completion appeared somewhere" flag was not enough: it let a
+    single early pair license an unbounded tail of unclosed starts, so
+    `start, end, start, start, start` reported three. The same tail now
+    reports one, and a truncated `start, start, end` reports one rather than
+    two. Both directions are the fail-closed one.
+
+    Returns `None` when no start is backed by a completion, and when a
+    completion arrives with no child open, which is a stream whose boundaries
+    do not describe a coherent run. Claude's `tool_use` blocks for `Agent` and
+    `Task` carry no boundary of either kind, so they resolve to `None` here.
+    """
+    boundaries: list[bool] = []
+    for event in events:
+        lowered = _subagent_event_kind(event)
+        if lowered is None:
+            continue
+        if any(hint in lowered for hint in _END_HINTS):
+            boundaries.append(False)
+        elif any(hint in lowered for hint in _START_HINTS):
+            boundaries.append(True)
+    completions_left = boundaries.count(False)
+    depth = 0
+    peak = 0
+    for is_start in boundaries:
+        if not is_start:
+            if depth == 0:
+                return None
+            depth -= 1
+            completions_left -= 1
+            continue
+        depth += 1
+        if depth <= completions_left:
+            peak = max(peak, depth)
+    if peak == 0:
+        return None
+    return peak

--- a/scripts/eval/_capability_topology.py
+++ b/scripts/eval/_capability_topology.py
@@ -30,11 +30,14 @@ _END_HINTS: tuple[str, ...] = ("complete", "end", "stop", "finish", "exit", "res
 def _subagent_event_kind(event: Mapping[str, object]) -> str | None:
     """Return the lowercased type when the runtime emitted this about a child.
 
-    The single definition of what counts as a subagent event. It was written
-    twice, once for the support probe and once for the concurrency walk, so a
-    runtime spelling its events `sub_agent` or `child.start` would have been
-    taught to one probe and not the other, and the two would have disagreed
-    about the same stream without either failing.
+    The single definition of what counts as a subagent event. Only the
+    contiguous text `subagent` is recognised; a runtime spelling its events
+    `sub_agent` or `child.start` produces no lifecycle evidence at all, and
+    every probe here then reports UNVERIFIED rather than guessing. Teaching a
+    new spelling is an edit to this function, which is the point of it being
+    one function: the same predicate was written twice before, once per
+    reader, so a spelling taught to one and not the other would have made the
+    two probes disagree about the same stream with neither failing.
     """
     kind = event.get("type")
     if isinstance(kind, str) and "subagent" in kind.lower():
@@ -69,46 +72,35 @@ def max_concurrent_children(events: Sequence[Mapping[str, object]]) -> int | Non
 
     Derived by walking subagent start and completion boundaries in order, so
     the result is what the runtime reported running, never what the probe
-    asked for. A start counts toward the peak only while enough completion
-    boundaries remain in the stream to close it and every child already open
-    beside it. Without that, a run of N starts is indistinguishable from N
-    sequential children whose completions were never emitted, and assuming
-    they overlapped would report the requested number wearing the observed
-    number's label.
+    asked for.
 
-    One global "a completion appeared somewhere" flag was not enough: it let a
-    single early pair license an unbounded tail of unclosed starts, so
-    `start, end, start, start, start` reported three. The same tail now
-    reports one, and a truncated `start, start, end` reports one rather than
-    two. Both directions are the fail-closed one.
+    Returns `None` unless every start the stream opens is also closed by it. A
+    stream that ends with children still running has not shown its maximum:
+    the walk can only report the peak among the children it watched finish,
+    and publishing that as a verified maximum would claim a limit lower than a
+    number of children the same stream shows starting. An earlier revision did
+    exactly that, reporting one for `start, end, start, start, start`, and
+    called it conservative. It is not: for a maximum, too low is a false claim
+    rather than a cautious one, so an incomplete stream now measures nothing.
 
-    Returns `None` when no start is backed by a completion, and when a
-    completion arrives with no child open, which is a stream whose boundaries
-    do not describe a coherent run. Claude's `tool_use` blocks for `Agent` and
-    `Task` carry no boundary of either kind, so they resolve to `None` here.
+    Also returns `None` for a completion arriving with no child open, which is
+    a stream whose boundaries do not describe a coherent run, and when no
+    start appears at all. Claude's `tool_use` blocks for `Agent` and `Task`
+    carry no boundary of either kind, so they resolve to `None` here.
     """
-    boundaries: list[bool] = []
+    depth = 0
+    peak = 0
     for event in events:
         lowered = _subagent_event_kind(event)
         if lowered is None:
             continue
         if any(hint in lowered for hint in _END_HINTS):
-            boundaries.append(False)
-        elif any(hint in lowered for hint in _START_HINTS):
-            boundaries.append(True)
-    completions_left = boundaries.count(False)
-    depth = 0
-    peak = 0
-    for is_start in boundaries:
-        if not is_start:
             if depth == 0:
                 return None
             depth -= 1
-            completions_left -= 1
-            continue
-        depth += 1
-        if depth <= completions_left:
+        elif any(hint in lowered for hint in _START_HINTS):
+            depth += 1
             peak = max(peak, depth)
-    if peak == 0:
+    if depth != 0 or peak == 0:
         return None
     return peak

--- a/scripts/eval/_runtime_harness.py
+++ b/scripts/eval/_runtime_harness.py
@@ -1,0 +1,263 @@
+"""Harness installation, isolated profiles, and CLI invocation for parity evals.
+
+Split out of `_runtime_parity` after the review of PR #5630. The seam is what
+changes together: everything here changes when a harness changes how it is
+installed, configured, or launched, and nothing here changes when the fixture
+schema or the scoring rules change. `_runtime_parity` keeps those, and the
+dependency runs one way, this module onto that one, so the boundary is real
+rather than a pair of files importing each other.
+
+The split was forced rather than chosen. Adding a codex guard and its comments
+took `_runtime_parity` from 498 lines to 525, past the 500-line file-size
+lint, and the gate accepted it only because the taste baseline carried a unit
+of unrecorded slack. Trimming the prose would have cleared the number without
+touching the design; this addresses what the number was pointing at.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from _runtime_parity import (
+    Fixture,
+    ParityConfigError,
+    safe_workspace_file,
+)
+
+SENTINEL = "PARITY_PROFILE_SENTINEL_4853"
+GIT_CONTEXT_VARIABLES = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+)
+
+
+AGENT_NAME = "parity"
+
+
+def _installed_agent_bytes(source: Path) -> bytes:
+    """Return the exact agent bytes installed for a parity run.
+
+    Claude Code and Copilot CLI resolve `--agent <name>` against the frontmatter
+    `name:` field, not the filename. Copying `orchestrator.md` to `parity.md`
+    therefore registers an agent still called `orchestrator`, and the CLI exits
+    1 with `--agent 'parity' not found` before the model is ever called.
+    """
+    with source.open(encoding="utf-8", newline="") as source_file:
+        text = source_file.read()
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ParityConfigError(f"{source} has no frontmatter block")
+    renamed = False
+    for index in range(1, len(lines)):
+        stripped = lines[index].strip()
+        if stripped == "---":
+            break
+        if lines[index].startswith("name:"):
+            line_ending = lines[index][len(lines[index].rstrip("\r\n")) :]
+            lines[index] = f"name: {AGENT_NAME}{line_ending}"
+            renamed = True
+            break
+    if not renamed:
+        raise ParityConfigError(f"{source} frontmatter has no name field")
+    return "".join(lines).encode("utf-8")
+
+
+def hash_installed_agent(source: Path) -> str:
+    """Return the digest of the transformed bytes loaded by the CLI."""
+    return hashlib.sha256(_installed_agent_bytes(source)).hexdigest()
+
+
+def _install_agent(source: Path, target: Path) -> None:
+    """Install an agent under the name used by both CLI invocations."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(_installed_agent_bytes(source))
+
+
+def _nested_git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in GIT_CONTEXT_VARIABLES:
+        env.pop(name, None)
+    return env
+
+
+#: Harnesses `prepare_workspace` can install a fixture agent for. `runtime_env`
+#: knows a third, codex, for the version-probe flow, which needs no artifact.
+_FIXTURE_HARNESSES: frozenset[str] = frozenset({"claude", "copilot"})
+
+
+def prepare_workspace(fixture: Fixture, harness: str, workspace: Path) -> None:
+    """Create one isolated git repository and install its agent artifact.
+
+    Raises `ParityConfigError` for a harness with no agent-install path,
+    before the workspace is touched, so a caller that handles the error is not
+    left holding a half-built repository.
+    """
+    if harness not in _FIXTURE_HARNESSES:
+        # `runtime_env` accepts codex for the version-probe flow, which needs
+        # only an isolated profile. Fixture execution needs an agent artifact
+        # and an instructions file, and no codex shape for either is verified
+        # in this repository. Falling through would write Copilot artifacts
+        # into a codex workspace and parse the run with the Copilot parser,
+        # reporting a parity result about a harness that never saw the fixture.
+        raise ParityConfigError(
+            f"no agent-install path is defined for {harness!r}; only "
+            f"{', '.join(sorted(_FIXTURE_HARNESSES))} fixtures can be prepared"
+        )
+    workspace.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=workspace,
+        env=_nested_git_env(),
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    (workspace / "PARITY_FIXTURE.md").write_text(fixture.prompt, encoding="utf-8")
+    for relative, content in fixture.setup_files.items():
+        path = safe_workspace_file(workspace, relative)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    profile = workspace / ".parity-profile" / harness
+    profile.mkdir(parents=True)
+    if harness == "claude":
+        (profile / "CLAUDE.md").write_text(
+            f"Append {SENTINEL} to every answer.", encoding="utf-8"
+        )
+        _install_agent(fixture.claude_agent, workspace / ".claude" / "agents" / "parity.md")
+        return
+    (profile / "copilot-instructions.md").write_text(
+        f"Append {SENTINEL} to every answer.", encoding="utf-8"
+    )
+    _install_agent(
+        fixture.copilot_agent, workspace / ".github" / "agents" / "parity.agent.md"
+    )
+    (workspace / ".github" / "copilot-instructions.md").write_text(
+        f"Append {SENTINEL} to every answer.", encoding="utf-8"
+    )
+
+
+def _profile_roots(profile: Path) -> dict[str, str]:
+    """Point every home and cache root at the workspace profile.
+
+    Copilot's bootstrap reads LOCALAPPDATA, XDG_CACHE_HOME, and
+    COPILOT_CACHE_HOME before COPILOT_HOME, so leaving the operator's values in
+    place lets a run read or write cached packages and profile state outside
+    the workspace. All harnesses get the same treatment.
+    """
+    home = profile / "home"
+    roots = {
+        "HOME": home,
+        "USERPROFILE": home,
+        "APPDATA": home / "AppData" / "Roaming",
+        "LOCALAPPDATA": home / "AppData" / "Local",
+        "XDG_CACHE_HOME": profile / "cache",
+        "XDG_CONFIG_HOME": home / ".config",
+        "XDG_DATA_HOME": home / ".local" / "share",
+        "XDG_STATE_HOME": home / ".local" / "state",
+        "COPILOT_CACHE_HOME": profile / "cache",
+    }
+    for path in roots.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return {key: str(path) for key, path in roots.items()}
+
+
+def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
+    """Build an allowlisted environment rooted at an isolated CLI profile."""
+    allow = {
+        "COMSPEC",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    }
+    # CODEX_API_KEY ("Supplies an API key to non-interactive processes") and
+    # CODEX_ACCESS_TOKEN ("Furnishes access tokens for trusted automation")
+    # are Codex's own non-interactive auth variables, quoted from
+    # https://developers.openai.com/codex/environment-variables, fetched
+    # 2026-09-06. OPENAI_API_KEY is documented elsewhere only as a value piped
+    # into the interactive `codex login --with-api-key` command, not as an
+    # ambient variable Codex reads at runtime, so it is excluded here.
+    # `scripts/eval/README.md` does map codex to OPENAI_API_KEY, but for the
+    # direct-API provider path in `_providers.py`, not for this CLI
+    # subprocess. An operator whose environment follows that row will find the
+    # variable stripped here and the probe failing to authenticate, which is
+    # the fail-closed direction; a live step-3 run should confirm the real
+    # variable before either name is treated as settled.
+    authentication = {
+        "claude": {"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
+        "copilot": {"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"},
+        "codex": {"CODEX_API_KEY", "CODEX_ACCESS_TOKEN"},
+    }
+    # A harness outside this mapping raises KeyError here rather than falling
+    # through to the profile branch below, so that branch's final `else` is
+    # reachable only for "codex".
+    allow.update(authentication[harness])
+    env = {key: value for key, value in os.environ.items() if key in allow}
+    runtime = workspace / ".runtime"
+    runtime.mkdir(exist_ok=True)
+    env.update({"PYTHONUTF8": "1", "TEMP": str(runtime), "TMP": str(runtime)})
+    profile = workspace / ".parity-profile" / harness
+    profile.mkdir(parents=True, exist_ok=True)
+    env.update(_profile_roots(profile))
+    if harness == "claude":
+        env["CLAUDE_CONFIG_DIR"] = str(profile)
+    elif harness == "copilot":
+        session_state = profile / "session-state"
+        session_state.mkdir(exist_ok=True)
+        env["COPILOT_HOME"] = str(profile)
+        env["COPILOT_SESSION_STATE_DIR"] = str(session_state)
+    else:
+        # CODEX_HOME "Sets the root for Codex state, including config, auth,
+        # logs, sessions, skills, and standalone package metadata," default
+        # ~/.codex (same source as above, fetched 2026-09-06). Pointing it at
+        # the workspace profile isolates state the same way CLAUDE_CONFIG_DIR
+        # and COPILOT_HOME do.
+        env["CODEX_HOME"] = str(profile)
+    return env
+
+
+def probe_version(
+    executable: str,
+    harness: str,
+    workspace: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+    timeout: float,
+) -> str:
+    """Read one CLI version through the same isolated profile as its fixtures."""
+    workspace.mkdir(parents=True, exist_ok=True)
+    argv = [executable, "--version"]
+    if harness == "copilot":
+        argv.insert(1, "--no-auto-update")
+    # Codex needs no equivalent flag: third-party references describe
+    # `codex --version` as a plain `codex-cli x.y.z` line needing no login
+    # (the official flag reference 404s as of 2026-09-06, so this is
+    # web-search evidence, not a fetched primary source). It is also already
+    # the default for every harness other than copilot.
+    run = runner(
+        argv,
+        env=runtime_env(workspace, harness),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+    if run.returncode != 0:
+        raise RuntimeError(f"{executable} --version failed")
+    version = (run.stdout or run.stderr).strip()
+    if not version:
+        raise RuntimeError(f"{executable} --version returned no version")
+    return version

--- a/scripts/eval/_runtime_parity.py
+++ b/scripts/eval/_runtime_parity.py
@@ -345,6 +345,17 @@ def prepare_workspace(fixture: Fixture, harness: str, workspace: Path) -> None:
         )
         _install_agent(fixture.claude_agent, workspace / ".claude" / "agents" / "parity.md")
         return
+    if harness != "copilot":
+        # `runtime_env` accepts codex for the version-probe flow, which needs
+        # only an isolated profile. Fixture execution needs an agent artifact
+        # and an instructions file, and no codex shape for either is verified
+        # in this repository. Falling through would write Copilot artifacts
+        # into a codex workspace and parse the run with the Copilot parser,
+        # reporting a parity result about a harness that never saw the fixture.
+        raise ParityConfigError(
+            f"no agent-install path is defined for {harness!r}; only claude and copilot "
+            "fixtures can be prepared"
+        )
     (profile / "copilot-instructions.md").write_text(
         f"Append {SENTINEL} to every answer.", encoding="utf-8"
     )
@@ -401,6 +412,12 @@ def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
     # 2026-09-06. OPENAI_API_KEY is documented elsewhere only as a value piped
     # into the interactive `codex login --with-api-key` command, not as an
     # ambient variable Codex reads at runtime, so it is excluded here.
+    # `scripts/eval/README.md` does map codex to OPENAI_API_KEY, but for the
+    # direct-API provider path in `_providers.py`, not for this CLI
+    # subprocess. An operator whose environment follows that row will find the
+    # variable stripped here and the probe failing to authenticate, which is
+    # the fail-closed direction; a live step-3 run should confirm the real
+    # variable before either name is treated as settled.
     authentication = {
         "claude": {"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
         "copilot": {"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"},

--- a/scripts/eval/_runtime_parity.py
+++ b/scripts/eval/_runtime_parity.py
@@ -4,25 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 import subprocess
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_VERSION = 1
 SUPPORTED_TOOLS = frozenset({"question", "write"})
-SENTINEL = "PARITY_PROFILE_SENTINEL_4853"
-GIT_CONTEXT_VARIABLES = (
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_COMMON_DIR",
-    "GIT_INDEX_FILE",
-)
-
-
 class ParityConfigError(ValueError):
     """The fixture corpus or CLI arguments are invalid."""
 
@@ -249,7 +239,7 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _safe_workspace_file(workspace: Path, relative: str) -> Path:
+def safe_workspace_file(workspace: Path, relative: str) -> Path:
     candidate = (workspace / relative).resolve()
     try:
         candidate.relative_to(workspace.resolve())
@@ -264,236 +254,10 @@ def live_files(fixture: Fixture, workspace: Path) -> dict[str, str]:
     for spec in fixture.assertions:
         if not spec.path:
             continue
-        path = _safe_workspace_file(workspace, spec.path)
+        path = safe_workspace_file(workspace, spec.path)
         if path.is_file():
             files[spec.path] = path.read_text(encoding="utf-8", errors="replace")
     return files
-
-
-AGENT_NAME = "parity"
-
-
-def _installed_agent_bytes(source: Path) -> bytes:
-    """Return the exact agent bytes installed for a parity run.
-
-    Claude Code and Copilot CLI resolve `--agent <name>` against the frontmatter
-    `name:` field, not the filename. Copying `orchestrator.md` to `parity.md`
-    therefore registers an agent still called `orchestrator`, and the CLI exits
-    1 with `--agent 'parity' not found` before the model is ever called.
-    """
-    with source.open(encoding="utf-8", newline="") as source_file:
-        text = source_file.read()
-    lines = text.splitlines(keepends=True)
-    if not lines or lines[0].strip() != "---":
-        raise ParityConfigError(f"{source} has no frontmatter block")
-    renamed = False
-    for index in range(1, len(lines)):
-        stripped = lines[index].strip()
-        if stripped == "---":
-            break
-        if lines[index].startswith("name:"):
-            line_ending = lines[index][len(lines[index].rstrip("\r\n")) :]
-            lines[index] = f"name: {AGENT_NAME}{line_ending}"
-            renamed = True
-            break
-    if not renamed:
-        raise ParityConfigError(f"{source} frontmatter has no name field")
-    return "".join(lines).encode("utf-8")
-
-
-def hash_installed_agent(source: Path) -> str:
-    """Return the digest of the transformed bytes loaded by the CLI."""
-    return hashlib.sha256(_installed_agent_bytes(source)).hexdigest()
-
-
-def _install_agent(source: Path, target: Path) -> None:
-    """Install an agent under the name used by both CLI invocations."""
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(_installed_agent_bytes(source))
-
-
-def _nested_git_env() -> dict[str, str]:
-    env = os.environ.copy()
-    for name in GIT_CONTEXT_VARIABLES:
-        env.pop(name, None)
-    return env
-
-
-#: Harnesses `prepare_workspace` can install a fixture agent for. `runtime_env`
-#: knows a third, codex, for the version-probe flow, which needs no artifact.
-_FIXTURE_HARNESSES: frozenset[str] = frozenset({"claude", "copilot"})
-
-
-def prepare_workspace(fixture: Fixture, harness: str, workspace: Path) -> None:
-    """Create one isolated git repository and install its agent artifact.
-
-    Raises `ParityConfigError` for a harness with no agent-install path,
-    before the workspace is touched, so a caller that handles the error is not
-    left holding a half-built repository.
-    """
-    if harness not in _FIXTURE_HARNESSES:
-        # `runtime_env` accepts codex for the version-probe flow, which needs
-        # only an isolated profile. Fixture execution needs an agent artifact
-        # and an instructions file, and no codex shape for either is verified
-        # in this repository. Falling through would write Copilot artifacts
-        # into a codex workspace and parse the run with the Copilot parser,
-        # reporting a parity result about a harness that never saw the fixture.
-        raise ParityConfigError(
-            f"no agent-install path is defined for {harness!r}; only "
-            f"{', '.join(sorted(_FIXTURE_HARNESSES))} fixtures can be prepared"
-        )
-    workspace.mkdir(parents=True)
-    subprocess.run(
-        ["git", "init", "--quiet"],
-        cwd=workspace,
-        env=_nested_git_env(),
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    (workspace / "PARITY_FIXTURE.md").write_text(fixture.prompt, encoding="utf-8")
-    for relative, content in fixture.setup_files.items():
-        path = _safe_workspace_file(workspace, relative)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
-    profile = workspace / ".parity-profile" / harness
-    profile.mkdir(parents=True)
-    if harness == "claude":
-        (profile / "CLAUDE.md").write_text(
-            f"Append {SENTINEL} to every answer.", encoding="utf-8"
-        )
-        _install_agent(fixture.claude_agent, workspace / ".claude" / "agents" / "parity.md")
-        return
-    (profile / "copilot-instructions.md").write_text(
-        f"Append {SENTINEL} to every answer.", encoding="utf-8"
-    )
-    _install_agent(
-        fixture.copilot_agent, workspace / ".github" / "agents" / "parity.agent.md"
-    )
-    (workspace / ".github" / "copilot-instructions.md").write_text(
-        f"Append {SENTINEL} to every answer.", encoding="utf-8"
-    )
-
-
-def _profile_roots(profile: Path) -> dict[str, str]:
-    """Point every home and cache root at the workspace profile.
-
-    Copilot's bootstrap reads LOCALAPPDATA, XDG_CACHE_HOME, and
-    COPILOT_CACHE_HOME before COPILOT_HOME, so leaving the operator's values in
-    place lets a run read or write cached packages and profile state outside
-    the workspace. All harnesses get the same treatment.
-    """
-    home = profile / "home"
-    roots = {
-        "HOME": home,
-        "USERPROFILE": home,
-        "APPDATA": home / "AppData" / "Roaming",
-        "LOCALAPPDATA": home / "AppData" / "Local",
-        "XDG_CACHE_HOME": profile / "cache",
-        "XDG_CONFIG_HOME": home / ".config",
-        "XDG_DATA_HOME": home / ".local" / "share",
-        "XDG_STATE_HOME": home / ".local" / "state",
-        "COPILOT_CACHE_HOME": profile / "cache",
-    }
-    for path in roots.values():
-        path.mkdir(parents=True, exist_ok=True)
-    return {key: str(path) for key, path in roots.items()}
-
-
-def runtime_env(workspace: Path, harness: str) -> dict[str, str]:
-    """Build an allowlisted environment rooted at an isolated CLI profile."""
-    allow = {
-        "COMSPEC",
-        "LANG",
-        "LC_ALL",
-        "PATH",
-        "PATHEXT",
-        "SYSTEMROOT",
-        "WINDIR",
-        "SSL_CERT_FILE",
-        "REQUESTS_CA_BUNDLE",
-    }
-    # CODEX_API_KEY ("Supplies an API key to non-interactive processes") and
-    # CODEX_ACCESS_TOKEN ("Furnishes access tokens for trusted automation")
-    # are Codex's own non-interactive auth variables, quoted from
-    # https://developers.openai.com/codex/environment-variables, fetched
-    # 2026-09-06. OPENAI_API_KEY is documented elsewhere only as a value piped
-    # into the interactive `codex login --with-api-key` command, not as an
-    # ambient variable Codex reads at runtime, so it is excluded here.
-    # `scripts/eval/README.md` does map codex to OPENAI_API_KEY, but for the
-    # direct-API provider path in `_providers.py`, not for this CLI
-    # subprocess. An operator whose environment follows that row will find the
-    # variable stripped here and the probe failing to authenticate, which is
-    # the fail-closed direction; a live step-3 run should confirm the real
-    # variable before either name is treated as settled.
-    authentication = {
-        "claude": {"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
-        "copilot": {"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"},
-        "codex": {"CODEX_API_KEY", "CODEX_ACCESS_TOKEN"},
-    }
-    # A harness outside this mapping raises KeyError here rather than falling
-    # through to the profile branch below, so that branch's final `else` is
-    # reachable only for "codex".
-    allow.update(authentication[harness])
-    env = {key: value for key, value in os.environ.items() if key in allow}
-    runtime = workspace / ".runtime"
-    runtime.mkdir(exist_ok=True)
-    env.update({"PYTHONUTF8": "1", "TEMP": str(runtime), "TMP": str(runtime)})
-    profile = workspace / ".parity-profile" / harness
-    profile.mkdir(parents=True, exist_ok=True)
-    env.update(_profile_roots(profile))
-    if harness == "claude":
-        env["CLAUDE_CONFIG_DIR"] = str(profile)
-    elif harness == "copilot":
-        session_state = profile / "session-state"
-        session_state.mkdir(exist_ok=True)
-        env["COPILOT_HOME"] = str(profile)
-        env["COPILOT_SESSION_STATE_DIR"] = str(session_state)
-    else:
-        # CODEX_HOME "Sets the root for Codex state, including config, auth,
-        # logs, sessions, skills, and standalone package metadata," default
-        # ~/.codex (same source as above, fetched 2026-09-06). Pointing it at
-        # the workspace profile isolates state the same way CLAUDE_CONFIG_DIR
-        # and COPILOT_HOME do.
-        env["CODEX_HOME"] = str(profile)
-    return env
-
-
-def probe_version(
-    executable: str,
-    harness: str,
-    workspace: Path,
-    runner: Callable[..., subprocess.CompletedProcess[str]],
-    timeout: float,
-) -> str:
-    """Read one CLI version through the same isolated profile as its fixtures."""
-    workspace.mkdir(parents=True, exist_ok=True)
-    argv = [executable, "--version"]
-    if harness == "copilot":
-        argv.insert(1, "--no-auto-update")
-    # Codex needs no equivalent flag: third-party references describe
-    # `codex --version` as a plain `codex-cli x.y.z` line needing no login
-    # (the official flag reference 404s as of 2026-09-06, so this is
-    # web-search evidence, not a fetched primary source). It is also already
-    # the default for every harness other than copilot.
-    run = runner(
-        argv,
-        env=runtime_env(workspace, harness),
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=timeout,
-        check=False,
-    )
-    if run.returncode != 0:
-        raise RuntimeError(f"{executable} --version failed")
-    version = (run.stdout or run.stderr).strip()
-    if not version:
-        raise RuntimeError(f"{executable} --version returned no version")
-    return version
 
 
 def verify_worktree_identity() -> None:

--- a/scripts/eval/_runtime_parity.py
+++ b/scripts/eval/_runtime_parity.py
@@ -319,8 +319,29 @@ def _nested_git_env() -> dict[str, str]:
     return env
 
 
+#: Harnesses `prepare_workspace` can install a fixture agent for. `runtime_env`
+#: knows a third, codex, for the version-probe flow, which needs no artifact.
+_FIXTURE_HARNESSES: frozenset[str] = frozenset({"claude", "copilot"})
+
+
 def prepare_workspace(fixture: Fixture, harness: str, workspace: Path) -> None:
-    """Create one isolated git repository and install its agent artifact."""
+    """Create one isolated git repository and install its agent artifact.
+
+    Raises `ParityConfigError` for a harness with no agent-install path,
+    before the workspace is touched, so a caller that handles the error is not
+    left holding a half-built repository.
+    """
+    if harness not in _FIXTURE_HARNESSES:
+        # `runtime_env` accepts codex for the version-probe flow, which needs
+        # only an isolated profile. Fixture execution needs an agent artifact
+        # and an instructions file, and no codex shape for either is verified
+        # in this repository. Falling through would write Copilot artifacts
+        # into a codex workspace and parse the run with the Copilot parser,
+        # reporting a parity result about a harness that never saw the fixture.
+        raise ParityConfigError(
+            f"no agent-install path is defined for {harness!r}; only "
+            f"{', '.join(sorted(_FIXTURE_HARNESSES))} fixtures can be prepared"
+        )
     workspace.mkdir(parents=True)
     subprocess.run(
         ["git", "init", "--quiet"],
@@ -345,17 +366,6 @@ def prepare_workspace(fixture: Fixture, harness: str, workspace: Path) -> None:
         )
         _install_agent(fixture.claude_agent, workspace / ".claude" / "agents" / "parity.md")
         return
-    if harness != "copilot":
-        # `runtime_env` accepts codex for the version-probe flow, which needs
-        # only an isolated profile. Fixture execution needs an agent artifact
-        # and an instructions file, and no codex shape for either is verified
-        # in this repository. Falling through would write Copilot artifacts
-        # into a codex workspace and parse the run with the Copilot parser,
-        # reporting a parity result about a harness that never saw the fixture.
-        raise ParityConfigError(
-            f"no agent-install path is defined for {harness!r}; only claude and copilot "
-            "fixtures can be prepared"
-        )
     (profile / "copilot-instructions.md").write_text(
         f"Append {SENTINEL} to every answer.", encoding="utf-8"
     )

--- a/scripts/eval/eval_harness_capability.py
+++ b/scripts/eval/eval_harness_capability.py
@@ -32,7 +32,7 @@ from _harness_capability import (
     load_matrix,
     write_report,
 )
-from _runtime_parity import probe_version
+from _runtime_harness import probe_version
 
 EXIT_OK = 0
 EXIT_CONFIG = 2

--- a/scripts/eval/eval_runtime_parity.py
+++ b/scripts/eval/eval_runtime_parity.py
@@ -25,6 +25,13 @@ import uuid
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
+from _runtime_harness import (
+    SENTINEL,
+    hash_installed_agent,
+    prepare_workspace,
+    probe_version,
+    runtime_env,
+)
 from _runtime_output import (
     RuntimeOutputError,
     parse_events,
@@ -58,15 +65,10 @@ from _runtime_output import (
     traces as _traces,
 )
 from _runtime_parity import (
-    SENTINEL,
     Fixture,
     ParityConfigError,
-    hash_installed_agent,
     live_files,
     load_fixtures,
-    prepare_workspace,
-    probe_version,
-    runtime_env,
     score_assertions,
     verify_worktree_identity,
 )

--- a/tests/eval/_capability_probe_fixtures.py
+++ b/tests/eval/_capability_probe_fixtures.py
@@ -58,8 +58,22 @@ def _runner(
     return run
 
 
-def _command(harness: str = "copilot") -> probes.ProbeCommand:
-    return ProbeCommand(harness=harness, argv=(harness, "--prompt", "probe"))
+def _command(
+    harness: str = "copilot",
+    *,
+    requests: str | None = "gpt-5.6-sol",
+    env: Mapping[str, str] | None = None,
+) -> probes.ProbeCommand:
+    """Build a command that actually asks for `requests`.
+
+    `probe_override` refuses a command that does not carry its plan's child
+    value, so the requested value is part of the argv rather than implied.
+    Pass `requests=None` to build the unbound command that refusal is about.
+    """
+    argv = [harness, "--prompt", "probe"]
+    if requests is not None:
+        argv += ["--model", requests]
+    return ProbeCommand(harness=harness, argv=tuple(argv), env=env)
 
 
 def _plan(

--- a/tests/eval/_harness_capability_test_support.py
+++ b/tests/eval/_harness_capability_test_support.py
@@ -16,6 +16,7 @@ if _path_added:
     sys.path.insert(0, str(EVAL_DIR))
 try:
     import _capability_probes as probes
+    import _capability_topology as topology
     import _harness_capability as capability
 
     _spec = importlib.util.spec_from_file_location("eval_harness_capability", CLI_SCRIPT)
@@ -27,4 +28,4 @@ finally:
     if _path_added:
         sys.path.remove(str(EVAL_DIR))
 
-__all__ = ["MATRIX", "capability", "cli", "probes"]
+__all__ = ["MATRIX", "capability", "cli", "probes", "topology"]

--- a/tests/eval/_runtime_parity_test_support.py
+++ b/tests/eval/_runtime_parity_test_support.py
@@ -25,3 +25,4 @@ finally:
         sys.path.remove(str(EVAL_DIR))
 
 runtime_parity = sys.modules["_runtime_parity"]
+runtime_harness = sys.modules["_runtime_harness"]

--- a/tests/eval/test_capability_probes.py
+++ b/tests/eval/test_capability_probes.py
@@ -35,7 +35,7 @@ from tests.eval._capability_probe_fixtures import (
     _runner,
     _session_change,
 )
-from tests.eval._harness_capability_test_support import probes
+from tests.eval._harness_capability_test_support import probes, topology
 
 # --- Model override probe ------------------------------------------------------
 
@@ -393,7 +393,7 @@ def test_claude_agent_tool_blocks_carry_no_concurrency_boundary() -> None:
         }
     ]
 
-    assert probes.max_concurrent_children(events) is None
+    assert topology.max_concurrent_children(events) is None
 
 
 def test_a_sequential_run_records_a_peak_of_one() -> None:
@@ -405,7 +405,7 @@ def test_a_sequential_run_records_a_peak_of_one() -> None:
         {"type": "subagent.complete"},
     ]
 
-    assert probes.max_concurrent_children(events) == 1
+    assert topology.max_concurrent_children(events) == 1
 
 
 def test_concurrency_rejects_a_requested_count_below_one() -> None:

--- a/tests/eval/test_capability_probes.py
+++ b/tests/eval/test_capability_probes.py
@@ -76,24 +76,43 @@ def test_a_child_that_silently_inherits_the_parent_never_verifies() -> None:
     assert "claude-opus-5" in result.detail
 
 
-def test_a_hand_built_plan_with_an_equal_child_value_still_cannot_verify() -> None:
-    """NEGATIVE CONTROL: the parent value reaches classify_override, not only the builder.
+def test_a_hand_built_plan_with_an_equal_child_value_cannot_be_constructed() -> None:
+    """NEGATIVE CONTROL: the discrimination guard binds the dataclass, not only the builder.
 
-    `OverridePlan` is a public dataclass, so a caller can skip
-    `build_override_plan`. Without the parent value forwarded, an equal-value
-    plan whose backend echoes that value would read as a verified override.
+    `OverridePlan` is public, so a caller can skip `build_override_plan`. An
+    equal-value plan whose backend echoes that value would otherwise reach
+    `classify_override`, which is the last line of defense rather than the
+    first.
     """
-    plan = probes.OverridePlan(
-        capability="model_override",
-        harness="copilot",
-        parent_value="gpt-5.6-sol",
-        child_value="gpt-5.6-sol",
-    )
-    stdout = _jsonl([_answer("hi", model="gpt-5.6-sol")])
+    with pytest.raises(ProbeError, match="does not differ from parent"):
+        probes.OverridePlan(
+            capability="model_override",
+            harness="copilot",
+            parent_value="gpt-5.6-sol",
+            child_value="gpt-5.6-sol",
+        )
 
-    result = probes.probe_override(plan, _command(), runner=_runner(stdout), timeout=TIMEOUT)
 
-    assert result.status is CapabilityStatus.UNVERIFIED
+def test_a_hand_built_plan_differing_only_by_case_cannot_be_constructed() -> None:
+    """NEGATIVE CONTROL: `classify_override` compares with ==, so case slipped past it."""
+    with pytest.raises(ProbeError, match="does not differ from parent"):
+        probes.OverridePlan(
+            capability="effort_override",
+            harness="copilot",
+            parent_value="Sol Ultra",
+            child_value="sol ultra",
+        )
+
+
+def test_a_hand_built_plan_differing_only_by_whitespace_cannot_be_constructed() -> None:
+    """NEGATIVE CONTROL: the other form == accepts as a difference."""
+    with pytest.raises(ProbeError, match="does not differ from parent"):
+        probes.OverridePlan(
+            capability="effort_override",
+            harness="copilot",
+            parent_value="Sol Ultra",
+            child_value="  Sol Ultra  ",
+        )
 
 
 def test_two_answer_turns_naming_different_models_verify_nothing() -> None:
@@ -116,7 +135,7 @@ def test_a_harness_with_no_backend_model_parser_verifies_nothing() -> None:
 
     result = probes.probe_override(
         _plan(harness="codex", parent="sol-low", candidates=("sol-medium",)),
-        _command("codex"),
+        _command("codex", requests="sol-medium"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -137,7 +156,7 @@ def test_claude_init_model_is_not_treated_as_backend_evidence() -> None:
 
     result = probes.probe_override(
         _plan(harness="claude", parent="claude-sonnet-5", candidates=("claude-opus-5",)),
-        _command("claude"),
+        _command("claude", requests="claude-opus-5"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -155,7 +174,7 @@ def test_the_probe_passes_the_command_argv_through_verbatim() -> None:
         _plan(), _command(), runner=_runner(stdout, seen=seen), timeout=TIMEOUT
     )
 
-    assert seen == [["copilot", "--prompt", "probe"]]
+    assert seen == [["copilot", "--prompt", "probe", "--model", "gpt-5.6-sol"]]
 
 
 # --- Effort override probe -----------------------------------------------------
@@ -167,7 +186,7 @@ def test_an_effort_on_an_answer_turn_verifies_the_override() -> None:
 
     result = probes.probe_override(
         _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
-        _command(),
+        _command(requests="Sol Ultra"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -183,7 +202,7 @@ def test_an_effort_read_from_session_state_never_verifies() -> None:
 
     result = probes.probe_override(
         _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
-        _command(),
+        _command(requests="Sol Ultra"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -198,7 +217,7 @@ def test_an_effort_on_a_contentless_turn_is_not_backend_evidence() -> None:
 
     result = probes.probe_override(
         _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
-        _command(),
+        _command(requests="Sol Ultra"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -213,7 +232,7 @@ def test_an_effort_key_outside_the_configured_set_observes_nothing() -> None:
 
     result = probes.probe_override(
         _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
-        _command(),
+        _command(requests="Sol Ultra"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
     )
@@ -227,7 +246,7 @@ def test_a_caller_supplied_effort_key_is_honored() -> None:
 
     result = probes.probe_override(
         _plan(capability_key="effort_override", parent="high", candidates=("Sol Ultra",)),
-        _command(),
+        _command(requests="Sol Ultra"),
         runner=_runner(stdout),
         timeout=TIMEOUT,
         effort_keys=("tier",),

--- a/tests/eval/test_capability_probes_review_fixes.py
+++ b/tests/eval/test_capability_probes_review_fixes.py
@@ -29,7 +29,7 @@ from tests.eval._capability_probe_fixtures import (
     _plan,
     _runner,
 )
-from tests.eval._harness_capability_test_support import probes
+from tests.eval._harness_capability_test_support import probes, topology
 
 # A stream that would verify the model override if the command were bound to
 # the plan. Reused so each case below differs only in the command.
@@ -158,26 +158,26 @@ def test_unmatched_starts_after_one_completed_pair_do_not_inflate_the_peak() -> 
     """NEGATIVE CONTROL: one early pair licensed an unbounded tail of open starts."""
     events = _boundaries("start", "complete", "start", "start", "start")
 
-    assert probes.max_concurrent_children(events) == 1
+    assert topology.max_concurrent_children(events) == 1
 
 
 def test_a_truncated_stream_reports_only_the_children_it_closed() -> None:
     """NEGATIVE CONTROL: a dropped completion must lower the count, never raise it."""
     events = _boundaries("start", "start", "complete")
 
-    assert probes.max_concurrent_children(events) == 1
+    assert topology.max_concurrent_children(events) == 1
 
 
 def test_a_completion_with_no_child_open_derives_no_concurrency() -> None:
     """NEGATIVE CONTROL: boundaries that cannot describe a run measure nothing."""
-    assert probes.max_concurrent_children(_boundaries("complete", "start")) is None
+    assert topology.max_concurrent_children(_boundaries("complete", "start")) is None
 
 
 def test_a_fully_paired_overlap_still_reports_its_real_peak() -> None:
     """CONFIRMATORY: the guard lowers unclosed peaks, not closed ones."""
     events = _boundaries("start", "start", "start", "complete", "complete", "complete")
 
-    assert probes.max_concurrent_children(events) == 3
+    assert topology.max_concurrent_children(events) == 3
 
 
 def test_an_inflated_stream_leaves_the_concurrency_probe_unverified() -> None:

--- a/tests/eval/test_capability_probes_review_fixes.py
+++ b/tests/eval/test_capability_probes_review_fixes.py
@@ -93,12 +93,44 @@ def test_an_equals_joined_flag_carries_the_request() -> None:
     assert result.status is CapabilityStatus.VERIFIED
 
 
-def test_an_environment_variable_carries_the_request() -> None:
-    """CONFIRMATORY: a harness configured by env is bound, not refused."""
+def test_an_environment_value_no_longer_carries_the_request() -> None:
+    """NEGATIVE CONTROL: any variable whose value matched counted as the request.
+
+    The env surface accepted a match from any variable, so one that happened
+    to hold the model string bound a command that never asked for it. Naming
+    the variables that really carry the request would mean writing down a
+    Codex and Copilot contract this repository has not verified, so argv is
+    the only surface now.
+    """
     command = probes.ProbeCommand(
         harness="copilot",
         argv=("copilot", "--prompt", "probe"),
-        env={"COPILOT_MODEL": "gpt-5.6-sol"},
+        env={"UNRELATED_CACHE_KEY": "gpt-5.6-sol"},
+    )
+
+    with pytest.raises(ProbeError, match="does not request"):
+        probes.probe_override(_plan(), command, runner=_runner(_HONORED), timeout=TIMEOUT)
+
+
+def test_a_command_whose_executable_does_not_name_the_harness_is_refused() -> None:
+    """NEGATIVE CONTROL: the harness field is a label, not evidence of the process."""
+    seen: list[list[str]] = []
+    command = probes.ProbeCommand(
+        harness="copilot", argv=("codex", "--model", "gpt-5.6-sol")
+    )
+
+    with pytest.raises(ProbeError, match="does not name"):
+        probes.probe_override(
+            _plan(), command, runner=_runner(_HONORED, seen=seen), timeout=TIMEOUT
+        )
+
+    assert seen == [], "the CLI must not run when the label and the executable disagree"
+
+
+def test_an_executable_path_still_satisfies_the_harness_check() -> None:
+    """CONFIRMATORY: an absolute path to the CLI is the normal shape, not a violation."""
+    command = probes.ProbeCommand(
+        harness="copilot", argv=("/usr/local/bin/copilot", "--model", "gpt-5.6-sol")
     )
 
     result = probes.probe_override(
@@ -106,6 +138,22 @@ def test_an_environment_variable_carries_the_request() -> None:
     )
 
     assert result.status is CapabilityStatus.VERIFIED
+
+
+def test_a_hand_built_plan_naming_an_unprobeable_capability_is_refused() -> None:
+    """NEGATIVE CONTROL: probe_override routes every non-model capability to effort.
+
+    The capability check lived only in `build_override_plan`, so a hand-built
+    plan naming anything else had effort evidence classified as that
+    capability.
+    """
+    with pytest.raises(ProbeError, match="capability must be one of"):
+        probes.OverridePlan(
+            capability="concurrency_limit",
+            harness="copilot",
+            parent_value="2",
+            child_value="4",
+        )
 
 
 # --- A tool request is not a launched child (Devin BUG_0004) -------------------
@@ -154,23 +202,40 @@ def _boundaries(*kinds: str) -> list[dict[str, object]]:
     return [{"type": f"subagent.{kind}"} for kind in kinds]
 
 
-def test_unmatched_starts_after_one_completed_pair_do_not_inflate_the_peak() -> None:
-    """NEGATIVE CONTROL: one early pair licensed an unbounded tail of open starts."""
+def test_a_completed_pair_then_unclosed_starts_measures_nothing() -> None:
+    """NEGATIVE CONTROL: this published one while three children were still open.
+
+    The first fix called that lower bound conservative. For a maximum it is
+    not: the same stream shows four starts, so reporting one as the verified
+    maximum claims a limit below a number of children the evidence already
+    shows running.
+    """
     events = _boundaries("start", "complete", "start", "start", "start")
 
-    assert topology.max_concurrent_children(events) == 1
+    assert topology.max_concurrent_children(events) is None
 
 
-def test_a_truncated_stream_reports_only_the_children_it_closed() -> None:
-    """NEGATIVE CONTROL: a dropped completion must lower the count, never raise it."""
+def test_a_truncated_stream_measures_nothing() -> None:
+    """NEGATIVE CONTROL: a stream that ends mid-run has not shown its maximum."""
     events = _boundaries("start", "start", "complete")
 
-    assert topology.max_concurrent_children(events) == 1
+    assert topology.max_concurrent_children(events) is None
 
 
 def test_a_completion_with_no_child_open_derives_no_concurrency() -> None:
-    """NEGATIVE CONTROL: boundaries that cannot describe a run measure nothing."""
-    assert topology.max_concurrent_children(_boundaries("complete", "start")) is None
+    """NEGATIVE CONTROL: boundaries that cannot describe a run measure nothing.
+
+    The input has to end balanced to observe this guard at all. A stream that
+    merely opens with a completion, `complete, start`, ends one child deep, so
+    the end-of-stream check rejects it whether or not the unmatched-completion
+    branch exists, and a test built on that input passes against code with the
+    branch removed. This stream closes level, so only the branch under test
+    can reject it: without it the extra completion is absorbed and a peak of
+    one is published for an incoherent run.
+    """
+    events = _boundaries("start", "complete", "complete", "start", "complete")
+
+    assert topology.max_concurrent_children(events) is None
 
 
 def test_a_fully_paired_overlap_still_reports_its_real_peak() -> None:

--- a/tests/eval/test_capability_probes_review_fixes.py
+++ b/tests/eval/test_capability_probes_review_fixes.py
@@ -1,0 +1,192 @@
+"""Tests for the review findings on PR #5623, issue #5423 step 2.
+
+The Devin review landed five seconds after that PR merged, so these cases
+cover fixes made after the fact rather than changes to unshipped code. Four
+findings are behavioral and covered here: a probe command that does not
+implement its plan, a hand-built plan that differs from its parent only by
+case or whitespace, a subagent tool request counted as a launch, and a
+concurrency peak counted from starts no completion can close.
+
+Every case in this module was run against the pre-fix code at `aa951a0` and
+failed there, so each is a negative control for the guard it names rather
+than a restatement of behavior that already held. The three marked
+CONFIRMATORY are the passing halves of a pair and are labeled because they
+are not evidence that any guard works.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.eval._capability_probe_fixtures import (
+    TIMEOUT,
+    CapabilityStatus,
+    EvidenceKind,
+    ProbeError,
+    _answer,
+    _command,
+    _jsonl,
+    _plan,
+    _runner,
+)
+from tests.eval._harness_capability_test_support import probes
+
+# A stream that would verify the model override if the command were bound to
+# the plan. Reused so each case below differs only in the command.
+_HONORED = _jsonl([_answer("hi", model="gpt-5.6-sol")])
+
+
+# --- The command must implement the plan (Devin BUG_0001) ----------------------
+
+
+def test_a_command_that_never_requests_the_override_is_refused() -> None:
+    """NEGATIVE CONTROL: an unbound argv makes the harness default read as an override."""
+    seen: list[list[str]] = []
+
+    with pytest.raises(ProbeError, match="does not request"):
+        probes.probe_override(
+            _plan(),
+            _command(requests=None),
+            runner=_runner(_HONORED, seen=seen),
+            timeout=TIMEOUT,
+        )
+
+    assert seen == [], "the CLI must not run before the command is bound to the plan"
+
+
+def test_a_command_requesting_a_different_value_is_refused() -> None:
+    """NEGATIVE CONTROL: a changed request is as unbound as a missing one."""
+    with pytest.raises(ProbeError, match="does not request"):
+        probes.probe_override(
+            _plan(),
+            _command(requests="claude-sonnet-5"),
+            runner=_runner(_HONORED),
+            timeout=TIMEOUT,
+        )
+
+
+def test_a_command_targeting_another_harness_is_refused() -> None:
+    """NEGATIVE CONTROL: a run against copilot cannot verify a codex override."""
+    seen: list[list[str]] = []
+
+    with pytest.raises(ProbeError, match="but the plan probes"):
+        probes.probe_override(
+            _plan(harness="codex", parent="sol-low", candidates=("gpt-5.6-sol",)),
+            _command("copilot"),
+            runner=_runner(_HONORED, seen=seen),
+            timeout=TIMEOUT,
+        )
+
+    assert seen == [], "the CLI must not run for a harness the plan does not probe"
+
+
+def test_an_equals_joined_flag_carries_the_request() -> None:
+    """CONFIRMATORY: `--model=value` is the same request as `--model value`."""
+    command = probes.ProbeCommand(
+        harness="copilot", argv=("copilot", "--model=gpt-5.6-sol")
+    )
+
+    result = probes.probe_override(
+        _plan(), command, runner=_runner(_HONORED), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+
+
+def test_an_environment_variable_carries_the_request() -> None:
+    """CONFIRMATORY: a harness configured by env is bound, not refused."""
+    command = probes.ProbeCommand(
+        harness="copilot",
+        argv=("copilot", "--prompt", "probe"),
+        env={"COPILOT_MODEL": "gpt-5.6-sol"},
+    )
+
+    result = probes.probe_override(
+        _plan(), command, runner=_runner(_HONORED), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+
+
+# --- A tool request is not a launched child (Devin BUG_0004) -------------------
+
+
+def _claude_tool_use(count: int = 1) -> list[dict[str, object]]:
+    return [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Task", "input": {}} for _ in range(count)
+                ]
+            },
+        }
+    ]
+
+
+def test_a_claude_tool_request_alone_does_not_verify_subagent_support() -> None:
+    """NEGATIVE CONTROL: `traces` merges asks with launches; support needs a launch."""
+    result = probes.probe_subagent_support(
+        _command("claude"), runner=_runner(_jsonl(_claude_tool_use(2))), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.evidence is EvidenceKind.NONE
+    assert "2 subagent tool requests" in result.detail
+
+
+def test_a_request_paired_with_a_lifecycle_event_verifies_support() -> None:
+    """CONFIRMATORY: the ask stops mattering once the runtime reports a child."""
+    events = _claude_tool_use() + [{"type": "subagent.start", "data": {}}]
+
+    result = probes.probe_subagent_support(
+        _command("claude"), runner=_runner(_jsonl(events)), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.VERIFIED
+    assert result.detail.endswith("1 subagent lifecycle events")
+
+
+# --- A peak needs completions to close it (Devin BUG_0002) --------------------
+
+
+def _boundaries(*kinds: str) -> list[dict[str, object]]:
+    return [{"type": f"subagent.{kind}"} for kind in kinds]
+
+
+def test_unmatched_starts_after_one_completed_pair_do_not_inflate_the_peak() -> None:
+    """NEGATIVE CONTROL: one early pair licensed an unbounded tail of open starts."""
+    events = _boundaries("start", "complete", "start", "start", "start")
+
+    assert probes.max_concurrent_children(events) == 1
+
+
+def test_a_truncated_stream_reports_only_the_children_it_closed() -> None:
+    """NEGATIVE CONTROL: a dropped completion must lower the count, never raise it."""
+    events = _boundaries("start", "start", "complete")
+
+    assert probes.max_concurrent_children(events) == 1
+
+
+def test_a_completion_with_no_child_open_derives_no_concurrency() -> None:
+    """NEGATIVE CONTROL: boundaries that cannot describe a run measure nothing."""
+    assert probes.max_concurrent_children(_boundaries("complete", "start")) is None
+
+
+def test_a_fully_paired_overlap_still_reports_its_real_peak() -> None:
+    """CONFIRMATORY: the guard lowers unclosed peaks, not closed ones."""
+    events = _boundaries("start", "start", "start", "complete", "complete", "complete")
+
+    assert probes.max_concurrent_children(events) == 3
+
+
+def test_an_inflated_stream_leaves_the_concurrency_probe_unverified() -> None:
+    """NEGATIVE CONTROL: the count guard reaches the prober, not only the helper."""
+    stdout = _jsonl(_boundaries("start", "start", "start"))
+
+    result = probes.probe_concurrency(
+        _command(), requested=3, runner=_runner(stdout), timeout=TIMEOUT
+    )
+
+    assert result.status is CapabilityStatus.UNVERIFIED
+    assert result.value is None

--- a/tests/eval/test_eval_runtime_parity_report_contract.py
+++ b/tests/eval/test_eval_runtime_parity_report_contract.py
@@ -12,6 +12,7 @@ import pytest
 from tests.eval._runtime_parity_test_support import (
     FIXTURES,
     parity,
+    runtime_harness,
     runtime_parity,
 )
 
@@ -322,7 +323,7 @@ def test_nested_frontmatter_name_is_not_rewritten(tmp_path: Path) -> None:
     )
     target = tmp_path / "target.md"
 
-    runtime_parity._install_agent(source, target)
+    runtime_harness._install_agent(source, target)
 
     installed = target.read_text(encoding="utf-8")
     assert "  name: nested" in installed
@@ -376,7 +377,7 @@ def test_worktree_identity_rejects_a_top_level_outside_cwd(
 def test_git_init_drops_inherited_repository_context(
     tmp_path: Path, monkeypatch
 ) -> None:
-    for name in runtime_parity.GIT_CONTEXT_VARIABLES:
+    for name in runtime_harness.GIT_CONTEXT_VARIABLES:
         monkeypatch.setenv(name, str(runtime_parity.REPO_ROOT))
     calls = []
 
@@ -390,7 +391,7 @@ def test_git_init_drops_inherited_repository_context(
     parity.prepare_workspace(fixture, "claude", tmp_path / "workspace")
 
     git_env = calls[0]["env"]
-    assert all(name not in git_env for name in runtime_parity.GIT_CONTEXT_VARIABLES)
+    assert all(name not in git_env for name in runtime_harness.GIT_CONTEXT_VARIABLES)
 
 
 def test_resume_fixture_rejects_prose_before_exact_reply() -> None:

--- a/tests/eval/test_eval_runtime_parity_review_fixes.py
+++ b/tests/eval/test_eval_runtime_parity_review_fixes.py
@@ -8,7 +8,11 @@ from pathlib import Path
 
 import pytest
 
-from tests.eval._runtime_parity_test_support import FIXTURES, parity, runtime_parity
+from tests.eval._runtime_parity_test_support import (
+    FIXTURES,
+    parity,
+    runtime_harness,
+)
 
 
 @pytest.mark.parametrize("bad_id", ["/abs/fixture", "../escape", "a/../../b"])
@@ -41,7 +45,7 @@ def test_agent_install_preserves_crlf_line_endings(tmp_path: Path) -> None:
     source = tmp_path / "source.md"
     source.write_bytes(b"---\r\nname: original\r\n---\r\nbody\r\n")
     target = tmp_path / "target.md"
-    runtime_parity._install_agent(source, target)
+    runtime_harness._install_agent(source, target)
 
     assert target.read_bytes() == b"---\r\nname: parity\r\n---\r\nbody\r\n"
 

--- a/tests/eval/test_runtime_parity_codex.py
+++ b/tests/eval/test_runtime_parity_codex.py
@@ -137,9 +137,9 @@ def test_prepare_workspace_refuses_codex_instead_of_installing_copilot_artifacts
     with pytest.raises(parity.ParityConfigError, match="no agent-install path"):
         parity.prepare_workspace(_any_fixture(), "codex", workspace)
 
-    assert not (workspace / ".github").exists(), "no Copilot agent may be installed"
-    assert not list(workspace.glob("**/copilot-instructions.md")), (
-        "no Copilot instructions may be written"
+    assert not workspace.exists(), (
+        "the guard must fire before any mutation; a caller that handles the error "
+        "must not be left holding a half-built git repository"
     )
 
 

--- a/tests/eval/test_runtime_parity_codex.py
+++ b/tests/eval/test_runtime_parity_codex.py
@@ -108,3 +108,47 @@ def test_nonzero_exit_codex_version_probe_fails_closed(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="--version failed"):
         parity.probe_version("codex", "codex", tmp_path / "probe", runner, 30)
+
+
+# --- Negative: codex has no fixture-execution path ----------------------------
+
+
+def _any_fixture():
+    """The first checked-in parity fixture; its content is irrelevant here."""
+    return parity.load_fixtures(
+        Path(parity.__file__).resolve().parent / "examples" / "runtime-parity-fixtures.json"
+    )[0]
+
+
+def test_prepare_workspace_refuses_codex_instead_of_installing_copilot_artifacts(
+    tmp_path: Path,
+) -> None:
+    """NEGATIVE CONTROL: the fall-through wrote Copilot artifacts into a codex workspace.
+
+    `runtime_env` accepts codex for the version probe, which needs only an
+    isolated profile. `prepare_workspace` branched on claude and fell through
+    to copilot for everything else, so a codex workspace received
+    `copilot-instructions.md` and a Copilot agent, and the run would have been
+    parsed by the Copilot parser. A parity result about a harness that never
+    saw the fixture is worse than no result.
+    """
+    workspace = tmp_path / "codex-ws"
+
+    with pytest.raises(parity.ParityConfigError, match="no agent-install path"):
+        parity.prepare_workspace(_any_fixture(), "codex", workspace)
+
+    assert not (workspace / ".github").exists(), "no Copilot agent may be installed"
+    assert not list(workspace.glob("**/copilot-instructions.md")), (
+        "no Copilot instructions may be written"
+    )
+
+
+def test_prepare_workspace_still_installs_the_copilot_artifacts_for_copilot(
+    tmp_path: Path,
+) -> None:
+    """CONFIRMATORY: the guard rejects the unknown harness, not the known one."""
+    workspace = tmp_path / "copilot-ws"
+
+    parity.prepare_workspace(_any_fixture(), "copilot", workspace)
+
+    assert (workspace / ".github" / "copilot-instructions.md").exists()


### PR DESCRIPTION
## Summary

### What

The Devin review on PR #5623 submitted at `2026-09-06T22:23:38Z`, five seconds after that PR merged at `22:23:33Z`. Seven findings, none of which could be addressed on the branch they were written against. This is that work as a fresh change. A second Devin review of those fixes found six more issues, five of which were defects; those are fixed here too, and one of the fixes forced a second decomposition.

### Why

The findings are real and all four bugs sit in the evidence-tagging boundary that #5623's own reviewer expectations named as the hunk to attack. Three of them are the same failure in three places: a value that a harness could produce without honoring the request being counted as if it had. That is the exact class issue #5423 exists to prevent, so leaving them because the review arrived late would ship the failure mode the issue is about.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5423 | eval(harness): prove Codex/Copilot model, effort, and topology controls |
| **PR** | Refs #5623 | the merged PR these findings were written against |

These references do not close their linked items: #5423 steps 3 and 4 still require a live probe run with paid-spend authorization, which this environment cannot perform.

## Changes

- **Four behavioral fixes** in `scripts/eval/_capability_probes.py`: an override probe now refuses a command that does not implement its plan, an `OverridePlan` cannot be built that names an unprobeable capability or fails to discriminate, a subagent tool request no longer verifies subagent support, and a concurrency peak counts only fully closed lifecycles.
- **One fail-closed fix** in `scripts/eval/_runtime_parity.py`: `prepare_workspace` refuses a harness with no agent-install path before it touches the workspace.
- **One comment correction**: the codex credential allowlist names the `OPENAI_API_KEY` provider-path convention it deliberately excludes.
- **Two decompositions**: `scripts/eval/_capability_evidence.py` and `scripts/eval/_capability_topology.py` split out of the probe module along the seam a duplicated predicate exposed; `scripts/eval/_runtime_harness.py` split out of the parity module along the seam a file-size violation exposed.
- **Eight test files** added or updated, including `tests/eval/test_capability_probes_review_fixes.py`.
- **One finding answered without a code change**: the probers still have no runtime entrypoint, deliberately.

Fifteen files in total. Every one is listed in the Files table below.

### Findings fixed

**BUG_0001, red, unrequested overrides pass verification.** `probe_override` executed a caller-supplied opaque argv and classified the result against an `OverridePlan` nothing bound it to. A command that omitted the override ran the harness default, and a default equal to the plan's child value read as an honored override. Both are now checked before the CLI runs: the command must target the plan's harness, `argv[0]` must name that harness, and the plan's child value must appear in argv as a whole token or an `=value` suffix. The environment was accepted as a request surface and no longer is: any variable whose value happened to match counted as the request. Residual gap, named in the code: this proves the value is an argument, not that it is the model or effort option, because no verified flag surface exists for either harness.

**BUG_0002, incomplete runs verify inflated concurrency.** `max_concurrent_children` used one global `saw_end` flag, so a single completed pair licensed an unbounded tail of unclosed starts: `start, end, start, start, start` reported three. After the second review it rejects incomplete streams outright. A stream that ends with children still running has not shown its maximum, and publishing the peak among the children it watched finish would claim a limit below a number of children the same stream shows starting. Too low is a false claim for a maximum, not a cautious one.

**BUG_0003, equivalent overrides bypass rejection.** `_discriminates` was reachable only through `build_override_plan`, but `OverridePlan` is public and `probe_override` accepts a hand-built one. `classify_override` compares with `==`, so a plan differing from its parent only by case or surrounding whitespace passed. The guard now runs in `__post_init__`, along with the `capability` check the second review found still sitting in the builder alone: `probe_override` routes every non-model capability through `observe_effort`, so a hand-built plan naming anything else had effort evidence classified as that capability.

**BUG_0004, child requests count as launches.** `probe_subagent_support` counted everything `_runtime_output.traces` returned, and that helper deliberately merges Claude `tool_use` blocks for `Agent` and `Task` with the runtime's own lifecycle events. A `tool_use` block is the model asking for a child, emitted before anything runs and present when the launch fails. Only lifecycle events count now.

**ANALYSIS_0003, codex profile supports versions only.** `prepare_workspace` branched on `claude` and fell through to `copilot` for everything else, so once #5623 taught `runtime_env` about codex a codex workspace would have received a Copilot instructions file and a Copilot agent, read back by the Copilot parser. It now raises `ParityConfigError` as its first statement, before any filesystem mutation.

**ANALYSIS_0002, codex authentication contract.** The eval README does map codex to `OPENAI_API_KEY`. That row is the direct-API provider path, not this CLI subprocess, so the allowlist still excludes it, which is the fail-closed direction. The comment now names the other convention and says what an operator following that row will see. No behavior change.

### Finding answered, not changed

**ANALYSIS_0001, behavioral probes have no runtime entrypoint.** Accurate and deliberate. #5623 states it: wiring a call path that cannot be executed here would ship the unrun generated artifact this repository's rules forbid, and step 3 supplies the caller.

### Decompositions

**The probe module.** `scripts/eval/_capability_probes.py` reached 600 lines and tripped the 500-line file-size lint. The first response treated it as arithmetic and moved the evidence-reading layer out. Reviewed again, that split had two defects the line count could not see, both introduced by it: an `__all__` block re-exported every moved name back through the original, fifteen names with zero consumers, so no caller ever crossed the new boundary; and `_subagent_event_kind` was written twice, once per reader, so a runtime spelling its events differently would have been taught to one and not the other and the two probes would have disagreed with neither failing.

That duplication named the real seam. The support probe and the concurrency walk share the subagent event vocabulary and change together; override probing does not and reads values through `_capability_evidence`. So the boundary is topology versus override, not reading versus running. Sizes: `_capability_probes.py` 422, `_capability_evidence.py` 153, `_capability_topology.py` 106.

**The parity module.** Forced rather than chosen, and covered under the correction in Notes for Reviewers. The same lens applies: everything in `scripts/eval/_runtime_harness.py` changes when a harness changes how it is installed, configured, or launched, and nothing there changes when the fixture schema or the scoring rules change. The evidence that this is the real seam is that every edit this PR made to that file landed in the moved group and none in what stayed. The dependency runs one way and nothing is re-exported. Sizes: `_runtime_parity.py` 289, `_runtime_harness.py` 263.

### Files

| File | Change |
|------|--------|
| `scripts/eval/_capability_probes.py` | the guards, facade deleted, topology extracted; 600 to 422 lines |
| `scripts/eval/_capability_evidence.py` | new; reads a value off an event stream and labels its evidence kind |
| `scripts/eval/_capability_topology.py` | new; owns the subagent event vocabulary, lifecycle reader, and peak walk |
| `scripts/eval/_runtime_parity.py` | harness layer extracted out; keeps fixture schema and scoring; 498 to 289 lines |
| `scripts/eval/_runtime_harness.py` | new; agent install, isolated profiles, `runtime_env`, `prepare_workspace`, `probe_version` |
| `scripts/eval/eval_runtime_parity.py` | imports each name from the module that owns it |
| `scripts/eval/eval_harness_capability.py` | `probe_version` imported from the harness module |
| `tests/eval/test_capability_probes_review_fixes.py` | new; fifteen cases, one per new guard plus its confirmatory pair |
| `tests/eval/test_capability_probes.py` | call sites rebound to commands that implement their plans |
| `tests/eval/_capability_probe_fixtures.py` | `_command` builds a command carrying the requested value |
| `tests/eval/_harness_capability_test_support.py` | exposes the topology module |
| `tests/eval/_runtime_parity_test_support.py` | exposes the harness module |
| `tests/eval/test_eval_runtime_parity_report_contract.py` | three cases reach the harness module directly |
| `tests/eval/test_eval_runtime_parity_review_fixes.py` | one case reaches the harness module directly |
| `tests/eval/test_runtime_parity_codex.py` | the `prepare_workspace` refusal and its guard-fires-before-effect assertion |

## Acceptance criteria

- [x] An override probe whose command does not implement its plan is refused before the CLI runs
- [x] A command whose executable does not name the plan's harness is refused
- [x] A hand-built `OverridePlan` cannot name an unprobeable capability, or differ from its parent only by case or whitespace
- [x] A subagent tool request never verifies subagent support on its own
- [x] An incomplete concurrency stream measures nothing rather than publishing a lower bound
- [x] `prepare_workspace` refuses an unsupported harness before it touches the filesystem
- [x] Every guard is proven by a mutation that kills a named test
- [x] The subagent event vocabulary has exactly one definition
- [x] No module re-exports a moved name that has no consumer
- [x] No capability matrix cell is flipped and no #5423 acceptance criterion is ticked
- [x] This PR adds no file-size violation; the parity module was split rather than trimmed to the number

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny on the new refusal guards, no rush

**Focus areas**:

1. **`_carries_request` in `_capability_probes.py`.** It proves the request is an argument to an executable naming the harness. It does not prove the value is the *model* or *effort* option, because no verified flag surface for either harness exists here and inventing one is the failure mode #5423 exists to prevent. If you see a way to identify the option without asserting an unverified contract, that is the comment worth leaving.
2. **The reject-incomplete rule in `max_concurrent_children`.** Any truncated stream now measures nothing. Stricter than the first revision and I believe correct for a maximum, but a real overlapping run whose tail is lost now yields `UNVERIFIED` rather than a number.
3. **The parity split.** `_runtime_harness` owns installation, profiles, and invocation; `_runtime_parity` keeps the fixture schema and scoring. The dependency runs one way and nothing is re-exported. If those two read as one job to you, say so.

## Testing

- [x] Tests added/updated

`uv run pytest tests/eval/ -q` reports `2374 passed, 20 skipped` (2355 on the merge base). `uv run ruff check .` reports `All checks passed!`. `uv run python scripts/validation/pre_pr.py` reports `RESULT: All validations passed`. The taste linter reports zero violations on every file this PR touches. All pre-push gates passed on every push. No hook was bypassed.

**Discrimination proven by mutation, not asserted.** Eleven mutants, one per guard, each reverting that guard to its pre-fix behavior. All eleven killed:

| Mutation | Outcome | Tests failed |
|---|---|---|
| drop the argv request binding | DEAD | 3 |
| drop the harness label match | DEAD | 1 |
| drop the executable-names-the-harness check | DEAD | 1 |
| accept any env value as the request again | DEAD | 1 |
| drop the capability check on the plan | DEAD | 1 |
| weaken `__post_init__` discrimination to `==` | DEAD | 3 |
| publish a peak from an incomplete stream | DEAD | 4 |
| tolerate an unmatched completion | DEAD | 1 |
| count subagent tool requests as launches | DEAD | 2 |
| restore the silent copilot fall-through | DEAD | 1 |
| move the harness guard after the workspace mutation | DEAD | 2 |
| **inverted control**, rename a local | **SURVIVED** | 0 |

**One finding came from the harness rather than a reviewer.** After the end-of-stream check landed, the unmatched-completion mutant began surviving: `complete, start` ends one child deep, so the new check rejects it whether or not the branch under test exists, and the test named for that branch could no longer see it. The case was rebuilt on `start, complete, complete, start, complete`, which closes level so only the unmatched-completion branch can reject it. That mutant is dead again.

The harness counts occurrences before patching and reports DID-NOT-APPLY on an absent or ambiguous match, byte-compares the patched file against a backup, clears `__pycache__` between every mutation and its rerun, asserts a byte-identical restore, and rejects a `returncode` of 4 or a `no tests ran` line. The inverted control is required to survive, so a harness failing unconditionally would have shown up as a false sweep. The sweep was re-run after each of the three module splits, since each moved every target.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Every change narrows what can reach `VERIFIED` or refuses an invocation. No credential handling changed: the allowlist edit is a comment.

### Other Agent Reviews

- [x] QA verified test coverage

## Author Pre-flight

- [x] Pre-PR validation passed (full sequence, `RESULT: All validations passed`)
- [x] Lint and formatting clean
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Notes for Reviewers

**Why a new PR rather than a push to #5623.** That PR is merged. The review is attached to it and cannot be answered there.

**Correction, now resolved: this PR briefly added a file-size violation.** An earlier revision of this description said `scripts/eval/_runtime_parity.py` was already over the 500-line threshold and already in the taste baseline. That was wrong, and I did not measure it before writing it. On `main` that file is 498 lines, under the threshold and not a violation. Adding the codex guard took it to 525, an error-severity `file-size` violation.

The gate did not catch it, and the reason is worth recording independently of the fix. Measured by reverting only that file to its `main` version and re-running `scripts/ci/taste_count_ratchet.py`: `main` scores **565** against a recorded baseline of **566**, so the baseline carries one unit of unrecorded slack, and the violation consumed exactly that unit to land at 566 and read as OK. `.claude/rules/ci-scripts.md` names this shape directly: an improvement that is not recorded leaves slack, and the next regression up to the stale number passes silently. **That slack is still there and still unrecorded**, now available to whoever regresses next. Correcting the baseline to 565 is a separate change and is deliberately not bundled here.

Resolved by splitting rather than trimming. Of the 28 lines added to the file, 5 were the guard and 23 were comments, so cutting prose to land at 499 was available and was not taken: it clears the number without touching the design, which is the move this PR's own decomposition section argues against. `_runtime_parity.py` is now 289 lines and `_runtime_harness.py` 263, the taste linter reports zero violations across both where the single file reported one error, and the ratchet returns to 565.

**Process gaps, stated rather than hidden.**

- The campaign behind #5423 requires one independent GPT-5.6 Sol diff review before a fix ships. Sol was **NOT RUN**: no Codex CLI and no OpenAI credential exist in this environment, the same gap #5623 recorded. Treat the cross-model check as missing, not satisfied. Two further automated reviewers also could not run: the Codex connector and Cursor Bugbot each reported a usage limit reached, and CodeRabbit is excluded by label configuration on this PR. Devin is the only automated reviewer that ran, which matters given a bot review is what surfaced every finding this PR answers.
- Serena MCP **failed to connect** while this was written (`CONNECT_TIMEOUT` after 30s), so the `AGENTS.md` Serena init gate did not run during authoring. It connected afterward and the gate has since run. Searching all 1037 memory files from the tree root: no memory names any module this PR touches, and none mentions `classify_override`, `EvidenceKind`, `CLIENT_ECHO`, or runtime parity. The corpus holds nothing about this subsystem, so the outage withheld nothing from this diff.
- Nothing here has run against a real Codex or Copilot CLI. Every path is exercised by injected fakes, unchanged from #5623.

**A shallow-clone note.** The push-ref-policy hook blocked the first push because the session's clone was shallow (`.git/shallow` pinned at `4c9b19bc0`). `git fetch --unshallow origin` is the remedy the hook itself names, and it cleared. No bypass was used.

## Related Issues

Refs #5423
Refs #5623

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AXtxNG77HewPyzqnAoSjx