### PR TITLE
fix(skills): clear the last live Forgetful references from skill bodies and the catalog

### DIFF
--- a/.claude/skills/ai-agents-docs-of-record/SKILL.md
+++ b/.claude/skills/ai-agents-docs-of-record/SKILL.md
@@ -260,7 +260,7 @@ relying on them:
 | FM-9 verbatim-quote rule | `.agents/governance/FAILURE-MODES.md:284-307` | `grep -n "character-for-character" .agents/governance/FAILURE-MODES.md` |
 | PR #908 lint scope story | `.agents/retrospective/2026-01-15-pr-908-comprehensive-retrospective.md:281-296` | `grep -n "markdownlint" .agents/retrospective/2026-01-15-pr-908-comprehensive-retrospective.md` |
 | CONTRIBUTING.md pre-PR #2871 staleness example | PR #2871 repointed `CONTRIBUTING.md` to `build/generate_agents.py` | `git show b320f4ac1 -- CONTRIBUTING.md` |
-| Serena canonical, Forgetful supplementary | `.agents/architecture/ADR-007-memory-first-architecture.md:83-102` | `grep -n "Canonical" .agents/architecture/ADR-007-memory-first-architecture.md` |
+| Serena is the only memory backend | `.agents/architecture/ADR-106-serena-only-memory-architecture.md:87` | `grep -n "the only memory backend" .agents/architecture/ADR-106-serena-only-memory-architecture.md` |
 
 Maintenance: when a validator, template path, or protocol phase changes, update
 the matching row here in the same PR. This file is itself a document of record;

--- a/.claude/skills/memory/references/zettelkasten-memory-agents.md
+++ b/.claude/skills/memory/references/zettelkasten-memory-agents.md
@@ -69,9 +69,9 @@ Compact operation: summarize long comment threads into main item description to 
 
 | Memory Skill Concept | Zettelkasten Equivalent |
 |---|---|
-| Serena memories | Forgetful knowledge base |
+| Serena memories | The slip-box |
 | Memory router search | Auto-linking via similarity |
 | Single-agent sessions | Multi-agent shared knowledge base |
 | Size validation thresholds | Atomic note constraint |
 
-The multi-agent knowledge sharing is the capability gap. Zettelkasten-style tools like Forgetful provide persistent memory graphs across agent sessions.
+The multi-agent knowledge sharing is the capability gap. Zettelkasten-style tools provide persistent memory graphs across agent sessions.

--- a/.claude/skills/programming-advisor/SKILL.md
+++ b/.claude/skills/programming-advisor/SKILL.md
@@ -43,7 +43,7 @@ Extract from user request:
 Before any web search, check whether the capability already exists in the current repo or org:
 
 - grep the codebase for the capability's keywords and likely symbol names
-- if Serena is available, run a symbol search; if Forgetful memory is available, query it
+- if Serena is available, run a symbol search and query its memories
 - check existing dependencies (`package.json` / `requirements.txt` / `Cargo.toml` / `go.mod`) for a library already pulled in
 
 If an internal implementation exists, recommend **Leverage** (use as-is) or **Extend** (adapt it) before proposing a build or an external buy. Internal reuse beats both a new dependency and a rewrite.

