### PR TITLE
fix(validation): a signal-killed child carries no verdict

### DIFF
--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -46,7 +46,6 @@ from scripts.validation.evidence import (  # noqa: E402
     REASON_BASE_REF_UNRESOLVED,
     REASON_DIFF_FAILED,
     REASON_INCOMPLETE_EVIDENCE,
-    REASON_TIMEOUT,
     REASON_TOOL_ABSENT,
     REASON_TREE_ABSENT,
     WORKING_TREE,
@@ -543,15 +542,21 @@ def validate_workflow_yaml(repo_root: Path) -> CheckOutcome:
                     "so no workflow file was examined"
                 ),
             )
-        if failure == REASON_TIMEOUT:
-            print("[UNKNOWN] actionlint timed out; its findings are incomplete")
+        if failure:
+            # Any reason the classifier named is an execution failure, so it
+            # cannot be a findings exit. Matching an allowlist of known reasons
+            # here is what let a signal-killed actionlint through as
+            # ``actionlint.violation`` (issue #5653); this branch does not need
+            # editing when the classifier learns a new one.
+            print(f"[UNKNOWN] actionlint did not complete ({failure}); its findings are incomplete")
             return CheckOutcome.unknown(
                 _WORKFLOW_YAML,
-                reason=REASON_TIMEOUT,
+                reason=failure,
                 scope=scope,
                 detail=(
-                    "actionlint timed out, so an unknown share of the scope went "
-                    "unexamined and its silence proves nothing"
+                    f"actionlint exited {exit_code} without completing, so an "
+                    "unknown share of the scope went unexamined and its silence "
+                    "proves nothing"
                 ),
             )
         print("[FAIL] actionlint found issues in workflow files")
@@ -642,15 +647,20 @@ def validate_yaml_style(repo_root: Path) -> CheckOutcome:
                     "so no YAML file was examined"
                 ),
             )
-        if failure == REASON_TIMEOUT:
-            print("[UNKNOWN] yamllint timed out; its findings are incomplete")
+        if failure:
+            # See the twin branch in validate_workflow_yaml. This half is the
+            # more dangerous of the two: its findings path returns PASS, so a
+            # signal-killed yamllint read as a clean advisory run rather than as
+            # a spurious red (issue #5653).
+            print(f"[UNKNOWN] yamllint did not complete ({failure}); its findings are incomplete")
             return CheckOutcome.unknown(
                 _YAML_STYLE,
-                reason=REASON_TIMEOUT,
+                reason=failure,
                 scope=scope,
                 detail=(
-                    "yamllint timed out, so an unknown share of the scope went "
-                    "unexamined and its silence proves nothing"
+                    f"yamllint exited {exit_code} without completing, so an "
+                    "unknown share of the scope went unexamined and its silence "
+                    "proves nothing"
                 ),
             )
         print("[WARNING] yamllint found style issues (non-blocking)")

