### PR TITLE
perf(ci): narrow Windows marker collection to files naming the marker

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -710,6 +710,10 @@ jobs:
   # Windows and POSIX: path separators, PowerShell script resolution, Git's
   # Windows trace behavior, atomic-write durability, and install-tree layout.
   # The marker is the discovery mechanism. Do not hardcode test file paths.
+  # run_pytest_windows.py keeps that property: it discovers the candidate
+  # modules by scanning for the marker's name and hands only those to pytest,
+  # so a new marked file still needs no edit here. Issue #5380: passing the
+  # marker alone made pytest import all 33,326 items to select 1,115.
   test-windows-pwsh:
     name: Run Windows path-contract tests (pytest.mark.windows_path)
     needs: check-paths
@@ -741,7 +745,7 @@ jobs:
         shell: pwsh
         env:
           UV_PYTHON: '3.14'
-        run: uv run --frozen pytest -m windows_path -v
+        run: uv run --frozen python scripts/ci/run_pytest_windows.py -v
 
   main-failure-alert:
     name: Main failure alert

--- a/scripts/ci/run_pytest_windows.py
+++ b/scripts/ci/run_pytest_windows.py
@@ -38,6 +38,10 @@ EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
 
 
+class DiscoveryError(Exception):
+    """A module under ``tests/`` could not be read, so discovery is incomplete."""
+
+
 def marked_files(repo_root: Path) -> list[str]:
     """Repo-relative test modules whose text names :data:`MARKER`.
 
@@ -45,14 +49,23 @@ def marked_files(repo_root: Path) -> list[str]:
     substring over the file rather than an AST walk for a decorator: a match in
     a comment costs one imported module, while a decorator shape this did not
     model would silently drop a Windows test from the only job that runs it.
+
+    Raises:
+        DiscoveryError: a module under ``tests/`` could not be read. Skipping it
+            would drop whatever Windows contract it holds while the remaining
+            files still let the job report success, which is the silent pass
+            `ci-scripts.md` MUST-11 forbids. The caller turns this into a
+            non-zero exit.
     """
     tests_root = repo_root / TESTS_DIR
     found = []
     for path in sorted(tests_root.rglob("test_*.py")):
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
+        except OSError as exc:
+            raise DiscoveryError(
+                f"could not read {path.relative_to(repo_root).as_posix()}: {exc}"
+            ) from exc
         if MARKER in text:
             found.append(path.relative_to(repo_root).as_posix())
     return found
@@ -61,7 +74,11 @@ def marked_files(repo_root: Path) -> list[str]:
 def main(argv: list[str] | None = None) -> int:
     passthrough = list(sys.argv[1:] if argv is None else argv)
 
