### PR TITLE
docs(adr): carry ADR-072's two withdrawals through to their restatements

### DIFF
--- a/.agents/architecture/ADR-072-jtbd-plugin-architecture.md
+++ b/.agents/architecture/ADR-072-jtbd-plugin-architecture.md
@@ -282,13 +282,13 @@ expressible via `keywords`; Cursor/Codex emission scope for v0.4.0 vs deferred.
 
 ### Negative / Costs
 
-- Cross-cutting change to the install contract for ~400 consumers.
+- Cross-cutting change to the install contract, for an installed population this repository does not measure. An earlier revision said ~400 consumers; "Distribution context" above withdraws that figure as ADR-045's future-tense target restated as a measurement, and this line kept it.
 - New emitters and drift checks for Codex and Cursor are net new code.
 - Transition window where directory-named and capability plugins coexist.
 
 ### Tracked follow-ups (not silent deferrals)
 
-- M1 to M5 issues opened under #1072 before implementation.
+- M1 to M5 issues opened before implementation, under issue #5669 rather than under epic #1072, which is closed. An earlier revision pointed this follow-up at the closed epic.
 - Analyst re-verification of #1148 coupling currency before M4.
 - ADR-045 amendment for the taxonomy relationship.
 - Deprecation note plus marketplace alias for directory-named plugins (M5).

--- a/.agents/critique/ADR-072-jtbd-plugin-architecture-debate-log.md
+++ b/.agents/critique/ADR-072-jtbd-plugin-architecture-debate-log.md
@@ -129,3 +129,29 @@ Status` section with the leading status word stripped. So a Status opening
 the first sentence so the remainder stands alone: "Proposed. Amended ..." works,
 a trailing clause does not. The staleness gate catches the drift but not the
 awkwardness.
+
+## Two corrections the round 1 amendment did not carry through, 2026-09-09
+
+Round 1's amendment withdrew two premises and repaired the statement of each
+without repairing its restatement elsewhere in the same file. Both were found by
+reading the record straight through after the amendment merged, which is the same
+way round 1's surviving findings were found.
+
+**The installed-base figure.** "Distribution context" withdraws the ~400 figure
+as ADR-045's future-tense target restated as a measurement, quoting ADR-045 lines
+24, 38 and 56, all three of which verify verbatim. The Negative consequences list
+kept "Cross-cutting change to the install contract for ~400 consumers" as a
+statement of fact, so the record withdrew the number in one place and spent it in
+another.
+
+**The tracked follow-up pointed at a closed epic.** The Status section records
+epic #1072 and issue #1774 as closed and names successor **#5669**. The tracked
+follow-ups list still read "M1 to M5 issues opened under #1072 before
+implementation", which instructs an implementer to file against a closed epic and
+bypasses the successor filed precisely so the work has somewhere to live.
+
+Both are corrected in place with the correction visible rather than deleted, per
+this record's own treatment of the premises round 1 refuted. The shape is worth
+naming because it recurred on ADR-101 in the same session: a correction reaches
+the sentence that carries the argument and not the paraphrase two hundred lines
+away, and no gate in this repository looks for the second one.


### PR DESCRIPTION
# Pull Request

## Summary

### What

Two one-line corrections to ADR-072 plus the debate-log entry recording them. The round 1 amendment withdrew a premise and repaired the sentence carrying it, twice, and both times left the restatement elsewhere in the same file standing.

### Why

Found by reading the record straight through after the amendment merged, which is how round 1's surviving findings were found too.

**The installed-base figure.** The "Distribution context" section withdraws the ~400 installed base as ADR-045's future-tense target restated as a measurement, quoting ADR-045 lines 24, 38 and 56. I re-read all three and they verify character-for-character. The Negative consequences list kept "Cross-cutting change to the install contract for ~400 consumers" as a statement of fact, so the record withdrew the number in one place and spent it in another.

**The tracked follow-up pointed at a closed epic.** The Status section records epic #1072 and issue #1774 closed and names successor #5669. The tracked follow-ups list still read "M1 to M5 issues opened under #1072 before implementation", which sends an implementer to file against a closed epic and bypasses the successor filed so the work would have somewhere to live.

Both are corrected in place with the correction visible rather than deleted, matching how this record treats the premises round 1 refuted.

The shape is worth naming because it recurred on ADR-101 in the same session: a correction reaches the sentence carrying the argument and not the paraphrase two hundred lines away, and no gate in this repository looks for the second one.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5669 | Settle ADR-072, blockers 1 through 4 |

These references do not close their linked item: #5669 tracks the four blockers, and these corrections are neither of them.

## Changes

- `.agents/architecture/ADR-072-jtbd-plugin-architecture.md`: withdraws the ~400 figure from the Negative consequences list, and retargets the M1 to M5 follow-up from closed epic #1072 to successor #5669.
- `.agents/critique/ADR-072-jtbd-plugin-architecture-debate-log.md`: records both corrections, how they were found, and the recurring shape they belong to.

## Acceptance criteria

- [x] No surviving statement in ADR-072 asserts the withdrawn installed-base figure as fact
- [x] No tracked follow-up directs work to a closed epic
- [x] The ADR-045 quotations backing the withdrawal were re-verified against ADR-045 before this landed
- [x] Corrections are visible in place rather than silently deleted

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, low scrutiny, no rush.

**Focus areas**: whether either correction changes what the record decides. Neither should; both remove a claim the record had already withdrawn elsewhere.

## Testing

Deliverables in this PR:

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Documentation only. No gate, script, or workflow changes.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

The six-seat panel reviewed this record in round 1. These are corrections to that round's own amendment, not new decision content.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5669

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj29cNqNwCTwcE9r8zSpEH


---
_Generated by [Claude Code](https://claude.ai/code)_