### PR TITLE
docs: retire two stale references left over from PR #5713

### DIFF
--- a/.agents/governance/test-location-standards.md
+++ b/.agents/governance/test-location-standards.md
@@ -1,101 +1,107 @@
 # Test Location Standards
 
-This document defines where test files should be located in the ai-agents repository.
+This document restates, for `.agents/` readers, rules already enforced by [`.claude/rules/testing.md`](../../.claude/rules/testing.md) (the binding rule; its `paths` frontmatter fires on `tests/**`, `**/*.Tests.ps1`, `**/tests/**`, `.claude/skills/**/tests/**`, `.agents/security/benchmarks/**`) and by the placement gates in [`scripts/validation/`](../../scripts/validation/). Nothing below is new policy; it is documentation catching up to [ADR-042](../architecture/ADR-042-python-migration-strategy.md) (accepted, Python-first migration) and to gates that already ship. Where a claim has no gate behind it, it carries a `Why:` paragraph instead of inventing one.
 
-## Directory Structure
+## PowerShell layout: retired, no tracked survivors
+
+The previous version of this document specified a Pester `*.Tests.ps1` layout under `tests/`. That layout no longer exists. Search performed for this revision, whole-repository scope:
+
+- `git ls-files '*.ps1'` → 0 files.
+- `git ls-files '*.Tests.ps1'` → 0 files.
+- `git ls-files '*.psd1' '*.psm1'` → one file, [`.PSScriptAnalyzerSettings.psd1`](../../.PSScriptAnalyzerSettings.psd1), linter configuration for CodeQL/PSScriptAnalyzer static analysis (see [`.agents/security/benchmarks/README.md`](../security/benchmarks/README.md)), not a production or test script.
+- Every workflow under `.github/workflows/` that has a Pester toggle sets `enable-pester: false` (12 occurrences, `grep -rn enable-pester .github/workflows/`). No workflow invokes `Invoke-Pester`.
+
+Per [`.claude/rules/universal.md`](../../.claude/rules/universal.md) MUST NOT 9, this is an absence claim scoped to the searches above; a PowerShell test file reintroduced later would need its own placement rule, not a revert of this one.
+
+## Directory structure (verified)
 
 ```text
 ai-agents/
-  tests/                          # All Pester test files
-    *.Tests.ps1                   # Test files following Pester naming convention
-  .claude/skills/github/
-    scripts/                      # Production PowerShell scripts
-    modules/                      # PowerShell modules
+  tests/                          # pytest root (testpaths = ["tests"])
+    test_*.py                     # python_files = ["test_*.py"]; most sit here
+    ci/, hooks/, skills/<name>/   # topic subdirs
+    mutation/                     # mutation harnesses (DEAD/SURVIVED/DID-NOT-APPLY)
+    evals/                        # ADR-057 prompt-change scenario JSON + runners
+    *.test.ts                     # 2 orphaned bun-shaped files (see TypeScript row below)
+  .agents/security/benchmarks/    # second sanctioned test location (security-agent evidence)
+  packages/ai-agents-cli/tests/   # live bun/TS suite, unrelated tree
+  evals/                          # held-out agent-vs-baseline spikes, NOT pytest input
+  .PSScriptAnalyzerSettings.psd1  # linter config, not a script or test
 ```
 
-## Test File Location Rules
+Source: `pyproject.toml` `[tool.pytest.ini_options]`. Counts are measurements of a commit, not permanent facts; re-derive with `git ls-files 'tests/**/test_*.py' | wc -l` (629 when this section was written) rather than quoting a number from here.
 
-### Rule 1: All tests in /tests directory
+## Placement rules
 
