### PR TITLE
fix(skills): repoint every retired metadata.adr binding and zero the ceiling

### DIFF
--- a/.claude/skills/memory-enhancement/SKILL.md
+++ b/.claude/skills/memory-enhancement/SKILL.md
@@ -9,7 +9,7 @@ license: MIT
 metadata:
   domains: [memory, citations, verification]
   type: utility
-  adr: ADR-007, ADR-038
+  adr: ADR-038, ADR-106
 ---
 
 # Memory Enhancement

--- a/.claude/skills/memory-gate/SKILL.md
+++ b/.claude/skills/memory-gate/SKILL.md
@@ -10,7 +10,7 @@ description: Memory-First Gate (BLOCKING) and the Chesterton's Fence investigati
   memory-reflexion).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-063, ADR-070
+  adr: ADR-063, ADR-070, ADR-106
   type: operation
   parent: memory
 ---

--- a/.claude/skills/memory-maintenance/SKILL.md
+++ b/.claude/skills/memory-maintenance/SKILL.md
@@ -9,7 +9,7 @@ description: Memory-system maintenance operations, split out of the memory route
   memory-search) or recording a session (use memory-reflexion).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-063
+  adr: ADR-063, ADR-106
   type: operation
   parent: memory
 ---

--- a/.claude/skills/memory-reflexion/SKILL.md
+++ b/.claude/skills/memory-reflexion/SKILL.md
@@ -9,7 +9,7 @@ description: Tier 2 episode extraction, the reflexion write path split out of th
   or for adding citations (use memory-enhancement).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-038, ADR-056, ADR-063, ADR-089
+  adr: ADR-038, ADR-063, ADR-089, ADR-103, ADR-106
   type: operation
   parent: memory
 ---

--- a/.claude/skills/memory-search/SKILL.md
+++ b/.claude/skills/memory-search/SKILL.md
@@ -9,7 +9,7 @@ description: Tier 1 semantic memory search across the Serena corpus with
   memory-enhancement).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-038, ADR-056, ADR-063
+  adr: ADR-038, ADR-063, ADR-103, ADR-106
   type: operation
   parent: memory
 ---

--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -9,7 +9,7 @@ description: Thin router for the tiered memory system. Points callers at the
   memory-enhancement) or narrative cross-system reports (use memory-documentary).
 license: MIT
 metadata:
-  adr: ADR-037, ADR-038, ADR-063
+  adr: ADR-038, ADR-063, ADR-106
   timelessness: 8/10
 ---
 # Memory System Skill

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -5,7 +5,7 @@ description: CRITICAL learning capture. Extracts HIGH/MED/LOW confidence pattern
 license: MIT
 metadata:
   timelessness: 8/10
-  adr: ADR-007, ADR-017
+  adr: ADR-017, ADR-106
 ---
 
 # Reflect Skill

--- a/.claude/skills/retrospective/SKILL.md
+++ b/.claude/skills/retrospective/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   type: workflow
   inputs: [scope-description, session-log, git-history]
   outputs: [retrospective-markdown-file]
-  adr: ADR-008, ADR-017, ADR-037
+  adr: ADR-008, ADR-017, ADR-106
 ---
 
 # Retrospective

--- a/scripts/validation/skill_adr_bindings_baseline.json
+++ b/scripts/validation/skill_adr_bindings_baseline.json
@@ -2,6 +2,6 @@
   "schema_version": "1",
   "description": "Ceiling on SKILL.md files declaring a retired ADR in metadata.adr (issue #5665). The count may fall but never rise. Regenerate with: uv run python scripts/validation/check_skill_adr_bindings.py --write-baseline",
   "counts": {
-    "skill-adr-binding": 16
+    "skill-adr-binding": 0
   }
 }

--- a/src/copilot-cli/skills/memory-enhancement/SKILL.md
+++ b/src/copilot-cli/skills/memory-enhancement/SKILL.md
@@ -9,7 +9,7 @@ license: MIT
 metadata:
   domains: [memory, citations, verification]
   type: utility
-  adr: ADR-007, ADR-038
+  adr: ADR-038, ADR-106
 ---
 
 # Memory Enhancement

--- a/src/copilot-cli/skills/memory-gate/SKILL.md
+++ b/src/copilot-cli/skills/memory-gate/SKILL.md
@@ -10,7 +10,7 @@ description: Memory-First Gate (BLOCKING) and the Chesterton's Fence investigati
   memory-reflexion).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-063, ADR-070
