### PR TITLE
fix(ci): arm spec validation on Refs and every GitHub keyword spelling

### DIFF
--- a/scripts/ci/spec_extract_refs.py
+++ b/scripts/ci/spec_extract_refs.py
@@ -60,6 +60,29 @@ _ISSUE_REF_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# GitHub does not link an issue from a keyword inside a code span or a fenced
+# block, so neither may arm this gate. Measured on PR #5648's own run: the body
+# discussed the bug using `Closes: #10`, `Refs #5600` and `Refs #5623` as
+# examples inside backticks, and the widened parser reported
+# `ISSUE_REFS: 10 5489 5600 5620 5621 5623`. Three of those six are prose, two
+# of them pull request numbers, and the loader fed all of them to the judge as
+# if they were this PR's requirements. `validate_pr_description.py` already
+# treats a closing keyword in a code span as not-a-link, for the same reason.
+#
+# Deliberately not applied to `_extract_spec_refs`: `.github/PULL_REQUEST_TEMPLATE.md`
+# writes spec paths in backticks (`| **Spec** | `.agents/planning/...` |`), so
+# masking there would disarm the gate on the template's own convention. The
+# asymmetry is real, because a code span suppresses GitHub's issue linking and
+# says nothing about a file path.
+_FENCED_BLOCK = re.compile(r"(?ms)^[ \t]*(`{3,}|~{3,})[^\n]*$.*?(?:^[ \t]*\1[ \t]*$|\Z)")
+_INLINE_CODE = re.compile(r"`+[^`]*`+")
+
+
+def _strip_code(text: str) -> str:
+    """Blank out fenced blocks and inline code spans, keeping the rest intact."""
+    without_fences = _FENCED_BLOCK.sub(" ", text)
+    return _INLINE_CODE.sub(" ", without_fences)
+
 
 def write_github_output(key: str, value: str) -> None:
     """Append key=value to GITHUB_OUTPUT; fall back to stdout."""
@@ -123,10 +146,11 @@ def _extract_spec_refs(combined: str) -> str:
 def _extract_issue_refs(combined: str) -> str:
     """Return space-delimited issue refs (numeric or owner/repo#N).
 
-    Accepts every GitHub closing keyword plus non-closing linkage. See
-    `_ISSUE_REF_PATTERN` for why the narrower set was a gate defect.
+    Accepts every GitHub closing keyword plus non-closing linkage, ignoring
+    anything inside a code span or fenced block. See `_ISSUE_REF_PATTERN` and
+    `_strip_code` for why each of those is a gate defect.
     """
-    raw = [match.group(1) for match in _ISSUE_REF_PATTERN.finditer(combined)]
+    raw = [match.group(1) for match in _ISSUE_REF_PATTERN.finditer(_strip_code(combined))]
     results: list[str] = []
     for ref in sorted(set(raw)):
         if ref.startswith("#"):

--- a/scripts/ci/spec_extract_refs.py
+++ b/scripts/ci/spec_extract_refs.py
@@ -51,12 +51,18 @@ EXIT_EXTERNAL = 3
 # repository most often points at a pull request rather than an issue, which
 # `gh issue view` cannot resolve.
 #
-# The leading `\b` is new and load-bearing: without it `prefixes #42` matched
-# on `fixes`.
+# The leading `\b` is load-bearing: without it `prefixes #42` matched on
+# `fixes`. The trailing guard and the `[1-9][0-9]*` number are load-bearing for
+# the same reason in the other direction: `#\d+` with no guard read
+# `Refs #4054garbage` as issue 4054 and loaded an unrelated issue into the
+# judge's context, and it accepted `#0` and `#007`, neither of which can resolve.
+# Ordinary sentence punctuation after a reference still matches, because the
+# guard excludes only identifier characters.
 _ISSUE_REF_PATTERN = re.compile(
     r"\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|implement(?:s|ed)?|refs?|part\s+of)"
     r"(?:\s*:\s*|\s+)"
-    r"((?:[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*)?#\d+)",
+    r"((?:[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*)?#[1-9][0-9]*)"
+    r"(?![0-9A-Za-z_])",
     re.IGNORECASE,
 )
 