-All Pester test files MUST be placed in the `/tests/` directory at the repository root.
+| Rule | Statement | Evidence |
+|---|---|---|
+| 1 | New tests MUST live in `tests/` or `.agents/security/benchmarks/`. No other location is sanctioned. | `.claude/rules/testing.md` MUST 6 |
+| 2 | Skill tests MUST live under `tests/skills/<name>/`, never colocated inside `.claude/skills/<name>/tests/` or `src/copilot-cli/skills/<name>/tests/`. Colocated files ship to plugin consumers, who would then execute repo-internal test code. | Issue #4838; gate `check_colocated_skill_tests.py` |
+| 3 | Test files MUST be named `test_*.py`. A file named `*_test.py` alone is never collected, because `python_files` lists only the `test_*` prefix. Two tracked files end in `_test.py` and are still collected: both also begin with `test_`, because the module under test is itself named `*_test` (`tests/context-optimizer/test_skill_passive_compliance_test.py`, `tests/validation/test_run_workflow_local_test.py`). That is a suffix inherited from the subject, not a second naming convention. | `pyproject.toml` `[tool.pytest.ini_options]`; `python_files = ["test_*.py"]` |
+| 4 | A `test_*.py` that pytest walks MUST collect at least one test, or MUST carry a `pytest-zero-collection:` marker naming why it is a non-suite (an import helper, or a checker another workflow invokes). | Issue #4494; gate `check_zero_collection_tests.py` |
+| 5 | A `test_*` function MUST NOT be nested inside another function; pytest never collects it, so a nested test is a silently absent regression guard. Nested test *classes* are collected and are not flagged. | Issue #3879, PR #3688; gate `check_nested_tests.py` |
+| 6 | A test file MUST NOT define two module-level helpers of the same name; ruff's F811 dummy-variable regex does not catch this for `_`-prefixed test helpers. | Gate `check_duplicate_test_helpers.py` |
+| 7 | A test MUST NOT write under a `PROJECT_ROOT`/`REPO_ROOT`/`ROOT`-rooted path outside `tmp_path` or `.pytest_tmp/`; four confirmed instances left litter that broke `git status` and inflated scanner baselines. | Issue #3772, PR #3688; gate `check_test_tree_writes.py` |
+| 8 | A `SKILL.md` that documents a script invocation plus an exit code MUST be named by at least one file under `tests/`, so the documented contract cannot drift silently. | Issue #4249; gate `check_skill_contract_tests.py` |
+| 9 | `.claude/rules/testing.md`'s own `.Tests.ps1` glob in its `paths:` frontmatter is a dead glob (zero matching files). It is left in place rather than edited here because narrowing that rule's scope is a `.claude/rules/testing.md` change, out of scope for this governance-doc rewrite. | Why: confirmed via `git ls-files '*.Tests.ps1'` (see above); changing the rule file itself needs its own PR |
 
-**Rationale:**
+## Placement gates: what each rejects, exit codes, where it runs
 
-- Centralized location makes test discovery simple
-- CI/CD workflows can easily target a single directory
-- Separation of concerns between production code and test code
-- Follows PowerShell community conventions
+| Script | Rejects | Exit codes | Wired at |
+|---|---|---|---|
+| [`check_nested_tests.py`](../../scripts/validation/check_nested_tests.py) | A `test_*` function AST-nested inside another function | 0 none found, 1 nested test found, 2 invalid repo root | pre-push, via `pre_pr.py` gate sequence (`scripts/validation/pre_pr_sequence.py`) |
+| [`check_colocated_skill_tests.py`](../../scripts/validation/check_colocated_skill_tests.py) | A newly added `test_*.py`/`*_test.py` under a shipped `.claude/skills/`, `src/copilot-cli/skills/`, or `src/claude/skills/` tree's `tests/` dir | 0 none (or legacy-only), 1 new colocated file found | pre-commit, `--staged-only` |
+| [`check_duplicate_test_helpers.py`](../../scripts/validation/check_duplicate_test_helpers.py) | Two module-level test helpers with the same name in one file | 0 none found, 1 duplicate found, 2 invalid repo root | pre-push, via `pre_pr.py` gate sequence |
+| [`check_test_tree_writes.py`](../../scripts/validation/check_test_tree_writes.py) | A test file writing outside `tmp_path`/`.pytest_tmp/` via a repo-root-bound path (AST heuristic; false positives possible) | 0 none found, 1 suspect write found, 2 invalid repo root | pre-push, via `pre_pr.py` gate sequence |
+| [`check_skill_contract_tests.py`](../../scripts/validation/check_skill_contract_tests.py) | A `SKILL.md` documenting a script + exit code with no test under `tests/` naming it | 0 every in-scope skill bound, 1 unbound skill found, 2 usage/I/O error | CI only, `.github/workflows/validate-vendor-portability.yml` |
+| [`check_zero_collection_tests.py`](../../scripts/validation/check_zero_collection_tests.py) | A `test_*.py` under `testpaths` that pytest walks but collects zero tests from (undeclared) | 0 ok, 1 violations found, 2 config error | pre-push (direct `lefthook.yml` job) and CI (`.github/workflows/pytest.yml`) |
 