--- a/.claude/skills/slashcommandcreator/SKILL.md
+++ b/.claude/skills/slashcommandcreator/SKILL.md
@@ -157,7 +157,7 @@ See `docs/SKILL-AUTHORING.md` ("Portable Script Invocations") for the full rule.
 ## Invocation Examples
 
 ```text
-SlashCommandCreator: create command for exporting Forgetful memories to JSON
+SlashCommandCreator: create command for exporting Serena memories to JSON
 
 SlashCommandCreator: design slash command for running security audit
 

--- a/.claude/skills/software-engineering-library/references/domain-driven-design.md
+++ b/.claude/skills/software-engineering-library/references/domain-driven-design.md
@@ -243,7 +243,7 @@ ai-agents already has implicit bounded contexts. Reuse, do not duplicate.
 
 - **Agent runtime**: agent definitions, agent invocation, the orchestrator, and the agent's view of the world. The ubiquitous language uses _agent_, _delegation_, _skill_, _tool_. New behavior that lives in this context belongs in the project agent sources or the orchestrator service.
 - **Session lifecycle**: session start, session end, handoff, retrospective. The language uses _session_, _handoff_, _retrospective_, _gate_. Session state is its own aggregate; the session log is the audit trail. New session-shape concepts go behind the session-management seam, not into hooks or skills.
-- **Memory**: long-lived knowledge across sessions. The language uses _memory_, _entity_, _observation_, _relation_. Serena and Forgetful are repositories of long-lived knowledge in this context; the named operation already exists for most use cases.
+- **Memory**: long-lived knowledge across sessions. The language uses _memory_, _entity_, _observation_, _relation_. Serena is a repository of long-lived knowledge in this context; the named operation already exists for most use cases.
 - **Skills and hooks**: entry points that translate between user or harness input and the agent runtime. Treat them as ACLs from the harness to the agent runtime. Keep them thin: parse, call a service, format output.
 - **GitHub integration**: a supporting subdomain. Reuse the established `gh` CLI patterns and PR template; do not invent a parallel issue model.
 

--- a/.claude/skills/software-engineering-library/references/enterprise-patterns.md
+++ b/.claude/skills/software-engineering-library/references/enterprise-patterns.md
@@ -146,7 +146,7 @@ ai-agents already has implicit versions of these patterns. Reuse, do not duplica
 - Sessions and the session log live behind a session-management seam. Treat that seam as the Repository for session state and the Service Layer for session lifecycle.
 - The orchestrator is the Service Layer for agent runs. New use cases that need a transactional or retryable boundary go here, not into a hook or skill.
 - Skills and hooks are entry points. Keep them thin: parse inputs, call a service, format output. They are not the place for business rules.
-- Memory systems (Serena, Forgetful) act as Repositories of long-lived knowledge. Do not bypass them with direct file reads when the named operation already exists.
+- Serena acts as a Repository of long-lived knowledge. Do not bypass it with direct file reads when the named operation already exists.
 
 When you find a place where the codebase deviates from this rule, prefer a small focused refactor on the path you are already touching over a large rewrite. Note the deviation in the PR description so future readers see your reasoning.
 

--- a/.claude/skills/software-engineering-library/references/release-it.md
+++ b/.claude/skills/software-engineering-library/references/release-it.md
@@ -235,7 +235,7 @@ ai-agents already has the seams these patterns belong on. Reuse them; do not dup
 - Lifecycle hooks (SessionStart, PreToolUse, PostToolUse, UserPromptSubmit, Stop) run in line with user-facing work. They MUST be fast, MUST timeout external calls, and MUST never block the agent on an unbounded retry. Hooks that do real work belong behind a circuit-broken adapter, not a raw network call.
 - Skills are entry points. Keep them thin: parse, call a service or adapter, format. Do not embed timeouts, retries, or breakers inside skill bodies; lift those into the adapter the skill uses.
 - MCP servers and external tooling (gh CLI, search APIs, model providers) are integration points. Treat them with the rules above, even when they are convenient.
-- Memory systems (Serena, Forgetful) are integration points too. A failed memory call must degrade to a documented fallback, not silently swallow context loss.
+- Serena is an integration point too. A failed memory call must degrade to a documented fallback, not silently swallow context loss.
 
 When you find code that deviates from this rule, prefer a small focused refactor on the path you are already touching over a sweeping cleanup. Note the deviation in the PR description so future readers see your reasoning.
 

--- a/.claude/skills/world-model-diagnostic/SKILL.md
+++ b/.claude/skills/world-model-diagnostic/SKILL.md
@@ -94,7 +94,7 @@ Evaluate without numeric scoring:
 
 ### Phase 1: Orientation
 
-1. **Memory check.** Search the project's memory layer (per the memory architecture in `AGENTS.md`) for prior diagnostic context. Use Serena memories or Forgetful. Treat every result as a hint, not confirmed fact. If memory tooling is unavailable, skip this step and note the gap in the final assessment. Suggested queries:
+1. **Memory check.** Search the project's memory layer (per the memory architecture in `AGENTS.md`) for prior diagnostic context. Use Serena memories. Treat every result as a hint, not confirmed fact. If memory tooling is unavailable, skip this step and note the gap in the final assessment. Suggested queries:
    - `world model`
    - `boundary layer`
    - Strategic context hints from prior sessions.
@@ -206,7 +206,7 @@ A JSON variant of the same shape is acceptable when a downstream tool consumes t
 
 ## Persistence
 
-Save exactly three artifacts via the repo's memory tooling, unless the user declines. Use Serena `write_memory` or the equivalent Forgetful entry point. Key the entries by company slug so future runs can detect drift.
+Save exactly three artifacts via the repo's memory tooling, unless the user declines. Use Serena `write_memory`. Key the entries by company slug so future runs can detect drift.
 
 ### 1. Intake Summary
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -53,7 +53,7 @@ Intercepts GitHub URLs in user input and routes them to the appropriate skill or
 
 ### memory
 
-Unified four-tier memory system for AI agents. Supports semantic search, knowledge graphs, and cross-session context persistence via Serena and Forgetful.
+Thin router for the tiered memory system. Points callers at focused sub-skills for Tier 1 semantic search over Serena memories and Tier 2 episode extraction.
 
 ### memory-enhancement
 

--- a/src/copilot-cli/skills/ai-agents-docs-of-record/SKILL.md
+++ b/src/copilot-cli/skills/ai-agents-docs-of-record/SKILL.md
@@ -260,7 +260,7 @@ relying on them:
 | FM-9 verbatim-quote rule | `.agents/governance/FAILURE-MODES.md:284-307` | `grep -n "character-for-character" .agents/governance/FAILURE-MODES.md` |
 | PR #908 lint scope story | `.agents/retrospective/2026-01-15-pr-908-comprehensive-retrospective.md:281-296` | `grep -n "markdownlint" .agents/retrospective/2026-01-15-pr-908-comprehensive-retrospective.md` |
 | CONTRIBUTING.md pre-PR #2871 staleness example | PR #2871 repointed `CONTRIBUTING.md` to `build/generate_agents.py` | `git show b320f4ac1 -- CONTRIBUTING.md` |
-| Serena canonical, Forgetful supplementary | `.agents/architecture/ADR-007-memory-first-architecture.md:83-102` | `grep -n "Canonical" .agents/architecture/ADR-007-memory-first-architecture.md` |
+| Serena is the only memory backend | `.agents/architecture/ADR-106-serena-only-memory-architecture.md:87` | `grep -n "the only memory backend" .agents/architecture/ADR-106-serena-only-memory-architecture.md` |
 
 Maintenance: when a validator, template path, or protocol phase changes, update
 the matching row here in the same PR. This file is itself a document of record;

--- a/src/copilot-cli/skills/memory/references/zettelkasten-memory-agents.md
+++ b/src/copilot-cli/skills/memory/references/zettelkasten-memory-agents.md
@@ -69,9 +69,9 @@ Compact operation: summarize long comment threads into main item description to 
 
 | Memory Skill Concept | Zettelkasten Equivalent |
 |---|---|
-| Serena memories | Forgetful knowledge base |
+| Serena memories | The slip-box |
 | Memory router search | Auto-linking via similarity |
 | Single-agent sessions | Multi-agent shared knowledge base |
 | Size validation thresholds | Atomic note constraint |
 
-The multi-agent knowledge sharing is the capability gap. Zettelkasten-style tools like Forgetful provide persistent memory graphs across agent sessions.
+The multi-agent knowledge sharing is the capability gap. Zettelkasten-style tools provide persistent memory graphs across agent sessions.

--- a/src/copilot-cli/skills/programming-advisor/SKILL.md
+++ b/src/copilot-cli/skills/programming-advisor/SKILL.md
@@ -43,7 +43,7 @@ Extract from user request:
 Before any web search, check whether the capability already exists in the current repo or org:
 
 - grep the codebase for the capability's keywords and likely symbol names
-- if Serena is available, run a symbol search; if Forgetful memory is available, query it
+- if Serena is available, run a symbol search and query its memories
 - check existing dependencies (`package.json` / `requirements.txt` / `Cargo.toml` / `go.mod`) for a library already pulled in
 
 If an internal implementation exists, recommend **Leverage** (use as-is) or **Extend** (adapt it) before proposing a build or an external buy. Internal reuse beats both a new dependency and a rewrite.

--- a/src/copilot-cli/skills/slashcommandcreator/SKILL.md
+++ b/src/copilot-cli/skills/slashcommandcreator/SKILL.md
@@ -157,7 +157,7 @@ See `docs/SKILL-AUTHORING.md` ("Portable Script Invocations") for the full rule.
 ## Invocation Examples
 
 ```text
