### PR TITLE
fix(memory): scope remaining Serena reference paths

### DIFF
--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -238,7 +238,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/.claude/agents/high-level-advisor.md
+++ b/.claude/agents/high-level-advisor.md
@@ -56,7 +56,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -125,6 +125,6 @@ Validated by: `scripts/validation/skill_size.py`
 
 ## Related References
 
-- Skill frontmatter standards: `.serena/memories/claude-code-skill-frontmatter-standards.md`
+- Skill frontmatter standards: `.serena/memories/claude/claude-code-skill-frontmatter-standards.md`
 - PowerShell standards: `scripts/AGENTS.md`
 - Official docs: <https://code.claude.com/docs/en/skills>

--- a/.claude/skills/ai-agents-docs-of-record/SKILL.md
+++ b/.claude/skills/ai-agents-docs-of-record/SKILL.md
@@ -125,7 +125,7 @@ retros and memories, not git archaeology, are the durable history (depth in
 `ai-agents-failure-archaeology`).
 
 Retro learnings MUST be persisted to Serena in the same session, not left as
-prose in the artifact (`.serena/memories/retrospective-accuracy.md`: "learnings
+prose in the artifact (`.serena/memories/agent-behavior/retrospective-accuracy.md`: "learnings
 were proposed in the retrospective but then not persisted to Serena, so they
 will be lost").
 

--- a/.claude/skills/memory/scripts/README-count-tokens.md
+++ b/.claude/skills/memory/scripts/README-count-tokens.md
@@ -66,9 +66,9 @@ cumulative budget line, so prefer the CLI when you only need the display.
 .serena/memories/memory-index.md: 1,234 tokens
 
 # Directory
-.serena/memories/memory-token-efficiency.md: 861 tokens
+.serena/memories/memory/memory-token-efficiency.md: 861 tokens
 .serena/memories/memory-index.md: 1,234 tokens
-.serena/memories/context-engineering-principles.md: 543 tokens
+.serena/memories/memory/context-engineering-principles.md: 543 tokens
 
 Total: 2,638 tokens across 3 files
 ```

--- a/.claude/skills/memory/scripts/README-test-size.md
+++ b/.claude/skills/memory/scripts/README-test-size.md
@@ -62,7 +62,7 @@ echo "✅ Memory sizes within thresholds"
 ### Passing File
 
 ```text
-✅ PASS: .serena/memories/memory-token-efficiency.md
+✅ PASS: .serena/memories/memory/memory-token-efficiency.md
   Characters: 3,875
   Skills: 15
   Categories: 3

--- a/.claude/skills/reflect/references/decision-tree-and-examples.md
+++ b/.claude/skills/reflect/references/decision-tree-and-examples.md
@@ -122,7 +122,7 @@ Remember testing preferences:
 - **Assertion styles**: Preferred assertion libraries, patterns
 - **Test naming**: Convention for test method names
 
-**Example memory**: `.serena/memories/testing-observations.md`
+**Example memory**: `.serena/memories/testing/testing-observations.md`
 
 ### 4. Documentation Skills
 
@@ -133,7 +133,7 @@ Learn documentation patterns:
 - **Tone preferences**: Formal vs casual, active vs passive voice
 - **Diagram styles**: Mermaid vs ASCII, detail level
 
-**Example memory**: `.serena/memories/documentation-observations.md`
+**Example memory**: `.serena/memories/documentation/documentation-observations.md`
 
 ## Anti-Patterns
 

--- a/.claude/skills/slashcommandcreator/SKILL.md
+++ b/.claude/skills/slashcommandcreator/SKILL.md
@@ -269,6 +269,6 @@ python3 "$SCRIPTS_DIR/validate_slash_command.py" <skill-dir>
 
 - `.agents/analysis/custom-slash-commands-research.md`
 - `.agents/archive/planning/slashcommandcreator-skill-spec.md`
-- `.serena/memories/slashcommand-best-practices.md`
+- `.serena/memories/skills/slashcommand-best-practices.md`
 
 <!-- vendor-portability: declared. This skill writes research and analysis notes under .agents/analysis/ and .agents/planning/ and cites AGENTS.md and a research doc. The analysis/planning paths are write targets created on demand; the AGENTS.md and research references are documentation citations. Issue #2050. -->

--- a/.github/agents/analyst.agent.md
+++ b/.github/agents/analyst.agent.md
@@ -210,7 +210,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/.github/agents/high-level-advisor.agent.md
+++ b/.github/agents/high-level-advisor.agent.md
@@ -61,7 +61,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 

--- a/src/claude/analyst.md
+++ b/src/claude/analyst.md
@@ -238,7 +238,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/src/claude/high-level-advisor.md
+++ b/src/claude/high-level-advisor.md
@@ -56,7 +56,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -210,7 +210,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/src/copilot-cli/agents/high-level-advisor.agent.md
+++ b/src/copilot-cli/agents/high-level-advisor.agent.md
@@ -61,7 +61,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 

--- a/src/copilot-cli/skills/ai-agents-docs-of-record/SKILL.md
+++ b/src/copilot-cli/skills/ai-agents-docs-of-record/SKILL.md
@@ -125,7 +125,7 @@ retros and memories, not git archaeology, are the durable history (depth in
 `ai-agents-failure-archaeology`).
 
 Retro learnings MUST be persisted to Serena in the same session, not left as
-prose in the artifact (`.serena/memories/retrospective-accuracy.md`: "learnings
+prose in the artifact (`.serena/memories/agent-behavior/retrospective-accuracy.md`: "learnings
 were proposed in the retrospective but then not persisted to Serena, so they
 will be lost").
 

--- a/src/copilot-cli/skills/memory/scripts/README-count-tokens.md
+++ b/src/copilot-cli/skills/memory/scripts/README-count-tokens.md
@@ -66,9 +66,9 @@ cumulative budget line, so prefer the CLI when you only need the display.
 .serena/memories/memory-index.md: 1,234 tokens
 
 # Directory
-.serena/memories/memory-token-efficiency.md: 861 tokens
+.serena/memories/memory/memory-token-efficiency.md: 861 tokens
 .serena/memories/memory-index.md: 1,234 tokens
-.serena/memories/context-engineering-principles.md: 543 tokens
+.serena/memories/memory/context-engineering-principles.md: 543 tokens
 
 Total: 2,638 tokens across 3 files
 ```

--- a/src/copilot-cli/skills/memory/scripts/README-test-size.md
+++ b/src/copilot-cli/skills/memory/scripts/README-test-size.md
@@ -62,7 +62,7 @@ echo "✅ Memory sizes within thresholds"
 ### Passing File
 
 ```text
-✅ PASS: .serena/memories/memory-token-efficiency.md
+✅ PASS: .serena/memories/memory/memory-token-efficiency.md
   Characters: 3,875
   Skills: 15
   Categories: 3

--- a/src/copilot-cli/skills/reflect/references/decision-tree-and-examples.md
+++ b/src/copilot-cli/skills/reflect/references/decision-tree-and-examples.md
@@ -122,7 +122,7 @@ Remember testing preferences:
 - **Assertion styles**: Preferred assertion libraries, patterns
 - **Test naming**: Convention for test method names
 
-**Example memory**: `.serena/memories/testing-observations.md`
+**Example memory**: `.serena/memories/testing/testing-observations.md`
 
 ### 4. Documentation Skills
 
@@ -133,7 +133,7 @@ Learn documentation patterns:
 - **Tone preferences**: Formal vs casual, active vs passive voice
 - **Diagram styles**: Mermaid vs ASCII, detail level
 
-**Example memory**: `.serena/memories/documentation-observations.md`
+**Example memory**: `.serena/memories/documentation/documentation-observations.md`
 
 ## Anti-Patterns
 

--- a/src/copilot-cli/skills/slashcommandcreator/SKILL.md
+++ b/src/copilot-cli/skills/slashcommandcreator/SKILL.md
@@ -269,6 +269,6 @@ python3 "$SCRIPTS_DIR/validate_slash_command.py" <skill-dir>
 
 - `.agents/analysis/custom-slash-commands-research.md`
 - `.agents/archive/planning/slashcommandcreator-skill-spec.md`
-- `.serena/memories/slashcommand-best-practices.md`
+- `.serena/memories/skills/slashcommand-best-practices.md`
 
 <!-- vendor-portability: declared. This skill writes research and analysis notes under .agents/analysis/ and .agents/planning/ and cites AGENTS.md and a research doc. The analysis/planning paths are write targets created on demand; the AGENTS.md and research references are documentation citations. Issue #2050. -->

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -209,7 +209,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/src/vs-code-agents/high-level-advisor.agent.md
+++ b/src/vs-code-agents/high-level-advisor.agent.md
@@ -62,7 +62,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -230,7 +230,7 @@ Consider these when the problem structure matches:
 | **Five Whys** | Root cause analysis for incidents |
 | **CAP Theorem** | Distributed system trade-offs |
 
-Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="knowledge/cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/knowledge/cynefin-framework.md` directly.
 
 ## Output Length Bounds
 

--- a/templates/agents/high-level-advisor.shared.md
+++ b/templates/agents/high-level-advisor.shared.md
@@ -60,7 +60,7 @@ Query these Serena memories when relevant:
 - `ooda-loop`: Structured decision cycle for rapid orientation
 - `inversion-thinking`: Identify failure modes by thinking backward
 - `three-horizons-framework`: Balance short, medium, and long-term priorities
-- `cynefin-framework`: Classify problem complexity for appropriate response
+- `knowledge/cynefin-framework`: Classify problem complexity for appropriate response
 
 **Strategic Planning** (Secondary):
 


### PR DESCRIPTION
# Pull Request

## Summary

Scope remaining literal Serena memory paths in agent and skill documentation mirrors.

## Why

Merged PR #5006 fixed pr-comment-responder references and added a skill-memory gate. These files still named existing memories by obsolete root-level paths. Each replacement points to a memory tracked under its current topic directory.

## Changes

- Scope analyst and high-level-advisor references across canonical, hand-maintained, and generated copies.
- Scope skill documentation examples for Claude and Copilot.
- Keep the existing merged PR #5006 changes unchanged.

## Validation

- python3 build/generate_agents.py --validate
- python3 scripts/validation/check_skill_memory_references.py
- git diff --check
- Frozen UV validation was unavailable because Python 3.14.7 is not installed.

## References

Refs #4897