--- a/scripts/validation/evidence.py
+++ b/scripts/validation/evidence.py
@@ -104,6 +104,7 @@ __all__ = [
     "REASON_LEGACY_BOOLEAN",
     "REASON_MALFORMED_OUTPUT",
     "REASON_NO_OUTCOMES",
+    "REASON_PROCESS_SIGNALED",
     "REASON_QUICK_MODE",
     "REASON_SCRIPT_ABSENT",
     "REASON_TIMEOUT",
@@ -161,6 +162,12 @@ REASON_SCRIPT_ABSENT: Final = "script.absent"
 REASON_TOOL_ABSENT: Final = "tool.absent"
 REASON_TREE_ABSENT: Final = "tree.absent"
 REASON_TIMEOUT: Final = "timeout"
+#: The child was killed by a signal rather than exiting on its own, so its
+#: return code is a negated signal number and carries no verdict. Distinct
+#: from :data:`REASON_TIMEOUT`, which is the wrapper killing a child it was
+#: watching: this one is the OS or an outside process, and the remedy is to
+#: find out what killed it rather than to raise a timeout (issue #5653).
+REASON_PROCESS_SIGNALED: Final = "process.signaled"
 REASON_MALFORMED_OUTPUT: Final = "output.malformed"
 REASON_INCOMPLETE_EVIDENCE: Final = "evidence.incomplete"
 REASON_AUTH_UNAVAILABLE: Final = "auth.unavailable"

--- a/scripts/validation/subprocess_runner.py
+++ b/scripts/validation/subprocess_runner.py
@@ -20,7 +20,11 @@ from pathlib import Path
 from scripts.cli_exec import resolve_executable
 
 # Reason codes for the typed evidence contract (issue #5635).
-from scripts.validation.evidence import REASON_TIMEOUT, REASON_TOOL_ABSENT
+from scripts.validation.evidence import (
+    REASON_PROCESS_SIGNALED,
+    REASON_TIMEOUT,
+    REASON_TOOL_ABSENT,
+)
 
 # The exit code :func:`_run_subprocess` returns when the child never produced
 # one of its own: a timeout or a missing executable. Any other non-zero value
@@ -102,6 +106,21 @@ def classify_subprocess_failure(exit_code: int, stderr: str, *, default: str) ->
         marker = f"Command timed out after {timeout}s"
         return -1, "", f"Command not found: {args[0]}"
 
+    A negative return code that matches neither marker is a child killed by a
+    signal: :func:`subprocess.run` reports that as the negated signal number,
+    so ``-9`` is SIGKILL and ``-15`` is SIGTERM. Those are not verdicts, and
+    before issue #5653 they fell through to ``default`` and were read as the
+    child's own findings exit: an actionlint killed by the OOM killer became
+    workflow violations that do not exist, and a killed yamllint became a
+    tolerated-findings PASS.
+
+    A bare ``-1`` with no marker belongs in that class too. This wrapper always
+    writes a marker when it returns ``-1`` itself, so a markerless ``-1`` is not
+    the sentinel, it is SIGHUP.
+
+    The rule is therefore the sign, not the sentinel: a negative code means the
+    child did not choose its own exit, so it cannot carry a finding.
+
     ``default`` is the caller's own reason for an ordinary non-zero exit, since
     only the caller knows what its child was doing (issue #5635).
     """
@@ -110,4 +129,6 @@ def classify_subprocess_failure(exit_code: int, stderr: str, *, default: str) ->
             return REASON_TIMEOUT
         if "Command not found:" in stderr:
             return REASON_TOOL_ABSENT
+    if exit_code < 0:
+        return REASON_PROCESS_SIGNALED
     return default

--- a/tests/validation/test_checks_common.py
+++ b/tests/validation/test_checks_common.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from scripts.validation import subprocess_runner
 from scripts.validation.evidence import (
     REASON_DIFF_FAILED,
+    REASON_PROCESS_SIGNALED,
     REASON_TIMEOUT,
     REASON_TOOL_ABSENT,
 )
@@ -95,15 +96,26 @@ class TestClassifySubprocessFailure:
 
         assert reason == REASON_DIFF_FAILED
 
-    def test_the_sentinel_exit_alone_keeps_the_caller_s_reason(self) -> None:
-        """Edge: exit -1 with neither marker is not evidence of a timeout.
+    def test_the_sentinel_exit_alone_reports_a_signal_not_the_caller_s_reason(
+        self,
+    ) -> None:
+        """Edge: exit -1 with neither marker is a signal, not a timeout.
 
-        NEGATIVE CONTROL: a classifier keyed on the exit code alone returns
-        REASON_TIMEOUT here and mislabels an unrecognized failure.
+        Was test_the_sentinel_exit_alone_keeps_the_caller_s_reason, which
+        asserted the caller's own reason survived here (issue #5653). It does
+        not any more, and the old assertion was the defect: ``_run_subprocess``
+        always writes a marker when it returns -1 itself, so a markerless -1
+        never came from the wrapper. It is SIGHUP, and handing it back to the
+        caller let a signal-killed child be read as that child's own verdict.
+
+        NEGATIVE CONTROL, unchanged and still the point: a classifier keyed on
+        the exit code alone returns REASON_TIMEOUT here and mislabels an
+        unrecognized failure. The new answer is not a timeout either.
         """
         reason = classify_subprocess_failure(-1, "", default=REASON_DIFF_FAILED)
 
-        assert reason == REASON_DIFF_FAILED
+        assert reason == REASON_PROCESS_SIGNALED
+        assert reason != REASON_TIMEOUT
 
     def test_the_marker_alone_keeps_the_caller_s_reason(self) -> None:
         """Edge: a child that printed the marker text and exited 1 is not a timeout.

--- a/tests/validation/test_signal_termination_is_not_a_verdict.py
+++ b/tests/validation/test_signal_termination_is_not_a_verdict.py
@@ -1,0 +1,226 @@
+"""A signal-killed child carries no verdict (issue #5653).
+
+``classify_subprocess_failure`` gated its whole body on
+``exit_code == _SENTINEL_EXIT`` (-1), the value ``_run_subprocess`` returns for
+the two failures it synthesizes itself. :func:`subprocess.run` reports a child
+killed by a signal as the negated signal number, so ``-9`` is SIGKILL and
+``-15`` is SIGTERM. Neither is -1 and neither carries a stderr marker, so both
+fell through to the caller's ``default``.
+
+For the two linter validators that ``default`` is the empty string, and the
+code then read the kill as the linter's own findings exit. ``validate_workflow
+_yaml`` reported workflow violations that do not exist, with an ``examined``
+count asserting it had read every file; ``validate_yaml_style`` returned a PASS
+whose scope claimed ``advisory findings tolerated``. The second is the
+dangerous one: its findings path is a PASS, so the fabricated verdict is green.
+
+Found by Devin Review on PR #5649, which fixed the two failures the wrapper
+documents and treated that enumeration as complete.
+
+The unit cases live here rather than beside the existing classifier tests
+because the wiring cases below are the point: the classifier can be correct
+while a call site still ignores it, which is exactly the shape #5649 shipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from scripts.validation.evidence import (
+    REASON_PROCESS_SIGNALED,
+    REASON_TIMEOUT,
+    REASON_TOOL_ABSENT,
+    EvidenceState,
+    default_pre_pr_policy,
+)
+from scripts.validation.pre_pr import validate_workflow_yaml, validate_yaml_style
+from scripts.validation.subprocess_runner import classify_subprocess_failure
+
+#: SIGKILL and SIGTERM as ``subprocess.run`` reports them, plus the markerless
+#: -1 that is SIGHUP rather than this wrapper's sentinel.
+_SIGNAL_EXITS = (-9, -15, -1, -2, -6)
+
+
+class TestClassifierReadsTheSign:
+    """The rule is the sign of the code, not one sentinel value."""
+
+    @pytest.mark.parametrize("exit_code", _SIGNAL_EXITS)
+    def test_a_signal_exit_is_named_rather_than_defaulted(self, exit_code: int) -> None:
+        """The discriminating case: every one of these returned "" before."""
+        assert (
+            classify_subprocess_failure(exit_code, "", default="") == REASON_PROCESS_SIGNALED
+        )
+
+    def test_a_markerless_minus_one_is_a_signal_not_the_sentinel(self) -> None:
+        """Edge, and the one that looks wrong until you read the wrapper.
+
+        ``_run_subprocess`` writes ``Command timed out after`` or ``Command not
+        found:`` whenever it returns -1 itself, so a markerless -1 cannot have
+        come from the wrapper. It is SIGHUP, and reading it as a findings exit
+        is the same defect with a different signal number.
+        """
+        assert classify_subprocess_failure(-1, "", default="") == REASON_PROCESS_SIGNALED
+
+    def test_the_two_marked_sentinels_still_win_over_the_sign_rule(self) -> None:
+        """Negative control on the new branch.
+
+        Both markers arrive on -1, which the sign rule also matches. If the new
+        branch were placed above them it would swallow both, collapsing three
+        remedies (find the killer, raise the timeout, install the tool) into
+        one. Ordering is the property under test, so assert it directly.
+        """
+        assert (
+            classify_subprocess_failure(-1, "Command timed out after 120s", default="")
+            == REASON_TIMEOUT
+        )
+        assert (
+            classify_subprocess_failure(-1, "Command not found: actionlint", default="")
+            == REASON_TOOL_ABSENT
+        )
+
+    @pytest.mark.parametrize("exit_code", (1, 2, 123))
+    def test_a_positive_exit_still_reaches_the_caller_default(self, exit_code: int) -> None:
+        """Positive control. A real findings exit must stay a findings exit.
+
+        Without this, a classifier that returned the signal reason for every
+        non-zero code would pass every test above while turning every genuine
+        lint violation into UNKNOWN.
+        """
+        assert classify_subprocess_failure(exit_code, "", default="lint.violation") == (
+            "lint.violation"
+        )
+
+    def test_a_signal_exit_outranks_a_non_empty_caller_default(self) -> None:
+        """The three call sites that pass a real default gain accuracy here.
+
+        ``validate_session_end`` passes ``diff.failed``; a killed ``git diff``
+        is not a diff that failed to resolve, and both already map to UNKNOWN,
+        so this changes the reason without changing the state.
+        """
+        assert (
+            classify_subprocess_failure(-9, "", default="diff.failed")
+            == REASON_PROCESS_SIGNALED
+        )
+
+
+def _run_workflow(tmp_path: Path, result: tuple[int, str, str]) -> Any:
+    """Drive the real actionlint validator over one changed workflow file."""
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    with patch("checks_tooling.shutil.which", return_value="/usr/bin/actionlint"):
+        with patch("checks_tooling._workflow_yaml_targets", return_value=["ci.yml"]):
+            with patch("checks_tooling._run_subprocess", return_value=result):
+                return validate_workflow_yaml(tmp_path)
+
+
+def _run_yaml_style(tmp_path: Path, result: tuple[int, str, str]) -> Any:
+    """Drive the real yamllint validator over one changed YAML file."""
+    with patch("checks_tooling.shutil.which", return_value="/usr/bin/yamllint"):
+        with patch("checks_tooling._yaml_style_targets", return_value=["config.yml"]):
+            with patch("checks_tooling._run_subprocess", return_value=result):
+                return validate_yaml_style(tmp_path)
+
+
+class TestWorkflowYamlWiring:
+    """A correct classifier proves nothing until the call site reads it."""
+
+    @pytest.mark.parametrize("exit_code", _SIGNAL_EXITS)
+    def test_a_killed_actionlint_reports_unknown(
+        self, tmp_path: Path, exit_code: int
+    ) -> None:
+        """The discriminating case: this was FAIL actionlint.violation."""
+        outcome = _run_workflow(tmp_path / str(exit_code), (exit_code, "", ""))
+
+        assert outcome.state is EvidenceState.UNKNOWN
+        assert outcome.reason == REASON_PROCESS_SIGNALED
+
+    def test_a_killed_actionlint_claims_no_examined_count(self, tmp_path: Path) -> None:
+        """``ci-scripts.md`` MUST 12. The old FAIL carried examined=1.
+
+        A count is the reader's evidence that the gate looked. Reporting one
+        for a run that was killed mid-scan is the same lie as the verdict.
+        """
+        outcome = _run_workflow(tmp_path, (-9, "", ""))
+
+        assert outcome.examined is None
+        assert outcome.findings is None
+
+    def test_a_killed_actionlint_is_not_licensed_by_the_pre_pr_policy(
+        self, tmp_path: Path
+    ) -> None:
+        """UNKNOWN blocks. Only an absent actionlint is licensed.
+
+        Licensing this would convert a spurious red into a silent green, which
+        is worse than the defect being fixed.
+        """
+        outcome = _run_workflow(tmp_path, (-9, "", ""))
+
+        assert not default_pre_pr_policy().accepts(outcome)
+
+    def test_a_real_actionlint_finding_still_fails(self, tmp_path: Path) -> None:
+        """Positive control for every case above."""
+        outcome = _run_workflow(tmp_path, (1, 'ci.yml:3:1: unexpected key "jobss"', ""))
+
+        assert outcome.state is EvidenceState.FAIL
+        assert outcome.reason == "actionlint.violation"
+        assert outcome.examined == 1
+
+
+class TestYamlStyleWiring:
+    """The half where the fabricated verdict was green rather than red."""
+
+    @pytest.mark.parametrize("exit_code", _SIGNAL_EXITS)
+    def test_a_killed_yamllint_reports_unknown(
+        self, tmp_path: Path, exit_code: int
+    ) -> None:
+        """The discriminating case: this was a PASS.
+
+        The scope string said ``advisory findings tolerated``, so the summary
+        showed a clean advisory run for a linter that never finished.
+        """
+        outcome = _run_yaml_style(tmp_path, (exit_code, "", ""))
+
+        assert outcome.state is EvidenceState.UNKNOWN
+        assert outcome.reason == REASON_PROCESS_SIGNALED
+
+    def test_a_killed_yamllint_does_not_claim_tolerated_findings(
+        self, tmp_path: Path
+    ) -> None:
+        """The specific false claim the old PASS made about its own scope."""
+        outcome = _run_yaml_style(tmp_path, (-15, "", ""))
+
+        assert "advisory findings tolerated" not in outcome.scope
+        assert outcome.examined is None
+
+    def test_a_killed_yamllint_is_not_licensed_by_the_pre_pr_policy(
+        self, tmp_path: Path
+    ) -> None:
+        """The advisory licence covers an absent yamllint, not an unfinished one."""
+        outcome = _run_yaml_style(tmp_path, (-9, "", ""))
+
+        assert not default_pre_pr_policy().accepts(outcome)
+
+    def test_tolerated_style_findings_still_pass(self, tmp_path: Path) -> None:
+        """Positive control. Issue #2374 keeps style findings non-blocking."""
+        outcome = _run_yaml_style(tmp_path, (1, "config.yml:1:1: [warning] ...", ""))
+
+        assert outcome.state is EvidenceState.PASS
+        assert "advisory findings tolerated" in outcome.scope
+
+    def test_an_absent_yamllint_is_still_blocked_and_licensed(
+        self, tmp_path: Path
+    ) -> None:
+        """Positive control on the branch above the new one.
+
+        The tool-absent case shares the -1 code with the sign rule, so a
+        misordered guard would reroute it to UNKNOWN and start blocking every
+        contributor who has not installed yamllint.
+        """
+        outcome = _run_yaml_style(tmp_path, (-1, "", "Command not found: yamllint"))
+
+        assert outcome.state is EvidenceState.BLOCKED
+        assert outcome.reason == REASON_TOOL_ABSENT
+        assert default_pre_pr_policy().accepts(outcome)


### PR DESCRIPTION
# Pull Request

## Summary

### What

`classify_subprocess_failure` now reads the sign of the return code rather than one sentinel value, so a child killed by a signal is reported as incomplete execution instead of as that child's own verdict. Both linter validators branch on whether the classifier named anything, rather than on an allowlist of known reasons.

### Why

`classify_subprocess_failure` gated its whole body on `exit_code == _SENTINEL_EXIT` (-1), the value `_run_subprocess` returns for the two failures it synthesizes itself. `subprocess.run` reports a signal kill as the negated signal number, so `-9` is SIGKILL and `-15` is SIGTERM: not `-1`, and carrying neither stderr marker, so both fell through to the caller's `default`.

For `validate_workflow_yaml` and `validate_yaml_style` that `default` is the empty string, and the kill was then read as the linter's own findings exit. The first reported workflow violations that do not exist, with an `examined` count asserting it had read every file. The second returned a PASS whose scope claimed `advisory findings tolerated`. The second is the dangerous half, because its findings path is green.

Found by Devin Review on PR #5649 and reproduced against `main` before filing #5653.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5653 | fix(validation): a signal-killed child is reported as linter violations, not incomplete evidence |
| **Issue** | Refs #5646 | The seven follow-ups; this is the door item 6 did not close |
| **Issue** | Refs #5635 | The typed evidence contract this fail-open class belongs to |

## Changes

- **`scripts/validation/subprocess_runner.py`**. `classify_subprocess_failure` returns the new reason for any negative exit code that matches no marker. The marked sentinels are still checked first, so a timeout and an absent tool keep their own reasons and remedies.
- **`scripts/validation/evidence.py`**. Adds `REASON_PROCESS_SIGNALED` (`process.signaled`) and exports it. Distinct from `REASON_TIMEOUT`, which is the wrapper killing a child it was watching; this one is the OS or an outside process, and the remedy is to find out what killed it rather than to raise a timeout.
- **`scripts/validation/checks_tooling.py`**. `validate_workflow_yaml` and `validate_yaml_style` keep `tool.absent` as BLOCKED and route every other named reason to UNKNOWN. Matching an allowlist is what let this through; the new shape needs no edit when the classifier learns another reason.
- **`tests/validation/test_signal_termination_is_not_a_verdict.py`** (new). 28 tests across the classifier and both call sites.
- **`tests/validation/test_checks_common.py`**. One contract flip, described under Testing.

### Why a markerless `-1` moved too

`_run_subprocess` always writes `Command timed out after` or `Command not found:` when it returns `-1` itself, so a markerless `-1` never came from the wrapper. It is SIGHUP. Handing it back to the caller let a signal-killed child be read as that child's verdict, which is the same defect with a different signal number.

## Acceptance criteria

- [x] A signal-killed child is never reported as the child's own findings exit
- [x] `tool.absent` and `timeout` keep their reasons and remedies, and are checked before the sign rule
- [x] A genuine non-zero findings exit still reaches the caller's default
- [x] Both linter validators route every classified execution failure away from their findings path
- [x] A killed run reports no `examined` count and no `findings` count
- [x] Neither killed-run outcome is licensed by `default_pre_pr_policy`

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: correctness review, normal scrutiny, no rush.

**Focus areas**:

1. **Guard ordering.** Both markers arrive on `-1`, which the sign rule also matches. Placing the sign rule above them would swallow both and collapse three remedies (find the killer, raise the timeout, install the tool) into one. `test_the_two_marked_sentinels_still_win_over_the_sign_rule` and `test_an_absent_yamllint_is_still_blocked_and_licensed` pin it from both sides, and the mutation below confirms they fire.
2. **Whether the broad `if failure:` at the call sites is too broad.** It routes any named reason to UNKNOWN. That is deliberate: the allowlist is the defect. The cost is that a future reason meaning "ran fine, here are findings" would be misrouted, but no such reason can exist, since the classifier only names failures.
3. **The flipped test.** `test_the_sentinel_exit_alone_keeps_the_caller_s_reason` asserted the replaced behavior directly. Its negative control is unchanged and still holds.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

**New tests**: 28, split into the classifier unit cases and a wiring class per call site. The wiring cases are the point: the classifier can be correct while a call site still ignores it, which is the shape #5649 shipped.

**Contract flip** (`testing.md` SHOULD 4): `test_the_sentinel_exit_alone_keeps_the_caller_s_reason` becomes `test_the_sentinel_exit_alone_reports_a_signal_not_the_caller_s_reason`, keeping its negative control that a markerless -1 must not read as a timeout.

**Mutation evidence**, run rather than asserted, with `__pycache__` cleared between each mutation and its rerun per `testing.md` SHOULD 8:

| Mutation | Kills |
|---|---|
| Drop the sign rule from the classifier | 20 |
| Hoist the sign rule above the marker checks | 2 (both ordering cases, and only those) |
| Revert the workflow call site to the `== REASON_TIMEOUT` allowlist | 8 |

Control after restoring each: 28 passed.

**Reproduction, before and after**, on the classifier:

```text
before                          after
exit=-9    -> ''                exit=-9    -> 'process.signaled'
exit=-15   -> ''                exit=-15   -> 'process.signaled'
exit=-1    -> ''                exit=-1    -> 'process.signaled'
exit=-1 +timeout marker -> 'timeout'       -> 'timeout'
exit=-1 +notfound marker -> 'tool.absent'  -> 'tool.absent'
exit=1     -> ''                exit=1     -> ''
```

**Full suite**: 33219 passed, 117 skipped.

Two tests failed under a local 4-worker run and are not this PR's: the mutation-workspace signal test and the pr-autofix late live-state gate test. Both pass in isolation (43 passed together), neither references `classify_subprocess_failure` or the new reason code, and the failing parameter of the first moved between runs (`[2]`, then `[15]`), which is a timing signature rather than a break. The first is the file whose own last commit (#5311) sized its wait for a loaded machine.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes

The change moves in the restrictive direction: outcomes that were PASS or FAIL become UNKNOWN, which blocks. No policy exception is added or widened, and no credential, network, or filesystem-write path is touched.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (full pre-push suite green on the pushed commit)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

One commit, five authored files.

**Blast radius on the call sites this PR does not change.** Three other callers pass a non-empty default: two in the tooling module and one in the mypy checks module. All three already map their result to UNKNOWN, so they gain a more accurate reason and no state change, since a killed `git diff` is not a diff that failed to resolve. Those files are deliberately not named as paths above, because they are not in this diff and the description validator counts a path under `## Changes` as a claimed change.

This is the follow-up #5649 earned. That PR fixed the two subprocess failures the wrapper documents and treated that enumeration as complete; the wrapper's sentinel only covers failures it synthesizes, not one the OS delivers. Devin Review caught it on #5649 and its review landed seconds before that PR merged, so the finding is being paid down here rather than in the PR that introduced it.

The first revision of this description listed an unchanged file as a path inside `## Changes`, which the PR Validation gate correctly flagged as CRITICAL. Reproduced locally against the real diff with `extract_mentioned_files` and `validate_pr_description` before and after the edit: 1 CRITICAL before, 0 issues after, with all five changed files now matched.

## Related Issues

Fixes #5653. Refs #5646, #5641, #5635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFP6QDfGaTvgDn2BWEk6Lj