-### Rule 2: Test file naming convention
+All six read the shell-fail-loud contract in [`.claude/rules/ci-scripts.md`](../../.claude/rules/ci-scripts.md) MUST 10-11: a detected violation MUST exit non-zero, never print-and-exit-0. Invoke any of them as `uv run python scripts/validation/<name>.py`.
 
-Test files MUST follow the pattern: `{ScriptName}.Tests.ps1`
+## Second sanctioned location: security benchmarks
 
-**Examples:**
+[`.agents/security/benchmarks/`](../security/benchmarks/) holds the security agent's benchmark suite (Issue #756): fixtures under `vulnerable_samples/`, `test_agent_review_quality.py`, `test_cwe22_path_traversal.py`, `test_cwe77_command_injection.py`. `.claude/rules/testing.md`'s `paths:` frontmatter names this tree explicitly, making it the one other placement `.claude/rules/testing.md` MUST 6 permits besides `tests/`.
 
-| Script | Test File |
-|--------|-----------|
-| `Invoke-CopilotAssignment.ps1` | `Invoke-CopilotAssignment.Tests.ps1` |
-| `Get-PRContext.ps1` | `Get-PRContext.Tests.ps1` |
+## Two TypeScript test trees, only one live
 
-### Rule 3: Module tests
+| Tree | Status | Runner |
+|---|---|---|
+| `packages/ai-agents-cli/tests/*.test.ts` (13 files) | Live | `bun test` inside `.github/workflows/cli-smoke.yml`'s `verify` job, `working-directory: packages/ai-agents-cli` |
+| `tests/*.test.ts` (2 files: `command-syntax-translator.test.ts`, `copilot-target-emitter.test.ts`) | Orphaned | Nothing. No root `package.json`/`tsconfig.json`/`bunfig.toml` wires them to any runner. |
 
-Module tests should be named after the module: `{ModuleName}.Tests.ps1`
+Why: `docs/project-structure.md` claims the repo-root pair runs via `cli-smoke.yml`'s `bun test`; that job's `working-directory` is the sibling `packages/ai-agents-cli/` tree, which cannot see repo-root `tests/`. Confirmed orphaned in `.agents/audit/2026-09-04-ponytail-audit-over-engineering.md`, finding 9. Do not add a new test to the orphaned pair; place TypeScript CLI tests under `packages/ai-agents-cli/tests/`.
 
-**Example:** `GitHubHelpers.Tests.ps1` for the GitHubHelpers.psm1 module.
+## `tests/evals/` vs top-level `evals/`
 
-### Rule 4: Path references in tests
+Same first six letters, unrelated content, unrelated consumers:
 
-Tests MUST use relative paths from the test file to locate production code.
+- [`tests/evals/`](../../tests/evals/): scenario JSON plus `test_*.py` runners, implementing [ADR-057](../architecture/ADR-057-prompt-behavioral-evaluation.md) prompt-change regression checks ("did this prompt edit help or hurt?"). These ARE pytest input and ARE gated by the placement rules above.
+- [`evals/`](../../evals/) (sibling of `tests/`, not inside it): held-out agent-vs-baseline research corpora and spike write-ups ("does this agent's specialization beat a generic baseline?"). Not pytest input; the scenario/spike distinction and the no-fixture-duplication rule are documented in `evals/README.md`.
 
-```powershell
-BeforeAll {
-    $repoRoot = Join-Path $PSScriptRoot ".."
-    $scriptPath = Join-Path $repoRoot ".claude" "skills" "github" "scripts" "issue" "ScriptName.ps1"
-}
-```
+## pytest configuration (verified against `pyproject.toml`)
 
-## Test Types and Organization
+| Key | Value |
+|---|---|
+| `testpaths` | `["tests"]` |
+| `python_files` | `["test_*.py"]` |
+| `import-mode` | `importlib` (lets same-named modules coexist across dirs with and without `__init__.py`) |
+| `timeout` | 120s per test |
+| `markers` | `unit`, `integration`, `safe_push_transport` (non-local transport, excluded from pre-push), `security`, `smoke` (real-CLI, nightly only), `windows_path` (Windows-runner only) |
 
-### Pattern-based tests
+Source: `pyproject.toml` `[tool.pytest.ini_options]`.
 
-Verify code structure, naming conventions, and presence of required elements. These tests read the script content and match against patterns.
+## What was dropped from the prior version, and why
 
