### PR TITLE
feat(validation): detect ruleset drift in both directions

### DIFF
--- a/scripts/validation/check_ruleset_params_drift.py
+++ b/scripts/validation/check_ruleset_params_drift.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
-"""Check recorded ruleset parameters against the live GitHub API.
+"""Check recorded ruleset state against the live GitHub API.
 
-Compares the values in ruleset_params_baseline.json against the live
-ruleset fetched via `gh api`. Exits non-zero when any parameter drifts.
+Compares ruleset_params_baseline.json against the live ruleset fetched via
+`gh api`, in both directions:
+
+  * every baseline parameter's value against its live value (and detects a
+    baseline parameter that disappeared from the live rule set)
+  * every live parameter key that has no baseline entry (unknown-key drift,
+    so an added rule or a widened permission cannot go unnoticed)
+  * the ruleset's top-level `enforcement` and `bypass_actors` state, which
+    live outside any rule's `parameters` block and were previously never
+    fetched at all
+
+Exits non-zero when any of the above drifts.
 
 Usage (local):
     python scripts/validation/check_ruleset_params_drift.py
@@ -11,10 +21,12 @@ Usage (CI, offline / no token):
     python scripts/validation/check_ruleset_params_drift.py --offline
 
 EXIT CODES (ADR-035):
-    0 - all parameters match or --offline skipped the live check
+    0 - all state matches or --offline skipped the live check
     1 - drift detected
-    2 - configuration error (missing baseline, bad JSON)
+    2 - configuration error (missing baseline, bad JSON, missing/malformed
+        'parameters' or 'ruleset' section)
     3 - external error (gh CLI unavailable, API failure)
+    4 - authentication error (gh CLI not authenticated)
 """
 
 from __future__ import annotations
@@ -34,6 +46,17 @@ EXIT_AUTH = 4
 BASELINE_PATH = Path(__file__).parent / "ruleset_params_baseline.json"
 REPO = "rjmurillo/ai-agents"
 
+# `required_status_checks` is both a rule TYPE and, within that rule's
+# `parameters` block, a parameter KEY holding the list of required status
+# check contexts. That key is owned by
+# scripts/ci/ruleset_required_contexts.py (module-level REQUIRED_CONTEXTS),
+# which scripts/ci/ruleset_context_drift.py already compares against the
+# live ruleset. Per the decision recorded in
+# .serena/memories/decision-ruleset-drift-must-not-create-a-second-baseline.md,
+# no second baseline of the required contexts may exist, so this module
+# excludes the key from both value comparison and unknown-key detection.
+DELEGATED_PARAM_KEYS: frozenset[str] = frozenset({"required_status_checks"})
+
 
 def load_baseline() -> dict[str, Any]:
     """Load the expected parameter baseline."""
@@ -50,11 +73,29 @@ def load_baseline() -> dict[str, Any]:
     if "parameters" not in result:
         print("ERROR: baseline missing 'parameters' key", file=sys.stderr)
         sys.exit(EXIT_CONFIG)
+    ruleset_state = result.get("ruleset")
+    if not isinstance(ruleset_state, dict):
+        print("ERROR: baseline missing 'ruleset' key", file=sys.stderr)
+        sys.exit(EXIT_CONFIG)
+    if "enforcement" not in ruleset_state or "bypass_actors" not in ruleset_state:
+        print(
+            "ERROR: baseline 'ruleset' section missing 'enforcement' or"
+            " 'bypass_actors'",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_CONFIG)
     return result
 
 
-def fetch_live_params(ruleset_id: int) -> dict[str, Any]:
-    """Fetch live ruleset parameters from GitHub API via gh CLI."""
+def fetch_live_ruleset(ruleset_id: int) -> dict[str, Any]:
+    """Fetch the full live ruleset payload from GitHub API via gh CLI.
+
+    Returns the raw decoded JSON object exactly as `gh api
+    repos/<repo>/rulesets/<id>` produces it, so callers can read both
+    per-rule `parameters` (see extract_live_params) and top-level ruleset
+    state such as `enforcement` and `bypass_actors` (see
+    extract_live_ruleset_state) from a single API call.
+    """
     try:
         result = subprocess.run(
             ["gh", "api", f"repos/{REPO}/rulesets/{ruleset_id}"],
@@ -76,11 +117,16 @@ def fetch_live_params(ruleset_id: int) -> dict[str, Any]:
         sys.exit(exit_code)
 
     try:
-        data = json.loads(result.stdout)
+        data: dict[str, Any] = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
         print(f"ERROR: invalid JSON from API: {exc}", file=sys.stderr)
         sys.exit(EXIT_EXTERNAL)
 
+    return data
+
+
+def extract_live_params(data: dict[str, Any]) -> dict[str, Any]:
+    """Union rule-level `parameters` across every rule in the ruleset payload."""
     params: dict[str, Any] = {}
     for rule in data.get("rules", []):
         rule_params = rule.get("parameters", {})
@@ -89,13 +135,31 @@ def fetch_live_params(ruleset_id: int) -> dict[str, Any]:
     return params
 
 
+def extract_live_ruleset_state(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract the ruleset's top-level `enforcement` and `bypass_actors`."""
+    return {
+        "enforcement": data.get("enforcement"),
+        "bypass_actors": data.get("bypass_actors", []),
+    }
+
+
 def check_drift(
     baseline: dict[str, Any], live: dict[str, Any]
 ) -> list[str]:
