### PR TITLE
docs(plans): map always-on rule sections to destination skills for M4

### DIFF
--- a/.agents/plans/active/5456-control-plane-subtraction-cohort-1.md
+++ b/.agents/plans/active/5456-control-plane-subtraction-cohort-1.md
@@ -267,3 +267,30 @@ treat it as reviewed and accepted, not unreviewed.
 - Specs: REQ-024/DESIGN-023/TASK-028, REQ-022/DESIGN-021/TASK-029,
   REQ-023/DESIGN-022/TASK-026
 - Ontology: `.agents/specs/ontology/control-plane-subtraction-cohort-1.md`
+
+## M4: fold always-on rule content into skills (mapped 2026-09-11, not started)
+
+Owner direction: no deletions; combine rule content into the skills that use it, keep always-on only cross-cutting text, send language idioms to path-scoped rules. Section map of the five always-on rules (byte figures are source-basis estimates within 15 percent; `voice.md` 19,748 and the five-rule mirror total 56,863 are exact):
+
+| Rule section | Bytes | Class | Destination |
+|---|---|---|---|
+| voice.md Confusion Protocol (with Unattended runs) | 2,548 | move | spec, plan |
+| voice.md Completeness Principle (with scores) | 2,084 | move | spec, plan |
+| search-before-building.md The Contradiction Log | 2,030 | move | memory-gate |
+| voice.md Writing Style (with User-Turn Override) | 1,853 | move | spec, plan, review, autoplan |
+| search-before-building.md The Three Layers | 1,624 | move | programming-advisor |
+| search-before-building.md Where To Search | 1,160 | move (spec and plan already quote the bound-the-search sentence) | memory-search |
+| search-before-building.md When To Apply, intro, self-review | 2,262 | move | programming-advisor, memory-gate |
+| claude-model-patches.md all sections | 4,434 | move (gstack preambles already carry the three nudges) | build, ship, test, plan, review |
+| builder-ethos.md Decision Procedure | 1,334 | move | autoplan |
+| builder-ethos.md Task Completion Contract: Forming, Reactivation | 1,044 | move | avoiding-manufactured-work (Finding disposition already there) |
+| builder-ethos.md Terminal predicate; voice.md Completion-Tail Audit; voice.md Clear The Gate | 3,070 | already in build, ship, test; residual copies to spec, plan, review | lifecycle skills |
+| builder-ethos.md Precedence Stack, Boil the Lake, User Sovereignty, Golden Age, How They Work Together | 7,769 | stays | always-on |
+| voice.md Definitions, Tier And Tension, prose rules, Banned Vocabulary, dash ban, Ownership, Quick Self-Review | 11,417 | stays | always-on |
+| universal.md MUST, SHOULD, MUST NOT, persistence surface | 9,720 | stays | always-on |
+
+Totals: stays about 31,400 bytes (56 percent); moves about 24,500 bytes (44 percent). No idiomatic-Python or PowerShell text exists in the five files; `python.md` and `powershell.md` already hold that content under path scopes.
+
+Gate: `.claude/skills/context-optimizer/references/rule-audit-procedure.md` Step 3 separates authoring guidance ("does not need an eval") from cutting existing always-on content ("changes measured behavior and does"). Copying a section into a skill needs no eval. Removing it from the always-on file afterwards is a cut under that procedure: scenario files, eight runs across two model families, adversarial review, and the two doctrine documents updated. Owner decides whether to run that procedure or waive it for a move whose text survives in a skill.
+
+Exit criteria: every "move" row has its text in the named skills; always-on files shrink by the moved bytes only after the owner's gate decision; `tests/validation/test_always_on_corpus_claims.py` and the doctrine figures updated in the same PR.


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds milestone M4 to the epic #5456 cohort plan: a section-by-section map of the five always-on rules to the skills or path-scoped rules that should carry each section, with byte estimates, the stays-versus-moves totals, the exit criteria, and the rule-audit gate that applies before any always-on file shrinks.

### Why

Owner direction on 2026-09-11: no deletions; fold rule content into the skills that use it, keep always-on only for cross-cutting text, send language idioms to path-scoped rules. The map is the plan for that milestone. This commit was on the branch of PR #5747 but landed after that PR was merged, so it ships here on its own.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5456 | epic(v0.7.0): subtract the control plane and prove the smaller system |
| **Plan** | `.agents/plans/active/5456-control-plane-subtraction-cohort-1.md` | M4 section added |

These references do not close their linked items.

## Changes

- `.agents/plans/active/5456-control-plane-subtraction-cohort-1.md`: new section "M4: fold always-on rule content into skills" with the map table (14 rows), totals, the gate from the rule-audit procedure, and exit criteria.

## Acceptance criteria

- [x] Every always-on rule section appears in exactly one row as stays or move
- [x] Every move row names an existing skill directory or scoped rule
- [x] The gate paragraph quotes the procedure's own distinction between authoring guidance and cutting content
- [x] No em-dashes or en-dashes in the edited file

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: design review, standard scrutiny, no rush

**Focus areas**: the destination skill per row; whether the eval gate is waived for moves whose text survives in a skill.

## Testing

Deliverables in this PR:

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

None.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`uv run python scripts/validation/pre_pr.py`; `--quick` drops four slow gates, measured at under 2 percent of the run, so prefer the full sequence)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines ([.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md)) and code quality standards ([.agents/governance/code-quality.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-quality.md))
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

<details>
<summary>Review norms (expand)</summary>

Canonical source: [.agents/governance/code-review-norms.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-review-norms.md). The summary below is for convenience; the canonical file is authoritative.

- **Assume competence and goodwill.** A "bad" PR usually means one party has information the other does not.
- **Explain *why*, not just *what*.** "This is wrong because..." beats "this is wrong."
- **Approve once the change improves overall code health.** Perfect is not the bar.
- **Target reply within ~1 business day.** If you cannot, leave a comment saying when you can.
- **Prefer "Approve with suggestions"** for minor issues, especially across timezones.
- **Authors: address every comment** by adopting, deferring (with a tracking issue), or pushing back with reasoning. Silence is not resolution.

**Comment severity prefixes** (so authors can triage):

| Prefix | Meaning |
|---|---|
| `Nit:` | Minor / style; do not block on it |
| `Optional:` | Worth considering; author may defer |
| `FYI:` | Future thought; no action needed |
| *(no prefix)* | Must address before merge |

</details>

## Related Issues

Refs #5456. Does not close on merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A7u8jFkyLQpjZhKrTwvmh