-SlashCommandCreator: create command for exporting Forgetful memories to JSON
+SlashCommandCreator: create command for exporting Serena memories to JSON
 
 SlashCommandCreator: design slash command for running security audit
 

--- a/src/copilot-cli/skills/software-engineering-library/references/domain-driven-design.md
+++ b/src/copilot-cli/skills/software-engineering-library/references/domain-driven-design.md
@@ -243,7 +243,7 @@ ai-agents already has implicit bounded contexts. Reuse, do not duplicate.
 
 - **Agent runtime**: agent definitions, agent invocation, the orchestrator, and the agent's view of the world. The ubiquitous language uses _agent_, _delegation_, _skill_, _tool_. New behavior that lives in this context belongs in the project agent sources or the orchestrator service.
 - **Session lifecycle**: session start, session end, handoff, retrospective. The language uses _session_, _handoff_, _retrospective_, _gate_. Session state is its own aggregate; the session log is the audit trail. New session-shape concepts go behind the session-management seam, not into hooks or skills.
-- **Memory**: long-lived knowledge across sessions. The language uses _memory_, _entity_, _observation_, _relation_. Serena and Forgetful are repositories of long-lived knowledge in this context; the named operation already exists for most use cases.
+- **Memory**: long-lived knowledge across sessions. The language uses _memory_, _entity_, _observation_, _relation_. Serena is a repository of long-lived knowledge in this context; the named operation already exists for most use cases.
 - **Skills and hooks**: entry points that translate between user or harness input and the agent runtime. Treat them as ACLs from the harness to the agent runtime. Keep them thin: parse, call a service, format output.
 - **GitHub integration**: a supporting subdomain. Reuse the established `gh` CLI patterns and PR template; do not invent a parallel issue model.
 

