### PR TITLE
feat(rules): forbid Serena memory writes from a linked worktree

### DIFF
--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -139,12 +139,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,889 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,889 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,984 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -139,12 +139,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,171 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,171 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,266 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/.claude/rules/pragmatic-programmer.md
+++ b/.claude/rules/pragmatic-programmer.md
@@ -27,16 +27,6 @@ paths:
 
 This repository follows **The Pragmatic Programmer** in the sense of Andrew Hunt and David Thomas: work pragmatically, take responsibility for quality, automate what is repetitive, and keep code and process adaptable.
 
-All code generation, edits, and reviews must optimize for:
-
-- clear ownership and responsibility
-- DRY at the knowledge level
-- orthogonality
-- incremental delivery
-- ruthless feedback
-- automation of repetitive work
-- code that is easy to change and easy to reason about
-
 This file is a binding engineering policy for Claude.
 
 For deeper design decisions, apply the same engineering qualities directly: maximize cohesion, minimize coupling, preserve encapsulation, prioritize testability, and avoid redundant knowledge.
@@ -241,34 +231,6 @@ Anti-patterns:
 2. Fix small quality problems before they signal that nobody cares.
 3. Tidy the code you touch where the cost is low and the value is immediate.
 4. Avoid leaving behind "temporary" hacks with no cleanup plan.
-
----
-
-## Forbidden Patterns
-
-### Cargo-Cult Process
-
-- rituals followed with no benefit
-- documentation and checklists replacing automation
-
-### Knowledge Duplication
-
-- same rule in many places
-- copied logic because "layers need it too"
-
-### Non-Orthogonal Design
-
-- modules with overlapping responsibilities
-- changes leaking across boundaries by default
-
-### Manual Everything
-
-- repeated human steps for build, test, release, setup, or validation
-- hidden local environment assumptions
-
-### Prototype Fossilization
-
-- experimental code promoted to production without redesign or hardening
 
 ---
 

--- a/.claude/rules/universal.md
+++ b/.claude/rules/universal.md
@@ -100,6 +100,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
+10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
+    directory is a linked worktree. Serena resolves its memory directory once at
+    server activation, so the write lands in the activating checkout, not yours,
+    and still returns success. Route it through the main checkout or hand the
+    content to the parent session. ADR-097 retired the hook that blocked this;
+    `check_serena_memory_worktree_scope.py` only reports it afterward, and never
+    fails. Refs Issue #5061.
+
 ## Choosing a persistence surface
 
 When you learn a durable fact, convention, or decision procedure that future sessions must honor, choose the persistence surface by who must obey it and across which harnesses. This repository runs under Claude, Codex, and Copilot. A convention that lives in only one harness's memory is invisible to the other two.

--- a/.claude/rules/universal.md
+++ b/.claude/rules/universal.md
@@ -100,11 +100,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
-10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
-    directory is a linked worktree. Serena resolves its memory directory once at
-    server activation, so the write lands in the activating checkout, not yours,
-    and still returns success. Route it through the main checkout or hand the
-    content to the parent session. ADR-097 retired the hook that blocked this;
+10. MUST NOT mutate Serena memory from an agent whose working directory is a
+    linked worktree. This covers writing, editing, renaming, and deleting a
+    memory, under whatever name the harness gives the tool (Claude Code spells
+    it `mcp__serena__write_memory`; other harnesses differ), because all of them
+    resolve through the project root Serena fixed once at server activation. The
+    change lands in the activating checkout, not yours, and still returns
+    success. Route it through the main checkout or hand the content to the
+    parent session. ADR-097 retired the hook that blocked this;
     `check_serena_memory_worktree_scope.py` only reports it afterward, and never
     fails. Refs Issue #5061.
 

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -246,8 +246,8 @@ it, not a reason to fork the stack.
 ## Where this repo stands
 
 Measured on this branch after issue #4871 rescoped `code-quality` and `pragmatic-programmer` to code files, issue #5492 narrowed `knowledge-persistence` out of the always-on set, PR #5498 dropped the jargon gloss list from `voice`, and issue #5404 added the task-completion contract to `builder-ethos` and the completion-tail audit to `voice`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 5 rules, 56,675 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,033 bytes