-```powershell
-It "Has IssueNumber as mandatory parameter" {
-    $scriptContent | Should -Match '\[Parameter\(Mandatory\)\]'
-}
-```
-
-### Functional tests
-
-Test actual function behavior with mock data. These tests extract functions from scripts and invoke them with test inputs.
-
-```powershell
-It "Returns null for empty comments array" {
-    $result = Get-MaintainerGuidance -Comments @() -Maintainers @("user")
-    $result | Should -BeNullOrEmpty
-}
-```
-
-### Integration tests
-
-Test multiple components working together. These may require mocking external dependencies like `gh` CLI.
-
-## CI/CD Integration
-
-The Pester tests workflow discovers tests via:
-
-```yaml
-- name: Run Pester Tests
-  run: |
-    Invoke-Pester -Path tests/ -CI -Output Detailed
-```
-
-## Exceptions
-
-No exceptions to these standards are currently defined. If a new pattern emerges that requires tests in a different location, update this document first.
+- All Pester-specific naming (`{ScriptName}.Tests.ps1`), the `BeforeAll`/`It` examples, and the Pester CI snippet: zero tracked `.ps1` files remain (see PowerShell section above); nothing in this repository executes that pattern today.
+- The single-directory "all tests in `/tests/`" rule: superseded by the two-location rule (`tests/` plus `.agents/security/benchmarks/`) that `.claude/rules/testing.md` MUST 6 actually enforces.
+- The "no exceptions currently defined" line: false under current gates, which carry documented, evidence-anchored exceptions (`pytest-zero-collection:`-marked non-suites, legacy colocated skill tests that predate the gate).
 
 ## Related Documents
 
-- [AGENTS.md](../../AGENTS.md) - Main project documentation
-- [powershell-testing-patterns](../../.serena/memories/powershell/powershell-testing-patterns.md) - Testing patterns memory
+- [`.claude/rules/testing.md`](../../.claude/rules/testing.md): binding rule this document expands on.
+- [`.claude/rules/ci-scripts.md`](../../.claude/rules/ci-scripts.md): exit-code and fail-loud contract every gate above follows.
+- [`.agents/governance/TESTING-RIGOR.md`](TESTING-RIGOR.md): pos+neg+edge evidence bar.
+- [`.agents/governance/TESTING-ANTI-PATTERNS.md`](TESTING-ANTI-PATTERNS.md): forbidden test shapes.
+- [`.agents/architecture/ADR-042-python-migration-strategy.md`](../architecture/ADR-042-python-migration-strategy.md): the migration this document catches up to.
+- [`.agents/architecture/ADR-057-prompt-behavioral-evaluation.md`](../architecture/ADR-057-prompt-behavioral-evaluation.md): scope of `tests/evals/`.
+- [`AGENTS.md`](../../AGENTS.md): main project documentation.

--- a/.agents/steering/testing-approach.md
+++ b/.agents/steering/testing-approach.md
@@ -392,7 +392,7 @@ $result.number | Should -Be 123
 
 ## Test File Placement
 