--- a/src/copilot-cli/skills/software-engineering-library/references/enterprise-patterns.md
+++ b/src/copilot-cli/skills/software-engineering-library/references/enterprise-patterns.md
@@ -146,7 +146,7 @@ ai-agents already has implicit versions of these patterns. Reuse, do not duplica
 - Sessions and the session log live behind a session-management seam. Treat that seam as the Repository for session state and the Service Layer for session lifecycle.
 - The orchestrator is the Service Layer for agent runs. New use cases that need a transactional or retryable boundary go here, not into a hook or skill.
 - Skills and hooks are entry points. Keep them thin: parse inputs, call a service, format output. They are not the place for business rules.
-- Memory systems (Serena, Forgetful) act as Repositories of long-lived knowledge. Do not bypass them with direct file reads when the named operation already exists.
+- Serena acts as a Repository of long-lived knowledge. Do not bypass it with direct file reads when the named operation already exists.
 
 When you find a place where the codebase deviates from this rule, prefer a small focused refactor on the path you are already touching over a large rewrite. Note the deviation in the PR description so future readers see your reasoning.
 

--- a/src/copilot-cli/skills/software-engineering-library/references/release-it.md
+++ b/src/copilot-cli/skills/software-engineering-library/references/release-it.md
@@ -235,7 +235,7 @@ ai-agents already has the seams these patterns belong on. Reuse them; do not dup
 - Lifecycle hooks (SessionStart, PreToolUse, PostToolUse, UserPromptSubmit, Stop) run in line with user-facing work. They MUST be fast, MUST timeout external calls, and MUST never block the agent on an unbounded retry. Hooks that do real work belong behind a circuit-broken adapter, not a raw network call.
 - Skills are entry points. Keep them thin: parse, call a service or adapter, format. Do not embed timeouts, retries, or breakers inside skill bodies; lift those into the adapter the skill uses.
 - MCP servers and external tooling (gh CLI, search APIs, model providers) are integration points. Treat them with the rules above, even when they are convenient.