@@ -74,14 +80,95 @@ _ISSUE_REF_PATTERN = re.compile(
 # masking there would disarm the gate on the template's own convention. The
 # asymmetry is real, because a code span suppresses GitHub's issue linking and
 # says nothing about a file path.
-_FENCED_BLOCK = re.compile(r"(?ms)^[ \t]*(`{3,}|~{3,})[^\n]*$.*?(?:^[ \t]*\1[ \t]*$|\Z)")
-_INLINE_CODE = re.compile(r"`+[^`]*`+")
+# Masking is a scanner rather than a regex because the delimiters carry length
+# semantics a regex backreference gets wrong in both directions, and both
+# directions were live defects found in review of PR #5648:
+#
+#   1. A fence closes on a run of the same character at least as long as the
+#      opener. `\1` demanded an exact-length match, so an opener of three
+#      backticks closed by four never matched, the block ran to `\Z`, and every
+#      reference after it in the body was masked. That is the same
+#      `has_specs=false` fail-open this file exists to close, reintroduced.
+#   2. A code span closes on a backtick run of exactly the opener's length and
+#      may contain shorter runs. ``a ` b`` ended the span at the inner single
+#      backtick, exposing the rest of the span as prose.
+#
+# Masked characters become NUL rather than a space so the keyword-to-reference
+# separator (`\s`) cannot bridge across removed content: `Fixes `x` #12` must
+# not become a link that the unmasked body never had.
+_MASK = "\x00"
+_FENCE_OPENER = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+
+
+def _mask_fenced_blocks(text: str) -> str:
+    """Blank fenced code blocks, honoring the same-character, at-least-as-long closer."""
+    masked: list[str] = []
+    fence_char = ""
+    fence_len = 0
+    for line in text.split("\n"):
+        if not fence_char:
+            opener = _FENCE_OPENER.match(line)
+            if opener:
+                run = opener.group(1)
+                fence_char, fence_len = run[0], len(run)
+                masked.append(_MASK)
+                continue
+            masked.append(line)
+            continue
+        closer = line.strip()
+        if closer and set(closer) == {fence_char} and len(closer) >= fence_len:
+            fence_char, fence_len = "", 0
+        masked.append(_MASK)
+    # An unclosed fence stays masked through the end of the body, which is what
+    # a Markdown renderer does with it too.
+    return "\n".join(masked)
+
+
+def _mask_inline_code(text: str) -> str:
+    """Blank inline code spans, closing each on a backtick run of the opener's length."""
+    masked: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        if text[index] != "`":
+            masked.append(text[index])
+            index += 1
+            continue
+        after_opener = index
+        while after_opener < length and text[after_opener] == "`":
+            after_opener += 1
+        opener_len = after_opener - index
+        close_at = _find_closing_run(text, after_opener, opener_len)
+        if close_at < 0:
+            # No closer of the right length: this is literal text, not a span.
+            masked.append("`" * opener_len)
+            index = after_opener
+            continue
+        masked.append(_MASK * (close_at + opener_len - index))
+        index = close_at + opener_len
+    return "".join(masked)
+
+
+def _find_closing_run(text: str, start: int, run_len: int) -> int:
+    """Return the index of the next backtick run of exactly run_len, or -1."""
+    index = start
+    length = len(text)
+    while index < length:
+        if text[index] != "`":
+            index += 1
+            continue
+        run_end = index
+        while run_end < length and text[run_end] == "`":
+            run_end += 1
+        if run_end - index == run_len:
+            return index
+        index = run_end
+    return -1
 
 
 def _strip_code(text: str) -> str:
     """Blank out fenced blocks and inline code spans, keeping the rest intact."""
-    without_fences = _FENCED_BLOCK.sub(" ", text)
-    return _INLINE_CODE.sub(" ", without_fences)
+    return _mask_inline_code(_mask_fenced_blocks(text))
 
 
 def write_github_output(key: str, value: str) -> None:

--- a/scripts/ci/spec_extract_refs.py
+++ b/scripts/ci/spec_extract_refs.py
@@ -34,6 +34,32 @@ from pathlib import Path
 EXIT_OK = 0
 EXIT_EXTERNAL = 3
 
+# GitHub resolves closing keywords case-insensitively, in every tense, and
+# tolerates a colon before the reference. This pattern also accepts the
+# non-closing linkage this repository mandates: `.claude/rules/universal.md`
+# MUST 2 offers `Refs #<n>`, and MUST 3 tells authors to downgrade an
+# unsupported `Fixes` claim to `Refs`. While `Refs` was absent here, following
+# that rule set `has_specs=false`, every judging step in
+# `.github/workflows/ai-spec-validation.yml` skipped on its
+# `has_specs == 'true'` guard, and the required `Validate Spec Coverage` check
+# reported success having evaluated nothing (issue #5489). The missing GitHub
+# spellings (`closed`, `fixed`, `resolved`, `Closes: #10`, `owner/repo.name#10`)
+# opened the same fail-open (issue #5620). `AB#` work-item tokens are issue
+# #5621 and are out of scope here.
+#
+# `See #<n>` is deliberately excluded. It reads as ordinary prose and in this
+# repository most often points at a pull request rather than an issue, which
+# `gh issue view` cannot resolve.
+#
+# The leading `\b` is new and load-bearing: without it `prefixes #42` matched
+# on `fixes`.
+_ISSUE_REF_PATTERN = re.compile(
+    r"\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|implement(?:s|ed)?|refs?|part\s+of)"
+    r"(?:\s*:\s*|\s+)"
+    r"((?:[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*)?#\d+)",
+    re.IGNORECASE,
+)
+
 
 def write_github_output(key: str, value: str) -> None:
     """Append key=value to GITHUB_OUTPUT; fall back to stdout."""
@@ -95,11 +121,12 @@ def _extract_spec_refs(combined: str) -> str:
 
 
 def _extract_issue_refs(combined: str) -> str:
-    """Return space-delimited issue refs (numeric or owner/repo#N)."""
-    raw = re.findall(
-        r"(?:Closes|Fixes|Resolves|Implements)\s+((?:[A-Za-z0-9_-]+/[A-Za-z0-9_-]+)?#\d+)",
-        combined,
-    )
+    """Return space-delimited issue refs (numeric or owner/repo#N).
+
+    Accepts every GitHub closing keyword plus non-closing linkage. See
+    `_ISSUE_REF_PATTERN` for why the narrower set was a gate defect.
+    """
+    raw = [match.group(1) for match in _ISSUE_REF_PATTERN.finditer(combined)]
     results: list[str] = []
     for ref in sorted(set(raw)):
         if ref.startswith("#"):

--- a/scripts/ci/spec_load_content.py
+++ b/scripts/ci/spec_load_content.py
@@ -17,7 +17,7 @@ Outputs:
 EXIT CODES (ADR-035):
   0 - content loaded
   2 - referenced spec content is missing
-  3 - GitHub issue lookup failed
+  3 - every GitHub issue lookup failed and nothing else loaded
 """
 
 from __future__ import annotations
@@ -123,16 +123,37 @@ def _load_spec_refs(spec_refs: list[str]) -> tuple[int, list[str]]:
 
 
 def _load_issue_refs(issue_refs: list[str], repository: str) -> tuple[int, list[str]]:
-    """Load linked issue references."""
+    """Load linked issue references, skipping the ones GitHub cannot resolve.
+
+    Returns the last lookup failure code alongside whatever did load. A single
+    unresolvable reference no longer aborts the load, because
+    `spec_extract_refs.py` now feeds this function every non-closing linkage in
+    the body (issues #5489 and #5620), and real bodies in this repository point
+    `Refs #<n>` at pull requests: PR #5609 carries `Refs #5600` and PR #5630
+    carries `Refs #5623`, both pull request numbers. `gh issue view` does not
+    resolve a pull request number, so aborting on the first failure would take
+    the required `Validate Spec Coverage` check red on a body that follows
+    `.claude/rules/universal.md` MUST 2.
+
+    This does not open a fail-open path. `run` still refuses to write spec
+    content when nothing resolved, and propagates this code so an outage is
+    still reported as external (exit 3) rather than as a config error.
+    """
     parts: list[str] = []
+    failure = EXIT_OK
     for issue in issue_refs:
         exit_code, body = _gh_issue_body(issue, repository)
         if exit_code != EXIT_OK:
-            return exit_code, []
+            print(
+                f"::warning::skipping issue reference that did not resolve: {issue}",
+                file=sys.stderr,
+            )
+            failure = exit_code
+            continue
         if body:
             display = f"#{issue}" if "/" not in issue else issue
             parts.append(f"## Issue {display}\n\n{body}")
-    return EXIT_OK, parts
+    return failure, parts
 
 
 def run(_argv: list[str] | None = None) -> int:
@@ -148,9 +169,7 @@ def run(_argv: list[str] | None = None) -> int:
     exit_code, parts = _load_spec_refs(spec_refs)
     if exit_code != EXIT_OK:
         return exit_code
-    exit_code, issue_parts = _load_issue_refs(issue_refs, repository)
-    if exit_code != EXIT_OK:
-        return exit_code
+    issue_failure, issue_parts = _load_issue_refs(issue_refs, repository)
     parts.extend(issue_parts)
 
     spec_content = "\n\n".join(parts)
@@ -159,7 +178,9 @@ def run(_argv: list[str] | None = None) -> int:
             f"::error::no spec content found for references: {spec_refs_raw} {issue_refs_raw}",
             file=sys.stderr,
         )
-        return EXIT_CONFIG
+        # Nothing loaded. When a lookup failed, that is the reason, so report it
+        # as external rather than flattening an outage into a config error.
+        return issue_failure if issue_failure != EXIT_OK else EXIT_CONFIG
 
     spec_file = Path(runner_temp) / f"spec-content-{os.environ.get('GITHUB_RUN_ID', '0')}.md"
     spec_file.write_text(spec_content, encoding="utf-8")

--- a/scripts/ci/spec_load_content.py
+++ b/scripts/ci/spec_load_content.py
@@ -17,7 +17,8 @@ Outputs:
 EXIT CODES (ADR-035):
   0 - content loaded
   2 - referenced spec content is missing
-  3 - every GitHub issue lookup failed and nothing else loaded
+  3 - a GitHub issue lookup failed for a reason other than the reference
+      not being an issue
 """
 
 from __future__ import annotations
@@ -30,6 +31,25 @@ from pathlib import Path
 EXIT_OK = 0
 EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
+
+# Internal classification, never a process exit code: the reference resolved to
+# something that is not an issue in this repository, most often a pull request
+# number. `.claude/rules/universal.md` MUST 2 linkage legitimately points at
+# pull requests (PR #5609 carries one, PR #5630 another), so this case is
+# skippable. A genuine gh launch failure or API outage is not: it leaves the
+# judge reasoning about a subset of the requirements while the gate reports
+# success, which is the silent-failure class `ci-scripts.md` SHOULD 4 warns a
+# repair like this one tends to introduce.
+NOT_AN_ISSUE = -1
+
+# Narrow on purpose, and it fails closed. Any stderr this does not recognize is
+# treated as an external failure, so an unrecognized benign message costs a red
+# check that names the reference, while no unrecognized outage can ever be
+# mistaken for a skippable reference. The exact wording is GitHub's GraphQL
+# error for `repository.issue(number:)` against a non-issue; it could not be
+# re-verified from this environment, and that is precisely why the default is
+# to fail rather than to skip.
+_NOT_AN_ISSUE_SIGNALS = ("could not resolve to an issue",)
 
 
 def write_github_output(key: str, value: str) -> None:
@@ -74,8 +94,15 @@ def _gh_issue_body(issue_ref: str, default_repo: str) -> tuple[int, str]:
         print(f"::error::failed to launch gh for issue {issue_ref}: {exc}", file=sys.stderr)
         return EXIT_EXTERNAL, ""
     if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if any(signal in stderr.casefold() for signal in _NOT_AN_ISSUE_SIGNALS):
+            print(
+                f"::warning::{issue_ref} is not an issue in this repository: {stderr}",
+                file=sys.stderr,
+            )
+            return NOT_AN_ISSUE, ""
         print(
-            f"::error::gh issue view failed for {issue_ref}: {result.stderr.strip()}",
+            f"::error::gh issue view failed for {issue_ref}: {stderr}",
             file=sys.stderr,
         )
         return EXIT_EXTERNAL, ""
@@ -123,37 +150,31 @@ def _load_spec_refs(spec_refs: list[str]) -> tuple[int, list[str]]:
 
 
 def _load_issue_refs(issue_refs: list[str], repository: str) -> tuple[int, list[str]]:
-    """Load linked issue references, skipping the ones GitHub cannot resolve.
+    """Load linked issue references, skipping those that are not issues at all.
 
-    Returns the last lookup failure code alongside whatever did load. A single
-    unresolvable reference no longer aborts the load, because
-    `spec_extract_refs.py` now feeds this function every non-closing linkage in
-    the body (issues #5489 and #5620), and real bodies in this repository point
-    `Refs #<n>` at pull requests: PR #5609 carries `Refs #5600` and PR #5630
-    carries `Refs #5623`, both pull request numbers. `gh issue view` does not
-    resolve a pull request number, so aborting on the first failure would take
-    the required `Validate Spec Coverage` check red on a body that follows
-    `.claude/rules/universal.md` MUST 2.
-
-    This does not open a fail-open path. `run` still refuses to write spec
-    content when nothing resolved, and propagates this code so an outage is
-    still reported as external (exit 3) rather than as a config error.
+    Returns the first genuine external failure alongside whatever loaded. The
+    two failure kinds are deliberately not merged. A reference that is simply
+    not an issue (a pull request number) is skipped, because
+    `spec_extract_refs.py` now extracts every non-closing linkage in the body
+    and `.claude/rules/universal.md` MUST 2 linkage legitimately points at pull
+    requests. A gh launch failure or API outage is propagated, because skipping
+    it would let the judge run against a subset of the requirements while the
+    required check reported success.
     """
     parts: list[str] = []
-    failure = EXIT_OK
+    external_failure = EXIT_OK
     for issue in issue_refs:
         exit_code, body = _gh_issue_body(issue, repository)
+        if exit_code == NOT_AN_ISSUE:
+            continue
         if exit_code != EXIT_OK:
-            print(
-                f"::warning::skipping issue reference that did not resolve: {issue}",
-                file=sys.stderr,
-            )
-            failure = exit_code
+            if external_failure == EXIT_OK:
+                external_failure = exit_code
             continue
         if body:
             display = f"#{issue}" if "/" not in issue else issue
             parts.append(f"## Issue {display}\n\n{body}")
-    return failure, parts
+    return external_failure, parts
 
 
 def run(_argv: list[str] | None = None) -> int:
@@ -169,8 +190,19 @@ def run(_argv: list[str] | None = None) -> int:
     exit_code, parts = _load_spec_refs(spec_refs)
     if exit_code != EXIT_OK:
         return exit_code
-    issue_failure, issue_parts = _load_issue_refs(issue_refs, repository)
+    external_failure, issue_parts = _load_issue_refs(issue_refs, repository)
     parts.extend(issue_parts)
+
+    # Fail closed on a genuine lookup failure even when other content loaded.
+    # Proceeding would hand the judge a subset of the requirements and let the
+    # required check pass against context it never saw.
+    if external_failure != EXIT_OK:
+        print(
+            "::error::an issue lookup failed, so the spec context would be "
+            f"incomplete: {issue_refs_raw}",
+            file=sys.stderr,
+        )
+        return external_failure
 
     spec_content = "\n\n".join(parts)
     if not spec_content:
@@ -178,9 +210,7 @@ def run(_argv: list[str] | None = None) -> int:
             f"::error::no spec content found for references: {spec_refs_raw} {issue_refs_raw}",
             file=sys.stderr,
         )
-        # Nothing loaded. When a lookup failed, that is the reason, so report it
-        # as external rather than flattening an outage into a config error.
-        return issue_failure if issue_failure != EXIT_OK else EXIT_CONFIG
+        return EXIT_CONFIG
 
     spec_file = Path(runner_temp) / f"spec-content-{os.environ.get('GITHUB_RUN_ID', '0')}.md"
     spec_file.write_text(spec_content, encoding="utf-8")

--- a/tests/ci/test_spec_extract_refs.py
+++ b/tests/ci/test_spec_extract_refs.py
@@ -188,6 +188,57 @@ class TestExtractIssueRefs:
         )
         assert _extract_issue_refs(body) == "5489 5620 5621"
 
+    # Devin Review on PR #5648 found the regex mask wrong in both delimiter
+    # directions. A fence closes on a run of the same character at least as long
+    # as the opener, so a three-backtick opener closed by four ran to the end of
+    # the body and masked every later reference: the same has_specs=false
+    # fail-open this file exists to close.
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "```\ncode\n````\n\nFixes #5489\n",
+            "~~~\ncode\n~~~~~\n\nFixes #5489\n",
+            '```python\nr"Fixes #99"\n``````\n\nFixes #5489\n',
+        ],
+    )
+    def test_fence_closes_on_a_longer_run_of_the_same_character(self, body: str) -> None:
+        assert _extract_issue_refs(body) == "5489"
+
+    def test_unclosed_fence_masks_through_the_end(self) -> None:
+        assert _extract_issue_refs("```\nFixes #999\nFixes #888") == ""
+
+    # A code span closes on a backtick run of exactly the opener's length and may
+    # contain shorter runs. The old mask ended the span at the inner run and
+    # exposed the example reference as prose.
+    def test_code_span_may_contain_a_shorter_backtick_run(self) -> None:
+        body = "``a ` Fixes #999`` and really Fixes #5489"
+        assert _extract_issue_refs(body) == "5489"
+
+    def test_unmatched_backtick_is_literal_text(self) -> None:
+        assert _extract_issue_refs("a ` stray tick, Fixes #5489") == "5489"
+
+    # Masked content becomes NUL, not a space, so the keyword-to-reference
+    # separator cannot bridge across what was removed.
+    @pytest.mark.parametrize(
+        "body",
+        ["Fixes `x` #12", "Fixes\n```\ncode\n```\n#12"],
+    )
+    def test_masking_does_not_create_a_link_the_body_never_had(self, body: str) -> None:
+        assert _extract_issue_refs(body) == ""
+
+    # `#\d+` with no trailing guard read `Refs #4054garbage` as issue 4054 and
+    # loaded an unrelated issue into the judge's context.
+    @pytest.mark.parametrize(
+        "body",
+        ["Refs #4054garbage", "Refs #0", "Refs #007", "Fixes #12_a", "Refs #0000"],
+    )
+    def test_rejects_malformed_reference_numbers(self, body: str) -> None:
+        assert _extract_issue_refs(body) == ""
+
+    def test_sentence_punctuation_after_a_reference_still_links(self) -> None:
+        body = "Fixes #12. Also Fixes #13, and Fixes #14; plus Fixes #15)"
+        assert sorted(_extract_issue_refs(body).split()) == ["12", "13", "14", "15"]
+
     def test_collects_every_reference_in_a_multi_ref_body(self) -> None:
         body = "Refs #5574\nRefs #5624\nCloses #5610"
         assert sorted(_extract_issue_refs(body).split()) == ["5574", "5610", "5624"]

--- a/tests/ci/test_spec_extract_refs.py
+++ b/tests/ci/test_spec_extract_refs.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from scripts.ci.spec_extract_refs import (
     EXIT_EXTERNAL,
@@ -71,6 +73,78 @@ class TestExtractIssueRefs:
         parts = result.split()
         assert parts.count("5") == 1
 
+    # Issue #5620: GitHub resolves every tense of every closing keyword, in any
+    # case. Each spelling the parser missed produced has_specs=false and a
+    # required check that judged nothing.
+    @pytest.mark.parametrize(
+        "keyword",
+        [
+            "close",
+            "closes",
+            "closed",
+            "fix",
+            "fixes",
+            "fixed",
+            "resolve",
+            "resolves",
+            "resolved",
+        ],
+    )
+    def test_extracts_every_github_closing_keyword(self, keyword: str) -> None:
+        assert _extract_issue_refs(f"{keyword} #123") == "123"
+        assert _extract_issue_refs(f"{keyword.upper()} #123") == "123"
+        assert _extract_issue_refs(f"{keyword.capitalize()} #123") == "123"
+
+    @pytest.mark.parametrize(
+        "body",
+        ["Closes: #10", "closes:#10", "CLOSES:  #10", "Fixes:\n#10"],
+    )
+    def test_extracts_colon_syntax(self, body: str) -> None:
+        assert _extract_issue_refs(body) == "10"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Fixes owner/repo.name#123",
+            "Fixes my-org/my-repo#123",
+            "Fixes owner/repo_name#123",
+        ],
+    )
+    def test_extracts_cross_repo_names_with_dots_and_hyphens(self, body: str) -> None:
+        assert _extract_issue_refs(body).endswith("#123")
+
+    # Issue #5489: universal.md MUST 2 and MUST 3 tell the author to write
+    # `Refs #<n>` when the change does not close the issue, and that spelling
+    # was the one that disarmed the gate.
+    @pytest.mark.parametrize(
+        "body",
+        ["Refs #4789", "refs #4789", "Ref #4789", "REFS: #4789", "Part of #4789"],
+    )
+    def test_extracts_non_closing_linkage(self, body: str) -> None:
+        assert _extract_issue_refs(body) == "4789"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "prefixes #42",
+            "postfixed #42",
+            "See #42",
+            "issue #42",
+            "Fixes #",
+            "Fixes 42",
+            "#42",
+        ],
+    )
+    def test_ignores_text_that_is_not_issue_linkage(self, body: str) -> None:
+        assert _extract_issue_refs(body) == ""
+
+    def test_deduplicates_across_keywords(self) -> None:
+        assert _extract_issue_refs("Fixes #7\nRefs #7") == "7"
+
+    def test_collects_every_reference_in_a_multi_ref_body(self) -> None:
+        body = "Refs #5574\nRefs #5624\nCloses #5610"
+        assert sorted(_extract_issue_refs(body).split()) == ["5574", "5610", "5624"]
+
 
 class TestExtractIncrementalScope:
     def test_returns_stdout_on_success(self) -> None:
@@ -118,6 +192,36 @@ class TestRun:
                 return_value=MagicMock(returncode=0, stdout=""),
             ):
                 run()
+        assert "has_specs=true" in out_file.read_text()
+
+    @pytest.mark.parametrize(
+        "body",
+        ["Refs #4789", "CLOSES: #123", "closed #123", "Part of #123"],
+    )
+    def test_has_specs_true_for_linkage_the_old_parser_missed(
+        self, body: str, tmp_path: Path
+    ) -> None:
+        """Pin the workflow guard, not the helper return value.
+
+        `.github/workflows/ai-spec-validation.yml` gates every judging step on
+        `steps.spec-ref.outputs.has_specs == 'true'`, so the output file is the
+        contract that decides whether the required check evaluates anything.
+        Issues #5489 and #5620.
+        """
+        out_file = tmp_path / "out.txt"
+        env = {
+            "PR_TITLE_INPUT": "fix(ci): a change with no spec ID in the title",
+            "PR_BODY_INPUT": body,
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+        with patch.dict(os.environ, env):
+            with patch(
+                "scripts.ci.spec_extract_refs.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout=""),
+            ):
+                assert run() == 0
         assert "has_specs=true" in out_file.read_text()
 
     def test_fallback_to_gh_when_no_inputs(self, tmp_path: Path) -> None:
@@ -203,6 +307,7 @@ class TestRun:
                 side_effect=OSError("python not found"),
             ):
                 assert main() == EXIT_EXTERNAL
+
 
 class TestMain:
     def test_main_delegates(self) -> None:

--- a/tests/ci/test_spec_extract_refs.py
+++ b/tests/ci/test_spec_extract_refs.py
@@ -46,6 +46,15 @@ class TestExtractSpecRefs:
     def test_empty_string_returns_empty(self) -> None:
         assert _extract_spec_refs("no references here") == ""
 
+    def test_backticked_spec_path_still_counts(self) -> None:
+        """`.github/PULL_REQUEST_TEMPLATE.md` writes spec paths in backticks.
+
+        The code-span mask applies to issue refs only. Masking here would
+        disarm the gate on the template's own convention.
+        """
+        result = _extract_spec_refs("| **Spec** | `.agents/planning/sprint.md` |")
+        assert ".agents/planning/sprint.md" in result
+
     def test_deduplicates(self) -> None:
         refs = _extract_spec_refs("REQ-001 REQ-001 REQ-002")
         parts = refs.split()
@@ -140,6 +149,44 @@ class TestExtractIssueRefs:
 
     def test_deduplicates_across_keywords(self) -> None:
         assert _extract_issue_refs("Fixes #7\nRefs #7") == "7"
+
+    # PR #5648's own run reported `ISSUE_REFS: 10 5489 5600 5620 5621 5623`
+    # from a body that only linked three issues. The other three came from
+    # backticked examples in the prose, two of them pull request numbers, and
+    # the loader handed all six to the judge as this PR's requirements.
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "See `Fixes #42` for the syntax",
+            "The old pattern was ``Closes: #42`` in prose",
+            "```\nFixes #42\n```",
+            "```python\n# Closes #42\n```",
+            "~~~\nRefs #42\n~~~",
+            "```\nFixes #42\n",
+        ],
+    )
+    def test_ignores_references_inside_code(self, body: str) -> None:
+        assert _extract_issue_refs(body) == ""
+
+    def test_keeps_a_real_reference_beside_a_code_span(self) -> None:
+        body = "Writing `Refs #99` is the honest form. Fixes #42"
+        assert _extract_issue_refs(body) == "42"
+
+    def test_pr_5648_body_shape(self) -> None:
+        """Regression fixture taken from the body that produced the defect."""
+        body = (
+            "The other misses (`closed`, `Closes: #10`, `owner/repo.name#10`) "
+            "opened the same hole.\n\n"
+            "```python\n"
+            'r"(?:Closes|Fixes|Resolves|Implements)\\s+(#\\d+)"\n'
+            "```\n\n"
+            "| **Issue** | Fixes #5489 | `Refs #n` disarms the judge |\n"
+            "| **Issue** | Fixes #5620 | missed variants |\n\n"
+            "`AB#` work-item tokens (#5621) are out of scope.\n\n"
+            "PR #5609 carries `Refs #5600` and PR #5630 carries `Refs #5623`.\n\n"
+            "## Related Issues\n\nFixes #5489\nFixes #5620\nRefs #5621\n"
+        )
+        assert _extract_issue_refs(body) == "5489 5620 5621"
 
     def test_collects_every_reference_in_a_multi_ref_body(self) -> None:
         body = "Refs #5574\nRefs #5624\nCloses #5610"

--- a/tests/ci/test_spec_load_content.py
+++ b/tests/ci/test_spec_load_content.py
@@ -194,6 +194,77 @@ class TestRun:
             with patch("scripts.ci.spec_load_content.subprocess.run", return_value=failure):
                 assert main() == EXIT_EXTERNAL
 
+    def test_unresolvable_ref_is_skipped_when_another_resolves(self, tmp_path: Path) -> None:
+        """A pull request number among the refs must not fail the whole gate.
+
+        `spec_extract_refs.py` now extracts non-closing linkage (issues #5489
+        and #5620), and real bodies point `Refs #<n>` at pull requests: PR #5609
+        carries `Refs #5600` and PR #5630 carries `Refs #5623`. `gh issue view`
+        cannot resolve a pull request number, so aborting on the first failure
+        would take the required check red on a compliant body.
+        """
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": "",
+            "ISSUE_REFS": "5600 5605",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if "5600" in argv:
+                return MagicMock(returncode=1, stdout="", stderr="Could not resolve to an Issue")
+            return MagicMock(returncode=0, stdout="Real issue\n\nAcceptance criteria")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", side_effect=fake_run):
+                assert main() == EXIT_OK
+
+        written = (tmp_path / "spec-content-0.md").read_text(encoding="utf-8")
+        assert "Acceptance criteria" in written
+        assert "5600" not in written
+
+    def test_unresolvable_ref_is_skipped_when_a_spec_file_resolves(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "REQ-010-spec.md"
+        spec_file.write_text("# REQ-010\nSpec body", encoding="utf-8")
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": str(spec_file),
+            "ISSUE_REFS": "5600",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+        failure = MagicMock(returncode=1, stdout="", stderr="Could not resolve to an Issue")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", return_value=failure):
+                assert main() == EXIT_OK
+
+        assert "Spec body" in (tmp_path / "spec-content-0.md").read_text(encoding="utf-8")
+
+    def test_every_ref_unresolvable_still_fails(self, tmp_path: Path) -> None:
+        """Skipping a single bad ref must not become a fail-open path."""
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": "",
+            "ISSUE_REFS": "5600 5623",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+        failure = MagicMock(returncode=1, stdout="", stderr="Could not resolve to an Issue")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", return_value=failure):
+                assert main() == EXIT_EXTERNAL
+
+        assert not (tmp_path / "spec-content-0.md").exists()
+
     def test_issue_lookup_launch_failure_main_returns_external(self, tmp_path: Path) -> None:
         out_file = tmp_path / "out.txt"
         env = {

--- a/tests/ci/test_spec_load_content.py
+++ b/tests/ci/test_spec_load_content.py
@@ -246,8 +246,79 @@ class TestRun:
 
         assert "Spec body" in (tmp_path / "spec-content-0.md").read_text(encoding="utf-8")
 
-    def test_every_ref_unresolvable_still_fails(self, tmp_path: Path) -> None:
-        """Skipping a single bad ref must not become a fail-open path."""
+    def test_an_outage_fails_even_when_another_reference_loaded(self, tmp_path: Path) -> None:
+        """A genuine lookup failure must not be skipped just because something loaded.
+
+        Devin Review on PR #5648: skipping every failure alike let the required
+        check pass while the judge saw a subset of the requirements. A reference
+        that is simply not an issue stays skippable; an outage does not.
+        """
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": "",
+            "ISSUE_REFS": "5605 5600 5610",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if "5600" in argv:
+                return MagicMock(returncode=1, stdout="", stderr="Could not resolve to an Issue")
+            if "5610" in argv:
+                return MagicMock(returncode=1, stdout="", stderr="API rate limit exceeded")
+            return MagicMock(returncode=0, stdout="Real issue\n\nAcceptance criteria")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", side_effect=fake_run):
+                assert main() == EXIT_EXTERNAL
+
+        assert not (tmp_path / "spec-content-0.md").exists()
+
+    def test_launch_failure_fails_even_when_another_reference_loaded(self, tmp_path: Path) -> None:
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": "",
+            "ISSUE_REFS": "5605 5610",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if "5610" in argv:
+                raise OSError("gh not found")
+            return MagicMock(returncode=0, stdout="Real issue\n\nAcceptance criteria")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", side_effect=fake_run):
+                assert main() == EXIT_EXTERNAL
+
+    def test_unrecognized_stderr_is_treated_as_an_outage(self, tmp_path: Path) -> None:
+        """The classifier fails closed on wording it does not recognize."""
+        out_file = tmp_path / "out.txt"
+        env = {
+            "SPEC_REFS": "",
+            "ISSUE_REFS": "5605 5600",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_RUN_ID": "0",
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if "5600" in argv:
+                return MagicMock(returncode=1, stdout="", stderr="some new gh wording")
+            return MagicMock(returncode=0, stdout="Real issue\n\nAcceptance criteria")
+
+        with patch.dict(os.environ, env):
+            with patch("scripts.ci.spec_load_content.subprocess.run", side_effect=fake_run):
+                assert main() == EXIT_EXTERNAL
+
+    def test_every_ref_is_not_an_issue_reports_config_not_external(self, tmp_path: Path) -> None:
+        """Skipping a non-issue ref must not become a fail-open path."""
         out_file = tmp_path / "out.txt"
         env = {
             "SPEC_REFS": "",
@@ -261,7 +332,7 @@ class TestRun:
 
         with patch.dict(os.environ, env):
             with patch("scripts.ci.spec_load_content.subprocess.run", return_value=failure):
-                assert main() == EXIT_EXTERNAL
+                assert main() == EXIT_CONFIG
 
         assert not (tmp_path / "spec-content-0.md").exists()
 


### PR DESCRIPTION
## Summary

### What

`scripts/ci/spec_extract_refs.py` now recognizes every GitHub closing-keyword spelling plus non-closing linkage (Refs, Ref, Part of), ignores anything inside a code span or fenced block, and rejects malformed reference numbers. `scripts/ci/spec_load_content.py` skips a reference that is not an issue at all, and fails closed on a genuine lookup failure.

### Why

The extractor matched exactly Closes, Fixes, Resolves and Implements, case-sensitively, whitespace-separated only. Anything else set `has_specs=false`. Every judging step in the spec validation workflow is guarded on `has_specs == 'true'`, including the failure check, so the required `Validate Spec Coverage` check reported success having evaluated nothing.

Refs is the worst miss because universal.md MUST 2 and MUST 3 instruct the author to write it: downgrading an unsupported Fixes claim to Refs is the honest move, and it silently disarmed the gate. The other misses (closed, fixed, resolved, colon syntax, cross-repo names carrying dots) opened the same hole for authors using ordinary GitHub syntax.

The symptom in the field: AI-Spec-Validation posts "No spec references found" on a body carrying three Refs lines while PR Validation, whose issue-keyword pattern already accepts refs case-insensitively, reports Issue linking keywords PASS in the same minute. Only PR Validation gates.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5489 | Non-closing linkage disarms the required Validate Spec Coverage judge, and MUST-3 mandates it |
| **Issue** | Fixes #5620 | AI Spec Validator misses official GitHub closing-keyword variants |

Azure Boards work-item tokens (#5621) are out of scope, per the explicit carve-out in #5620.

## Changes

- `scripts/ci/spec_extract_refs.py`: a documented `_ISSUE_REF_PATTERN` module constant replaces the inline regex. Case-insensitive; all nine GitHub closing keywords in every tense; implement/implements/implemented retained; ref/refs/part of added; optional colon; cross-repo owner and repository names may carry dots, hyphens and underscores. Reference numbers are `[1-9][0-9]*` with a trailing non-identifier guard. `_strip_code` masks fenced blocks and inline code spans with a delimiter-aware scanner before extraction.
- `scripts/ci/spec_load_content.py`: `_gh_issue_body` classifies a failed lookup as either "not an issue in this repository" or an external failure. The first is skipped; the second is propagated non-zero by `run` even when other content already loaded.
- `tests/ci/test_spec_extract_refs.py`: keyword, case, colon, cross-repo, word-boundary, fence-length, code-span-length, malformed-number and guard-path coverage.
- `tests/ci/test_spec_load_content.py`: non-issue beside a resolvable issue, beside a spec file, every reference a non-issue, and outages arriving after a successful load.

Three commits: `c07406a` widens the parser and softens the loader; `d91087d` adds code-span masking after this PR's own CI run showed the widened parser harvesting examples from its own body; `02d9eacf` fixes the three defects Devin Review found in those two.

## Design notes

Bare "See" plus an issue number is deliberately excluded from the keyword set. It reads as ordinary prose and in this repository usually points at a pull request.

The code-span mask is applied to issue references but not to spec references. The repository pull request template writes spec paths inside backticks, so masking there would disarm the gate on the template's own convention. A code span suppresses GitHub's issue linking; it says nothing about a file path.

Masked characters become NUL rather than a space, so the keyword-to-reference separator cannot bridge across removed content and turn a masked span into a link the body never had.

The loader's failure classifier is a narrow stderr allowlist that fails closed: wording it does not recognize is treated as an outage, not as a skippable reference. GitHub's exact message could not be re-verified from the authoring environment, which is the reason the default is to fail rather than to skip. A wording drift costs a red check naming the reference; it cannot cost a silent pass.

## Acceptance criteria

- [x] A PR body linking an issue with a non-closing reference and no closing keyword sets `has_specs=true` (#5489)
- [x] A PR with no issue reference of any kind still sets `has_specs=false`
- [x] Every one of the nine GitHub closing keywords is recognized in any case, with optional colon (#5620)
- [x] Same-repository and cross-repository references, including dots and hyphens in the repository name, are extracted
- [x] Azure Boards tokens are not treated as references; #5621 owns that
- [x] Regression tests drive the workflow guard path and its `has_specs` output, not only the helper return value
- [x] A reference inside a code span or fenced block does not arm the gate
- [x] A fenced block closed by a longer run of the same character does not mask the rest of the body
- [x] A code span containing a shorter backtick run does not end early and expose its contents
- [x] Masking cannot create a link the unmasked body did not contain
- [x] Malformed reference numbers are rejected, and ordinary sentence punctuation after a reference still links
- [x] A reference that is not an issue does not fail the load when other content resolves
- [x] A genuine lookup failure fails the load even when other content resolved
- [x] A load where nothing resolves still exits non-zero

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny, no rush. The change arms a required check that has been passing vacuously, so the first PRs after merge will get judged for the first time.

**Focus areas**:

1. The keyword set. Bare "See" is excluded on purpose; say so if you want it in.
2. The loader's two-way failure classification, and whether the stderr allowlist should be widened once GitHub's message can be confirmed from an environment with working gh access.
3. The code-span mask covers issue references but not spec references. The asymmetry is deliberate and documented; disagree if the template convention should change instead.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

**Unit tests.** 99 passed across the two test modules.

**Negative controls.** Every guard was mutated and its tests confirmed to fail:

| Mutation | Result |
|---|---|
| Pattern reverted to the original regex, loader reverted to abort-on-first-failure | 25 of 73 fail |
| Code-span mask bypassed | 8 fail |
| Fence closer required to be exactly the opener's length | 3 fail |
| Code span closed on a backtick run of any length | 1 fail |
| Reference-number guard removed | 3 fail |
| Outage skipped like a non-issue reference | 5 fail |

**Two defects were found by running this gate against reality, not by unit tests.** The first: run 34162149597 on `c07406a` logged `ISSUE_REFS: 10 5489 5600 5620 5621 5623` on a body that links three issues, because the widened parser read backticked examples out of its own prose. The second: Devin Review found that the mask added to fix that got fence and span delimiter lengths wrong in both directions, so a body closing a three-character fence with four masked every later reference. That is the same fail-open this PR exists to close, reintroduced by its own fix, and it is why the masking is now a scanner rather than a regex.

**Corpus measurement, re-run on the final commit.** Over the 25 most recent pull request bodies:

```
bodies sampled: 25
gate armed before: 5  after: 22
regressions: 0
```

Seventeen bodies newly arm the gate, all via non-closing references. That is the size of the hole this closes: 20 percent of recent PRs were judged, and 88 percent will be.

**Bare-python3 portability (ci-scripts MUST 18).** Both scripts are invoked with bare python3 from the workflow. The rewritten masking is a hand-rolled scanner rather than a Markdown library for exactly this reason. Importing both modules outside the uv environment succeeds; the diff adds no import.

**Pre-PR.** `uv run --frozen python scripts/validation/pre_pr.py` reports `RESULT: All validations passed` on every commit. Two gates report BLOCKED with `reason=tool.absent` (actionlint, yamllint not on PATH in the authoring container). Neither examined a file in this diff, and this diff touches no workflow or YAML file.

**This body is validated against its own gates before each post**, after an earlier revision failed them: change-claim extraction returns exactly the four files in the diff, template compliance returns PASS on all four sections, issue keywords PASS, dash prohibition clean.

### Note on the AI-SPEC-VALIDATION comment showing FAIL

That comment reports CRITICAL_FAIL on both judges. The cause is "You have exceeded your monthly quota" from Copilot CLI across all three attempts, on both the analyst and the critic. It is an external service this diff does not touch and it reproduces on every PR in the repository until the quota resets.

The `Validate Spec Coverage` check run itself concluded **success**: the failure check saw both infrastructure flags set true and returned 0 with "Spec validation skipped due to infrastructure failure. Not blocking merge."

So the gate is green and the comment is not. The report generator does not read the infrastructure flags that the failure check acts on, so an infra outage renders as a red FAIL verdict beside a green required check. Pre-existing, not introduced here, not fixed here. Worth its own issue.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The parser reads PR title and body, which are author-controlled, and the workflow already passes both through env rather than shell interpolation. The pattern captures only digits, or an owner and repository prefix plus digits, a narrower character set than the text it scans. Both the code-span mask and the reference-number guard narrow what reaches the loader rather than widening it.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files): ruff check, ruff format --check, mypy all clean
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5489
Fixes #5620
Refs #5621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXpVKAdPA9UCaRtBScRqgQ