-    """Compare baseline parameters against live values. Return drift messages."""
+    """Compare baseline parameters against live values. Return drift messages.
+
+    Bidirectional: reports a baseline value that no longer matches live (or
+    disappeared from it), AND a live parameter key with no baseline entry
+    (unknown-key drift), so a widened permission is caught even though it was
+    never baselined. DELEGATED_PARAM_KEYS is excluded from both directions;
+    see its module-level comment for why.
+    """
     drifts: list[str] = []
     baseline_params = baseline.get("parameters", {})
+
     for key, expected in baseline_params.items():
+        if key in DELEGATED_PARAM_KEYS:
+            continue
         actual = live.get(key)
         if actual is None:
             drifts.append(
@@ -103,6 +167,70 @@ def check_drift(
             )
         elif actual != expected:
             drifts.append(f"  {key}: expected={expected!r}, actual={actual!r}")
+
+    for key, actual in live.items():
+        if key in baseline_params or key in DELEGATED_PARAM_KEYS:
+            continue
+        drifts.append(
+            f"  {key}: unrecognized live parameter (value={actual!r}),"
+            " not present in baseline"
+        )
+
+    return drifts
+
+
+def _bypass_actor_sort_key(actor: dict[str, Any]) -> tuple[str, ...]:
+    """Stable sort key for one bypass actor dict.
+
+    Every component is stringified so a heterogeneous list (an actor missing
+    a field, or a future actor type whose actor_id is not an int) sorts
+    instead of raising TypeError. Ordering only has to be stable here, not
+    semantically meaningful: it exists so list reordering is not read as
+    drift, and equality is still compared on the original dicts.
+    """
+    return (
+        str(actor.get("actor_id")),
+        str(actor.get("actor_type")),
+        str(actor.get("bypass_mode")),
+    )
+
+
+def _normalize_bypass_actors(actors: list[Any]) -> list[Any]:
+    """Sort bypass actors so list reordering is not read as drift."""
+    return sorted(actors, key=_bypass_actor_sort_key)
+
+
+def check_ruleset_drift(
+    baseline: dict[str, Any], live_ruleset: dict[str, Any]
+) -> list[str]:
+    """Compare baseline top-level ruleset state against live state.
+
+    `live_ruleset` is the shape extract_live_ruleset_state returns:
+    {"enforcement": ..., "bypass_actors": [...]}. `bypass_actors` is compared
+    order-insensitively (GitHub may return the list in a different order
+    without any actor having changed), but an added, removed, or modified
+    actor is still reported.
+    """
+    drifts: list[str] = []
+    baseline_ruleset = baseline.get("ruleset", {})
+
+    expected_enforcement = baseline_ruleset.get("enforcement")
+    actual_enforcement = live_ruleset.get("enforcement")
+    if actual_enforcement != expected_enforcement:
+        drifts.append(
+            f"  enforcement: expected={expected_enforcement!r},"
+            f" actual={actual_enforcement!r}"
+        )
+
+    expected_actors = _normalize_bypass_actors(
+        baseline_ruleset.get("bypass_actors", [])
+    )
+    actual_actors = _normalize_bypass_actors(live_ruleset.get("bypass_actors", []))
+    if actual_actors != expected_actors:
+        drifts.append(
+            f"  bypass_actors: expected={expected_actors!r},"
+            f" actual={actual_actors!r}"
+        )
 
     return drifts
 
@@ -121,8 +249,12 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: ruleset_id missing from baseline", file=sys.stderr)
         sys.exit(EXIT_CONFIG)
 
-    live = fetch_live_params(ruleset_id)
-    drifts = check_drift(baseline, live)
+    data = fetch_live_ruleset(ruleset_id)
+    live_params = extract_live_params(data)
+    live_ruleset_state = extract_live_ruleset_state(data)
+
+    drifts = check_drift(baseline, live_params)
+    drifts += check_ruleset_drift(baseline, live_ruleset_state)
 
     if drifts:
         print("DRIFT DETECTED between baseline and live ruleset:")

--- a/scripts/validation/ruleset_params_baseline.json
+++ b/scripts/validation/ruleset_params_baseline.json
@@ -2,9 +2,24 @@
   "ruleset_id": 11104075,
   "ref": "main",
   "parameters": {
-    "strict_required_status_checks_policy": false,
+    "allowed_merge_methods": ["squash"],
+    "dismiss_stale_reviews_on_push": true,
+    "do_not_enforce_on_create": false,
+    "require_code_owner_review": false,
+    "require_extra_approval_for_unattributed_changes": true,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 0,
     "required_review_thread_resolution": true,
-    "required_approving_review_count": 0
+    "required_reviewers": [],
+    "review_draft_pull_requests": false,
+    "review_on_push": true,
+    "strict_required_status_checks_policy": false
   },
-  "measured": "2026-08-14"
+  "ruleset": {
+    "enforcement": "active",
+    "bypass_actors": [
+      {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+    ]
+  },
+  "measured": "2026-09-12"
 }

--- a/tests/validation/test_check_ruleset_params_drift.py
+++ b/tests/validation/test_check_ruleset_params_drift.py
@@ -16,9 +16,16 @@ sys.path.insert(
 )
 import check_ruleset_params_drift as mod
 
+# Matches scripts/validation/ruleset_params_baseline.json's "ruleset" section
+# so TestMainLive's default mock stays in sync with the committed baseline.
+_DEFAULT_ENFORCEMENT = "active"
+_DEFAULT_BYPASS_ACTORS = [
+    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+]
+
 
 class TestCheckDrift:
-    """Unit tests for the drift comparison logic."""
+    """Unit tests for the parameter drift comparison logic."""
 
     def test_no_drift(self):
         baseline = {"parameters": {"strict_required_status_checks_policy": False}}
@@ -53,6 +60,150 @@ class TestCheckDrift:
         }
         assert mod.check_drift(baseline, live) == []
 