-- Memory systems (Serena, Forgetful) are integration points too. A failed memory call must degrade to a documented fallback, not silently swallow context loss.
+- Serena is an integration point too. A failed memory call must degrade to a documented fallback, not silently swallow context loss.
 
 When you find code that deviates from this rule, prefer a small focused refactor on the path you are already touching over a sweeping cleanup. Note the deviation in the PR description so future readers see your reasoning.
 

--- a/src/copilot-cli/skills/world-model-diagnostic/SKILL.md
+++ b/src/copilot-cli/skills/world-model-diagnostic/SKILL.md
@@ -94,7 +94,7 @@ Evaluate without numeric scoring:
 
 ### Phase 1: Orientation
 
-1. **Memory check.** Search the project's memory layer (per the memory architecture in `AGENTS.md`) for prior diagnostic context. Use Serena memories or Forgetful. Treat every result as a hint, not confirmed fact. If memory tooling is unavailable, skip this step and note the gap in the final assessment. Suggested queries:
+1. **Memory check.** Search the project's memory layer (per the memory architecture in `AGENTS.md`) for prior diagnostic context. Use Serena memories. Treat every result as a hint, not confirmed fact. If memory tooling is unavailable, skip this step and note the gap in the final assessment. Suggested queries:
    - `world model`
    - `boundary layer`
    - Strategic context hints from prior sessions.
@@ -206,7 +206,7 @@ A JSON variant of the same shape is acceptable when a downstream tool consumes t
 
 ## Persistence
 
-Save exactly three artifacts via the repo's memory tooling, unless the user declines. Use Serena `write_memory` or the equivalent Forgetful entry point. Key the entries by company slug so future runs can detect drift.
+Save exactly three artifacts via the repo's memory tooling, unless the user declines. Use Serena `write_memory`. Key the entries by company slug so future runs can detect drift.
 
 ### 1. Intake Summary
 

--- a/tests/skills/test_forgetful_decommission_guards.py
+++ b/tests/skills/test_forgetful_decommission_guards.py
@@ -11,6 +11,13 @@ This module guards the surfaces cleaned in the follow-up. It does not cover the
 three Forgetful-native skills, whose call sites were not fixable in place: the
 owner retired them under #5624, so their surfaces are gone rather than guarded.
 
+A second wave added eight more entries: the last skill files in the acceptance
+criterion's scope that still named the server. They were live instructions
+(`programming-advisor`, `world-model-diagnostic`), a stale claim citing an ADR
+that ADR-106 superseded (`ai-agents-docs-of-record`), an invocation example
+(`slashcommandcreator`), and prose treating the server as a second live backend
+(`software-engineering-library` references, `memory/references`).
+
 Each guard is parametrized over the canonical `.claude/` tree and the generated
 `src/copilot-cli/` mirror so a regeneration cannot reintroduce a surface on one
 side only. `test_guard_detects_every_removed_spelling` is the negative control:
