### PR TITLE
fix(e2e): classify Copilot quota exhaustion as a blocked run

### DIFF
--- a/tests/e2e/copilot_hook_probe.py
+++ b/tests/e2e/copilot_hook_probe.py
@@ -146,6 +146,29 @@ COPILOT_AUTH_REJECTED_MARKERS = ("github returned: bad credentials",)
 # correct advice is to retry after the reset window, not to rotate the token.
 # This predicate takes precedence over both auth predicates.
 COPILOT_RATE_LIMIT_MARKERS = ("api rate limit exceeded", "secondary rate limit")
+
+# Quota-exhaustion detection. A Copilot plan whose monthly allowance is spent
+# gets an HTTP 402 whose body is neither a rate limit nor an auth failure: the
+# token is valid and the request is well formed, the account is out of credits.
+# None of the marker sets above match that wording, so the run fell through to
+# unclassified and the smoke failed as though the branch were broken. That
+# blocked every push touching the plugin-load-e2e globs until the billing
+# period rolled over.
+#
+# Two markers because the CLI surfaces the same condition two ways: the plain
+# ``-p`` path prints the prose sentence on stderr, and the agent path emits a
+# JSON event carrying ``"errorCode":"quota_exceeded"`` (the prose also appears
+# there, escaped, inside ``errorMessage``). Matching either keeps both probe
+# shapes classified.
+#
+# This class takes precedence over every other marker set: a 402 body can carry
+# the same auth-method boilerplate a 403 does, and "out of credits" needs
+# different operator advice from both "wait for the reset window" and "rotate
+# the token".
+COPILOT_QUOTA_EXHAUSTED_MARKERS = (
+    "exceeded your monthly quota",
+    "quota_exceeded",
+)
 COPILOT_TRANSPORT_FAILURE_MARKERS = (
     "failed to fetch pat user login",
     "your token may still be valid",
@@ -158,7 +181,9 @@ COPILOT_TRANSPORT_FAILURE_MARKERS = (
     "tls handshake timeout",
 )
 
-CopilotBlockReason = Literal["rate_limit", "transport", "auth_rejected", "auth_absent"]
+CopilotBlockReason = Literal[
+    "quota_exhausted", "rate_limit", "transport", "auth_rejected", "auth_absent"
+]
 
 
 def _copilot_haystack(result: subprocess.CompletedProcess[str]) -> str:
@@ -189,6 +214,8 @@ def copilot_block_reason(
         return None
 
     haystack = _copilot_haystack(result)
+    if any(marker in haystack for marker in COPILOT_QUOTA_EXHAUSTED_MARKERS):
+        return "quota_exhausted"
     if any(marker in haystack for marker in COPILOT_RATE_LIMIT_MARKERS):
         return "rate_limit"
     if any(marker in haystack for marker in COPILOT_AUTH_REJECTED_MARKERS):
@@ -198,6 +225,17 @@ def copilot_block_reason(
     if any(marker in haystack for marker in COPILOT_TRANSPORT_FAILURE_MARKERS):
         return "transport"
     return None
+
+
+def copilot_quota_exhausted(result: subprocess.CompletedProcess[str]) -> bool:
+    """True when the account's Copilot allowance is spent for the billing period.
+
+    Distinct from :func:`copilot_rate_limited`: a rate limit clears in minutes
+    or an hour, so "re-run shortly" is right advice. A spent monthly quota does
+    not clear until the plan resets or someone buys more credits, so telling the
+    operator to wait for a reset window would send them to poll for a day.
+    """
+    return copilot_block_reason(result) == "quota_exhausted"
 
 
 def copilot_rate_limited(result: subprocess.CompletedProcess[str]) -> bool:
@@ -211,8 +249,13 @@ def copilot_transport_failure(result: subprocess.CompletedProcess[str]) -> bool:
 
 
 def copilot_transient_failure(result: subprocess.CompletedProcess[str]) -> bool:
-    """True when retrying later can succeed without changing credentials."""
-    return copilot_block_reason(result) in {"rate_limit", "transport"}
+    """True when retrying later can succeed without changing credentials.
+
+    Includes quota exhaustion. "Later" is a longer wait there than for a rate
+    limit, but the remediation class is the same: wait or add capacity, do not
+    touch the token. The headline separates the two.
+    """
+    return copilot_block_reason(result) in {"quota_exhausted", "rate_limit", "transport"}
 
 
 def _transient_diagnostics(result: subprocess.CompletedProcess[str]) -> str:
@@ -224,8 +267,16 @@ def _transient_diagnostics(result: subprocess.CompletedProcess[str]) -> str:
 
 
 def copilot_transient_failure_headline(result: subprocess.CompletedProcess[str]) -> str:
-    """Skip reason that separates rate limiting from transport failure."""
+    """Skip reason that separates quota, rate limiting, and transport failure."""
     reason = copilot_block_reason(result)
+    if reason == "quota_exhausted":
+        return (
+            "Copilot monthly quota is exhausted (HTTP 402). This is not an auth "
+            "failure and not a rate limit. The account is out of credits until "
+            "the plan's billing period resets or more capacity is purchased. Do "
+            "not change credentials based on this result. "
+            f"{_transient_diagnostics(result)}"
+        )
     if reason == "rate_limit":
         return (
             "GitHub rate limit blocked Copilot CLI. This is not an auth failure. "
@@ -255,6 +306,8 @@ def copilot_auth_rejected(result: subprocess.CompletedProcess[str]) -> bool:
 
     Rate-limited runs are excluded: the CLI may print the same auth-method list
     after a 403 refusal, so rate-limit detection takes precedence (issue #4504).
+    Quota-exhausted runs are excluded for the same reason and take precedence
+    over both.
     """
     return copilot_block_reason(result) == "auth_rejected"
 
@@ -279,7 +332,8 @@ def copilot_auth_absent(result: subprocess.CompletedProcess[str]) -> bool:
     caller checking :func:`copilot_auth_rejected` first.
 
     Rate-limited runs are also excluded: they share auth-boilerplate wording but
-    have healthy credentials (issue #4504).
+    have healthy credentials (issue #4504). Quota-exhausted runs are excluded on
+    the same grounds.
     """
     return copilot_block_reason(result) == "auth_absent"
 
@@ -297,8 +351,8 @@ def copilot_run_blocked(result: subprocess.CompletedProcess[str]) -> bool:
 def copilot_auth_failed(result: subprocess.CompletedProcess[str]) -> bool:
     """True when the run died at the auth gate, whether absent or rejected.
 
-    Does not include rate-limited runs: those have healthy auth and should
-    not trigger a credential-rotation or provision headline.
+    Does not include rate-limited or quota-exhausted runs: those have healthy
+    auth and should not trigger a credential-rotation or provision headline.
     """
     return copilot_block_reason(result) in {"auth_rejected", "auth_absent"}
 

--- a/tests/e2e/test_copilot_hook_probe.py
+++ b/tests/e2e/test_copilot_hook_probe.py
@@ -26,6 +26,7 @@ try:
         copilot_auth_failure_headline,
         copilot_auth_rejected,
         copilot_block_reason,
+        copilot_quota_exhausted,
         copilot_rate_limited,
         copilot_run_blocked,
         copilot_run_blocked_headline,
@@ -288,6 +289,111 @@ def test_rate_limited_takes_precedence_over_auth_absent_when_list_appears() -> N
     assert copilot_rate_limited(result) is True
     assert copilot_auth_absent(result) is False
     assert copilot_run_blocked(result) is True
+
+
+# ---------------------------------------------------------------------------
+# Quota-exhaustion detection
+# ---------------------------------------------------------------------------
+#
+# Both payloads below are verbatim captures from a real run of
+# tests/e2e/test_plugin_load_smoke.py against an account whose monthly Copilot
+# allowance was spent, with the request and session identifiers replaced.
+# Before this class existed, neither shape matched any marker set, so
+# copilot_block_reason returned None, _skip_on_copilot_block did not skip, and
+# the smoke reported a plugin-load failure that the branch could not have
+# caused.
+
+_QUOTA_STDERR = (
+    "\nYou have exceeded your monthly quota (Request ID: C612:60CD4:E4E4F:1063A0:6AA0928A)\n"
+    "\n\nChanges    +0 -0\n"
+    "AI Credits 0 (3s)\n"
+    "Resume     copilot --resume=e3d31814-eee1-4944-9d77-c27710b7b0b7\n"
+)
+
+# The agent path emits JSON events instead of prose. This fragment carries the
+# error code and the 402 but not the prose sentence, which is why the code is a
+# marker in its own right rather than a redundant second spelling.
+_QUOTA_AGENT_STDOUT = (
+    '{"type":"error","data":{"statusCode":402,'
+    '"providerCallId":"A52E:26C4B7:FF31F:12203A:6AA092B1",'
+    '"errorCode":"quota_exceeded"},"id":"1726daed"}\n'
+    '{"type":"result","exitCode":1}\n'
+)
+
+
+def test_quota_exhausted_detects_prose_on_stderr() -> None:
+    result = _completed(stderr=_QUOTA_STDERR, returncode=1)
+    assert copilot_quota_exhausted(result) is True
+    assert copilot_block_reason(result) == "quota_exhausted"
+
+
+def test_quota_exhausted_detects_json_error_code_on_stdout() -> None:
+    """The agent probe never prints the prose sentence, only the error code."""
+    result = _completed(stdout=_QUOTA_AGENT_STDOUT, returncode=1)
+    assert "exceeded your monthly quota" not in _QUOTA_AGENT_STDOUT
+    assert copilot_quota_exhausted(result) is True
+
+
+def test_quota_exhausted_false_on_healthy_run() -> None:
+    """A rc=0 run that echoes the phrase is not a blocked run."""
+    result = _completed(stdout=_QUOTA_STDERR, returncode=0)
+    assert copilot_quota_exhausted(result) is False
+    assert copilot_run_blocked(result) is False
+
+
+def test_quota_exhausted_tolerates_none_streams() -> None:
+    result = _completed(stdout=None, stderr=None, returncode=1)
+    assert copilot_quota_exhausted(result) is False
+
+
+def test_quota_exhausted_takes_precedence_over_auth_and_rate_limit() -> None:
+    """A 402 body can carry the same auth-method list and limit wording a 403 does."""
+    result = _completed(
+        stderr=(
+            "You have exceeded your monthly quota (Request ID: C612:60CD4).\n"
+            "API rate limit exceeded for user ID 123.\n"
+            "GitHub returned: Bad credentials\n"
+            "To authenticate, you can use any of the following methods:\n"
+            "  Set the COPILOT_GITHUB_TOKEN environment variable\n"
+        ),
+        returncode=1,
+    )
+    assert copilot_block_reason(result) == "quota_exhausted"
+    assert copilot_rate_limited(result) is False
+    assert copilot_auth_rejected(result) is False
+    assert copilot_auth_absent(result) is False
+    assert copilot_auth_failed(result) is False
+
+
+def test_secondary_rate_limit_wording_is_not_read_as_quota() -> None:
+    """A secondary-rate-limit sentence also starts with "you have exceeded"."""
+    result = _completed(
+        stderr="You have exceeded a secondary rate limit. Please wait a few minutes.",
+        returncode=1,
+    )
+    assert copilot_block_reason(result) == "rate_limit"
+    assert copilot_quota_exhausted(result) is False
+
+
+def test_quota_exhausted_is_transient_and_blocked_but_not_auth() -> None:
+    """Skipping is the whole point: the branch cannot cause a spent allowance."""
+    result = _completed(stderr=_QUOTA_STDERR, returncode=1)
+    assert copilot_run_blocked(result) is True
+    assert copilot_transient_failure(result) is True
+    assert copilot_auth_failed(result) is False
+    assert copilot_transport_failure(result) is False
+
+
+def test_quota_headline_says_out_of_credits_not_reset_window_or_rotate() -> None:
+    """Wrong advice here sends the operator to poll for a day or rotate a live token."""
+    headline = copilot_run_blocked_headline(
+        _completed(stderr=_QUOTA_STDERR, returncode=1)
+    ).lower()
+    assert "quota" in headline
+    assert "402" in headline
+    assert "reset window" not in headline
+    assert "rotate" not in headline
+    assert "provision" not in headline
 
 
 def test_run_blocked_covers_rate_limit_absent_and_rejected() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds a `quota_exhausted` class to the Copilot run classifier in `tests/e2e/copilot_hook_probe.py`, ahead of every other marker set, with its own operator headline.

### Why

An exhausted monthly Copilot allowance answers with HTTP 402 and the sentence `You have exceeded your monthly quota`. No marker tuple matched it, so `copilot_block_reason` returned `None`, `_skip_on_copilot_block` did not skip, and `plugin-load-e2e` reported a plugin-load failure the branch could not have caused. Exit 1 refused every push touching the gate's globs until the billing period reset.

The only ways past that were the bypass mechanisms `.claude/rules/universal.md` MUST NOT item 2 forbids, or waiting out the billing period. This restores the gate's stated contract: an external condition is not a branch defect, so it skips locally and stays red in the nightly.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5664 | Copilot monthly quota exhaustion fails plugin-load-e2e instead of skipping it |

## Changes

- `tests/e2e/copilot_hook_probe.py`: adds `COPILOT_QUOTA_EXHAUSTED_MARKERS` (`exceeded your monthly quota`, `quota_exceeded`), adds `quota_exhausted` to `CopilotBlockReason`, checks it first in `copilot_block_reason`, adds the `copilot_quota_exhausted` predicate, includes the class in `copilot_transient_failure`, and gives it a dedicated branch in `copilot_transient_failure_headline`.
- Two markers because the CLI surfaces the same condition two ways: the plain `-p` path prints the prose on stderr, and the agent path emits only `"errorCode":"quota_exceeded"` in a JSON event.
- Precedence over the other sets because a 402 body can carry the same auth-method boilerplate a 403 does.
- The headline names the quota and the 402 and avoids both reset-window and credential-rotation advice, which are wrong for an allowance that does not return until the plan resets or capacity is purchased. The class stays out of `copilot_auth_failed`, so it never suggests rotating a healthy token.
- Docstrings on `copilot_auth_rejected`, `copilot_auth_absent`, and `copilot_auth_failed` updated: their exclusion lists were accurate before this change and would not be after it.
- `tests/e2e/test_copilot_hook_probe.py`: eight tests covering both payload shapes, the rc=0 negative control, `None` streams, precedence over the rate-limit and both auth classes, the secondary-rate-limit wording that must not be read as a quota, transient and blocked membership, and the headline's content.

## Acceptance criteria

- [x] `copilot_block_reason` returns `quota_exhausted` for both the stderr prose shape and the agent-path JSON shape
- [x] Quota exhaustion takes precedence over the rate-limit and both auth classes when their wording appears in the same payload
- [x] `You have exceeded a secondary rate limit` still classifies as `rate_limit`, not as a quota
- [x] A run with `returncode == 0` that echoes the phrase is not classified as blocked
- [x] The headline names the quota and the 402, and contains neither reset-window nor credential-rotation advice
- [x] `plugin-load-e2e` exits 0 while the quota is exhausted, with the affected tests reported as skips carrying the quota headline
- [x] The nightly stays red: `scripts/validation/assert_smoke_ran.py` already fails on any skipped smoke, so this does not turn a missing verification into a green CI run

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, unblocks pushes that touch the `plugin-load-e2e` globs

**Focus areas**: marker precedence in `copilot_block_reason`, and whether `quota_exhausted` belongs in `copilot_transient_failure`. The argument for including it: the remediation class is the same as a rate limit, wait or add capacity, never touch the token. The wait is longer, which is why the headline is separate rather than shared.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Evidence, all run on an account whose Copilot allowance was spent:

Before, on `fix/4462-squash-merge-audit`:

```
3 failed, 38 passed in 62.47s
```

exit 1, each failure carrying the quota sentence.

After, on this branch:

```
37 passed, 4 skipped in 67.50s
```

exit 0, each skip carrying the quota headline.

The fourth skip is `test_copilot_empty_plugin_dir_does_not_fire_probe_hook`. It had been passing during the failing run: it asserts the probe hook does not fire for an empty plugin directory, and under quota exhaustion the CLI never starts, so the hook could not fire. A negative control that passes because the runtime never ran is a false pass, and classifying the quota converts it to a loud skip.

Mutation check on the new tests: deleting the two-line `quota_exhausted` branch from `copilot_block_reason` fails 5 of the 8 new tests. Full unit file: 58 passed.

Push-time gates ran green with no bypass, including `plugin-load-e2e` (85.19s) and `pre-pr-validation` (146.51s).

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

This touches a test-side classifier, not an auth path. It cannot widen access: it changes only how a failed run is reported, and the classifier is gated on `returncode != 0`, so no successful run is reclassified.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #5664