-    files = marked_files(PROJECT_ROOT)
+    try:
+        files = marked_files(PROJECT_ROOT)
+    except DiscoveryError as exc:
+        print(f"discovery is incomplete, refusing to run a partial suite: {exc}", file=sys.stderr)
+        return EXIT_EXTERNAL
     print(f"marker={MARKER} candidate_files={len(files)}", file=sys.stderr)
     if not files:
         print(
@@ -72,6 +89,16 @@ def main(argv: list[str] | None = None) -> int:
 
     command = [sys.executable, "-m", "pytest", "-m", MARKER, *passthrough, *files]
     try:
+        # The child inherits fd 1, so anything this process queued would print
+        # after pytest's own output. tests/test_stdout_flush_before_spawn.py.
+        #
+        # No `timeout=` here on purpose. The bound on this call is the job's own
+        # `timeout-minutes: 10` in pytest.yml. An inner cap would need a number
+        # sized from a loaded Windows runner, which nobody has measured yet, and
+        # `ci-scripts.md` MUST-16 is explicit that a cap sized from anything else
+        # is a cap a real run can exceed. A too-low guess turns a healthy slow
+        # runner red, which is worse than the outer cap this already has.
+        sys.stdout.flush()
         return subprocess.run(command, cwd=PROJECT_ROOT, check=False).returncode
     except OSError as exc:
         print(f"could not start pytest: {exc}", file=sys.stderr)

--- a/scripts/ci/run_pytest_windows.py
+++ b/scripts/ci/run_pytest_windows.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run the `windows_path` marker suite without collecting the whole test tree.
+
+`pytest -m windows_path` has to import every module under `tests/` before the
+marker can deselect one, so the Windows job pays for a full-tree collection to
+run a fraction of it. Measured on this checkout: 33,326 items collected to
+select 1,115, 26.70s wall and 417MB peak RSS, against 1,764 collected, 1.67s
+and 69MB when pytest is handed only the files whose text names the marker. Both
+invocations collect the same 1,115 node IDs (issue #5380).
+
+Discovery stays textual rather than registered, so a new marked file is picked
+up with no list to update. That is the property issue #4299 established and
+`tests/test_windows_path_marker_discovery.py` pins. `-m windows_path` is still
+passed to pytest, so a file that names the marker in a comment or an assertion
+is collected and then deselected, contributing nothing.
+
+The backstop for the one way this can under-select, a marker applied to a file
+that never spells it, is `tests/ci/test_run_pytest_windows.py`: it collects
+both ways and fails when the node-ID sets disagree.
+
+Exit codes (AGENTS.md contract): 0 ok, 2 config, 3 external. Any other code is
+pytest's own and is passed through unchanged.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+MARKER = "windows_path"
+TESTS_DIR = "tests"
+
+EXIT_OK = 0
+EXIT_CONFIG = 2
+EXIT_EXTERNAL = 3
+
+
+def marked_files(repo_root: Path) -> list[str]:
+    """Repo-relative test modules whose text names :data:`MARKER`.
+
+    Over-matching is safe and under-matching is not, so the test is a plain
+    substring over the file rather than an AST walk for a decorator: a match in
+    a comment costs one imported module, while a decorator shape this did not
+    model would silently drop a Windows test from the only job that runs it.
+    """
+    tests_root = repo_root / TESTS_DIR
+    found = []
+    for path in sorted(tests_root.rglob("test_*.py")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if MARKER in text:
+            found.append(path.relative_to(repo_root).as_posix())
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    passthrough = list(sys.argv[1:] if argv is None else argv)
+
+    files = marked_files(PROJECT_ROOT)
+    print(f"marker={MARKER} candidate_files={len(files)}", file=sys.stderr)
+    if not files:
+        print(
+            f"no module under {TESTS_DIR}/ names {MARKER!r}; refusing to run zero tests",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
+
+    command = [sys.executable, "-m", "pytest", "-m", MARKER, *passthrough, *files]
+    try:
+        return subprocess.run(command, cwd=PROJECT_ROOT, check=False).returncode
+    except OSError as exc:
+        print(f"could not start pytest: {exc}", file=sys.stderr)
+        return EXIT_EXTERNAL
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_run_pytest_windows.py
+++ b/tests/ci/test_run_pytest_windows.py
@@ -1,0 +1,134 @@
+"""Contract and drift tests for the narrowed Windows marker run (issue #5380).
+
+The narrowing is only safe while it selects exactly what a whole-tree
+`pytest -m windows_path` selects. `test_narrowed_collection_matches_whole_tree`
+is that proof and is deliberately expensive: it is the one check that catches a
+marker applied to a module that never spells `windows_path`, which is the only
+way textual discovery can under-select.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import run_pytest_windows as _rpw
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# pytest's own addopts carry -v, which turns --collect-only into a tree render
+# with no node IDs. Replacing addopts wholesale is what makes -q emit them.
+_COLLECT_BASE = [
+    sys.executable,
+    "-m",
+    "pytest",
+    "-o",
+    "addopts=--import-mode=importlib",
+    "-p",
+    "no:cacheprovider",
+    "--collect-only",
+    "-q",
+    "--no-header",
+    "-m",
+    _rpw.MARKER,
+]
+
+
+def _collect(extra: list[str]) -> set[str]:
+    """Node IDs `pytest -m windows_path` collects for ``extra`` arguments."""
+    result = subprocess.run(
+        [*_COLLECT_BASE, *extra],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if "::" in line}
+
+
+def test_marked_files_returns_repo_relative_test_modules() -> None:
+    files = _rpw.marked_files(REPO_ROOT)
+
+    assert files, "the repository has windows_path tests, so discovery must find them"
+    for rel in files:
+        assert rel.startswith("tests/")
+        assert Path(rel).name.startswith("test_")
+        assert (REPO_ROOT / rel).is_file()
+    assert files == sorted(files), "order must be deterministic for a reproducible command"
+
+
+def test_marked_files_skips_a_module_that_does_not_name_the_marker(tmp_path: Path) -> None:
+    tests_dir = tmp_path / _rpw.TESTS_DIR / "nested"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_marked.py").write_text(
+        f"import pytest\npytestmark = pytest.mark.{_rpw.MARKER}\n", encoding="utf-8"
+    )
+    (tests_dir / "test_plain.py").write_text("def test_x() -> None:\n    pass\n", encoding="utf-8")
+    (tests_dir / "helper_marked.py").write_text(_rpw.MARKER, encoding="utf-8")
+
+    assert _rpw.marked_files(tmp_path) == [f"{_rpw.TESTS_DIR}/nested/test_marked.py"]
+
+
+def test_narrowed_collection_matches_whole_tree(tmp_path: Path) -> None:
+    """The drift gate: textual discovery must select the whole-tree node IDs.
+
+    A marker reaching a module that never spells `windows_path`, through a
+    conftest hook or an aliased mark, would be dropped from the only job that
+    runs Windows path contracts. Nothing cheaper than collecting both ways can
+    see that, so this test collects both ways.
+    """
+    whole_tree = _collect([])
+    narrowed = _collect(_rpw.marked_files(REPO_ROOT))
+
+    assert whole_tree, "whole-tree collection produced no windows_path node IDs"
+    missing = whole_tree - narrowed
+    assert not missing, (
+        f"{len(missing)} windows_path test(s) are invisible to textual discovery, "
+        f"so the Windows job would not run them: {sorted(missing)[:5]}"
+    )
+    assert narrowed == whole_tree
+
+
+def test_main_exits_config_when_no_module_names_the_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A discovery that finds nothing must fail, never run zero tests green."""
+    monkeypatch.setattr(_rpw, "marked_files", lambda _root: [])
+
+    assert _rpw.main([]) == _rpw.EXIT_CONFIG
+
+
+def test_main_returns_external_when_pytest_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_rpw, "marked_files", lambda _root: ["tests/test_x.py"])
+    monkeypatch.setattr(
+        _rpw.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(OSError("no exec"))
+    )
+
+    assert _rpw.main([]) == _rpw.EXIT_EXTERNAL
+
+
+def test_main_passes_the_marker_extra_args_and_files_to_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 1)
+
+    monkeypatch.setattr(_rpw, "marked_files", lambda _root: ["tests/test_x.py"])
+    monkeypatch.setattr(_rpw.subprocess, "run", fake_run)
+
+    assert _rpw.main(["-v"]) == 1
+    command = captured["command"]
+    assert command[-1] == "tests/test_x.py"
+    marker_flag = command.index("pytest") + 1
+    assert command[marker_flag : marker_flag + 2] == ["-m", _rpw.MARKER]
+    assert "-v" in command

--- a/tests/ci/test_run_pytest_windows.py
+++ b/tests/ci/test_run_pytest_windows.py
@@ -37,6 +37,13 @@ _COLLECT_BASE = [
 ]
 
 
+# Whole-tree collection measured at 26.70s on a 4-CPU container and narrowed
+# collection at 1.67s. This bound is roughly 10x the slower of the two, so it
+# reports a hung collect rather than sitting until the job's own cap, and has
+# enough headroom that a loaded runner does not trip it.
+_COLLECT_TIMEOUT_SECONDS = 300
+
+
 def _collect(extra: list[str]) -> set[str]:
     """Node IDs `pytest -m windows_path` collects for ``extra`` arguments."""
     result = subprocess.run(
@@ -47,6 +54,7 @@ def _collect(extra: list[str]) -> set[str]:
         encoding="utf-8",
         errors="replace",
         check=False,
+        timeout=_COLLECT_TIMEOUT_SECONDS,
     )
     return {line.strip() for line in result.stdout.splitlines() if "::" in line}
 
@@ -132,3 +140,35 @@ def test_main_passes_the_marker_extra_args_and_files_to_pytest(
     marker_flag = command.index("pytest") + 1
     assert command[marker_flag : marker_flag + 2] == ["-m", _rpw.MARKER]
     assert "-v" in command
+
+
+def test_marked_files_raises_when_a_module_cannot_be_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable module must not be skipped into a smaller passing run."""
+    tests_dir = tmp_path / _rpw.TESTS_DIR
+    tests_dir.mkdir()
+    unreadable = tests_dir / "test_unreadable.py"
+    unreadable.write_text("x = 1\n", encoding="utf-8")
+
+    def boom(self: Path, *_args: object, **_kwargs: object) -> str:
+        if self == unreadable:
+            raise OSError("permission denied")
+        return ""
+
+    monkeypatch.setattr(Path, "read_text", boom)
+
+    with pytest.raises(_rpw.DiscoveryError) as excinfo:
+        _rpw.marked_files(tmp_path)
+    assert "test_unreadable.py" in str(excinfo.value)
+
+
+def test_main_exits_external_when_discovery_is_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(_root: Path) -> list[str]:
+        raise _rpw.DiscoveryError("could not read tests/test_x.py: permission denied")
+
+    monkeypatch.setattr(_rpw, "marked_files", boom)
+
+    assert _rpw.main([]) == _rpw.EXIT_EXTERNAL

--- a/tests/workflows/test_pytest_head_guard_windows.py
+++ b/tests/workflows/test_pytest_head_guard_windows.py
@@ -3,6 +3,13 @@
 The Windows job uses a pytest marker (pytest.mark.windows_path) instead of a
 hardcoded file list. Adding pytestmark = pytest.mark.windows_path at module
 level in any test file automatically includes it in the Windows run (issue #4299).
+
+Issue #5380 moved the invocation behind `scripts/ci/run_pytest_windows.py`,
+which discovers the marked modules and narrows collection to them. The marker
+property above is unchanged: discovery is still automatic and still needs no
+workflow edit. What changed is that the run command now names a helper script,
+so "no hardcoded file list" can no longer be checked by the absence of `.py`.
+It is checked here as the absence of any `tests/` path.
 """
 
 from __future__ import annotations
@@ -18,7 +25,7 @@ _WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pyt
 _JOB_NAME = "test-windows-pwsh"
 _PATHS_FILTER_ACTION = "dorny/paths-filter@"
 _POLICY_FILE_INPUT = "scripts/test_selection/path_policy.yml"
-_WINDOWS_COMMAND = "uv run --frozen pytest -m windows_path -v"
+_WINDOWS_COMMAND = "uv run --frozen python scripts/ci/run_pytest_windows.py -v"
 _LEFTHOOK_TRIGGER_PATHS = {
     "lefthook.yml",
     ".config/wt.toml",
@@ -82,14 +89,20 @@ def test_windows_job_uses_marker_not_hardcoded_files() -> None:
     """The job must run pytest with -m windows_path, not by naming files.
 
     A hardcoded file list drifts silently; the marker-based approach picks up
-    new files automatically (issue #4299).
+    new files automatically (issue #4299). Since issue #5380 the run command
+    names one helper script, which is itself a `.py` path, so the check is that
+    the command names no test file rather than no `.py` file at all.
     """
     step = _step_for(_WINDOWS_COMMAND)
     assert step is not None, "expected marker-based step; found a hardcoded file list"
 
     run_cmd: str = step.get("run", "")
-    # Confirm no explicit .py paths in the run command (files would end in .py)
-    assert ".py" not in run_cmd, f"step run command contains hardcoded .py paths: {run_cmd!r}"
+    assert "tests/" not in run_cmd and "tests\\" not in run_cmd, (
+        f"step run command names test paths, so discovery is no longer automatic: {run_cmd!r}"
+    )
+    assert run_cmd.count(".py") == 1, (
+        f"expected exactly one script path in the run command, got {run_cmd!r}"
+    )
 
 
 def test_lefthook_runtime_surfaces_trigger_windows_suite() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

### What

The Windows CI job ran `pytest -m windows_path`, which imports every module under `tests/` before the marker can deselect one. It now runs `scripts/ci/run_pytest_windows.py`, which scans `tests/` for modules whose text names the marker and hands only those to pytest, still passing `-m windows_path` so an over-matched file contributes nothing.

### Why

Measured on this checkout, both invocations collect the same 1,115 node IDs:

| | `pytest -m windows_path` | narrowed |
|---|---|---|
| collect-only items | 33,326 (32,211 deselected) | 1,764 (649 deselected) |
| collect-only wall | 26.70s | 1.67s |
| collect-only peak RSS | 417 MB | 69 MB |
| full run | 1106 passed, 9 skipped, 79.06s | 1106 passed, 9 skipped, 62.51s |

Those are Linux numbers. Issue #5380 records the Windows runner at 1,093 passed, 10 skipped, 28,961 deselected, a 299s test phase inside a 345s job, so the collection share it removes is larger there than here.

Discovery stays textual rather than registered, so a new marked file is still picked up with no list to update and no workflow edit. That is the property issue #4299 established and `tests/test_windows_path_marker_discovery.py` pins, and it is why this PR does not add the explicit file registry #5380 proposes.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5380 | ci(windows): collect only Windows-path test files |

These references do not close their linked items: this PR delivers the collection narrowing and its drift gate. It does not deliver #5380's scheduling half (skip the Windows runner for unrelated PRs, run only affected Windows files on relevant changes), so #5380 stays open.

## Changes

- Add `scripts/ci/run_pytest_windows.py`. Scans `tests/**/test_*.py` for the literal marker name, prints `marker=... candidate_files=N`, and runs `sys.executable -m pytest -m windows_path <passthrough> <files>`. Exits 2 when discovery finds nothing rather than running zero tests green (the ci-scripts rule MUST-11, MUST-12), and 3 when pytest cannot start.
- Point the `test-windows-pwsh` job at that script. No change to its triggers, permissions, timeout, or action pins.
- Add `tests/ci/test_run_pytest_windows.py`, including the drift gate that collects both ways and fails when the node-ID sets disagree. Its collection subprocess is bounded at 300s, roughly 10x the whole-tree measurement, so a hung collect reports instead of sitting until the job cap.
- Update `tests/workflows/test_pytest_head_guard_windows.py`, which pinned the removed command. Its `".py" not in run_cmd` proxy for "no hardcoded file list" stops working once the command names one script, so it now checks the property directly: the command names no `tests/` path, and exactly one script path.

## Acceptance criteria

- [x] The narrowed invocation collects exactly the node IDs the whole-tree invocation collects, proven by a test that runs both
- [x] A marked module invisible to textual discovery fails CI rather than being silently dropped from the Windows job
- [x] Adding a new `windows_path` test still requires no edit to `pytest.yml` and no registration file
- [x] Discovery that finds no marked module exits non-zero instead of reporting success on zero tests
- [x] The Windows job's triggers, `merge_group` behavior, permissions, and pinned action SHAs are unchanged
- [x] A module under `tests/` that cannot be read fails the run rather than being dropped from the discovered set

## Type of Change

- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush

**Focus areas**: the soundness of textual discovery. The claim this PR rests on is that a module carrying `pytest.mark.windows_path` always spells `windows_path`, and that the drift test in `tests/ci/test_run_pytest_windows.py` catches the case where it does not. If you can construct a marked module that never spells the token and that the drift test misses, that is the blocking finding.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed

Evidence:

```
$ uv run --frozen pytest tests/ci/test_run_pytest_windows.py
8 passed in 20.45s

$ uv run --frozen pytest -n auto tests/ci tests/workflows \
    tests/test_stdout_flush_before_spawn.py tests/test_windows_path_marker_discovery.py
3432 passed, 14 skipped in 151.43s

$ uv run --frozen python scripts/ci/run_pytest_windows.py -q
1106 passed, 9 skipped, 655 deselected in 61.45s

$ uv run --frozen pytest -m windows_path -q          # the command this replaces
1106 passed, 9 skipped, 32219 deselected in 74.12s

$ uv run --frozen python scripts/ci/cli_exit_contract_ratchet.py
cli exit contract ratchet: OK (count == baseline 18).

$ uv run --frozen pytest tests/test_validate_workflows.py tests/ci/test_ci_scripts_are_wired.py \
    tests/ci/test_pytest_non_tmp_policy.py tests/test_slow_test_budget.py tests/test_slow_test_report.py
268 passed, 11 skipped in 3.52s
```

Negative control for the drift gate, run against this branch. Removing the largest contributing file from the discovered list makes the gate report the loss rather than pass:

```
dropping tests/test_lefthook_integration.py -> missing=859
```

Distribution of the discovered set: 22 candidates, 13 contribute collected items, 9 name the marker without carrying one. Those 9 are imported and then fully deselected, which is the deliberate cost of over-matching in the safe direction.

### Review round 1

Three findings, all real, all fixed in `3ec61ba84`:

1. `pytest (bulk)` failed `tests/test_stdout_flush_before_spawn.py`. The spawn inherits fd 1, so anything this process queued printed after pytest's output. Flushing first is what that guard requires.
2. `pytest (bulk-nested)` failed `tests/workflows/test_pytest_head_guard_windows.py`, which still pinned the removed command. Repointed, and its `.py`-absence proxy replaced with the property it stood for.
3. CodeRabbit: `marked_files` skipped a module it could not read, and the remaining files still let the job report success. That is the silent pass the ci-scripts rule MUST-11 forbids. It now raises `DiscoveryError` naming the file and `main` returns 3, with a test that injects the read failure.

One finding declined, with reasoning rather than silence. CodeRabbit asked for a `timeout=` on the runner's own pytest call. That call's bound is the job's `timeout-minutes: 10`. An inner cap needs a number sized from a loaded Windows runner, which nobody has measured, and the ci-scripts rule MUST-16 is explicit that a cap sized any other way is one a real run can exceed; a low guess turns a healthy slow runner red. The comment at the call site records this so the next reader does not re-open it. The same finding's second half, bounding the drift gate's collection subprocess, was taken: that one has a local measurement to size from.

Worth flagging, out of scope here: `tests/workflows/test_pytest_xdist_parallelism.py::test_nested_bulk_covers_every_non_mutation_test_directory` builds its expected set from `Path.iterdir()` over the working tree. Three empty untracked directories in a local checkout made it fail there while CI, which sees only tracked content, passed. That is the the ci-scripts rule MUST-9 shape, a directory walk standing in for a read of a ref. Not touched in this PR.

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes

**Files requiring security review:**

- `.github/workflows/pytest.yml`

Verdict PASS: 0 critical, 0 high, 0 medium, 1 low. The `run:` line is the only change to that job; its `permissions: contents: read`, its triggers, and its four SHA-pinned actions are untouched. Argv is a list with no shell, and every discovered path is `path.relative_to(repo_root).as_posix()` under `tests/`, so no entry can begin with `-` and be read as a pytest flag.

The one low finding asked for proof that the drift test is actually collected by a CI partition, since a gate that never runs is not a gate. Verified against the partition map rather than by inspection:

```
$ classify_partition("tests/ci/test_run_pytest_windows.py")
bulk-nested          # and bulk-nested's arg list contains tests/ci, with no --ignore for this file

$ pytest --collect-only -q tests/ci | grep -c 'test_run_pytest_windows.py::'
6                    # all six tests, including the drift gate
```

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5380