+  adr: ADR-063, ADR-070, ADR-106
   type: operation
   parent: memory
 ---

--- a/src/copilot-cli/skills/memory-maintenance/SKILL.md
+++ b/src/copilot-cli/skills/memory-maintenance/SKILL.md
@@ -9,7 +9,7 @@ description: Memory-system maintenance operations, split out of the memory route
   memory-search) or recording a session (use memory-reflexion).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-063
+  adr: ADR-063, ADR-106
   type: operation
   parent: memory
 ---

--- a/src/copilot-cli/skills/memory-reflexion/SKILL.md
+++ b/src/copilot-cli/skills/memory-reflexion/SKILL.md
@@ -9,7 +9,7 @@ description: Tier 2 episode extraction, the reflexion write path split out of th
   or for adding citations (use memory-enhancement).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-038, ADR-056, ADR-063, ADR-089
+  adr: ADR-038, ADR-063, ADR-089, ADR-103, ADR-106
   type: operation
   parent: memory
 ---

--- a/src/copilot-cli/skills/memory-search/SKILL.md
+++ b/src/copilot-cli/skills/memory-search/SKILL.md
@@ -9,7 +9,7 @@ description: Tier 1 semantic memory search across the Serena corpus with
   memory-enhancement).
 license: MIT
 metadata:
-  adr: ADR-007, ADR-037, ADR-038, ADR-056, ADR-063
+  adr: ADR-038, ADR-063, ADR-103, ADR-106
   type: operation
   parent: memory
 ---

--- a/src/copilot-cli/skills/memory/SKILL.md
+++ b/src/copilot-cli/skills/memory/SKILL.md
@@ -9,7 +9,7 @@ description: Thin router for the tiered memory system. Points callers at the
   memory-enhancement) or narrative cross-system reports (use memory-documentary).
 license: MIT
 metadata:
-  adr: ADR-037, ADR-038, ADR-063
+  adr: ADR-038, ADR-063, ADR-106
   timelessness: 8/10
 ---
 # Memory System Skill

--- a/src/copilot-cli/skills/reflect/SKILL.md
+++ b/src/copilot-cli/skills/reflect/SKILL.md
@@ -5,7 +5,7 @@ description: CRITICAL learning capture. Extracts HIGH/MED/LOW confidence pattern
 license: MIT
 metadata:
   timelessness: 8/10
-  adr: ADR-007, ADR-017
+  adr: ADR-017, ADR-106
 ---
 
 # Reflect Skill

--- a/src/copilot-cli/skills/retrospective/SKILL.md
+++ b/src/copilot-cli/skills/retrospective/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   type: workflow
   inputs: [scope-description, session-log, git-history]
   outputs: [retrospective-markdown-file]
-  adr: ADR-008, ADR-017, ADR-037
+  adr: ADR-008, ADR-017, ADR-106
 ---
 
 # Retrospective


### PR DESCRIPTION
# Pull Request

## Summary

### What

Repoints every `metadata.adr` declaration that named a retired ADR, and lowers the skill-ADR-binding ceiling from 16 to 0.

### Why

The gate that shipped in #5685 measured 16 real violations and was deliberately a ratchet so it would not red every push while they stood. This fixes them rather than tolerating them. Until now, eight skills declared decision records the generated index marks Do Not Cite, so an agent loading one read a retired record as current.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5574 | Memory decommission; this is the skill-binding stage |

These references do not close their linked items: #5574 has remaining stages, including 110 agent-prompt lines that still name the withdrawn Memory Router.

## Changes

- Eight skill manifests under `.claude/skills`: `memory`, `memory-enhancement`, `memory-gate`, `memory-maintenance`, `memory-reflexion`, `memory-search`, `reflect`, `retrospective`. Each `metadata.adr` value now names live records only.
- Their eight generated mirrors under `src/copilot-cli/skills`, produced by the build, not hand-edited.
- `scripts/validation/skill_adr_bindings_baseline.json`: ceiling 16 to 0.

## The mapping, and why it is not a find-and-replace

Successors were read from frontmatter, where the key is `superseded-by` with a hyphen. A probe for the underscore spelling returns nothing, which is the same wrong-spelling trap the gate's own module docstring records for `metadata.adr`.

