### PR TITLE
docs(handoff): close out issue 5706 second wave

### DIFF
--- a/.agents/sessions/handoffs/2026-09-11-5706-handoff.md
+++ b/.agents/sessions/handoffs/2026-09-11-5706-handoff.md
@@ -6,7 +6,7 @@
 - **Branch**: none in flight; work landed on `main` through PRs #5724, #5729, #5730, #5726, #5731
 - **Task**: spec, plan, ADR amendment, compile pipeline, and the eight-skill pilot for issue #5706
 - **Phase**: complete
-- **Progress**: A0, A1, A2 merged; issue closed by #5731
+- **Progress**: A0, A1, A2 merged; issue closed by #5731. Second wave (fifteen more skills, PRs #5739 `fcc5ea0cc`, #5740 `915281c25`, #5741 `1335030e1`) merged; ADR-108 accepted (#5736); guard citations repaired (#5737)
 
 ## Files Modified
 
@@ -19,6 +19,8 @@
 - `tests/build_scripts/test_generate_skills_template_compile.py`, `test_skill_template_grammar.py`, `test_skill_templates_pilot_scope.py`, `test_skill_templates_symlink_security.py`, `test_skill_partials_rule_parity.py`, `tests/skills/<pilot>/test_skill_md_contract.py` (eight), `tests/test_frontgate_crosslink_1927.py`
 - `.agents/governance/GENERATOR-FILES.md`, `build/AGENTS.md`, `templates/AGENTS.md`, `.claude/rules/generated-artifacts.md`, `.claude/rules/templates.md`, `.claude/skills/CLAUDE.md`, `.agents/steering/claude-skills.md`, `.agents/governance/SKILL-CREATION-CRITERIA.md`, `.github/CODEOWNERS`
 - `.agents/plans/completed/5706-skill-guidance-excerpts.md` (moved from `active/`)
+- Second wave (PRs #5739, #5740, #5741): `templates/skills/<name>.SKILL.md.tmpl` for fifteen more skills (`agent-harness-reference`, `ai-agents-architecture-contract`, `ai-agents-build-and-env`, `ai-agents-change-control`, `ai-agents-debugging-playbook`, `ai-agents-docs-of-record`, `ai-agents-empirical-probe-toolkit`, `ai-agents-external-claims`, `ai-agents-failure-archaeology`, `ai-agents-portability-campaign`, `ai-agents-research-methodology`, `ai-agents-validation-and-qa`, `avoiding-manufactured-work`, `orphan-ref-validator`, `prose-self-check`), six new partials (`own-and-flag`, `user-sovereignty`, `runtime-contract-test`, `no-secrets`, `voice-banned-vocabulary`, `no-generated-headers`), rendered files and mirrors, fifteen contract tests, `PILOT` at 23 names, roughly forty stale citations re-anchored, the template-owned pointer sentences now name `templates/skills/`
+- `.agents/architecture/ADR-108-template-owned-skill-files.md` `status: accepted` (#5736); guard citations in three knowledge-pack files re-anchored (#5737)
 
 ## Decisions Made
 
@@ -36,8 +38,8 @@
 
 ## Next Steps
 
-1. Owner decision on whether ADR-108 moves from `proposed` to `accepted`; A1 flipped `implemented: true`.
-2. Second wave (deferred in REQ-025): migrate more skills by adding a `.tmpl` and widening `PILOT`; consider `references/*.md` templates; consider replacing `chevron` with an in-tree expander.
+1. ADR-108 accepted (#5736). Nothing pending.
+2. Second wave done (23 of 111 skills template-owned). ADR-109 (template-first plugin distribution, proposed 2026-09-11) generalizes ADR-108 to every artifact class; the remaining 88 skills migrate under its B3 step, not as a third wave of this issue. Eight of the fifteen entered the class with no partial yet because their rule citations are whole-file pointers or table cells (a `{{> }}` tag needs its own line); the next wave can lift guidance into partials for those, and can consider `references/*.md` templates and replacing `chevron` with an in-tree expander.
 3. Always-on rule cut (issues #5400, #5492, #4871) now that the pilot proves partials; owner's word first.
 4. Spec id allocation raced twice today (#5725 and #5727 took the same next-free ids as this work in parallel). A follow-up on id allocation is worth an issue; not filed here because #5706 forbids filing follow-ups from this work.
 
@@ -47,6 +49,7 @@
 - Partials MUST end with exactly one trailing newline and MUST be verbatim contiguous spans of their `rule-source` rule file (`tests/build_scripts/test_skill_partials_rule_parity.py`).
 - The taste count ratchet had zero slack on `main` after #5725; a branch adding any error-severity taste finding fails the merge-tree ratchet even when it passes standalone.
 - The pre-push hook refuses non-fast-forward pushes; merge `main` into a PR branch rather than rebasing a published one.
+- Templating a skill makes every line of its new `.tmpl` count as added for the citation-freshness gate, so pre-existing stale `path:line` citations surface at that moment; budget for re-anchoring them (about forty across the second wave). The description validator reads any backticked repository path outside `## Changes` as a changed-file claim.
 - Pilot byte report (before, on `main` at `cd0f9561d`; after, on #5731): always-on rules unchanged at 56,984 bytes; pilot `SKILL.md` files grew by 380 to 688 bytes each (sync 6581 to 6961, test 11555 to 11965, spec 11027 to 11433, ship 14296 to 14984, research 8526 to 8939, plan 5637 to 6045, checkpoint 4651 to 5136, build 10773 to 11192). No pilot carries a NO-REGEN sentinel.
 
 ## Verification on Resume
@@ -60,4 +63,4 @@
 
 - Session log: discontinued
 - Previous handoff: none
-- PRs: #5724 (A0), #5729 and #5730 (spec id hotfixes), #5726 (A1), #5731 (A2)
+- PRs: #5724 (A0), #5729 and #5730 (spec id hotfixes), #5726 (A1), #5731 (A2), #5734 (closeout), #5736 (ADR-108 accepted), #5737 (guard citations), #5739, #5740, #5741 (second wave)


### PR DESCRIPTION
# Pull Request

## Summary

### What

Updates the issue #5706 handoff with the second wave: fifteen more skills template-owned across three merged PRs, ADR-108 accepted, guard citations repaired, and the note that ADR-109 carries the remaining skills.

### Why

The handoff is the document of record for the issue; it still described only the three pilot milestones.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5706 | Skill guidance excerpts (closed by #5731) |

These references do not close their linked items: #5706 is already closed.

## Changes

- `.agents/sessions/handoffs/2026-09-11-5706-handoff.md`: progress line, second-wave summary with merge SHAs, ADR-108 acceptance, the eight no-partial cases, the citation-freshness and description-validator traps, PR list.

## Acceptance criteria

- [x] The handoff names all three second-wave PRs with their merge commits
- [x] The handoff states the template-owned count (23 of 111)
- [x] The handoff points remaining skill migration at ADR-109

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

## Testing

- [x] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`)
- [x] Self-review completed (read the diff as if you did not write it)

## Related Issues

- #5706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M4qLAptnWDBp4aHuFUs6L
