### PR TITLE
fix(github-url-intercept): accept the PR comment URL shape GitHub emits

### DIFF
--- a/.claude/skills/github-url-intercept/scripts/test_url_routing.py
+++ b/.claude/skills/github-url-intercept/scripts/test_url_routing.py
@@ -222,16 +222,39 @@ def _parse_repo_path(split: SplitResult) -> tuple[str, str, str] | None:
     return owner, repo, rest
 
 
-def _fragment_matches_url_type(fragment_type: str | None, url_type: UrlType) -> bool:
+# A pull request's conversation comments ARE issue comments in the REST API, so
+# `#issuecomment-` is legitimate on `/issues/{n}` and on `/pull/{n}` alike. GitHub
+# emits the pull form itself: the comment's own `html_url` for
+# https://github.com/rjmurillo/ai-agents/pull/5710#issuecomment-5620280328 is that
+# exact string. Mapping the fragment to ISSUE alone rejected the more common of the
+# two shapes (issue #5719).
+_FRAGMENT_URL_TYPES: dict[str, frozenset[UrlType]] = {
+    "pullrequestreview": frozenset({UrlType.PULL}),
+    "discussion_r": frozenset({UrlType.PULL}),
+    "issuecomment": frozenset({UrlType.ISSUE, UrlType.PULL}),
+}
+
+
+def _fragment_matches_url_type(
+    fragment_type: str | None,
+    url_type: UrlType,
+    subroute: str | None,
+) -> bool:
     if fragment_type is None:
         return True
 
-    expected_url_type = {
-        "pullrequestreview": UrlType.PULL,
-        "discussion_r": UrlType.PULL,
-        "issuecomment": UrlType.ISSUE,
-    }.get(fragment_type)
-    return expected_url_type == url_type
+    allowed = _FRAGMENT_URL_TYPES.get(fragment_type)
+    if allowed is None or url_type not in allowed:
+        return False
+
+    # Stricter than the fragment grammar alone: GitHub anchors a conversation
+    # comment on the bare pull view and never on a tab, so `/pull/{n}/files` and
+    # `/pull/{n}/changes` keep rejecting it. Widening those would accept a shape
+    # GitHub does not produce and would undo the tightening from PR #5002.
+    if fragment_type == "issuecomment" and url_type == UrlType.PULL:
+        return subroute is None
+
+    return True
 
 
 def parse_github_url(url: str) -> dict[str, Any] | None:
@@ -265,7 +288,7 @@ def parse_github_url(url: str) -> dict[str, Any] | None:
         return None
     url_type, resource_id, subroute, secondary_id, ref, path = resource
 