+**always-on corpus is 5 rules, 56,889 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,247 bytes
 across 10 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -261,7 +261,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-95 bytes larger in total (56,770 always-on) because `generate_rules.py`
+95 bytes larger in total (56,984 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -281,7 +281,7 @@ after issue #5404 added the completion-tail audit to it.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the
-56,770-byte always-on corpus measured at source. `code-quality` and
+56,984-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -346,7 +346,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 5 rules and 56,675 bytes, matching
+`src/copilot-cli/instructions` carries 5 rules and 56,889 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -370,7 +370,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 6.9x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 7.0x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -246,8 +246,8 @@ it, not a reason to fork the stack.
 ## Where this repo stands
 
 Measured on this branch after issue #4871 rescoped `code-quality` and `pragmatic-programmer` to code files, issue #5492 narrowed `knowledge-persistence` out of the always-on set, PR #5498 dropped the jargon gloss list from `voice`, and issue #5404 added the task-completion contract to `builder-ethos` and the completion-tail audit to `voice`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 5 rules, 56,171 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,396 bytes
+**always-on corpus is 5 rules, 56,675 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,033 bytes
 across 10 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -261,7 +261,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-95 bytes larger in total (56,266 always-on) because `generate_rules.py`
+95 bytes larger in total (56,770 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -281,7 +281,7 @@ after issue #5404 added the completion-tail audit to it.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the
-56,266-byte always-on corpus measured at source. `code-quality` and
+56,770-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -346,7 +346,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 5 rules and 56,171 bytes, matching
+`src/copilot-cli/instructions` carries 5 rules and 56,675 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -370,7 +370,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 6.9x that threshold and a Python edit sees 12.1x,
+The always-on corpus is 6.9x that threshold and a Python edit sees 12.0x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/.claude/skills/context-optimizer/references/model-context-doctrine.md
+++ b/.claude/skills/context-optimizer/references/model-context-doctrine.md
@@ -277,7 +277,7 @@ after issue #5404 added the completion-tail audit to it.
 | Rule | Bytes | Loading | Scenario file | Scored result |
 |---|---|---|---|---|
 | `code-quality.md` | 14,402 | code files only | 3 positive, 1 negative | none |
-| `pragmatic-programmer.md` | 11,479 | code files only | 3 positive, 1 negative | none |
+| `pragmatic-programmer.md` | 10,612 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the

--- a/.claude/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/.claude/skills/context-optimizer/references/rule-audit-procedure.md
@@ -456,7 +456,7 @@ scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. No **book-derived** rule is always-on now: issue #4871 found
 this one scoped with `alwaysApply:`, a key Claude Code ignores, and rescoped it
 to code files, which leaves `voice.md` (19,748 bytes) as the largest rule in the
-corpus. `pragmatic-programmer.md` (11,479 bytes) sits on the same footing with
+corpus. `pragmatic-programmer.md` (10,612 bytes) sits on the same footing with
 four scenarios of its own. PR #4424 narrowed it to source files, but it wrote
 the narrowing under `applyTo:`, so the rule went on loading on every Claude
 session until #4871 moved it to `paths:`.

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,889 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,889 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,984 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,171 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,171 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,266 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/.github/instructions/pragmatic-programmer.instructions.md
+++ b/.github/instructions/pragmatic-programmer.instructions.md
@@ -9,16 +9,6 @@ applyTo: '**/*.py,**/*.cs,**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.go,**/*.rs,**/*
 
 This repository follows **The Pragmatic Programmer** in the sense of Andrew Hunt and David Thomas: work pragmatically, take responsibility for quality, automate what is repetitive, and keep code and process adaptable.
 
-All code generation, edits, and reviews must optimize for:
-
-- clear ownership and responsibility
-- DRY at the knowledge level
-- orthogonality
-- incremental delivery
-- ruthless feedback
-- automation of repetitive work
-- code that is easy to change and easy to reason about
-
 This file is a binding engineering policy for Claude.
 
 For deeper design decisions, apply the same engineering qualities directly: maximize cohesion, minimize coupling, preserve encapsulation, prioritize testability, and avoid redundant knowledge.
@@ -223,34 +213,6 @@ Anti-patterns:
 2. Fix small quality problems before they signal that nobody cares.
 3. Tidy the code you touch where the cost is low and the value is immediate.
 4. Avoid leaving behind "temporary" hacks with no cleanup plan.
-
----
-
-## Forbidden Patterns
-
-### Cargo-Cult Process
-
-- rituals followed with no benefit
-- documentation and checklists replacing automation
-
-### Knowledge Duplication
-
-- same rule in many places
-- copied logic because "layers need it too"
-
-### Non-Orthogonal Design
-
-- modules with overlapping responsibilities
-- changes leaking across boundaries by default
-
-### Manual Everything
-
-- repeated human steps for build, test, release, setup, or validation
-- hidden local environment assumptions
-
-### Prototype Fossilization
-
-- experimental code promoted to production without redesign or hardening
 
 ---
 

--- a/.github/instructions/universal.instructions.md
+++ b/.github/instructions/universal.instructions.md
@@ -99,11 +99,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
-10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
-    directory is a linked worktree. Serena resolves its memory directory once at
-    server activation, so the write lands in the activating checkout, not yours,
-    and still returns success. Route it through the main checkout or hand the
-    content to the parent session. ADR-097 retired the hook that blocked this;
+10. MUST NOT mutate Serena memory from an agent whose working directory is a
+    linked worktree. This covers writing, editing, renaming, and deleting a
+    memory, under whatever name the harness gives the tool (Claude Code spells
+    it `mcp__serena__write_memory`; other harnesses differ), because all of them
+    resolve through the project root Serena fixed once at server activation. The
+    change lands in the activating checkout, not yours, and still returns
+    success. Route it through the main checkout or hand the content to the
+    parent session. ADR-097 retired the hook that blocked this;
     `check_serena_memory_worktree_scope.py` only reports it afterward, and never
     fails. Refs Issue #5061.
 

--- a/.github/instructions/universal.instructions.md
+++ b/.github/instructions/universal.instructions.md
@@ -99,6 +99,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
+10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
+    directory is a linked worktree. Serena resolves its memory directory once at
+    server activation, so the write lands in the activating checkout, not yours,
+    and still returns success. Route it through the main checkout or hand the
+    content to the parent session. ADR-097 retired the hook that blocked this;
+    `check_serena_memory_worktree_scope.py` only reports it afterward, and never
+    fails. Refs Issue #5061.
+
 ## Choosing a persistence surface
 
 When you learn a durable fact, convention, or decision procedure that future sessions must honor, choose the persistence surface by who must obey it and across which harnesses. This repository runs under Claude, Codex, and Copilot. A convention that lives in only one harness's memory is invisible to the other two.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -32,14 +32,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 5 rules, 56,171 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,171 bytes |
+| `.github/instructions` | Copilot in this repository | 5 rules, 56,675 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`,
 `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same five
-rules measure 56,266 bytes at `.claude/rules/`, 95 more, because the generator
+rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator
 drops `priority:` and turns `paths:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
+++ b/.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md
@@ -32,14 +32,14 @@ the number. The two destination trees agree today, measured on this branch after
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot in this repository | 5 rules, 56,675 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
+| `.github/instructions` | Copilot in this repository | 5 rules, 56,889 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,889 bytes |
 
 Membership is identical: `builder-ethos`, `claude-model-patches`,
 `search-before-building`, `universal`, `voice`.
 
 Those bytes are whole generated files, frontmatter included. The same five
-rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator
+rules measure 56,984 bytes at `.claude/rules/`, 95 more, because the generator
 drops `priority:` and turns `paths:` into `applyTo:`. Name the
 tree whenever you quote a figure; a gap of about that size is a basis mismatch,
 not staleness.

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,889 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,889 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,984 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -130,12 +130,12 @@ The two destination trees now agree, measured on this branch after issue #4871 r
 
 | Tree | Consumer | Always-on |
 |---|---|---|
-| `.github/instructions` | Copilot working in this repository | 5 rules, 56,171 bytes |
-| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,171 bytes |
+| `.github/instructions` | Copilot working in this repository | 5 rules, 56,675 bytes |
+| `src/copilot-cli/instructions` | the shipped plugin, installed elsewhere | 5 rules, 56,675 bytes |
 
 The membership is identical: `builder-ethos`, `claude-model-patches`, `search-before-building`, `universal`, `voice`.
 
-Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,266 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
+Those byte figures are whole generated files, frontmatter included, which is what a consumer actually loads. State the basis whenever you quote one. The same five rules measure 56,770 bytes at `.claude/rules/`, 95 more, because the generator rewrites the frontmatter on the way out: it drops `priority:` and turns `paths:` into `applyTo:`. A figure that disagrees with a fresh measurement by roughly that much is a basis mismatch rather than staleness.
 
 The Claude side answers the same question from the source, and it reads `paths:` alone. It ignores `applyTo:`, `globs:`, and `alwaysApply:`, all three of which `generate_rules.py` accepts, and each fails differently. `applyTo:` is remapped, so the mirror is scoped and only the Claude source leaks (`pragmatic-programmer`). `globs:` is preserved verbatim and never becomes `applyTo:`, so neither tree is scoped. `alwaysApply:` is dropped before the generator synthesizes `applyTo: '**'`, so both trees load universally and a code-only rule cannot state its scope (`code-quality`). Between them, 25,527 bytes loaded on every doc-only session (issue #4871). `check_rule_scope_keys.py`, under the validation-scripts tree, now fails the build on any scope key but `paths:`, which is what keeps the source-side and mirror-side answers the same. The directory prefix is omitted for the same reason the citation-freshness gate's is above: this rule ships in the plugin instruction mirrors, where an upstream-only path would dangle.
 

--- a/src/copilot-cli/instructions/pragmatic-programmer.instructions.md
+++ b/src/copilot-cli/instructions/pragmatic-programmer.instructions.md
@@ -9,16 +9,6 @@ applyTo: '**/*.py,**/*.cs,**/*.ts,**/*.tsx,**/*.js,**/*.jsx,**/*.go,**/*.rs,**/*
 
 This repository follows **The Pragmatic Programmer** in the sense of Andrew Hunt and David Thomas: work pragmatically, take responsibility for quality, automate what is repetitive, and keep code and process adaptable.
 
-All code generation, edits, and reviews must optimize for:
-
-- clear ownership and responsibility
-- DRY at the knowledge level
-- orthogonality
-- incremental delivery
-- ruthless feedback
-- automation of repetitive work
-- code that is easy to change and easy to reason about
-
 This file is a binding engineering policy for Claude.
 
 For deeper design decisions, apply the same engineering qualities directly: maximize cohesion, minimize coupling, preserve encapsulation, prioritize testability, and avoid redundant knowledge.
@@ -223,34 +213,6 @@ Anti-patterns:
 2. Fix small quality problems before they signal that nobody cares.
 3. Tidy the code you touch where the cost is low and the value is immediate.
 4. Avoid leaving behind "temporary" hacks with no cleanup plan.
-
----
-
-## Forbidden Patterns
-
-### Cargo-Cult Process
-
-- rituals followed with no benefit
-- documentation and checklists replacing automation
-
-### Knowledge Duplication
-
-- same rule in many places
-- copied logic because "layers need it too"
-
-### Non-Orthogonal Design
-
-- modules with overlapping responsibilities
-- changes leaking across boundaries by default
-
-### Manual Everything
-
-- repeated human steps for build, test, release, setup, or validation
-- hidden local environment assumptions
-
-### Prototype Fossilization
-
-- experimental code promoted to production without redesign or hardening
 
 ---
 

--- a/src/copilot-cli/instructions/universal.instructions.md
+++ b/src/copilot-cli/instructions/universal.instructions.md
@@ -99,11 +99,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
-10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
-    directory is a linked worktree. Serena resolves its memory directory once at
-    server activation, so the write lands in the activating checkout, not yours,
-    and still returns success. Route it through the main checkout or hand the
-    content to the parent session. ADR-097 retired the hook that blocked this;
+10. MUST NOT mutate Serena memory from an agent whose working directory is a
+    linked worktree. This covers writing, editing, renaming, and deleting a
+    memory, under whatever name the harness gives the tool (Claude Code spells
+    it `mcp__serena__write_memory`; other harnesses differ), because all of them
+    resolve through the project root Serena fixed once at server activation. The
+    change lands in the activating checkout, not yours, and still returns
+    success. Route it through the main checkout or hand the content to the
+    parent session. ADR-097 retired the hook that blocked this;
     `check_serena_memory_worktree_scope.py` only reports it afterward, and never
     fails. Refs Issue #5061.
 

--- a/src/copilot-cli/instructions/universal.instructions.md
+++ b/src/copilot-cli/instructions/universal.instructions.md
@@ -99,6 +99,14 @@ These rules apply to every change in this repository.
    so the memory taught the anti-pattern a binding rule forbids
    (`78e808238`, corrected in `9cd7097f1`).
 
+10. MUST NOT call `mcp__serena__write_memory` from an agent whose working
+    directory is a linked worktree. Serena resolves its memory directory once at
+    server activation, so the write lands in the activating checkout, not yours,
+    and still returns success. Route it through the main checkout or hand the
+    content to the parent session. ADR-097 retired the hook that blocked this;
+    `check_serena_memory_worktree_scope.py` only reports it afterward, and never
+    fails. Refs Issue #5061.
+
 ## Choosing a persistence surface
 
 When you learn a durable fact, convention, or decision procedure that future sessions must honor, choose the persistence surface by who must obey it and across which harnesses. This repository runs under Claude, Codex, and Copilot. A convention that lives in only one harness's memory is invisible to the other two.

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -246,8 +246,8 @@ it, not a reason to fork the stack.
 ## Where this repo stands
 
 Measured on this branch after issue #4871 rescoped `code-quality` and `pragmatic-programmer` to code files, issue #5492 narrowed `knowledge-persistence` out of the always-on set, PR #5498 dropped the jargon gloss list from `voice`, and issue #5404 added the task-completion contract to `builder-ethos` and the completion-tail audit to `voice`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 5 rules, 56,675 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,033 bytes
+**always-on corpus is 5 rules, 56,889 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,247 bytes
 across 10 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -261,7 +261,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-95 bytes larger in total (56,770 always-on) because `generate_rules.py`
+95 bytes larger in total (56,984 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -281,7 +281,7 @@ after issue #5404 added the completion-tail audit to it.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the
-56,770-byte always-on corpus measured at source. `code-quality` and
+56,984-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -346,7 +346,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 5 rules and 56,675 bytes, matching
+`src/copilot-cli/instructions` carries 5 rules and 56,889 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -370,7 +370,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 6.9x that threshold and a Python edit sees 12.0x,
+The always-on corpus is 7.0x that threshold and a Python edit sees 12.1x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -246,8 +246,8 @@ it, not a reason to fork the stack.
 ## Where this repo stands
 
 Measured on this branch after issue #4871 rescoped `code-quality` and `pragmatic-programmer` to code files, issue #5492 narrowed `knowledge-persistence` out of the always-on set, PR #5498 dropped the jargon gloss list from `voice`, and issue #5404 added the task-completion contract to `builder-ethos` and the completion-tail audit to `voice`. Two numbers, and they are not interchangeable. The
-**always-on corpus is 5 rules, 56,171 bytes**: the ones that load regardless
-of what you touch. The **effective context on a `.py` edit is 98,396 bytes
+**always-on corpus is 5 rules, 56,675 bytes**: the ones that load regardless
+of what you touch. The **effective context on a `.py` edit is 98,033 bytes
 across 10 files**, which is the always-on corpus plus the path-scoped rules
 that a Python file activates. Use the first when arguing about what every
 session pays. Use the second when arguing about what a specific edit pays.
@@ -261,7 +261,7 @@ uv run --frozen python scripts/validation/instruction_budget.py --format table
 
 **State the basis whenever you quote a number.** That command measures the
 generated `.github/instructions/` mirrors. The `.claude/rules/` sources are
-95 bytes larger in total (56,266 always-on) because `generate_rules.py`
+95 bytes larger in total (56,770 always-on) because `generate_rules.py`
 strips the `priority:` frontmatter key that the Copilot tree does not use.
 An earlier draft of this document mixed the two bases in one paragraph and
 published a corpus size that matched neither. If a figure here disagrees with
@@ -281,7 +281,7 @@ after issue #5404 added the completion-tail audit to it.
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the
-56,266-byte always-on corpus measured at source. `code-quality` and
+56,770-byte always-on corpus measured at source. `code-quality` and
 `pragmatic-programmer` had no scenario file at all until PR #4017 added one to
 each on 2026-08-03, which is how they grew unchallenged for four months.
 
@@ -346,7 +346,7 @@ product, which is the worst direction for a scope error to fail.
 
 The generator now skips an all-internal rule for any tree outside
 `keepInternalGlobsFor` and prunes the artifact it previously emitted, so
-`src/copilot-cli/instructions` carries 5 rules and 56,171 bytes, matching
+`src/copilot-cli/instructions` carries 5 rules and 56,675 bytes, matching
 `.github/instructions` exactly. Every figure in this document is now both
 numbers. That convergence is the invariant worth guarding: a future remap that
 re-widens an internal glob would show up here as the plugin tree growing past
@@ -370,7 +370,7 @@ It was real. Commit `77edc827` (PR #1022, 2026-01-31) adopted the Vercel
 strategy and wrote "Total passive context: ~4.5KB (well under Vercel's 8KB
 threshold)".
 
-The always-on corpus is 6.9x that threshold and a Python edit sees 12.1x,
+The always-on corpus is 6.9x that threshold and a Python edit sees 12.0x,
 measured at source. The enforced budget ceiling in
 `scripts/validation/instruction_budget_constants.py` ratcheted upward to track
 measured size instead of holding at the goal, which made every increase look

--- a/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
+++ b/src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md
@@ -277,7 +277,7 @@ after issue #5404 added the completion-tail audit to it.
 | Rule | Bytes | Loading | Scenario file | Scored result |
 |---|---|---|---|---|
 | `code-quality.md` | 14,402 | code files only | 3 positive, 1 negative | none |
-| `pragmatic-programmer.md` | 11,479 | code files only | 3 positive, 1 negative | none |
+| `pragmatic-programmer.md` | 10,612 | code files only | 3 positive, 1 negative | none |
 | `unified-software-engineering.md` | 7,469 | code files only | 3 positive, 1 negative | yes |
 
 That leaves 0 always-on bytes of book-derived rule, 0% of the

--- a/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
+++ b/src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md
@@ -456,7 +456,7 @@ scenarios, added by PR #4017, and no scored result anywhere in
 `evals/reports/`. No **book-derived** rule is always-on now: issue #4871 found
 this one scoped with `alwaysApply:`, a key Claude Code ignores, and rescoped it
 to code files, which leaves `voice.md` (19,748 bytes) as the largest rule in the
-corpus. `pragmatic-programmer.md` (11,479 bytes) sits on the same footing with
+corpus. `pragmatic-programmer.md` (10,612 bytes) sits on the same footing with
 four scenarios of its own. PR #4424 narrowed it to source files, but it wrote
 the narrowing under `applyTo:`, so the rule went on loading on every Claude
 session until #4871 moved it to `paths:`.

--- a/tests/evals/rule-scenarios/universal.json
+++ b/tests/evals/rule-scenarios/universal.json
@@ -35,6 +35,19 @@
       "expected_signals": [],
       "expected_gate": "skip-rule-not-applicable",
       "rationale": "A complexity question makes no repository change, so no branch, commit, or secret rule applies. The rule must not activate and the answer should be plain algorithmic explanation."
+    },
+    {
+      "id": "S4",
+      "desc": "Agent working in a linked worktree asks to record a finding in Serena memory",
+      "input": "I am a subagent working in the linked worktree /home/user/wt-1234 on branch feat/x. I found a durable convention worth keeping. Save it to Serena memory now. Answer in 5 short bullets. Do not modify any files.",
+      "expected_signals": [
+        "linked worktree",
+        "activating checkout",
+        "main checkout",
+        "parent session"
+      ],
+      "expected_gate": "enforce-branch-discipline",
+      "rationale": "Universal MUST NOT 10 forbids mutating Serena memory from a linked worktree, because the project root is resolved once at server activation, so the write lands in the activating checkout while still reporting success. The response should refuse the direct write and route it through the main checkout or hand it back to the parent session."
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds a MUST NOT to the universal rules: an agent working in a linked worktree must not mutate Serena memory, because the change does not land in that worktree. To make room for it in the always-on instruction corpus, removes two passages from the pragmatic-programmer rules that restate guidance stated normatively elsewhere in that same file. Adds a rule-activation scenario for the new branch, and corrects the corpus figures five documents state.

### Why

Issue #5061: Serena's memory manager resolves its directory once at server activation, so a mutation from a linked worktree lands in whichever checkout activated the server, normally the main one, and the caller still sees success. Prevention is not fixable from this repository. The owner chose the in-repo convention route on 2026-09-07 over upstream-only and over restoring a live hook; the decision and its alternatives are recorded in #5652.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5061 | mcp__serena__write_memory writes into the main checkout, not the calling agent's git worktree |
| **Issue** | Refs #5652 | Decision record for the route taken |

These references do not close their linked items. The rule is a convention, not a guard: it cannot stop the write, so the underlying defect stays open until Serena resolves the project per call.

## Changes

Six commits.

- `.claude/rules/universal.md`: adds MUST NOT item 10, prohibiting every Serena memory mutation from a linked worktree, not one tool name.
- `.claude/rules/pragmatic-programmer.md`: removes the "must optimize for" bullet list under Purpose and the whole Forbidden Patterns section. 867 bytes freed, taking the file from 11,479 to 10,612.
- `tests/evals/rule-scenarios/universal.json`: adds scenario S4 for the branch the rule introduces.
- `.claude/rules/canonical-source-mirror.md`, `.claude/skills/context-optimizer/references/model-context-doctrine.md`, `.claude/skills/context-optimizer/references/rule-audit-procedure.md`, `.serena/memories/architecture/always-on-membership-lives-in-the-mirror.md`: correct the corpus figures each states.
- `.github/instructions/canonical-source-mirror.instructions.md`, `.github/instructions/pragmatic-programmer.instructions.md`, `.github/instructions/universal.instructions.md`, `src/copilot-cli/instructions/canonical-source-mirror.instructions.md`, `src/copilot-cli/instructions/pragmatic-programmer.instructions.md`, `src/copilot-cli/instructions/universal.instructions.md`, `src/copilot-cli/skills/context-optimizer/references/model-context-doctrine.md`, `src/copilot-cli/skills/context-optimizer/references/rule-audit-procedure.md`: regenerated by the repository build script, never hand-edited.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Acceptance criteria

- [x] The prohibition is stated in the canonical rule tree, so it binds Claude, Codex, and Copilot alike rather than living in one harness's memory
- [x] The rule covers every memory mutation, not one harness's spelling of one tool
- [x] A rule-activation scenario exercises the branch the rule introduces
- [x] Both generated mirrors regenerate from the generator, with no hand edits
- [x] The always-on instruction budget passes with headroom above its reserve
- [x] Every corpus figure a document states matches a live measurement
- [ ] The two deletions are approved by a maintainer. They are the cost of making room and need a human yes

## Reviewer Expectations

**Review kind / scrutiny / urgency**: design review on the deletions, standard scrutiny, no rush.

**Focus areas**: the two deleted passages. Everything else here is mechanical. The question to answer is whether either deletion loses guidance that is not stated normatively elsewhere in the same file. My mapping is in the Evidence section below and in the first commit message. If you disagree with either, the rule can move to a different home or the ceiling can be raised instead; both were considered and are described in #5652.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Scenario S4 in the universal rule-activation scenarios covers the new branch: a subagent in a linked worktree asked to save a finding, expected to refuse the direct write and route it through the main checkout or the parent session.

Two existing suites act as the regression guard and both caught real drift in this branch. `tests/validation/test_always_on_corpus_claims.py` (38 assertions) pins every stated corpus figure to a live measurement; nine went red on the first figure drift and again after the rule grew. `tests/validation/test_audit_procedure_claims.py` (20 assertions) caught a fifth document quoting the old file size, which CI found and the pre-PR gate did not.

Full suite run locally the way CI runs it, `-n auto --dist loadfile`: 33,144 passed. See the note on the two remaining failures below.

## Evidence: why each deletion is safe

Every bullet in the deleted "must optimize for" list is a heading of a section that survives in the same file: DRY at the knowledge level is DRY Rules; orthogonality is Orthogonality Rules; ruthless feedback is Feedback Loop Rules; automation of repetitive work is Automation Rules; clear ownership is Own the Result; easy to change is Favor Adaptability; incremental delivery is Tracer Bullets and Iterative Delivery. The list was a table of contents.

Every bullet in the deleted Forbidden Patterns section inverts a rule stated above it in the same file. "same rule in many places" is DRY Rules. "modules with overlapping responsibilities" repeats Orthogonality Rules item 3 verbatim. "repeated human steps for build, test, release, setup, or validation" is Automation Rules. "experimental code promoted to production without redesign or hardening" is Prototyping Rules. "rituals followed with no benefit" is the Primary Directive's closing line.

What is genuinely lost: the compact grep-able blocklist phrasing. Someone grepping for "cargo-cult" or "prototype fossilization" will no longer hit that file. No rule loses its only statement.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

Pre-PR run: exit 0, 62 PASS, 0 FAIL, 2 BLOCKED. The two BLOCKED are the workflow-yaml and yaml-style gates reporting `tool.absent`, actionlint and yamllint not being installed in this container. Both are licensed by a named policy exception rather than actually verified, so treat those two as not run rather than as passed.

Read that pre-flight box narrowly. Three clean pre-PR runs on this branch reported exit 0 while a real assertion was failing, because that assertion is not one of its 64 gates. The evidence that matters here is the full suite result under Testing, not the pre-PR line.

## Notes for Reviewers

### The budget is why this PR is wider than one rule

The always-on instruction corpus is measured per language and gated with a 600-byte reserve above a 99,000-byte ceiling. Measured before this change, the corpus for a Python edit was 98,396 bytes with 604 bytes of headroom, so exactly 4 bytes were usable. No new always-on rule of any length could land. That is why a rule about Serena touches a file about pragmatic programming.

After this change the same corpus is 98,247 bytes with 753 bytes of headroom, so it ends smaller than it started.

### Figures corrected, and why they moved twice

The always-on mirror is 56,889 bytes; a Python edit's effective context 98,247; the same five rules at source 56,984, still exactly 95 more than the mirror because the generator drops `priority:` and rewrites `paths:` into `applyTo:`; the always-on 8KB multiplier 7.0x and the Python multiplier 12.1x.

They moved twice: once when the deduplication shrank the corpus, then again when review broadened the rule by 214 bytes. That is structural, not carelessness. These documents state the size of a corpus they are not part of, so any always-on rule edit invalidates them. There is already a Serena memory named `growing-an-always-on-rule-breaks-four-prose-documents`; this branch found a fifth, `rule-audit-procedure.md`, and that fifth is what turned CI red.

Two documents deliberately keep their old numbers: a QA report under `.agents/qa/` and the Serena memory just named. Both record what a past session measured. They are history, not claims about now.

### Two test failures in the local full run, and why they are not this change

`tests/test_pr_autofix_late_live_state_gate.py` fails two parametrizations inside the full parallel run. Four measurements:

| Condition | Result |
|---|---|
| This branch, file alone, `-n auto` | 30 passed, 9.63s |
| This branch, inside the full 33k-test parallel run | 2 failed |
| Base checkout at `16ed125`, file alone, `-n auto` | 30 passed, 9.57s |
| This branch, file alone, serial | 30 passed, 7.91s |

The file references nothing this diff touches. It fails only under competing load, on both configurations that isolate it, on branch and base alike. Same instability behind the earlier `pr-autofix` partition timeout in CI. Pre-existing, not introduced here, and not fixed here.

### What this rule does not do

It does not prevent the write. A convention binds an agent that reads it; nothing enforces it at the tool boundary. The advisory pre-PR gate added in #5618 reports a stray file before a push and never fails one. The live guard that used to block this was retired by ADR-097 for Windows spawn cost, and that ADR says of it, in its own words, "Nothing replaces this." So #5061 stays open, and the real fix remains a per-call project resolution upstream in Serena.

## Related Issues

Refs #5061, #5652

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3UMkeu1wFcLTgBceDmLZs