-Place test files according to the standards in [AGENTS.md](../../AGENTS.md#test-location-standards):
+Place test files according to [`.agents/governance/test-location-standards.md`](../governance/test-location-standards.md), whose rules the placement gates enforce:
 
 | Category | Location |
 |----------|----------|

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -488,12 +488,17 @@ def _build_hooks(repo_root: Path, config_path: Path, platform: str) -> Generator
     return result
 
 
-# Order matters: agents → agent-catalog → adr-index → skills → commands → rules → lib → hooks.
-# The skills generator copies .claude/skills/* first; the commands bridge
-# layers user-invocable skills beside them; rules write to a separate dir
-# (.github/instructions/); lib MUST land before hooks so the manifest-
-# walk-up bootstrap in shimmed hooks finds .claude-plugin/plugin.json
+# Order matters: agents → agent-catalog → adr-index → skills → rules → lib → hooks.
+# The skills generator copies .claude/skills/* first; rules write to a
+# separate dir (.github/instructions/); lib MUST land before hooks so the
+# manifest-walk-up bootstrap in shimmed hooks finds .claude-plugin/plugin.json
 # alongside lib/; hooks write src/copilot-cli/hooks/.
+#
+# A `commands` step sat between skills and rules until ADR-064 made skills the
+# single user-invocable surface and issue #5632 deleted the command-to-skill
+# bridge (build/scripts/generate_commands.py). Do not add it back:
+# scripts/validation/check_commands_retired.py fails on any command file under
+# a plugin root.
 GENERATORS: list[tuple[str, Callable[[Path, Path, str], GeneratorResult]]] = [
     ("agents", _build_agents),
     ("agent-catalog", _build_agent_catalog),
@@ -911,8 +916,8 @@ def clean_outputs(repo_root: Path, config_path: Path) -> int:
     # Only clean output dirs whose contents are exclusively generator
     # output. Skills outputs to src/<provider>/skills/ — safe to nuke.
     # Agents legacy outputDir is src/copilot-cli (not a subdir), so
-    # cleaning would destroy unrelated content. Hooks/commands/rules
-    # share dirs with hand-authored files. Restrict to skills for now.
+    # cleaning would destroy unrelated content. Hooks and rules share dirs
+    # with hand-authored files. Restrict to skills for now.
     cleanable = {"skills"}
     removed = 0
     for name, stanza in artifacts.items():


### PR DESCRIPTION
# Pull Request

## Summary

### What

Clears the two follow-ups PR #5713 recorded and left open: a generator-order comment naming a step that no longer exists, and a governance document specifying a test layout the repository abandoned.

### Why

Both were pointers to things that are gone. The comment above `GENERATORS` listed an eight-step order whose `commands` step ADR-064 retired, so a reader checking the comment against the seven-entry list found a discrepancy with no explanation. The test-location document specified a Pester layout for a repository with zero tracked `.ps1` files, and three separate files had grown warnings telling readers not to trust it. A document that needs a warning label attached elsewhere is a document that should be fixed.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5712 | Follow-ups recorded in that issue's PR and in the retrospective it shipped |

## Changes

- `build/scripts/build_all.py`: the generator-order comment now lists the seven steps that exist. A short note records that ADR-064 retired the `commands` bridge and issue #5632 deleted the generator, and names the guard that rejects a re-added command file, so the step is not restored by someone who remembers it. A second comment that listed `commands` among dirs shared with hand-authored files was corrected the same way.
- `.agents/governance/test-location-standards.md`: replaced. It now restates what the binding testing rule and the six placement gates already enforce, with an evidence anchor per rule as governance MUST 4 requires. Covers the two sanctioned locations, the naming pattern, each gate with its rejection condition, exit codes and wiring, the two TypeScript test trees, and the `tests/evals` versus `evals` split. The retired PowerShell layout is recorded as retired, with the searches that establish the absence named, per universal MUST NOT 9.
- `.agents/steering/testing-approach.md`: one link. It pointed test placement at a `#test-location-standards` anchor that does not exist in the repository's root agent guide; it now points at the governance document.

This is documentation catching up to already-accepted decisions, not new policy. No constraint is reversed: ADR-042 moved the repository to Python, and the gates cited here already run.

## Acceptance criteria

- [x] The generator-order comment matches the `GENERATORS` list.
- [x] No claim in the rewritten document is unverified; counts carry the command that re-derives them rather than a pinned number.
- [x] Every normative line carries an evidence anchor (ADR, issue, gate, or a `Why:` paragraph).
- [x] Every relative link in the rewritten document resolves.
- [x] No invented issue or ADR numbers; each citation matches the cited source.

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, no rush

**Focus areas**: the gate table's exit codes and wiring column, and the evidence anchor on each placement rule.

## Testing

Deliverables in this PR:

- [x] No testing required (documentation only)

Gates run locally, all exit 0: ruff on the changed module; generated-artifact drift check; path normalization; doc-interpreter portability; stale script references; commands-retired guard; ADR link resolution; citation freshness; canonical citations. Test suites: the build-scripts suite plus the path-normalization and stale-script-ref suites, 1941 passed and 2 skipped. Full pre-push sequence green.

Verification of the delegated draft found and corrected four errors before commit: two file counts that did not match a tracked-file listing, a wrong issue number on the skill-contract rule (the gate's own docstring cites #4249), and a claim that two files ending in `_test.py` were grandfathered legacy, when both also begin with `test_` and are collected normally.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

This touches `.agents/governance/`, so governance MUST 1 applies: a human maintainer reviews and approves, and auto-merge is not enabled on it.

Three files still carry "do not trust the test-location doc" warnings written when the warning was true: the tests directory guide at three places, and the validation-and-qa skill in both its source and generated copies. They are accurate as history but now point at a corrected document. Retiring them is a separate change because the skill copy is generated and would need a regeneration pass.

One finding left alone, outside these follow-ups: the testing-approach steering document is itself substantially PowerShell-era beyond the link fixed here. It carries 14 PowerShell or Pester mentions and two links to Pester test files that do not exist. Rewriting it is its own scoped change.

## Related Issues

Refs #5712

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gvEkXJEUSPweCnv1VEgoo