-    if not _fragment_matches_url_type(fragment_type, url_type):
+    if not _fragment_matches_url_type(fragment_type, url_type, subroute):
         return None
 
     return {

--- a/src/copilot-cli/skills/github-url-intercept/scripts/test_url_routing.py
+++ b/src/copilot-cli/skills/github-url-intercept/scripts/test_url_routing.py
@@ -222,16 +222,39 @@ def _parse_repo_path(split: SplitResult) -> tuple[str, str, str] | None:
     return owner, repo, rest
 
 
-def _fragment_matches_url_type(fragment_type: str | None, url_type: UrlType) -> bool:
+# A pull request's conversation comments ARE issue comments in the REST API, so
+# `#issuecomment-` is legitimate on `/issues/{n}` and on `/pull/{n}` alike. GitHub
+# emits the pull form itself: the comment's own `html_url` for
+# https://github.com/rjmurillo/ai-agents/pull/5710#issuecomment-5620280328 is that
+# exact string. Mapping the fragment to ISSUE alone rejected the more common of the
+# two shapes (issue #5719).
+_FRAGMENT_URL_TYPES: dict[str, frozenset[UrlType]] = {
+    "pullrequestreview": frozenset({UrlType.PULL}),
+    "discussion_r": frozenset({UrlType.PULL}),
+    "issuecomment": frozenset({UrlType.ISSUE, UrlType.PULL}),
+}
+
+
+def _fragment_matches_url_type(
+    fragment_type: str | None,
+    url_type: UrlType,
+    subroute: str | None,
+) -> bool:
     if fragment_type is None:
         return True
 
-    expected_url_type = {
-        "pullrequestreview": UrlType.PULL,
-        "discussion_r": UrlType.PULL,
-        "issuecomment": UrlType.ISSUE,
-    }.get(fragment_type)
-    return expected_url_type == url_type
+    allowed = _FRAGMENT_URL_TYPES.get(fragment_type)
+    if allowed is None or url_type not in allowed:
+        return False
+
+    # Stricter than the fragment grammar alone: GitHub anchors a conversation
+    # comment on the bare pull view and never on a tab, so `/pull/{n}/files` and
+    # `/pull/{n}/changes` keep rejecting it. Widening those would accept a shape
+    # GitHub does not produce and would undo the tightening from PR #5002.
+    if fragment_type == "issuecomment" and url_type == UrlType.PULL:
+        return subroute is None
+
+    return True
 
 
 def parse_github_url(url: str) -> dict[str, Any] | None:
@@ -265,7 +288,7 @@ def parse_github_url(url: str) -> dict[str, Any] | None:
         return None
     url_type, resource_id, subroute, secondary_id, ref, path = resource
 
-    if not _fragment_matches_url_type(fragment_type, url_type):
+    if not _fragment_matches_url_type(fragment_type, url_type, subroute):
         return None
 
     return {

--- a/tests/skills/github/test_url_routing.py
+++ b/tests/skills/github/test_url_routing.py
@@ -161,6 +161,11 @@ def test_routing_success(
             "GhApi",
             'gh api "repos/rjmurillo/ai-agents/issues/comments/789123456"',
         ),
+        (
+            "https://github.com/rjmurillo/ai-agents/pull/123#issuecomment-123456789",
+            "GhApi",
+            'gh api "repos/rjmurillo/ai-agents/issues/comments/123456789"',
+        ),
     ],
 )
 def test_fragment_routes_success(
@@ -187,9 +192,10 @@ def test_fragment_routes_success(
         "https://github.com/rjmurillo/ai-agents/commit/abcxyz",
         "https://github.com/rjmurillo/ai-agents/pull/123/checks/extra",
         "https://github.com/rjmurillo/ai-agents/actions/runs/123/job/456/extra",
-        "https://github.com/rjmurillo/ai-agents/pull/123#issuecomment-123456789",
         "https://github.com/rjmurillo/ai-agents/pull/123/files#issuecomment-789",
         "https://github.com/rjmurillo/ai-agents/pull/123/changes#issuecomment-789",
+        "https://github.com/rjmurillo/ai-agents/pull/123/checks#issuecomment-789",
+        "https://github.com/rjmurillo/ai-agents/pull/123/commits#issuecomment-789",
         "https://github.com/rjmurillo/ai-agents/issues/456#discussion_r123",
         "https://github.com/rjmurillo/ai-agents/discussions/789#issuecomment-123",
         "https://github.com/rjmurillo/ai-agents/actions/runs/123#issuecomment-123",


### PR DESCRIPTION
# Pull Request

## Summary

### What

The `github-url-intercept` router exited 1 with `Invalid GitHub URL format` on `/pull/{n}#issuecomment-{id}`. That is the shape GitHub itself emits for a PR conversation comment. It now parses and routes, while every shape GitHub does not emit stays rejected.

### Why

The skill documents that route in three places and its command builder already produced the correct call. Only the parse rejected it, so the skill's own mandatory Verification step, "test_url_routing.py exited 0", could not pass on a URL the skill says it supports. An agent following the skill either reported a valid URL as unroutable or learned to ignore a failing gate.

GitHub's API is the authority here. For comment 5620280328 it returns `html_url` = `https://github.com/rjmurillo/ai-agents/pull/5710#issuecomment-5620280328`, the exact string the router called invalid.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #5719 | bug(github-url-intercept): router rejects `/pull/{n}#issuecomment-{id}`, the shape GitHub itself emits |

## Changes

- `.claude/skills/github-url-intercept/scripts/test_url_routing.py` replaces the one-type-per-fragment map with `_FRAGMENT_URL_TYPES`, a fragment to frozenset map, so `issuecomment` is accepted on both the issue and the pull type. A PR's conversation comments are issue comments in the REST API, so the fragment is legitimate on both. A subroute guard keeps the fragment rejected on every pull tab, because GitHub anchors a conversation comment on the bare pull view only; widening those would accept a shape GitHub does not produce and undo the tightening from PR #5002.
- `tests/skills/github/test_url_routing.py` moves the bare pull case from `test_rejects_non_exact_routes` to `test_fragment_routes_success` rather than deleting it, since PR #5002 pinned that rejection deliberately. Two subroute cases are added, `checks` and `commits`, so the guard is covered on all four pull subroutes instead of the two #5002 pinned.
- `src/copilot-cli/skills/github-url-intercept/scripts/test_url_routing.py` is the generated Copilot mirror, regenerated by the build rather than hand-edited, and the canonical-versus-mirror identity test covers it.

## Acceptance criteria

- [x] `/pull/{n}#issuecomment-{id}` parses and routes to `gh api "repos/{o}/{r}/issues/comments/{id}"`, exit 0
- [x] `/issues/{n}#issuecomment-{id}` keeps its existing behavior
- [x] `/issues/{n}#discussion_r{id}` stays rejected, since a review comment cannot exist on an issue
- [x] The decision on `/files` and `/changes` is explicit and recorded, with its reason, in the code rather than left to inference
- [x] A positive test asserts both exit 0 and the exact command string
- [x] The mirror is regenerated by the generator

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: whether the subroute guard is drawn in the right place. I kept `/files`, `/changes`, `/checks` and `/commits` rejecting the fragment on the grounds that GitHub never anchors a conversation comment on a tab. If you know of a real URL that carries that shape, the guard is too strict and should go.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Six shapes measured before and after. The first line is the defect; the rest are controls proving the change is narrow.

| URL shape | before | after |
|---|---|---|
| `/pull/{n}#issuecomment-{id}` | 1 | **0** |
| `/issues/{n}#issuecomment-{id}` | 0 | 0 |
| `/pull/{n}/files#issuecomment-{id}` | 1 | 1 |
| `/pull/{n}/changes#issuecomment-{id}` | 1 | 1 |
| `/pull/{n}#discussion_r{id}` | 0 | 0 |
| `/issues/{n}#discussion_r{id}` | 1 | 1 |

The emitted command is `gh api "repos/rjmurillo/ai-agents/issues/comments/5620280328"`, character-for-character the route the skill documents. It is also the command I ran by hand to read that comment before filing the issue, so the contract is honored end to end.

Suite goes 172 passed to 174 passed. Exit codes were read directly, not through a pipe.

**Discrimination probe.** With the frozenset narrowed back to `{UrlType.ISSUE}`, the run is 1 failed / 34 passed and names exactly the new parametrization with `assert 1 == 0`. Restored, it is 35 passed. Without that control the added case would be unfalsifiable.

`uv run python scripts/validation/pre_pr.py` reports 69 of 71 gates proved their contract. The 2 BLOCKED are `validate_workflow_yaml` and `validate_yaml_style`, both `reason=tool.absent` because yamllint is not on this PATH, both licensed by the pre-PR policy, and neither reachable by this diff, which touches no YAML.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The change widens a URL parser's accepted set by one shape and narrows nothing. `is_safe_input` validation on owner, repo, ref and path is untouched, and the control-character rejection at `_has_disallowed_control_characters` still runs first.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

### Why the rejection existed, and why removing it is not a regression

PR #5002 (`944427e0a`) introduced this rejection while closing #4993, under the heading "reject unsupported suffixes and unknown fragments". Reading #4993, it never asked for this: its acceptance criteria were to fully match each supported path shape, reject leftover suffixes instead of truncating them, implement or remove the checks, short comment, Actions and discussion claims, and add positive and negative CLI tests. The pull-plus-`issuecomment` combination was swept in as collateral, and the skill body was never changed to match, so the router and its own documentation have disagreed since.

That is why the pinned case moves rather than disappears. The rejection was deliberate, so silently deleting the assertion would lose the record of the decision being reversed.

### The subroute guard is the interesting half

The minimal fix is one line: add `UrlType.PULL` to the `issuecomment` entry. I did not stop there, because that alone would also accept `/pull/{n}/files#issuecomment-{id}`, which GitHub does not emit. Accepting a shape the platform does not produce buys nothing and weakens the tightening #5002 was right to add. The guard encodes that distinction where the next reader will see it, with the reason.

### Found while routing a real URL

This was not found by reading the code. A PR comment URL was pasted into a session, the skill's mandatory validator returned exit 1 on it, and the `gh api` call the skill recommends succeeded on the same fragment ID. The gap between those two results is the bug.

## Related Issues

Fixes #5719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156anMjWG1sggpCwqT7dBdF


---
_Generated by [Claude Code](https://claude.ai/code)_