| Retired | Status | Successor | Status |
|---|---|---|---|
| ADR-007 | superseded | ADR-106 | accepted |
| ADR-037 | superseded | ADR-106 | accepted |
| ADR-056 | superseded | ADR-103 | accepted |

Each declaration was decided against the skill text and the successor's Decision section, not substituted mechanically. Asserting a dependency on a successor a skill does not rely on is the false-citation failure this gate exists to prevent, so a blanket rewrite would have reintroduced the harm in a form the gate cannot see.

ADR-106 item 1 states the memory-first principle "is carried forward here without amendment" and that "citations to the memory-first principle now resolve to this item", which is what makes the ADR-007 repoints correct rather than convenient. ADR-106 item 3 takes governance of ADR-037's surviving unified entry point. Where a skill declared both ADR-007 and ADR-037, set union collapses them to a single ADR-106 entry.

Live ids are untouched. ADR-008, ADR-017, ADR-038, ADR-063, ADR-070 and ADR-089 all remain, and `proposed` is deliberately not retired, so ADR-070 and ADR-089 stay.

## The ADR-056 decision, which went the other way

Review first proposed **dropping** ADR-056 from `memory-reflexion` and `memory-search`, reasoning that the script does not comply with the envelope contract: it takes `--format` with choices json/table rather than ADR-103's `--output-format`, and emits bare keys instead of the Success/Data/Error envelope.

That was refuted, and the refutation is the most consequential judgement in this PR. **Non-compliance is not non-dependency.** `metadata.adr` declares the records a skill depends on, so a skill that violates a contract still depends on it. Dropping the declaration would have hidden a live violation behind a green gate, with the gate certifying the absence of exactly what it exists to surface.

The obligation is normative and still binding. ADR-063, status accepted and still declared by both skills after this change, says verbatim:

> **Boundaries from ADR-007, ADR-037, ADR-038, and ADR-056 are preserved.** ... Every sub-skill emits the standard output envelope (ADR-056).

ADR-103 supersedes ADR-056 and restates that requirement with items 2 and 6 corrected, so ADR-103 is the live form. Both skills repoint to it.

Locating that evidence needed care: the script lives under the `memory` skill rather than the declaring skill, so a grep scoped to the declaring skill's own directory returns nothing and reads as absence of dependency.

## Out of scope, found while doing this

Reported rather than folded in, because neither is a frontmatter change and both deserve their own diff:

1. **Bodies still cite retired records.** `memory-gate` lists ADR-007 and ADR-037 under Related Decisions in prose, and its bundled reference file does the same. The gate reads frontmatter only, so it is now green while the body still points a reader at two superseded records. This is the larger half of the problem the gate was built for.
2. **A missing declaration.** `memory-gate` instructs the reader to escalate to Tier 2 episodes but never declares ADR-038, which governs them. The gate flags retired declarations, not absent ones, so nothing catches this.

## Testing

- [x] Tests added/updated (no new tests: this is a data change to declarations the existing gate and its 79 tests already cover)
- [x] Manual testing completed

### Evidence

Gate before and after, on the full corpus:

```
before: [skill-adr-binding] at baseline: 16 of a permitted 16, across 222 of 222 tracked SKILL.md file(s).
after:  [skill-adr-binding] at baseline: 0 of a permitted 0, across 222 of 222 tracked SKILL.md file(s).
```

Both exit 0. The examined count is quoted alongside the violation count deliberately: a bare "0 violations" cannot be told from "0 examined", which is the distinction `ci-scripts.md` MUST 12 requires and which this gate prints for that reason.

**Mirror regeneration is attributable.** A full `build_all.py` run on untouched main produced zero drift first, so the 8 mirror changes here are caused by these edits and nothing else. Exactly 16 files changed plus the baseline.

**No retired id survives, verified directly:** a grep for ADR-007, ADR-037 or ADR-056 across every canonical `metadata.adr` value returns nothing, and 0 of 18 declarations across both trees are quoted, so house style is unchanged.

**Tests:** 266 passed, 2 skipped across the gate's own suite, its wiring suite, the ADR-063 decomposition suite that pins these boundaries, the skill cross-reference link suite, and the ADR link resolver. The shipped-baseline pin now measures 0 against 0.

## Author Pre-flight

- [x] Builds locally
- [x] Pre-PR validation passed
- [x] Lint and formatting clean
- [x] Self-review completed
- [x] No new warnings introduced

## Related Issues

Refs #5574

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF

---
_Generated by [Claude Code](https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF)_