+    def test_unknown_live_param_is_drift(self) -> None:
+        """A live parameter absent from the baseline is now reported, not ignored.
+
+        This is the core defect fix: check_drift() used to iterate only
+        baseline_params.items(), so an added rule or a widened permission
+        with no baseline entry was invisible.
+        """
+        baseline = {"parameters": {"strict_required_status_checks_policy": False}}
+        live = {
+            "strict_required_status_checks_policy": False,
+            "require_linear_history": True,
+        }
+        drifts = mod.check_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "require_linear_history" in drifts[0]
+        assert "True" in drifts[0]
+
+    def test_delegated_key_excluded_from_unknown_key_detection(self) -> None:
+        """required_status_checks is never flagged as an unknown live key.
+
+        Regression pin for the constraint in
+        .serena/memories/decision-ruleset-drift-must-not-create-a-second-baseline.md:
+        scripts/ci/ruleset_required_contexts.py owns REQUIRED_CONTEXTS and no
+        second baseline of the required contexts may exist here.
+        """
+        baseline = {"parameters": {"strict_required_status_checks_policy": False}}
+        live = {
+            "strict_required_status_checks_policy": False,
+            "required_status_checks": [{"context": "Validate PR"}],
+        }
+        assert mod.check_drift(baseline, live) == []
+
+    def test_delegated_key_in_baseline_is_not_value_compared(self) -> None:
+        """A delegated key placed in the baseline by mistake is not compared.
+
+        Defensive: DELEGATED_PARAM_KEYS is excluded from the baseline-to-live
+        value comparison as well as unknown-key detection, so this module
+        never becomes a second source of truth for required contexts even if
+        someone adds the key to the baseline file.
+        """
+        baseline = {
+            "parameters": {
+                "strict_required_status_checks_policy": False,
+                "required_status_checks": [{"context": "Old Context"}],
+            }
+        }
+        live = {
+            "strict_required_status_checks_policy": False,
+            "required_status_checks": [{"context": "New Context"}],
+        }
+        assert mod.check_drift(baseline, live) == []
+
+
+class TestBypassActorSortKey:
+    """Sort key must not raise on actors with missing or non-int fields."""
+
+    def test_heterogeneous_actors_sort_without_raising(self) -> None:
+        baseline: dict[str, Any] = {
+            "ruleset": {
+                "enforcement": "active",
+                "bypass_actors": [
+                    {"actor_id": 5, "actor_type": "RepositoryRole",
+                     "bypass_mode": "always"},
+                    {"actor_type": "DeployKey", "bypass_mode": "always"},
+                ],
+            }
+        }
+        live: dict[str, Any] = {
+            "enforcement": "active",
+            "bypass_actors": [
+                {"actor_type": "DeployKey", "bypass_mode": "always"},
+                {"actor_id": 5, "actor_type": "RepositoryRole",
+                 "bypass_mode": "always"},
+            ],
+        }
+        assert mod.check_ruleset_drift(baseline, live) == []
+
+
+class TestCheckRulesetDrift:
+    """Unit tests for the top-level ruleset state comparison (enforcement,
+    bypass_actors), which fetch_live_params() previously never fetched."""
+
+    def _baseline(self, enforcement: str = "active", bypass_actors=None) -> dict:
+        if bypass_actors is None:
+            bypass_actors = list(_DEFAULT_BYPASS_ACTORS)
+        return {"ruleset": {"enforcement": enforcement, "bypass_actors": bypass_actors}}
+
+    def test_no_drift_when_matching(self) -> None:
+        baseline = self._baseline()
+        live = {
+            "enforcement": "active",
+            "bypass_actors": list(_DEFAULT_BYPASS_ACTORS),
+        }
+        assert mod.check_ruleset_drift(baseline, live) == []
+
+    def test_enforcement_change_is_drift(self) -> None:
+        baseline = self._baseline(enforcement="active")
+        live = {"enforcement": "evaluate", "bypass_actors": list(_DEFAULT_BYPASS_ACTORS)}
+        drifts = mod.check_ruleset_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "enforcement" in drifts[0]
+        assert "expected='active'" in drifts[0]
+        assert "actual='evaluate'" in drifts[0]
+
+    def test_added_bypass_actor_is_drift(self) -> None:
+        """An added bypass actor is the highest-value signal this check exists for."""
+        baseline = self._baseline()
+        extra_actor = {"actor_id": 99, "actor_type": "Team", "bypass_mode": "always"}
+        live = {
+            "enforcement": "active",
+            "bypass_actors": [*_DEFAULT_BYPASS_ACTORS, extra_actor],
+        }
+        drifts = mod.check_ruleset_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "bypass_actors" in drifts[0]
+
+    def test_removed_bypass_actor_is_drift(self) -> None:
+        baseline = self._baseline()
+        live = {"enforcement": "active", "bypass_actors": []}
+        drifts = mod.check_ruleset_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "bypass_actors" in drifts[0]
+
+    def test_modified_bypass_actor_is_drift(self) -> None:
+        """Same actor_id, different bypass_mode: a modification, not a reorder."""
+        baseline = self._baseline()
+        modified_actor = {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "pull_request",
+        }
+        live = {"enforcement": "active", "bypass_actors": [modified_actor]}
+        drifts = mod.check_ruleset_drift(baseline, live)
+        assert len(drifts) == 1
+        assert "bypass_actors" in drifts[0]
+
+    def test_reordered_bypass_actors_not_drift(self) -> None:
+        """Same actors in a different order is not drift; GitHub reorders freely."""
+        actor_a = {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+        actor_b = {"actor_id": 99, "actor_type": "Team", "bypass_mode": "always"}
+        baseline = self._baseline(bypass_actors=[actor_a, actor_b])
+        live = {"enforcement": "active", "bypass_actors": [actor_b, actor_a]}
+        assert mod.check_ruleset_drift(baseline, live) == []
+
 
 class TestMainOffline:
     """Test the --offline flag."""
@@ -64,33 +215,61 @@ class TestMainOffline:
 
 
 class TestMainLive:
-    """Integration-style tests with mocked subprocess."""
+    """Integration-style tests with mocked subprocess.
 
-    def _mock_gh(self, params: dict):
-        """Return a mock that simulates gh api returning given params."""
+    The mock defaults to the exact "ruleset" section of the committed
+    baseline (scripts/validation/ruleset_params_baseline.json) so a test that
+    only wants to vary rule-level parameters does not also trip top-level
+    ruleset drift.
+    """
+
+    def _mock_gh(
+        self,
+        params: dict,
+        enforcement: str = _DEFAULT_ENFORCEMENT,
+        bypass_actors: list | None = None,
+    ):
+        """Return a mock that simulates gh api returning given ruleset state."""
+        if bypass_actors is None:
+            bypass_actors = list(_DEFAULT_BYPASS_ACTORS)
         rules = [{"type": "required_status_checks", "parameters": params}]
-        payload = json.dumps({"rules": rules})
+        payload = json.dumps(
+            {
+                "rules": rules,
+                "enforcement": enforcement,
+                "bypass_actors": bypass_actors,
+            }
+        )
         return subprocess.CompletedProcess(
             args=[], returncode=0, stdout=payload, stderr=""
         )
 
-    def test_match_returns_zero(self, capsys):
-        live_params = {
-            "strict_required_status_checks_policy": False,
-            "required_review_thread_resolution": True,
+    def _matching_params(self) -> dict:
+        """Rule parameters matching every non-delegated key in the baseline."""
+        return {
+            "allowed_merge_methods": ["squash"],
+            "dismiss_stale_reviews_on_push": True,
+            "do_not_enforce_on_create": False,
+            "require_code_owner_review": False,
+            "require_extra_approval_for_unattributed_changes": True,
+            "require_last_push_approval": False,
             "required_approving_review_count": 0,
+            "required_review_thread_resolution": True,
+            "required_reviewers": [],
+            "review_draft_pull_requests": False,
+            "review_on_push": True,
+            "strict_required_status_checks_policy": False,
         }
-        with patch("subprocess.run", return_value=self._mock_gh(live_params)):
+
+    def test_match_returns_zero(self, capsys):
+        with patch("subprocess.run", return_value=self._mock_gh(self._matching_params())):
             rc = mod.main([])
         assert rc == 0
         assert "OK" in capsys.readouterr().out
 
     def test_drift_returns_one(self, capsys):
-        live_params = {
-            "strict_required_status_checks_policy": True,
-            "required_review_thread_resolution": True,
-            "required_approving_review_count": 0,
-        }
+        live_params = self._matching_params()
+        live_params["strict_required_status_checks_policy"] = True
         with patch("subprocess.run", return_value=self._mock_gh(live_params)):
             rc = mod.main([])
         assert rc == 1
@@ -120,9 +299,72 @@ class TestMainLive:
                 mod.main([])
             assert exc_info.value.code == 3
 
+    def test_added_bypass_actor_returns_one(self, capsys) -> None:
+        """CLI-level proof that an added bypass actor fails the check.
+
+        main([]) returning 1 is the assertion, not check_ruleset_drift()'s
+        return value alone (testing.md MUST-8).
+        """
+        extra_actor = {"actor_id": 99, "actor_type": "Team", "bypass_mode": "always"}
+        mock = self._mock_gh(
+            self._matching_params(),
+            bypass_actors=[*_DEFAULT_BYPASS_ACTORS, extra_actor],
+        )
+        with patch("subprocess.run", return_value=mock):
+            rc = mod.main([])
+        assert rc == 1
+        assert "bypass_actors" in capsys.readouterr().out
+
+    def test_removed_bypass_actor_returns_one(self, capsys) -> None:
+        mock = self._mock_gh(self._matching_params(), bypass_actors=[])
+        with patch("subprocess.run", return_value=mock):
+            rc = mod.main([])
+        assert rc == 1
+        assert "bypass_actors" in capsys.readouterr().out
+
+    def test_enforcement_change_returns_one(self, capsys) -> None:
+        mock = self._mock_gh(self._matching_params(), enforcement="evaluate")
+        with patch("subprocess.run", return_value=mock):
+            rc = mod.main([])
+        assert rc == 1
+        assert "enforcement" in capsys.readouterr().out
+
+    def test_unknown_live_param_returns_one(self, capsys) -> None:
+        live_params = self._matching_params()
+        live_params["require_linear_history"] = True
+        with patch("subprocess.run", return_value=self._mock_gh(live_params)):
+            rc = mod.main([])
+        assert rc == 1
+        assert "require_linear_history" in capsys.readouterr().out
+
+    def test_required_status_checks_delegated_not_reported(self, capsys) -> None:
+        """Edge case, regression pin: the delegated key never causes drift here.
+
+        Even though required_status_checks is not in the baseline and its
+        live value is a 9-entry context list, main() must exit 0. Ownership
+        lives at scripts/ci/ruleset_required_contexts.py per the
+        must-not-create-a-second-baseline decision.
+        """
+        live_params = self._matching_params()
+        live_params["required_status_checks"] = [
+            {"context": f"Check {i}"} for i in range(9)
+        ]
+        with patch("subprocess.run", return_value=self._mock_gh(live_params)):
+            rc = mod.main([])
+        assert rc == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_bypass_actors_reordered_returns_zero(self, capsys) -> None:
+        reordered = list(reversed(_DEFAULT_BYPASS_ACTORS))
+        mock = self._mock_gh(self._matching_params(), bypass_actors=reordered)
+        with patch("subprocess.run", return_value=mock):
+            rc = mod.main([])
+        assert rc == 0
+        assert "OK" in capsys.readouterr().out
+
 
 class TestEdgeCases:
-    """Edge cases: malformed baseline, extra live params."""
+    """Edge cases: malformed baseline, unknown live params, delegated keys."""
 
     def test_malformed_baseline_exits_config(self, tmp_path: Path) -> None:
         bad = tmp_path / "bad.json"
@@ -140,8 +382,48 @@ class TestEdgeCases:
                 mod.main([])
             assert exc_info.value.code == mod.EXIT_CONFIG
 
-    def test_extra_live_params_ignored(self) -> None:
-        """Extra live params not in baseline are not flagged as drift."""
+    def test_missing_ruleset_section_exits_config(self, tmp_path: Path) -> None:
+        """A baseline with 'parameters' but no 'ruleset' section is config error.
+
+        Same treatment as today's missing-'parameters' handling: the new
+        top-level state section is mandatory, not optional.
+        """
+        no_ruleset = tmp_path / "no_ruleset.json"
+        no_ruleset.write_text(
+            json.dumps({"ruleset_id": 1, "parameters": {}}), encoding="utf-8"
+        )
+        with patch.object(mod, "BASELINE_PATH", no_ruleset):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == mod.EXIT_CONFIG
+
+    def test_ruleset_section_missing_bypass_actors_exits_config(
+        self, tmp_path: Path
+    ) -> None:
+        """A malformed 'ruleset' section (missing a required subkey) is config error."""
+        malformed = tmp_path / "malformed_ruleset.json"
+        malformed.write_text(
+            json.dumps(
+                {
+                    "ruleset_id": 1,
+                    "parameters": {},
+                    "ruleset": {"enforcement": "active"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch.object(mod, "BASELINE_PATH", malformed):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main([])
+            assert exc_info.value.code == mod.EXIT_CONFIG
+
+    def test_unknown_live_params_are_reported_as_drift(self) -> None:
+        """Live params not in the baseline are now drift, not ignored.
+
+        Was test_extra_live_params_ignored, asserting drifts == [] under the
+        old one-directional contract. check_drift() now also iterates
+        live.items(), so an added rule or a widened permission is caught.
+        """
         baseline: dict[str, Any] = {
             "parameters": {"strict_required_status_checks_policy": False}
         }
@@ -151,16 +433,30 @@ class TestEdgeCases:
             "do_not_enforce_on_create": False,
         }
         drifts = mod.check_drift(baseline, live)
-        assert drifts == []
-
+        assert len(drifts) == 2
+        joined = "\n".join(drifts)
+        assert "require_linear_history" in joined
+        assert "do_not_enforce_on_create" in joined
 
     def test_realistic_multi_rule_payload(self) -> None:
-        """Baseline subset matches despite many extra live params (real API shape)."""
+        """Full baseline matches the full multi-rule live payload (real API shape).
+
+        Was test_realistic_multi_rule_payload, previously asserting
+        drifts == [] with 5 baseline-absent live params ignored. Under the
+        bidirectional contract the baseline now carries every non-delegated
+        key, and required_status_checks (delegated) is still excluded from
+        comparison even though it is present in live and absent from
+        baseline.
+        """
         baseline: dict[str, Any] = {
             "parameters": {
                 "strict_required_status_checks_policy": False,
                 "required_review_thread_resolution": True,
                 "required_approving_review_count": 0,
+                "do_not_enforce_on_create": False,
+                "dismiss_stale_reviews_on_push": True,
+                "require_code_owner_review": False,
+                "allowed_merge_methods": ["squash"],
             }
         }
         live: dict[str, Any] = {


### PR DESCRIPTION
# Pull Request

## Summary

### What

The ruleset drift checker now compares in both directions and reads the ruleset's top-level state. Previously it iterated only the baseline's own keys, so a live parameter with no baseline entry was invisible, and it never fetched `enforcement` or `bypass_actors` at all.

### Why

ADR-101 Phase 0 item 5. The daily drift job has been green for eight consecutive days. That green meant three baselined parameters matched. It said nothing about the other ten parameters, the enforcement mode, or who can bypass the ruleset entirely.

Measured live while writing this: the ruleset has one bypass actor (`RepositoryRole` 5, `bypass_mode: always`) that nothing was watching. An added bypass actor is the highest-value signal this change makes visible.

This is the detection half of Phase 0 only. It changes no repository state, no secret, and no branch protection. It makes the existing gaps measurable rather than closing them.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #5244 | Implement ADR-101 Phase 0: control plane hardening |

## Changes

- `scripts/validation/check_ruleset_params_drift.py`: bidirectional comparison, top-level `enforcement` and `bypass_actors` fetching, and a `DELEGATED_PARAM_KEYS` exclusion
- `scripts/validation/ruleset_params_baseline.json`: records twelve parameters plus a new `ruleset` section, measured live
- `tests/validation/test_check_ruleset_params_drift.py`: suite goes from 15 to 32 tests, including two that asserted the old contract and are flipped rather than deleted

## Acceptance criteria

- [x] A live parameter absent from the baseline is reported as drift
- [x] The ruleset's `enforcement` value is compared against a recorded baseline
- [x] The `bypass_actors` list is compared, order-insensitively, so an added or removed actor is caught but a reordering is not
- [x] `required_status_checks` is excluded from this baseline, with a regression test pinning the exclusion
- [x] The exit-code contract is unchanged: 0 clean, 1 drift, 2 config, 3 external, 4 auth
- [x] The checker reports OK against the real live ruleset, so the daily job stays green on merge

## Type of Change

- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, high scrutiny (control-plane monitoring), no rush

**Focus areas**: the `DELEGATED_PARAM_KEYS` carve-out, and whether unknown-key drift is the behavior you want on the daily job. Under this change, GitHub adding a new ruleset parameter field will turn the daily job red until the baseline records it. That is deliberate fail-closed behavior, but it is a maintenance cost worth agreeing on.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes

No new attack surface. The `gh api` subprocess call is unchanged in argv construction and encoding handling; this change adds comparison logic over data already fetched, plus one additional read of the same response. The script only ever reads the GitHub API, and never mutates.

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] No new warnings introduced

## Evidence

Verified against the live API with exit codes read without pipe masking, since a pipeline would have reported `grep`'s status instead of the script's:

| Condition | Expected | True exit |
|---|---|---|
| Baseline unmodified | 0 | 0 |
| Bypass actor dropped from baseline | 1 | 1 |
| `enforcement` flipped to `evaluate` | 1 | 1 |
| A live parameter removed from baseline | 1 | 1 |
| `ruleset` section missing | 2 | 2 |

`uv run pytest tests/validation/test_check_ruleset_params_drift.py` reports 32 passed. `uv run ruff check` on both Python files passes. `uv run python scripts/validation/pre_pr.py` exits 0, with two checks reporting `tool.absent` because yamllint is not on PATH; this diff contains no YAML, so nothing in scope went unchecked.

The `required_status_checks` exclusion obeys the decision recorded in `.serena/memories/decision-ruleset-drift-must-not-create-a-second-baseline.md`. `scripts/ci/ruleset_required_contexts.py` owns that contract and `scripts/ci/ruleset_context_drift.py` already compares it against the live ruleset, so copying the nine contexts into this baseline would create the second baseline that decision forbids.

## Out of Scope

The remaining five Phase 0 items in #5244 (secret containment, approval-count and code-owner review, CODEOWNERS closure, credential probes, and moving `determine_should_run_from_filters.py` to a base-ref job) all change repository state and are tracked separately.

One pre-existing behavior was noticed and deliberately not changed: `check_drift` cannot distinguish a baseline key absent from live from one present with value `None`. None of the thirteen live parameters is ever `None`, so it is not reachable today.

## Related Issues

Refs #5244

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj29cNqNwCTwcE9r8zSpEH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sj29cNqNwCTwcE9r8zSpEH)_