### PR TITLE
fix(github): preserve preflight rate-limit classification

### DIFF
--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -52,8 +52,9 @@ if _lib_dir not in sys.path:
 
 from github_core.api import (
     GhAuthStatus,
-    assert_gh_authenticated,
+    check_gh_auth,
     classify_gh_failure_text,
+    describe_gh_auth_failure,
     is_auth_failure_text,
     resolve_repo_params,
 )
@@ -115,17 +116,16 @@ def _exit_with_error(
     raise SystemExit(exit_code)
 
 
+def _require_gh_auth(fmt: str) -> None:
+    """Preserve the GitHub CLI failure classification at preflight."""
+    auth = check_gh_auth()
+    if auth.is_authenticated:
+        return
+    message, code, error_type = describe_gh_auth_failure(auth)
+    _exit_with_error(message, code, fmt, error_type)
+
+
 def _resolve_repo(args: argparse.Namespace, fmt: str) -> tuple[str, str]:
-    try:
-        assert_gh_authenticated()
-    except SystemExit as exc:
-        code = exc.code if isinstance(exc.code, int) else 4
-        _exit_with_error(
-            "GitHub CLI (gh) is not installed or not authenticated. Run 'gh auth login' first.",
-            code,
-            fmt,
-            "AuthError",
-        )
     stderr = io.StringIO()
     try:
         with contextlib.redirect_stderr(stderr):
@@ -312,6 +312,7 @@ def main(argv: list[str] | None = None) -> int:
             "InvalidParams",
         )
 
+    _require_gh_auth(fmt)
     owner, repo = _resolve_repo(args, fmt)
     issues = _run_issue_list(_build_issue_list_args(args, f"{owner}/{repo}"), fmt)
     output = [

--- a/src/copilot-cli/skills/github/scripts/issue/list_issues.py
+++ b/src/copilot-cli/skills/github/scripts/issue/list_issues.py
@@ -52,8 +52,9 @@ if _lib_dir not in sys.path:
 
 from github_core.api import (
     GhAuthStatus,
-    assert_gh_authenticated,
+    check_gh_auth,
     classify_gh_failure_text,
+    describe_gh_auth_failure,
     is_auth_failure_text,
     resolve_repo_params,
 )
@@ -115,17 +116,16 @@ def _exit_with_error(
     raise SystemExit(exit_code)
 
 
+def _require_gh_auth(fmt: str) -> None:
+    """Preserve the GitHub CLI failure classification at preflight."""
+    auth = check_gh_auth()
+    if auth.is_authenticated:
+        return
+    message, code, error_type = describe_gh_auth_failure(auth)
+    _exit_with_error(message, code, fmt, error_type)
+
+
 def _resolve_repo(args: argparse.Namespace, fmt: str) -> tuple[str, str]:
-    try:
-        assert_gh_authenticated()
-    except SystemExit as exc:
-        code = exc.code if isinstance(exc.code, int) else 4
-        _exit_with_error(
-            "GitHub CLI (gh) is not installed or not authenticated. Run 'gh auth login' first.",
-            code,
-            fmt,
-            "AuthError",
-        )
     stderr = io.StringIO()
     try:
         with contextlib.redirect_stderr(stderr):
@@ -312,6 +312,7 @@ def main(argv: list[str] | None = None) -> int:
             "InvalidParams",
         )
 
+    _require_gh_auth(fmt)
     owner, repo = _resolve_repo(args, fmt)
     issues = _run_issue_list(_build_issue_list_args(args, f"{owner}/{repo}"), fmt)
     output = [

--- a/tests/test_list_issues.py
+++ b/tests/test_list_issues.py
@@ -35,6 +35,11 @@ def _import_script(name: str):
 _mod = _import_script("list_issues")
 main = _mod.main
 build_parser = _mod.build_parser
+_lib_api = sys.modules["github_core.api"]
+GhAuthResult = _lib_api.GhAuthResult
+GhAuthStatus = _lib_api.GhAuthStatus
+# Existing tests patch the former auth seam while exercising later paths.
+_mod.assert_gh_authenticated = _mod.check_gh_auth
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +49,16 @@ build_parser = _mod.build_parser
 
 def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
     return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture(autouse=True)
+def _authenticated(monkeypatch):
+    """Keep existing listing tests past the authentication preflight."""
+    monkeypatch.setattr(
+        _mod,
+        "check_gh_auth",
+        lambda: GhAuthResult(GhAuthStatus.AUTHENTICATED),
+    )
 
 
 def _issue(
@@ -107,8 +122,8 @@ class TestBuildParser:
 class TestMain:
     def test_not_authenticated_exits_4(self, capsys):
         with patch(
-            "list_issues.assert_gh_authenticated",
-            side_effect=SystemExit(4),
+            "list_issues.check_gh_auth",
+            return_value=GhAuthResult(GhAuthStatus.INVALID_CREDENTIALS),
         ):
             with pytest.raises(SystemExit) as exc:
                 main([])
@@ -117,6 +132,24 @@ class TestMain:
         assert payload["Success"] is False
         assert payload["Error"]["Code"] == 4
         assert payload["Error"]["Type"] == "AuthError"
+
+    def test_rate_limited_preflight_stays_api_error(self, capsys):
+        """A quota failure must not become the generic auth envelope."""
+        with patch(
+            "list_issues.check_gh_auth",
+            return_value=GhAuthResult(
+                GhAuthStatus.RATE_LIMITED,
+                "GraphQL: API rate limit exceeded for user ID 6811113",
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+        error = json.loads(capsys.readouterr().out)["Error"]
+        assert error["Code"] == 3
+        assert error["Type"] == "ApiError"
+        assert "rate limit" in error["Message"].lower()
+        assert "gh auth login" not in error["Message"]
 
     def test_success_open_issues(self, capsys):
         issues = [


### PR DESCRIPTION
## Summary

PR #5028 classified rate-limit errors from the issue-list subprocess, but `list_issues.py` still rewrote rate-limit failures from its authentication preflight as `AuthError`.

This follow-up uses the existing `check_gh_auth` and `describe_gh_auth_failure` contract before repository resolution. It preserves API error exit 3 and rate-limit details, while real missing or invalid credentials remain `AuthError` exit 4. The canonical script, Copilot CLI mirror, and focused tests stay aligned.

## Validation

- `python3 -m pytest tests/test_list_issues.py -q`: 30 passed
- `python3 -m ruff check .claude/skills/github/scripts/issue/list_issues.py tests/test_list_issues.py`: passed
- Mirror comparison: passed
- `git diff --check`: passed

`uv run` was unavailable because Python 3.14.7 is not installed. The installed Python 3.14.6 ran the focused suite.

Refs #4901
Related #5028