@@ -34,13 +41,21 @@ MIRROR_ROOT = REPO_ROOT / "src" / "copilot-cli" / "skills"
 # removed; see the PR body for what each one was.
 CLEANED_SKILL_FILES = (
     "ai-agents-build-and-env/SKILL.md",
+    "ai-agents-docs-of-record/SKILL.md",
     "memory-consolidate/SKILL.md",
     "memory-documentary/SKILL.md",
     "memory-documentary/references/execution-protocol.md",
+    "memory/references/zettelkasten-memory-agents.md",
+    "programming-advisor/SKILL.md",
     "reflect/SKILL.md",
     "reflect/references/integration-and-design.md",
+    "slashcommandcreator/SKILL.md",
+    "software-engineering-library/references/domain-driven-design.md",
+    "software-engineering-library/references/enterprise-patterns.md",
+    "software-engineering-library/references/release-it.md",
     "threat-modeling/SKILL.md",
     "using-serena-symbols/SKILL.md",
+    "world-model-diagnostic/SKILL.md",
 )
 
 TREE_ROOTS = (


### PR DESCRIPTION
# Pull Request

## Summary

### What

Nine authored files stopped naming the memory backend that #5574 removed, and the decommission guard grew from 8 files to 16 so they cannot silently regain it. Eight Copilot mirrors were regenerated by `build_all.py`.

### Why

Every line changed here was a dead end for a reading agent or a false claim about the repository. Two skills told an agent to query a backend whose MCP server, skill, commands and sync scripts are already deleted from main. One cited an ADR that has since been superseded, for a claim its successor reverses. The rest treated the removed server as a second live memory system standing beside Serena.

The scope measurement fell from 45 files to 28. The 28 that remain are the classes the issue owner already ruled permanently exempt: assertion needles inside absence tests, retired-name registries, frozen eval run records, and generated mirrors of those.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5574 | chore(memory): decommission the forgetful subsystem, Serena only |

Deliberately `Refs`, not `Closes`. Two items under #5574 stay open and are the owner's to decide: the acceptance-criterion-1 rescoping raised in #5624, and the orphaned prompt deletion in #5643.

## Changes

- `.claude/skills/programming-advisor/SKILL.md` offered two prior-art actions, a Serena symbol search and a memory query. Only the second named the dead backend, so the query is renamed rather than deleted. Removing it would have left a section titled "Internal prior-art" with no instruction to check memory at all.
- `.claude/skills/world-model-diagnostic/SKILL.md` had a Process step and a Persistence step, each offering the removed backend as an alternative to Serena.
- `.claude/skills/slashcommandcreator/SKILL.md` had an invocation example. An example asserts the task is one a user could ask for today.
- `.claude/skills/ai-agents-docs-of-record/SKILL.md` claimed "Serena canonical, Forgetful supplementary" and cited ADR-007 lines 83 to 102. That ADR's frontmatter reads `superseded-by: ADR-106`, and ADR-106 is `accepted`. Its line 87 reads `**2. Serena is the only memory backend.**`, so the row now cites that instead.
- `.claude/skills/software-engineering-library/references/domain-driven-design.md` carried one bullet pairing the two systems under a single predicate. The predicate stays true of the survivor, so only the name goes.
- `.claude/skills/software-engineering-library/references/enterprise-patterns.md` carried the same shape.
- `.claude/skills/software-engineering-library/references/release-it.md` carried the same shape.
- `.claude/skills/memory/references/zettelkasten-memory-agents.md` had a row in a "Memory Skill Concept | Zettelkasten Equivalent" table whose right cell named a tool of ours rather than a Zettelkasten concept, so it was wrong on its own terms before the decommission. It now reads "The slip-box", and does not duplicate the "Atomic note constraint" row two lines down.
- `docs/skill-reference.md` carried two false claims, not one. It called the memory skill a "Unified four-tier memory system ... via Serena and Forgetful". The skill names exactly Tier 1 and Tier 2, and its own frontmatter calls it "the tiered memory system" with no count.
- `tests/skills/test_forgetful_decommission_guards.py` grows `CLEANED_SKILL_FILES` from 8 entries to 16. Each is checked against both the canonical and the mirror root, so the suite goes from 38 tests to 54.

## Acceptance criteria

- [x] No live instruction in the changed files names the removed backend
- [x] Every superseded-ADR citation in the changed files points at the accepted successor
- [x] Each of the eight cleaned skill files is covered by the decommission guard against both the canonical and the mirror root
- [x] The decommission guard is proved non-vacuous by a discrimination probe
- [x] Copilot mirrors regenerated by `build_all.py` rather than hand-edited
- [x] No file under `.agents/sessions/`, `.agents/archive/`, or `.serena/memories/` is modified

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the three replacements where I overrode the automated proposal, and the five matches deliberately left alone. Both are argued below; a reviewer who disagrees with a classification should say so, because the taxonomy is the whole substance of this PR.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Guard suite goes 38 passed to 54 passed. Discrimination probe: appending `Query Forgetful memory when available.` to `programming-advisor/SKILL.md` turns the run to 1 failed / 53 passed, naming that exact parametrization; removing it returns 54 passed. Without that probe the added entries would be unfalsifiable.

`uv run python scripts/validation/pre_pr.py` reports 68 of 70 gates proved their contract. The 2 BLOCKED are `validate_workflow_yaml` and `validate_yaml_style`, both `reason=tool.absent` because yamllint is not on this PATH, both licensed by the pre-PR policy, and neither reachable by this diff, which touches no YAML.

Drift is attributable: `build_all.py` was run on the untouched tree first and wrote 0 files with a clean `git status`, so every one of the 17 changed files traces to these edits.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Prose and one test tuple. No auth, secrets, CI, hooks, or infrastructure paths.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

### The adversarial pass returned a suspicious result, so I re-verified by hand

Classification ran as a fan-out with one independent skeptic per proposal, each prompted to refute and told to default to refuted when uncertain. It refuted **0 of 11**. The earlier pass on this same corpus refuted **19 of 36**.

A unanimous survival rate is the rubber-stamping signature in `FAILURE-MODES.md` #6, so I re-checked every survivor against the tree myself. The mechanical checks held: all 11 `old_str` values were verbatim, unique, and on their cited line, with no banned dash in any replacement. Three did not survive my own read:

1. **`docs/skill-reference.md` kept a false claim.** The proposal dropped the dead backend but preserved "four-tier". The skill names exactly two tiers. The refuter ran an explicit factual-error check against this replacement and passed it. This is the finding the adversarial pass was built to catch and did not.
2. **`programming-advisor/SKILL.md` lost an action.** The first proposal deleted the memory query outright; its refuter caught that and supplied "query memory", which is vague about whose memory. I used "query its memories", which keeps the antecedent unambiguous.
3. **`zettelkasten-memory-agents.md` gained an overlap.** The refuter's correction, "Slip-box of atomic notes", duplicates the "Atomic note constraint" row two lines below. "The slip-box" says the same thing without the collision.

The other eight I confirmed unchanged.

### What was deliberately left, and why

Five matches were classified and left. Each is load-bearing:

- `.claude/skills/context-gather/references/context-retrieval.md`, four matches, all prose explaining the removal itself. Deleting it destroys the explanation of why the surrounding table lost a row.
- `.claude/hooks/PostToolUse/README.md`, a past-tense description of a hook ADR-097 retired. Rewriting it would assert that history happened differently.
- `.claude/skills/orphan-ref-validator/scripts/filters.py`, the `KNOWN_RETIRED_KEBAB_SKILLS` frozenset. Its own comment says retired names are listed so references "keep surfacing instead of going silent". Removing the entry silently disables orphan detection for that name.
- `scripts/consolidate_skills.py` and `scripts/restructure_memories.py`, keyword lookup keys for historical data.

### Flagged, not fixed

`memory/references/zettelkasten-memory-agents.md:73` reads "Memory router search". That names the ADR-037 Memory Router, which ADR-106 withdrew. It is one line from an edit I made, so leaving it is a deliberate choice rather than an oversight: ADR-106 line 210 records that repoint as "not done here", spanning 110 lines across six agent trees. Sweeping one line of it into this PR would leave the other 109 inconsistent and hide the real scope. It wants its own change.

Separately, #5719 was filed during this session: the `github-url-intercept` router exits 1 on `/pull/{n}#issuecomment-{id}`, the shape GitHub's own API returns as that comment's `html_url`, while the skill documents the route as supported. Unrelated to this diff.

## Related Issues

Refs #5574
Refs #5624
Refs #5643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF


---
_Generated by [Claude Code](https://claude.ai/code)_