### PR TITLE
docs(claude): document Sonnet/Haiku delegation with Opus review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,6 @@
-## Model Delegation For Token Efficiency
+## Delegate To Cheaper Models
 
-Delegate non-trivial work to subagents (`Agent` tool) or, when the user has opted into multi-agent orchestration, the `Workflow` tool, instead of doing it inline in the primary session. This keeps the primary context window, which carries the full conversation, smaller and cheaper than doing the work directly.
-
-- **Delegate down to Sonnet or Haiku.** Pass `model: "sonnet"` or `model: "haiku"` on `Agent` calls for implementation, research, and other bounded subtasks. Haiku for mechanical work (search, formatting, simple edits); Sonnet for anything needing more judgment.
-- **Reserve Opus for review.** Use Opus to review completed work, code review, architecture review, critique, rather than for the first implementation pass. If the primary session is already running on Opus, that review can happen there instead of a separate agent call.
-- Applies to both delegation surfaces: `Agent`/`Task` subagent calls and `Workflow` orchestration. The goal is spending expensive-model tokens on judgment (review), not throughput (execution).
+Push non-trivial implementation and research to subagents (`Agent`) or `Workflow`, on Sonnet or Haiku (`model: "sonnet"`/`"haiku"`), rather than working inline. Reserve Opus for reviewing finished work, not the first pass.
 
 <claude-mem-context>
 # Recent Activity

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,11 @@
+## Model Delegation For Token Efficiency
+
+Delegate non-trivial work to subagents (`Agent` tool) or, when the user has opted into multi-agent orchestration, the `Workflow` tool, instead of doing it inline in the primary session. This keeps the primary context window, which carries the full conversation, smaller and cheaper than doing the work directly.
+
+- **Delegate down to Sonnet or Haiku.** Pass `model: "sonnet"` or `model: "haiku"` on `Agent` calls for implementation, research, and other bounded subtasks. Haiku for mechanical work (search, formatting, simple edits); Sonnet for anything needing more judgment.
+- **Reserve Opus for review.** Use Opus to review completed work, code review, architecture review, critique, rather than for the first implementation pass. If the primary session is already running on Opus, that review can happen there instead of a separate agent call.
+- Applies to both delegation surfaces: `Agent`/`Task` subagent calls and `Workflow` orchestration. The goal is spending expensive-model tokens on judgment (review), not throughput (execution).
+
 <claude-mem-context>
 # Recent Activity
 


### PR DESCRIPTION
## Summary

### What

Adds a "Model Delegation For Token Efficiency" section to `.claude/CLAUDE.md`, placed outside the file's auto-generated `<claude-mem-context>` block so it survives regeneration by the claude-mem hook.

### Why

Requested directly: use subagents and `Workflow` orchestration to reduce token spend in the primary session, delegating implementation/research work down to Sonnet or Haiku, and reserving Opus for reviewing completed work.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5717 | docs(claude): document Sonnet/Haiku delegation with Opus review in .claude/CLAUDE.md |

## Changes

- `.claude/CLAUDE.md`: new "Model Delegation For Token Efficiency" section instructing delegation to Sonnet/Haiku via `Agent`/`Workflow`, with Opus reserved for review.

## Acceptance criteria

- [x] `.claude/CLAUDE.md` carries an instruction to delegate execution to Sonnet/Haiku subagents and reserve Opus for review
- [x] The new content sits outside the `<claude-mem-context>` auto-generated block

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

**Focus areas**: wording of the new section only

## Testing

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [ ] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`; ran as part of the pre-push hook suite)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #5717

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5vr5qDXG6jnpXAfa4CB4A


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5vr5qDXG6jnpXAfa4CB4A)_